### PR TITLE
Improve the Header Authentication Method

### DIFF
--- a/cmd/admin/auth.go
+++ b/cmd/admin/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/jmpsec/osctrl/pkg/settings"
 )
@@ -102,8 +103,57 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 				samlMiddleware.RequireAccount(h).ServeHTTP(w, r)
 			}
 		case settings.AuthHeaders:
-			// Access always granted
-			h.ServeHTTP(w, r)
+			username := r.Header.Get(headersConfig.TrustedPrefix + headersConfig.UserName)
+			groups := strings.Split(r.Header.Get(headersConfig.TrustedPrefix+headersConfig.Groups), ",")
+		    fullname := r.Header.Get(headersConfig.TrustedPrefix + headersConfig.DisplayName)
+
+			// A username is required to use this system
+			if username == "" {
+				http.Redirect(w, r, forbiddenPath, http.StatusBadRequest)
+				return
+			}
+
+			s := make(contextValue)
+			s["user"] = username
+
+			for _, group := range groups {
+				if group == headersConfig.AdminGroup {
+					s["level"] = adminLevel
+					// We can break because there is no greater permission level
+					break
+				} else if group == headersConfig.UserGroup {
+					s["level"] = userLevel
+					// We can't break because we might still find a higher permission level
+				}
+			}
+
+			// This user didn't present a group that has permission to use the service
+			if _, ok := s["level"]; !ok {
+				http.Redirect(w, r, forbiddenPath, http.StatusForbidden)
+				return
+			}
+
+			if !adminUsers.Exists(username) {
+			  log.Printf("User not found, creating: %s", username)
+			  _, err := adminUsers.New(username, "", fullname, (s["level"] == adminLevel))
+
+			  if err != nil {
+				log.Printf("Error creating user %s: %v", username, err)
+				http.Redirect(w, r, forbiddenPath, http.StatusFound)
+				return
+			  }
+			} else {
+			  if err := adminUsers.UpdateMetadata(r.RemoteAddr, r.Header.Get("User-Agent"), username); err != nil {
+				log.Printf("error updating metadata for user %s: %v", username, err)
+			  }
+			}
+
+			// _, session := sessionsmgr.CheckAuth(r)
+			// s["csrftoken"] = session.Values["csrftoken"].(string)
+			ctx := context.WithValue(r.Context(), contextKey("session"), s)
+
+			// Access granted
+			h.ServeHTTP(w, r.WithContext(ctx))
 		}
 	})
 }

--- a/cmd/admin/headers.go
+++ b/cmd/admin/headers.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/spf13/viper"
+)
+
+// Function to load the configuration file
+func loadHeaders(file string) (types.JSONConfigurationHeaders, error) {
+	var cfg types.JSONConfigurationHeaders
+	log.Printf("Loading %s", file)
+	// Load file and read config
+	viper.SetConfigFile(file)
+	err := viper.ReadInConfig()
+	if err != nil {
+		return cfg, err
+	}
+	// Header values
+	headersRaw := viper.Sub(settings.AuthHeaders)
+	err = headersRaw.Unmarshal(&cfg)
+	if err != nil {
+		return cfg, err
+	}
+
+	// No errors!
+	return cfg, nil
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,3 +20,17 @@ type JSONConfigurationService struct {
 	Auth     string `json:"auth"`
 	Logging  string `json:"logging"`
 }
+
+// JSONConfigurationHeaders to keep all SAML details for auth
+type JSONConfigurationHeaders struct {
+	TrustedPrefix		string `json:"trustedPrefix"`
+	AdminGroup			string `json:"adminGroup"`
+	UserGroup			string `json:"userGroup"`
+	Email				string `json:"email"`
+	UserName			string `json:"userName"`
+	FirstName			string `json:"firstName"`
+	LastName			string `json:"lastName"`
+	DisplayName			string `json:"displayName"`
+	DistinguishedName	string `json:"distinguishedName"`
+	Groups				string `json:"groups"`
+}


### PR DESCRIPTION
This adds more of the code needed to properly authenticate a user based on headers present added by a reverse proxy.

I'm wary of the CSRF token line that's commented out but I must just be missing something there. Also updating users always fails and I assume that's because the login flow never runs with header authentication.

The way this is designed to work is to be put behind a proxy that handles the authentication for you that then passes the request along with newly added trusted headers from the proxy.

Admin vs User level permissions are handled by checking for the presence of specified groups passed along from the proxy.