### PR TITLE
Logging plugins fixes and random stuff

### DIFF
--- a/cmd/admin/handlers-get.go
+++ b/cmd/admin/handlers-get.go
@@ -139,7 +139,7 @@ func environmentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if settingsmgr.DebugService(settings.ServiceAdmin) {
-		log.Println("DebugService:  Environment table template served")
+		log.Println("DebugService: Environment table template served")
 	}
 	incMetric(metricAdminOK)
 }
@@ -963,7 +963,7 @@ func envsGETHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if settingsmgr.DebugService(settings.ServiceAdmin) {
-		log.Println("DebugService:  Environments template served")
+		log.Println("DebugService: Environments template served")
 	}
 	incMetric(metricAdminOK)
 }

--- a/cmd/admin/templates/environments.html
+++ b/cmd/admin/templates/environments.html
@@ -20,13 +20,13 @@
 
             <div class="card mt-2">
               <div class="card-header">
-                <i class="fas fa-tools"></i> All TLS  Environments</b>
+                <i class="fas fa-tools"></i> All TLS Environments</b>
 
                   <div class="card-header-actions">
                     <div class="row">
                       <div class="card-header-action mr-3">
                         <button id="environment_add" class="btn btn-sm btn-block btn-dark"
-                          data-tooltip="true" data-placement="bottom" title="Add  Environment" onclick="createEnvironment();">
+                          data-tooltip="true" data-placement="bottom" title="Add Environment" onclick="createEnvironment();">
                           <i class="fas fa-plus"></i>
                         </button>
                       </div>

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -187,7 +187,7 @@ func main() {
 	// FIXME Implement Redis cache
 	// FIXME splay this?
 	if settingsmgr.DebugService(settings.ServiceTLS) {
-		log.Println("DebugService:  Environments ticker")
+		log.Println("DebugService: Environments ticker")
 	}
 	// Refresh environments as soon as service starts
 	go refreshEnvironments()

--- a/pkg/environments/environments.go
+++ b/pkg/environments/environments.go
@@ -74,7 +74,7 @@ type TLSEnvironment struct {
 // MapEnvironments to hold the TLS environments by name
 type MapEnvironments map[string]TLSEnvironment
 
-// Environment keeps all TLS  Environments
+// Environment keeps all TLS Environments
 type Environment struct {
 	DB *gorm.DB
 }

--- a/pkg/environments/flags.go
+++ b/pkg/environments/flags.go
@@ -17,6 +17,7 @@ const (
 --config_plugin=tls
 --config_tls_endpoint=/{{ .Environment.Name }}/{{ .Environment.ConfigPath }}
 --config_tls_refresh={{ .Environment.ConfigInterval }}
+--config_tls_max_attempts=5
 --logger_plugin=tls
 --logger_tls_compress=true
 --logger_tls_endpoint=/{{ .Environment.Name }}/{{ .Environment.LogPath }}
@@ -28,7 +29,7 @@ const (
 --disable_distributed=false
 --distributed_interval={{ .Environment.QueryInterval }}
 --distributed_plugin=tls
---distributed_tls_max_attempts=3
+--distributed_tls_max_attempts=5
 --distributed_tls_read_endpoint=/{{ .Environment.Name }}/{{ .Environment.QueryReadPath }}
 --distributed_tls_write_endpoint=/{{ .Environment.Name }}/{{ .Environment.QueryWritePath }}
 --tls_dump=true
@@ -49,17 +50,17 @@ type flagData struct {
 }
 
 // GenerateFlags to generate flags
-func GenerateFlags(env TLSEnvironment, secret, certificate string) (string, error) {
+func GenerateFlags(env TLSEnvironment, secretPath, certificatePath string) (string, error) {
 	t, err := template.New("flags").Parse(FlagsTemplate)
 	if err != nil {
 		return "", err
 	}
-	flagSecret := secret
-	if secret == "" {
+	flagSecret := secretPath
+	if secretPath == "" {
 		flagSecret = emptyFlagSecret
 	}
-	flagCertificate := certificate
-	if certificate == "" {
+	flagCertificate := certificatePath
+	if certificatePath == "" {
 		flagCertificate = emptyFlagCert
 	}
 	data := flagData{
@@ -75,10 +76,10 @@ func GenerateFlags(env TLSEnvironment, secret, certificate string) (string, erro
 }
 
 // GenerateFlagsEnv to generate flags by environment name
-func (environment *Environment) GenerateFlagsEnv(name string, secret, certificate string) (string, error) {
+func (environment *Environment) GenerateFlagsEnv(name string, secretPath, certificatePath string) (string, error) {
 	env, err := environment.Get(name)
 	if err != nil {
 		return "", fmt.Errorf("error getting environment %v", err)
 	}
-	return GenerateFlags(env, secret, certificate)
+	return GenerateFlags(env, secretPath, certificatePath)
 }

--- a/pkg/environments/flags.go
+++ b/pkg/environments/flags.go
@@ -32,7 +32,6 @@ const (
 --distributed_tls_max_attempts=5
 --distributed_tls_read_endpoint=/{{ .Environment.Name }}/{{ .Environment.QueryReadPath }}
 --distributed_tls_write_endpoint=/{{ .Environment.Name }}/{{ .Environment.QueryWritePath }}
---tls_dump=true
 --tls_hostname={{ .Environment.Hostname }}
 --tls_server_certs={{ .CertFile }}
 `

--- a/plugins/logging_dispatcher/control.go
+++ b/plugins/logging_dispatcher/control.go
@@ -1,0 +1,10 @@
+package main
+
+const (
+	// splunkEnabled
+	splunkEnabled bool = false
+	// graylogEnabled
+	graylogEnabled bool = false
+	// dbEnabled
+	dbEnabled bool = true
+)

--- a/plugins/logging_dispatcher/db.go
+++ b/plugins/logging_dispatcher/db.go
@@ -8,6 +8,11 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
+const (
+	// Graylog value
+	dbName string = "DB"
+)
+
 var (
 	dbLog   func(string, *gorm.DB, []byte, string, string, bool)
 	dbQuery func(*gorm.DB, []byte, string, string, string, int, bool)


### PR DESCRIPTION
## Overview

* Added extra debug logging to the logging plugins.
* Splunk and Graylog plugins were never initialized despite the configuration being loaded. That was throwing a panic when using any of those plugins.
* Metadata for nodes is updated before logging, so in the case the plugins crashes, the metadata will be up to date.
* Removing flag `--tls_dump`.
* Adding flag `--distributed_tls_max_attempts`.
* Random clean-up code.