### PR TITLE
bug: fix invalid logging method for api, default to none

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -121,10 +121,10 @@ func loadConfiguration(file string) (types.JSONConfigurationService, error) {
 	}
 	// Check if values are valid
 	if !validAuth[cfg.Auth] {
-		return cfg, fmt.Errorf("Invalid auth method")
+		return cfg, fmt.Errorf("Invalid auth method: '%s'", cfg.Auth)
 	}
 	if !validLogging[cfg.Logging] {
-		return cfg, fmt.Errorf("Invalid logging method")
+		return cfg, fmt.Errorf("Invalid logging method: '%s'", cfg.Logging)
 	}
 	// No errors!
 	return cfg, nil

--- a/docker/dockerize.sh
+++ b/docker/dockerize.sh
@@ -225,7 +225,7 @@ API_JSON="$CONFIGDIR/api.json"
 if [[ -f "$API_JSON" && "$_FORCE" == false ]]; then
   log "Using existing $API_JSON"
 else
-  configuration_service "$DEPLOYDIR/service.json" "$API_JSON" "localhost|9002" "api" "0.0.0.0" "jwt" "db"
+  configuration_service "$DEPLOYDIR/service.json" "$API_JSON" "localhost|9002" "api" "0.0.0.0" "jwt" "none"
 fi
 
 log "Preparing configuration for JWT"


### PR DESCRIPTION
There is an error in the generated `api.json`. 

`"db"` is not a valid option in validLogging in `api/main.go:102`

```
var validLogging = map[string]bool{
	settings.LoggingNone: true,
}
```

This was the error I got:

```
~/g/osctrl ❯❯❯ docker logs -f 0593dd8239167c3cc113779241b4cfc59896b9dbb1e19a0d603ffdf5ce926459
Postgres is up - Starting osctrl-api
main.go:109: Loading config/api.json
main.go:153: Error loading config/api.json - Invalid logging method: 'db'
Postgres is up - Starting osctrl-api
main.go:109: Loading config/api.json
main.go:153: Error loading config/api.json - Invalid logging method: 'db'
```

Nit: adding method in error strings to help with debugging.