### PR TITLE
Fix for none auth in admin

### DIFF
--- a/cmd/admin/auth.go
+++ b/cmd/admin/auth.go
@@ -12,9 +12,6 @@ import (
 func handlerAuthCheck(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch adminConfig.Auth {
-		case settings.AuthNone:
-			// Access always granted
-			h.ServeHTTP(w, r)
 		case settings.AuthDB:
 			// Check if user is already authenticated
 			authenticated, session := sessionsmgr.CheckAuth(r)

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -86,6 +87,17 @@ var (
 	dbFlag      *string
 )
 
+// Valid values for auth and logging in configuration
+var validAuth = map[string]bool{
+	settings.AuthDB:      true,
+	settings.AuthSAML:    true,
+	settings.AuthHeaders: true,
+	settings.AuthJSON:    true,
+}
+var validLogging = map[string]bool{
+	settings.LoggingDB:      true,
+}
+
 // Function to load the configuration file
 func loadConfiguration(file, service string) (types.JSONConfigurationService, error) {
 	var cfg types.JSONConfigurationService
@@ -96,11 +108,18 @@ func loadConfiguration(file, service string) (types.JSONConfigurationService, er
 	if err != nil {
 		return cfg, err
 	}
-	// TLS Admin values
+	// Admin values
 	adminRaw := viper.Sub(service)
 	err = adminRaw.Unmarshal(&cfg)
 	if err != nil {
 		return cfg, err
+	}
+	// Check if values are valid
+	if !validAuth[cfg.Auth] {
+		return cfg, fmt.Errorf("Invalid auth method")
+	}
+	if !validLogging[cfg.Logging] {
+		return cfg, fmt.Errorf("Invalid logging method")
 	}
 	// Load configuration for the auth method
 	/*

--- a/cmd/admin/types-server.go
+++ b/cmd/admin/types-server.go
@@ -8,6 +8,14 @@ type JSONConfigurationSAML struct {
 	RootURL     string `json:"rooturl"`
 }
 
+// JSONAdminUsers to keep all admin users for auth JSON
+type JSONAdminUsers struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Fullname string `json:"fullname"`
+	Admin    bool   `json:"admin"`
+}
+
 // OsqueryTable to show tables to query
 type OsqueryTable struct {
 	Name      string   `json:"name"`

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -66,6 +67,16 @@ var (
 	dbFlag      *string
 )
 
+// Valid values for auth and logging in configuration
+var validAuth = map[string]bool{
+	settings.AuthNone:    true,
+}
+var validLogging = map[string]bool{
+	settings.LoggingDB:      true,
+	settings.LoggingGraylog: true,
+	settings.LoggingSplunk:  true,
+}
+
 // Function to load the configuration file and assign to variables
 func loadConfiguration(file string) (types.JSONConfigurationService, error) {
 	var cfg types.JSONConfigurationService
@@ -81,6 +92,13 @@ func loadConfiguration(file string) (types.JSONConfigurationService, error) {
 	err = tlsRaw.Unmarshal(&cfg)
 	if err != nil {
 		return cfg, err
+	}
+	// Check if values are valid
+	if !validAuth[cfg.Auth] {
+		return cfg, fmt.Errorf("Invalid auth method")
+	}
+	if !validLogging[cfg.Logging] {
+		return cfg, fmt.Errorf("Invalid logging method")
 	}
 	// No errors!
 	return cfg, nil

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -23,6 +23,7 @@ const (
 // Types of authentication
 const (
 	AuthNone    string = "none"
+	AuthJSON    string = "json"
 	AuthDB      string = "db"
 	AuthSAML    string = "saml"
 	AuthHeaders string = "headers"
@@ -36,6 +37,7 @@ const (
 	LoggingGraylog string = "graylog"
 	LoggingSplunk  string = "splunk"
 	LoggingELK     string = "elk"
+	LoggingKafka   string = "kafka"
 )
 
 // Names for all possible settings values


### PR DESCRIPTION
## Overview

Fix for #4, where using `auth = none` in the `osctrl-admin` was making the service to crash with a panic.
This code prevents using no authentication in the admin service. Also adds some other code to potentially have admin users in a JSON file, but that isn't completed.