### PR TITLE
Separation between users and admins

### DIFF
--- a/cmd/admin/auth.go
+++ b/cmd/admin/auth.go
@@ -8,6 +8,16 @@ import (
 	"github.com/jmpsec/osctrl/pkg/settings"
 )
 
+const (
+	adminLevel string = "admin"
+	userLevel  string = "user"
+)
+
+// Helper to verify if user is an admin
+func checkAdminLevel(level string) bool {
+	return (level == adminLevel)
+}
+
 // Handler to check access to a resource based on the authentication enabled
 func handlerAuthCheck(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,6 +38,11 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 			s := make(contextValue)
 			s["user"] = session.Username
 			s["csrftoken"] = session.Values["csrftoken"].(string)
+			if session.Values["admin"].(bool) {
+				s["level"] = adminLevel
+			} else {
+				s["level"] = userLevel
+			}
 			ctx := context.WithValue(r.Context(), contextKey("session"), s)
 			// Access granted
 			h.ServeHTTP(w, r.WithContext(ctx))
@@ -75,6 +90,11 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 				s := make(contextValue)
 				s["user"] = session.Username
 				s["csrftoken"] = session.Values["csrftoken"].(string)
+				if session.Values["admin"].(bool) {
+					s["level"] = adminLevel
+				} else {
+					s["level"] = userLevel
+				}
 				ctx := context.WithValue(r.Context(), contextKey("session"), s)
 				// Access granted
 				samlMiddleware.RequireAccount(h).ServeHTTP(w, r.WithContext(ctx))

--- a/cmd/admin/handlers-get.go
+++ b/cmd/admin/handlers-get.go
@@ -27,9 +27,9 @@ func loginGETHandler(w http.ResponseWriter, r *http.Request) {
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/login.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html")
+		templatesFilesFolder+"/login.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting login template: %v", err)
@@ -91,13 +91,13 @@ func environmentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/table.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/table.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -124,6 +124,7 @@ func environmentHandler(w http.ResponseWriter, r *http.Request) {
 		Title:          "Nodes in " + env,
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Selector:       "environment",
 		SelectorName:   env,
 		Target:         target,
@@ -167,13 +168,13 @@ func platformHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/table.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/table.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -200,6 +201,7 @@ func platformHandler(w http.ResponseWriter, r *http.Request) {
 		Title:          "Nodes in " + platform,
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Selector:       "platform",
 		SelectorName:   platform,
 		Target:         target,
@@ -224,15 +226,23 @@ func platformHandler(w http.ResponseWriter, r *http.Request) {
 func queryRunGETHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/queries-run.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/queries-run.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -266,13 +276,12 @@ func queryRunGETHandler(w http.ResponseWriter, r *http.Request) {
 		uuids = append(uuids, n.UUID)
 		hosts = append(hosts, n.Localname)
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Prepare template data
 	templateData := QueryRunTemplateData{
 		Title:          "Query osquery Nodes",
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environments:   envAll,
 		Platforms:      platforms,
 		UUIDs:          uuids,
@@ -298,15 +307,23 @@ func queryRunGETHandler(w http.ResponseWriter, r *http.Request) {
 func queryListGETHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/queries.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/queries.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -326,13 +343,12 @@ func queryListGETHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("error getting platforms: %v", err)
 		return
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Prepare template data
 	templateData := QueryTableTemplateData{
 		Title:          "All on-demand queries",
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environments:   envAll,
 		Platforms:      platforms,
 		Target:         "all",
@@ -355,15 +371,23 @@ func queryListGETHandler(w http.ResponseWriter, r *http.Request) {
 func carvesRunGETHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/carves-run.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/carves-run.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -397,13 +421,12 @@ func carvesRunGETHandler(w http.ResponseWriter, r *http.Request) {
 		uuids = append(uuids, n.UUID)
 		hosts = append(hosts, n.Localname)
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Prepare template data
 	templateData := CarvesRunTemplateData{
 		Title:          "Query osquery Nodes",
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environments:   envAll,
 		Platforms:      platforms,
 		UUIDs:          uuids,
@@ -429,15 +452,23 @@ func carvesRunGETHandler(w http.ResponseWriter, r *http.Request) {
 func carvesListGETHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/carves.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/carves.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -457,13 +488,12 @@ func carvesListGETHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("error getting platforms: %v", err)
 		return
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Prepare template data
 	templateData := CarvesTableTemplateData{
 		Title:          "All carved files",
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environments:   envAll,
 		Platforms:      platforms,
 		Target:         "all",
@@ -486,6 +516,14 @@ func carvesListGETHandler(w http.ResponseWriter, r *http.Request) {
 func queryLogsHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	vars := mux.Vars(r)
 	// Extract name
 	name, ok := vars["name"]
@@ -496,13 +534,13 @@ func queryLogsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Prepare template
 	t, err := template.New("queries-logs.html").ParseFiles(
-		templatesFilesFolder + "/queries-logs.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/queries-logs.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -536,13 +574,12 @@ func queryLogsHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("error getting targets %v", err)
 		return
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Prepare template data
 	templateData := QueryLogsTemplateData{
 		Title:          "Query logs " + query.Name,
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environments:   envAll,
 		Platforms:      platforms,
 		Query:          query,
@@ -566,6 +603,14 @@ func queryLogsHandler(w http.ResponseWriter, r *http.Request) {
 func carvesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	vars := mux.Vars(r)
 	// Extract name
 	name, ok := vars["name"]
@@ -576,13 +621,13 @@ func carvesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Prepare template
 	t, err := template.New("carves-details.html").ParseFiles(
-		templatesFilesFolder + "/carves-details.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/carves-details.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -635,13 +680,12 @@ func carvesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		blocks[c.SessionID] = bs
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Prepare template data
 	templateData := CarvesDetailsTemplateData{
 		Title:          "Carve details " + query.Name,
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environments:   envAll,
 		Platforms:      platforms,
 		Query:          query,
@@ -683,13 +727,13 @@ func confGETHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/conf.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-modals.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html")
+		templatesFilesFolder+"/conf.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-modals.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting conf template: %v", err)
@@ -723,6 +767,7 @@ func confGETHandler(w http.ResponseWriter, r *http.Request) {
 		Title:          envVar + " Configuration",
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environment:    env,
 		Environments:   envAll,
 		Platforms:      platforms,
@@ -761,13 +806,13 @@ func enrollGETHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/enroll.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/enroll.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting enroll template: %v", err)
@@ -805,6 +850,7 @@ func enrollGETHandler(w http.ResponseWriter, r *http.Request) {
 		Title:                 envVar + " Enroll",
 		Username:              ctx["user"],
 		CSRFToken:             ctx["csrftoken"],
+		Level:                 ctx["level"],
 		EnvName:               envVar,
 		EnrollExpiry:          strings.ToUpper(inFutureTime(env.EnrollExpire)),
 		EnrollExpired:         environments.IsItExpired(env.EnrollExpire),
@@ -848,20 +894,20 @@ func nodeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Custom functions to handle formatting
 	funcMap := template.FuncMap{
-		"pastTimeAgo":   pastTimeAgo,
-		"jsonRawIndent": jsonRawIndent,
+		"pastTimeAgo":    pastTimeAgo,
+		"jsonRawIndent":  jsonRawIndent,
 		"statusLogsLink": statusLogsLink,
 		"resultLogsLink": resultLogsLink,
 	}
 	// Prepare template
 	t, err := template.New("node.html").Funcs(funcMap).ParseFiles(
-		templatesFilesFolder + "/node.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/node.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -895,6 +941,7 @@ func nodeHandler(w http.ResponseWriter, r *http.Request) {
 		Title:          "Node View " + node.Hostname,
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Logs:           adminConfig.Logging,
 		Node:           node,
 		Environments:   envAll,
@@ -918,15 +965,23 @@ func nodeHandler(w http.ResponseWriter, r *http.Request) {
 func envsGETHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/environments.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/environments.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting environments template: %v", err)
@@ -946,13 +1001,12 @@ func envsGETHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("error getting platforms: %v", err)
 		return
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Prepare template data
 	templateData := EnvironmentsTemplateData{
 		Title:          "Manage environments",
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environments:   envAll,
 		Platforms:      platforms,
 		TLSDebug:       settingsmgr.DebugService(settings.ServiceTLS),
@@ -975,6 +1029,14 @@ func settingsGETHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
 	vars := mux.Vars(r)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	// Extract service
 	serviceVar, ok := vars["service"]
 	if !ok {
@@ -990,13 +1052,13 @@ func settingsGETHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder + "/settings.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/settings.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting environments template: %v", err)
@@ -1022,8 +1084,6 @@ func settingsGETHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("error getting settings: %v", err)
 		return
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Get JSON values
 	svcJSON, err := settingsmgr.RetrieveAllJSON(serviceVar)
 	if err != nil {
@@ -1035,6 +1095,7 @@ func settingsGETHandler(w http.ResponseWriter, r *http.Request) {
 		Title:           "Manage settings",
 		Username:        ctx["user"],
 		CSRFToken:       ctx["csrftoken"],
+		Level:           ctx["level"],
 		Service:         serviceVar,
 		Environments:    envAll,
 		Platforms:       platforms,
@@ -1059,19 +1120,27 @@ func settingsGETHandler(w http.ResponseWriter, r *http.Request) {
 func usersGETHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	// Custom functions to handle formatting
 	funcMap := template.FuncMap{
 		"pastTimeAgo": pastTimeAgo,
 	}
 	// Prepare template
 	t, err := template.New("users.html").Funcs(funcMap).ParseFiles(
-		templatesFilesFolder + "/users.html",
-		templatesFilesFolder + "/components/page-head.html",
-		templatesFilesFolder + "/components/page-js.html",
-		templatesFilesFolder + "/components/page-header.html",
-		templatesFilesFolder + "/components/page-sidebar.html",
-		templatesFilesFolder + "/components/page-aside.html",
-		templatesFilesFolder + "/components/page-modals.html")
+		templatesFilesFolder+"/users.html",
+		templatesFilesFolder+"/components/page-head.html",
+		templatesFilesFolder+"/components/page-js.html",
+		templatesFilesFolder+"/components/page-header.html",
+		templatesFilesFolder+"/components/page-sidebar.html",
+		templatesFilesFolder+"/components/page-aside.html",
+		templatesFilesFolder+"/components/page-modals.html")
 	if err != nil {
 		incMetric(metricAdminErr)
 		log.Printf("error getting environments template: %v", err)
@@ -1098,13 +1167,12 @@ func usersGETHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("error getting users: %v", err)
 		return
 	}
-	// Get context data
-	ctx := r.Context().Value(contextKey("session")).(contextValue)
 	// Prepare template data
 	templateData := UsersTemplateData{
 		Title:          "Manage users",
 		Username:       ctx["user"],
 		CSRFToken:      ctx["csrftoken"],
+		Level:          ctx["level"],
 		Environments:   envAll,
 		Platforms:      platforms,
 		CurrentUsers:   users,
@@ -1128,6 +1196,14 @@ func carvesDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	incMetric(metricAdminReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
 	vars := mux.Vars(r)
+	// Get context data
+	ctx := r.Context().Value(contextKey("session")).(contextValue)
+	// Check permissions
+	if !checkAdminLevel(ctx["level"]) {
+		log.Printf("%s has insuficient permissions", ctx["user"])
+		incMetric(metricAdminErr)
+		return
+	}
 	// Extract id to download
 	carveSession, ok := vars["sessionid"]
 	if !ok {

--- a/cmd/admin/handlers.go
+++ b/cmd/admin/handlers.go
@@ -11,6 +11,9 @@ const (
 	metricAdminReq  = "admin-req"
 	metricAdminErr  = "admin-err"
 	metricAdminOK   = "admin-ok"
+	metricJSONReq   = "admin-json-req"
+	metricJSONErr   = "admin-json-err"
+	metricJSONOK    = "admin-json-ok"
 	metricHealthReq = "health-req"
 	metricHealthOK  = "health-ok"
 )
@@ -55,7 +58,6 @@ func forbiddenHTTPHandler(w http.ResponseWriter, r *http.Request) {
 // Handler for the favicon
 func faviconHandler(w http.ResponseWriter, r *http.Request) {
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
-
 	w.Header().Set("Content-Type", "image/png")
 	http.ServeFile(w, r, "./static/favicon.png")
 }

--- a/cmd/admin/json-logs.go
+++ b/cmd/admin/json-logs.go
@@ -50,41 +50,41 @@ type QueryLogJSON struct {
 
 // Handler GET requests for JSON status/result logs by node and environment
 func jsonLogsHandler(w http.ResponseWriter, r *http.Request) {
-	incMetric(metricAdminReq)
+	incMetric(metricJSONReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
 	vars := mux.Vars(r)
 	// Extract type
 	logType, ok := vars["type"]
 	if !ok {
-		incMetric(metricAdminErr)
 		log.Println("error getting log type")
+		incMetric(metricJSONErr)
 		return
 	}
 	// Verify log type
 	if !LogTypes[logType] {
-		incMetric(metricAdminErr)
 		log.Printf("invalid log type %s", logType)
+		incMetric(metricJSONErr)
 		return
 	}
 	// Extract environment
 	env, ok := vars["environment"]
 	if !ok {
-		incMetric(metricAdminErr)
 		log.Println("environment is missing")
+		incMetric(metricJSONErr)
 		return
 	}
 	// Check if environment is valid
 	if !envs.Exists(env) {
-		incMetric(metricAdminErr)
 		log.Printf("error unknown environment (%s)", env)
+		incMetric(metricJSONErr)
 		return
 	}
 	// Extract UUID
 	// FIXME verify UUID
 	UUID, ok := vars["uuid"]
 	if !ok {
-		incMetric(metricAdminErr)
 		log.Println("error getting UUID")
+		incMetric(metricJSONErr)
 		return
 	}
 	// Extract parameter for seconds
@@ -102,8 +102,8 @@ func jsonLogsHandler(w http.ResponseWriter, r *http.Request) {
 	if logType == "status" {
 		statusLogs, err := postgresStatusLogs(UUID, env, secondsBack)
 		if err != nil {
-			incMetric(metricAdminErr)
 			log.Printf("error getting logs %v", err)
+			incMetric(metricJSONErr)
 			return
 		}
 		// Prepare data to be returned
@@ -122,8 +122,8 @@ func jsonLogsHandler(w http.ResponseWriter, r *http.Request) {
 	} else if logType == "result" {
 		resultLogs, err := postgresResultLogs(UUID, env, secondsBack)
 		if err != nil {
-			incMetric(metricAdminErr)
 			log.Printf("error getting logs %v", err)
+			incMetric(metricJSONErr)
 			return
 		}
 		// Prepare data to be returned
@@ -145,8 +145,8 @@ func jsonLogsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serialize JSON
 	returnedJSON, err := json.Marshal(returned)
 	if err != nil {
-		incMetric(metricAdminErr)
 		log.Printf("error serializing JSON %v", err)
+		incMetric(metricJSONErr)
 		return
 	}
 	incMetric(metricAdminOK)
@@ -154,26 +154,27 @@ func jsonLogsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", JSONApplicationUTF8)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(returnedJSON)
+	incMetric(metricJSONOK)
 }
 
 // Handler for JSON query logs by query name
 func jsonQueryLogsHandler(w http.ResponseWriter, r *http.Request) {
-	incMetric(metricAdminReq)
+	incMetric(metricJSONReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
 	vars := mux.Vars(r)
 	// Extract query name
 	// FIXME verify name
 	name, ok := vars["name"]
 	if !ok {
-		incMetric(metricAdminErr)
 		log.Println("error getting name")
+		incMetric(metricJSONErr)
 		return
 	}
 	// Get logs
 	queryLogs, err := postgresQueryLogs(name)
 	if err != nil {
-		incMetric(metricAdminErr)
 		log.Printf("error getting logs %v", err)
+		incMetric(metricJSONErr)
 		return
 	}
 	// Prepare data to be returned
@@ -195,8 +196,8 @@ func jsonQueryLogsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serialize JSON
 	returnedJSON, err := json.Marshal(returned)
 	if err != nil {
-		incMetric(metricAdminErr)
 		log.Printf("error serializing JSON %v", err)
+		incMetric(metricJSONErr)
 		return
 	}
 	incMetric(metricAdminOK)
@@ -204,4 +205,5 @@ func jsonQueryLogsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", JSONApplicationUTF8)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(returnedJSON)
+	incMetric(metricJSONOK)
 }

--- a/cmd/admin/json-nodes.go
+++ b/cmd/admin/json-nodes.go
@@ -39,39 +39,39 @@ type NodeJSON struct {
 
 // Handler for JSON endpoints by environment
 func jsonEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	incMetric(metricAdminReq)
+	incMetric(metricJSONReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
 	vars := mux.Vars(r)
 	// Extract environment
 	env, ok := vars["environment"]
 	if !ok {
-		incMetric(metricAdminErr)
 		log.Println("error getting environment")
+		incMetric(metricJSONErr)
 		return
 	}
 	// Check if environment is valid
 	if !envs.Exists(env) {
-		incMetric(metricAdminErr)
 		log.Printf("error unknown environment (%s)", env)
+		incMetric(metricJSONErr)
 		return
 	}
 	// Extract target
 	target, ok := vars["target"]
 	if !ok {
-		incMetric(metricAdminErr)
 		log.Println("error getting target")
+		incMetric(metricJSONErr)
 		return
 	}
 	// Verify target
 	if !NodeTargets[target] {
-		incMetric(metricAdminErr)
 		log.Printf("invalid target %s", target)
+		incMetric(metricJSONErr)
 		return
 	}
 	nodes, err := nodesmgr.GetByEnv(env, target, settingsmgr.InactiveHours())
 	if err != nil {
-		incMetric(metricAdminErr)
 		log.Printf("error getting nodes %v", err)
+		incMetric(metricJSONErr)
 		return
 	}
 	// Prepare data to be returned
@@ -98,45 +98,46 @@ func jsonEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
 	// Serialize JSON
 	returnedJSON, err := json.Marshal(returned)
 	if err != nil {
-		incMetric(metricAdminErr)
 		log.Printf("error serializing JSON %v", err)
+		incMetric(metricJSONErr)
 		return
 	}
-	incMetric(metricAdminOK)
 	// Header to serve JSON
 	w.Header().Set("Content-Type", JSONApplicationUTF8)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(returnedJSON)
+	incMetric(metricJSONOK)
 }
 
 // Handler for JSON endpoints by platform
 func jsonPlatformHandler(w http.ResponseWriter, r *http.Request) {
+	incMetric(metricJSONReq)
 	utils.DebugHTTPDump(r, settingsmgr.DebugHTTP(settings.ServiceAdmin), false)
 	vars := mux.Vars(r)
 	// Extract platform
 	platform, ok := vars["platform"]
 	if !ok {
-		incMetric(metricAdminErr)
 		log.Println("error getting platform")
+		incMetric(metricJSONErr)
 		return
 	}
 	// Extract target
 	target, ok := vars["target"]
 	if !ok {
-		incMetric(metricAdminErr)
 		log.Println("error getting target")
+		incMetric(metricJSONErr)
 		return
 	}
 	// Verify target
 	if !NodeTargets[target] {
-		incMetric(metricAdminErr)
 		log.Printf("invalid target %s", target)
+		incMetric(metricJSONErr)
 		return
 	}
 	nodes, err := nodesmgr.GetByPlatform(platform, target, settingsmgr.InactiveHours())
 	if err != nil {
-		incMetric(metricAdminErr)
 		log.Printf("error getting nodes %v", err)
+		incMetric(metricJSONErr)
 		return
 	}
 	// Prepare data to be returned
@@ -163,13 +164,13 @@ func jsonPlatformHandler(w http.ResponseWriter, r *http.Request) {
 	// Serialize JSON
 	returnedJSON, err := json.Marshal(returned)
 	if err != nil {
-		incMetric(metricAdminErr)
 		log.Printf("error serializing JSON %v", err)
+		incMetric(metricJSONErr)
 		return
 	}
-	incMetric(metricAdminOK)
 	// Header to serve JSON
 	w.Header().Set("Content-Type", JSONApplicationUTF8)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(returnedJSON)
+	incMetric(metricJSONOK)
 }

--- a/cmd/admin/templates/carves-details.html
+++ b/cmd/admin/templates/carves-details.html
@@ -201,7 +201,9 @@
 
       </main>
 
+    {{ if eq .Level "admin" }}
       {{ template "page-aside" . }}
+    {{ end }}
 
     </div>
 

--- a/cmd/admin/templates/carves-run.html
+++ b/cmd/admin/templates/carves-run.html
@@ -180,7 +180,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 

--- a/cmd/admin/templates/carves.html
+++ b/cmd/admin/templates/carves.html
@@ -57,7 +57,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 
@@ -83,7 +85,7 @@
           searching : true,
           dom: "<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'f>>" +
                "<'row'<'col-sm-12'tr>>" +
-               "<'row'<'col-sm-12 col-md-4'B><'col-sm-12 col-md-4'i><'col-sm-12 col-md-4'p>>",
+               "<'row'<'col-sm-12 col-md-4'B><'col-sm-12 col-md-4 text-center'i><'col-sm-12 col-md-4'p>>",
           processing : true,
           order : [[ 3, "desc" ]],
           ajax : {
@@ -120,7 +122,7 @@
               data: 'path',
               render: function (data, type, row, meta) {
                 if (type === 'display') {
-                  return '<span style="font-family: monospace;"><a href="/carves/details/'+data.name+'">'+data.path+'</a></span>';
+                  return '<span style="font-family: monospace; font-size: 1.3em;"><a href="/carves/details/'+data.name+'">'+data.path+'</a></span>';
                 } else {
                   return data;
                 }

--- a/cmd/admin/templates/components/page-header.html
+++ b/cmd/admin/templates/components/page-header.html
@@ -24,6 +24,7 @@
             </div>
           </li>
       </ul>
+    {{ if eq .Level "admin" }}
       <button class="navbar-toggler aside-menu-toggler d-md-down-none" type="button" data-toggle="aside-menu-lg-show">
         <span>
           <i class="fas fa-cogs"></i>
@@ -34,6 +35,7 @@
           <i class="fas fa-cogs"></i>
         </span>
       </button>
+    {{ end }}
     </header>
 
 {{ end }}

--- a/cmd/admin/templates/components/page-sidebar.html
+++ b/cmd/admin/templates/components/page-sidebar.html
@@ -11,7 +11,7 @@
         </a>
       </li>
       -->
-
+      
       <li class="nav-title">Nodes by environment</li>
       {{range  $i, $e := $.Environments}}
       <li class="nav-item nav-dropdown">
@@ -225,6 +225,7 @@
 
       <li class="divider"></li>
 
+    {{ if eq .Level "admin" }}
       <li class="nav-title">On-Demand Queries</li>
       <li class="nav-item">
         <a class="nav-link" href="/query/run">
@@ -250,6 +251,7 @@
           <i class="nav-icon fas fa-archive"></i> All Carved Files
         </a>
       </li>
+    {{ end }}
 
     </ul>
   </nav>

--- a/cmd/admin/templates/conf.html
+++ b/cmd/admin/templates/conf.html
@@ -21,12 +21,14 @@
               <div id="intervals_header" class="card-header">
                 <i class="far fa-clock"></i> osquery intervals for environment <b>{{ .Environment.Name }}</b>
                 <div class="card-header-actions">
+                {{ if eq .Level "admin" }}
                   <div class="card-header-action">
                     <button id="intervals_save" class="btn btn-sm btn-block btn-dark"
                       data-tooltip="true" data-placement="bottom" title="Save Intervals" onclick="saveIntervals();">
                       <i class="far fa-save"></i>
                     </button>
                   </div>
+                {{ end }}
                 </div>
               </div>
               <div class="card-body">
@@ -70,12 +72,14 @@
               <div id="configuration_header" class="card-header">
                 <i class="far fa-file-alt"></i> osquery configuration for environment <b>{{ .Environment.Name }}</b>
                 <div class="card-header-actions">
+                {{ if eq .Level "admin" }}
                   <div class="card-header-action">
                     <button id="json_save" class="btn btn-sm btn-block btn-dark"
                       data-tooltip="true" data-placement="bottom" title="Save Changes" onclick="saveConfiguration();">
                       <i class="far fa-save"></i>
                     </button>
                   </div>
+                {{ end }}
                 </div>
               </div>
               <div class="card-body">
@@ -99,7 +103,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 

--- a/cmd/admin/templates/enroll.html
+++ b/cmd/admin/templates/enroll.html
@@ -24,6 +24,7 @@
                   <div class="card-header-actions">
                     <div class="row">
                       <span class="align-self-center mr-1"><b>{{ .EnrollExpiry }}</b></span>
+                    {{ if eq .Level "admin" }}
                       {{ if not .EnrollExpired }}
                       <div class="card-header-action mr-3">
                         <button id="enroll_expire" class="btn btn-sm btn-block btn-danger"
@@ -40,6 +41,7 @@
                           </button>
                       </div>
                       {{ end }}
+                    {{end }}
 
                     </div>
 
@@ -97,6 +99,7 @@
 
                   <div class="row">
                     <span class="align-self-center mr-1"><b>{{ .RemoveExpiry }}</b></span>
+                  {{ if eq .Level "admin" }}
                     {{ if not .RemoveExpired }}
                     <div class="card-header-action mr-3">
                       <button id="remove_expire" class="btn btn-sm btn-block btn-danger"
@@ -113,6 +116,7 @@
                       </button>
                     </div>
                     {{ end }}
+                  {{ end }}
 
                   </div>
 
@@ -229,10 +233,12 @@
                       Enrollment certificate:
                     </div>
                     <div class="col-md-2">
+                    {{ if eq .Level "admin" }}
                       <button id="" class="btn btn-sm btn-block btn-dark"
                         data-tooltip="true" data-placement="bottom" title="Upload new certificate" onclick="confirmUploadCertificate();">
                         <i class="fas fa-upload"></i>
                       </button>
+                    {{ end }}
                     </div>
                   </div>
                 </div>
@@ -256,7 +262,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 

--- a/cmd/admin/templates/environments.html
+++ b/cmd/admin/templates/environments.html
@@ -129,7 +129,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 

--- a/cmd/admin/templates/node.html
+++ b/cmd/admin/templates/node.html
@@ -33,6 +33,7 @@
 
                     <div class="row float-right">
                       <div class="col-md-12">
+                      {{ if eq $template.Level "admin" }}
                         <button type="button" class="btn custom-size-btn btn-outline-danger"
                         data-tooltip="true" data-placement="top" title="Remove" onclick="confirmRemoveNodes([{{ .UUID }}]);">
                           <i class="far fa-trash-alt"></i>
@@ -45,6 +46,7 @@
                         data-tooltip="true" data-placement="top" title="Carve File" onclick="showCarveFiles([{{ .UUID }}]);">
                           <i class="fas fa-file-upload"></i>
                         </button>
+                      {{ end }}
                         <button type="button" class="btn custom-size-btn btn-outline-primary"
                         data-tooltip="true" data-placement="top" title="Refresh" onclick="refreshCurrentNode();">
                           <i class="fas fa-sync-alt"></i>
@@ -393,7 +395,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 
@@ -538,6 +542,9 @@
         $("#carveModal").on('shown.bs.modal', function(){
           $(this).find('#carve').focus();
         });
+
+        // Maintain open the node's environment toggle
+        $("input[value='{{ .Environment }}']").parent().parent().addClass("open");
 
         // Enable all tooltips
         $('[data-tooltip="true"]').tooltip({trigger : 'hover'});

--- a/cmd/admin/templates/queries-logs.html
+++ b/cmd/admin/templates/queries-logs.html
@@ -87,7 +87,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 

--- a/cmd/admin/templates/queries-run.html
+++ b/cmd/admin/templates/queries-run.html
@@ -229,7 +229,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 

--- a/cmd/admin/templates/queries.html
+++ b/cmd/admin/templates/queries.html
@@ -57,7 +57,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 
@@ -82,7 +84,7 @@
           searching : true,
           dom: "<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'f>>" +
                "<'row'<'col-sm-12'tr>>" +
-               "<'row'<'col-sm-12 col-md-4'B><'col-sm-12 col-md-4'i><'col-sm-12 col-md-4'p>>",
+               "<'row'<'col-sm-12 col-md-4'B><'col-sm-12 col-md-4 text-center'i><'col-sm-12 col-md-4'p>>",
           processing : true,
           order : [[ 3, "desc" ]],
           ajax : {

--- a/cmd/admin/templates/settings.html
+++ b/cmd/admin/templates/settings.html
@@ -176,7 +176,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 

--- a/cmd/admin/templates/table.html
+++ b/cmd/admin/templates/table.html
@@ -66,7 +66,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 
@@ -91,7 +93,7 @@
           searching : true,
           dom: "<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'f>>" +
                "<'row'<'col-sm-12'tr>>" +
-               "<'row'<'col-sm-12 col-md-4'B><'col-sm-12 col-md-4'i><'col-sm-12 col-md-4'p>>",
+               "<'row'<'col-sm-12 col-md-4'B><'col-sm-12 col-md-4 text-center'i><'col-sm-12 col-md-4'p>>",
           processing : true,
           order : [[ 8, "desc" ]],
           ajax : {
@@ -189,6 +191,7 @@
             style:    'os',
             selector: 'td:first-child'
           },
+        {{ if eq .Level "admin" }}
           buttons: [
             {
               className: 'btn custom-size-btn btn-outline-danger',
@@ -266,6 +269,9 @@
               }
             }
           ]
+        {{ else }}
+          buttons: []
+        {{ end }}
         });
 
         // Select and deselect all

--- a/cmd/admin/templates/users.html
+++ b/cmd/admin/templates/users.html
@@ -120,7 +120,9 @@
 
       </main>
 
-      {{ template "page-aside" . }}
+      {{ if eq .Level "admin" }}
+        {{ template "page-aside" . }}
+      {{ end }}
 
     </div>
 

--- a/cmd/admin/types-templates.go
+++ b/cmd/admin/types-templates.go
@@ -21,6 +21,7 @@ type TableTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Selector       string
 	SelectorName   string
 	Target         string
@@ -36,6 +37,7 @@ type ConfTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Environment    environments.TLSEnvironment
 	Environments   []environments.TLSEnvironment
 	Platforms      []string
@@ -49,6 +51,7 @@ type EnrollTemplateData struct {
 	Title                 string
 	Username              string
 	CSRFToken             string
+	Level                 string
 	EnvName               string
 	EnrollExpiry          string
 	EnrollExpired         bool
@@ -73,6 +76,7 @@ type QueryRunTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Environments   []environments.TLSEnvironment
 	Platforms      []string
 	UUIDs          []string
@@ -92,6 +96,7 @@ type GenericTableTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Environments   []environments.TLSEnvironment
 	Platforms      []string
 	Target         string
@@ -111,6 +116,7 @@ type CarvesDetailsTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Environments   []environments.TLSEnvironment
 	Platforms      []string
 	Query          queries.DistributedQuery
@@ -127,6 +133,7 @@ type QueryLogsTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Environments   []environments.TLSEnvironment
 	Platforms      []string
 	Query          queries.DistributedQuery
@@ -141,6 +148,7 @@ type EnvironmentsTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Environments   []environments.TLSEnvironment
 	Platforms      []string
 	TLSDebug       bool
@@ -153,6 +161,7 @@ type SettingsTemplateData struct {
 	Title           string
 	Username        string
 	CSRFToken       string
+	Level           string
 	Service         string
 	Environments    []environments.TLSEnvironment
 	Platforms       []string
@@ -168,6 +177,7 @@ type UsersTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Environments   []environments.TLSEnvironment
 	Platforms      []string
 	CurrentUsers   []users.AdminUser
@@ -181,6 +191,7 @@ type NodeTemplateData struct {
 	Title          string
 	Username       string
 	CSRFToken      string
+	Level          string
 	Logs           string
 	Node           nodes.OsqueryNode
 	Environments   []environments.TLSEnvironment


### PR DESCRIPTION
## Overview

* Code to make possible having users in `osctrl-admin` that only see information, but can not take any actions such as run queries, run carves, delete nodes, change settings, change environments, modify users, change configuration, change intervals or modify enrolling links or certificates.
* Better metrics around JSON distribution endpoints.
* When visiting a node, the environment collapsible stays open.