### PR TITLE
Upload certificate from admin and regenerate flags

### DIFF
--- a/cmd/admin/handlers.go
+++ b/cmd/admin/handlers.go
@@ -22,13 +22,13 @@ const JSONApplicationUTF8 string = JSONApplication + "; charset=UTF-8"
 // Empty default osquery configuration
 const emptyConfiguration string = "data/osquery-empty.json"
 
-// Handle testing requests
-func testingHTTPHandler(w http.ResponseWriter, r *http.Request) {
+// Handle health requests
+func healthHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), true)
 	// Send response
 	w.Header().Set("Content-Type", JSONApplicationUTF8)
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("test"))
+	_, _ = w.Write([]byte("✅"))
 }
 
 // Handle error requests

--- a/cmd/admin/static/js/enrolls.js
+++ b/cmd/admin/static/js/enrolls.js
@@ -24,3 +24,25 @@ function extendRemoveLink() {
 function expireRemoveLink() {
   genericLinkAction('remove', 'expire');
 }
+
+function confirmUploadCertificate() {
+  $('#certificate_action').click(function () {
+    $('#certificateModal').modal('hide');
+    uploadCertificate();
+  });
+  $("#certificateModal").modal();
+}
+
+function uploadCertificate() {
+  var _csrftoken = $("#csrftoken").val();
+  var _blob = $('#certificate').data('CodeMirrorInstance');
+  var _certificate = _blob.getValue();
+
+  var _url = window.location.pathname;
+
+  var data = {
+    csrftoken: _csrftoken,
+    certificate: btoa(_certificate),
+  };
+  sendPostRequest(data, _url, window.location.pathname, false);
+}

--- a/cmd/admin/templates/components/page-modals.html
+++ b/cmd/admin/templates/components/page-modals.html
@@ -136,4 +136,27 @@
           </div>
           <!-- /.modal -->
 
+        <div class="modal fade" id="certificateModal" tabindex="-1" role="dialog" aria-labelledby="certificateModalLabel" aria-hidden="true">
+          <div class="modal-dialog modal-dark modal-lg" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title">Upload new certificate</h4>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+              <div class="modal-body">
+                <textarea id="certificate" name="certificate"></textarea>
+              </div>
+              <div class="modal-footer">
+                <button id="certificate_action" type="button" class="btn btn-dark" data-dismiss="modal">Upload</button>
+                <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
+              </div>
+            </div>
+            <!-- /.modal-content -->
+          </div>
+          <!-- /.modal-dialog -->
+        </div>
+        <!-- /.modal -->
+
 {{ end }}

--- a/cmd/admin/templates/enroll.html
+++ b/cmd/admin/templates/enroll.html
@@ -224,8 +224,16 @@
                 <hr>
 
                 <div class="row mb-4">
-                  <div class="col-md-12">
-                    Enrollment certificate:
+                  <div class="row col-md-12">
+                    <div class="col-md-10">
+                      Enrollment certificate:
+                    </div>
+                    <div class="col-md-2">
+                      <button id="" class="btn btn-sm btn-block btn-dark"
+                        data-tooltip="true" data-placement="bottom" title="Upload new certificate" onclick="confirmUploadCertificate();">
+                        <i class="fas fa-upload"></i>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div class="row mb-4">
@@ -262,6 +270,14 @@
       hljs.initHighlightingOnLoad();
 
       $(document).ready(function() {
+        // Codemirror editor for configuration
+        var certificateBlob = CodeMirror.fromTextArea(document.getElementById("certificate"), {
+          mode: 'text/plain',
+          lineNumbers: true
+        });
+        $('#certificate').data('CodeMirrorInstance', certificateBlob);
+        certificateBlob.setSize("100%", "100%");
+
         // Highlight.js code element initialization
         $('code').each(function(i, block) {
           hljs.highlightBlock(block);

--- a/cmd/admin/types-requests.go
+++ b/cmd/admin/types-requests.go
@@ -70,6 +70,12 @@ type ConfigurationRequest struct {
 	ConfigurationB64 string `json:"configuration"`
 }
 
+// EnrollRequest to receive changes to enroll certificates
+type EnrollRequest struct {
+	CSRFToken      string `json:"csrftoken"`
+	CertificateB64 string `json:"certificate"`
+}
+
 // IntervalsRequest to receive changes to intervals
 type IntervalsRequest struct {
 	CSRFToken      string `json:"csrftoken"`

--- a/cmd/tls/handlers-tls.go
+++ b/cmd/tls/handlers-tls.go
@@ -59,12 +59,12 @@ func okHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("💥"))
 }
 
-// Handle testing requests
-func testingHTTPHandler(w http.ResponseWriter, r *http.Request) {
+// Handle health requests
+func healthHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	// Send response
 	w.Header().Set("Content-Type", JSONApplicationUTF8)
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("test"))
+	_, _ = w.Write([]byte("✅"))
 }
 
 // Handle error requests

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -32,8 +32,8 @@ const (
 	serviceDescription string = "TLS service for osctrl"
 	// Application description
 	appDescription string = serviceDescription + ", a fast and efficient osquery management"
-	// Default endpoint to handle HTTP testing
-	testingPath string = "/testing"
+	// Default endpoint to handle HTTP health
+	healthPath string = "/health"
 	// Default endpoint to handle HTTP errors
 	errorPath string = "/error"
 	// Default service configuration file
@@ -168,7 +168,7 @@ func main() {
 	// TLS: root
 	routerTLS.HandleFunc("/", okHTTPHandler)
 	// TLS: testing
-	routerTLS.HandleFunc(testingPath, testingHTTPHandler).Methods("GET")
+	routerTLS.HandleFunc(healthPath, healthHTTPHandler).Methods("GET")
 	// TLS: error
 	routerTLS.HandleFunc(errorPath, errorHTTPHandler).Methods("GET")
 	// TLS: Specific routes for osquery nodes

--- a/pkg/environments/environments.go
+++ b/pkg/environments/environments.go
@@ -14,17 +14,17 @@ const (
 	// DefaultLogPath as default value for logging data from nodes
 	DefaultLogPath string = "log"
 	// DefaultLogInterval as default interval for logging data from nodes
-	DefaultLogInterval int = 10
+	DefaultLogInterval int = 600
 	// DefaultConfigPath as default value for configuring nodes
 	DefaultConfigPath string = "config"
 	// DefaultConfigInterval as default interval for configuring nodes
-	DefaultConfigInterval int = 10
+	DefaultConfigInterval int = 300
 	// DefaultQueryReadPath as default value for distributing on-demand queries to nodes
 	DefaultQueryReadPath string = "read"
 	// DefaultQueryWritePath as default value for collecting results from on-demand queries
 	DefaultQueryWritePath string = "write"
 	// DefaultQueryInterval as default interval for distributing on-demand queries to nodes
-	DefaultQueryInterval int = 10
+	DefaultQueryInterval int = 60
 	// DefaultCarverInitPath as default init endpoint for the carver
 	DefaultCarverInitPath string = "init"
 	// DefaultCarverBlockPath as default block endpoint for the carver
@@ -204,6 +204,18 @@ func (environment *Environment) UpdateConfiguration(name, configuration string) 
 		return fmt.Errorf("error getting environment %v", err)
 	}
 	if err := environment.DB.Model(&env).Update("configuration", configuration).Error; err != nil {
+		return fmt.Errorf("Update %v", err)
+	}
+	return nil
+}
+
+// UpdateCertificate to update certificate for an environment
+func (environment *Environment) UpdateCertificate(name, certificate string) error {
+	env, err := environment.Get(name)
+	if err != nil {
+		return fmt.Errorf("error getting environment %v", err)
+	}
+	if err := environment.DB.Model(&env).Update("certificate", certificate).Error; err != nil {
 		return fmt.Errorf("Update %v", err)
 	}
 	return nil

--- a/pkg/environments/flags.go
+++ b/pkg/environments/flags.go
@@ -2,6 +2,7 @@ package environments
 
 import (
 	"bytes"
+	"fmt"
 	"text/template"
 )
 
@@ -71,4 +72,13 @@ func GenerateFlags(env TLSEnvironment, secret, certificate string) (string, erro
 		return "", err
 	}
 	return tpl.String(), nil
+}
+
+// GenerateFlagsEnv to generate flags by environment name
+func (environment *Environment) GenerateFlagsEnv(name string, secret, certificate string) (string, error) {
+	env, err := environment.Get(name)
+	if err != nil {
+		return "", fmt.Errorf("error getting environment %v", err)
+	}
+	return GenerateFlags(env, secret, certificate)
 }


### PR DESCRIPTION
## Overview

Several changes added in this PR:
* Environment certificate can be uploaded from the admin UI.
* Flags will be re-generated when changes are made to intervals.
* Default intervals are increased.
* Added health check for for `osctrl-tls` and `osctrl-admin` so it can be easy to monitor using things like k8s.
* Attempting to save an empty configuration will throw an error.