### PR TITLE
Redirect to SAML login

### DIFF
--- a/cmd/admin/auth.go
+++ b/cmd/admin/auth.go
@@ -51,13 +51,13 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 				cookiev, err := r.Cookie(samlConfig.TokenName)
 				if err != nil {
 					log.Printf("error extracting JWT data: %v", err)
-					http.Redirect(w, r, forbiddenPath, http.StatusFound)
+					http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
 					return
 				}
 				jwtdata, err := parseJWTFromCookie(samlData.KeyPair, cookiev.Value)
 				if err != nil {
 					log.Printf("error parsing JWT: %v", err)
-					http.Redirect(w, r, forbiddenPath, http.StatusFound)
+					http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
 					return
 				}
 				// Check if user is already authenticated
@@ -79,6 +79,8 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 					session, err = sessionsmgr.Save(r, w, u)
 					if err != nil {
 						log.Printf("session error: %v", err)
+						http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
+						return
 					}
 				}
 				// Update metadata for the user

--- a/cmd/admin/saml.go
+++ b/cmd/admin/saml.go
@@ -17,6 +17,7 @@ type JSONConfigurationSAML struct {
 	KeyPath     string `json:"keypath"`
 	MetaDataURL string `json:"metadataurl"`
 	RootURL     string `json:"rooturl"`
+	LoginURL    string `json:"loginurl"`
 	TokenName   string `json:"nametoken"`
 	EmailAttr   string `json:"attremail"`
 	UserAttr    string `json:"attruser"`

--- a/cmd/admin/static/css/custom.css
+++ b/cmd/admin/static/css/custom.css
@@ -11,7 +11,7 @@
 
 .img-logo {
   max-width: 100%;
-  height: auto;
+  height: 20em;
   object-fit: cover;
 }
 


### PR DESCRIPTION
## Overview

* Adding `loginurl` field in the `saml.json` configuration, to provide the login URL to redirect to, if the session is expired or there is an error parsing the JWT token.
* Make login logo image a bit smaller.