### PR TITLE
Create directories for docker certs and config

### DIFF
--- a/docker/dockerize.sh
+++ b/docker/dockerize.sh
@@ -67,6 +67,10 @@ CERTSDIR="$DOCKERDIR/certs"
 CONFIGDIR="$DOCKERDIR/config"
 COMPOSERFILE="$DOCKERDIR/docker-compose.yml"
 
+# Directories to generate certificates and configuration
+mkdir -p "$CERTSDIR"
+mkdir -p "$CONFIGDIR"
+
 # Default values for arguments
 SHOW_USAGE=true
 _BUILD=false


### PR DESCRIPTION
## Overview

There has been a problem with `make docker_all` spotted by a couple of people (#9 and #18) and it seems that the folders `certs` and `config` was not created before running the command. This should fix that.