### PR TITLE
Bump to osctrl 0.2.0

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -31,7 +31,7 @@ const (
 	// Service name
 	serviceName string = projectName + "-" + settings.ServiceAdmin
 	// Service version
-	serviceVersion string = "0.1.9"
+	serviceVersion string = "0.2.0"
 	// Service description
 	serviceDescription string = "Admin service for osctrl"
 	// Application description

--- a/api/main.go
+++ b/api/main.go
@@ -28,7 +28,7 @@ const (
 	// Service name
 	serviceName string = projectName + "-" + settings.ServiceAPI
 	// Service version
-	serviceVersion string = "0.1.9"
+	serviceVersion string = "0.2.0"
 	// Service description
 	serviceDescription string = "API service for osctrl"
 	// Application description

--- a/cli/main.go
+++ b/cli/main.go
@@ -6,11 +6,11 @@ import (
 	"os"
 
 	"github.com/jmpsec/osctrl/backend"
+	"github.com/jmpsec/osctrl/environments"
 	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/queries"
-	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/settings"
-	"github.com/jmpsec/osctrl/environments"
+	"github.com/jmpsec/osctrl/users"
 
 	"github.com/jinzhu/gorm"
 	"github.com/urfave/cli"
@@ -24,7 +24,7 @@ const (
 	// Application name
 	appName string = projectName + "-cli"
 	// Application version
-	appVersion string = "0.1.9"
+	appVersion string = "0.2.0"
 	// Application usage
 	appUsage string = "CLI for " + projectName
 	// Application description

--- a/go.mod
+++ b/go.mod
@@ -11,17 +11,17 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.1.3
 	github.com/jinzhu/gorm v1.9.12
-	github.com/jmpsec/osctrl/backend v0.1.9
-	github.com/jmpsec/osctrl/carves v0.1.9
-	github.com/jmpsec/osctrl/environments v0.1.9
-	github.com/jmpsec/osctrl/logging v0.1.9
-	github.com/jmpsec/osctrl/metrics v0.1.9
-	github.com/jmpsec/osctrl/nodes v0.1.9
-	github.com/jmpsec/osctrl/queries v0.1.9
-	github.com/jmpsec/osctrl/settings v0.1.9
-	github.com/jmpsec/osctrl/types v0.1.9
-	github.com/jmpsec/osctrl/users v0.1.9
-	github.com/jmpsec/osctrl/utils v0.1.9
+	github.com/jmpsec/osctrl/backend v0.2.0
+	github.com/jmpsec/osctrl/carves v0.2.0
+	github.com/jmpsec/osctrl/environments v0.2.0
+	github.com/jmpsec/osctrl/logging v0.2.0
+	github.com/jmpsec/osctrl/metrics v0.2.0
+	github.com/jmpsec/osctrl/nodes v0.2.0
+	github.com/jmpsec/osctrl/queries v0.2.0
+	github.com/jmpsec/osctrl/settings v0.2.0
+	github.com/jmpsec/osctrl/types v0.2.0
+	github.com/jmpsec/osctrl/users v0.2.0
+	github.com/jmpsec/osctrl/utils v0.2.0
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7 // indirect

--- a/logging/go.sum
+++ b/logging/go.sum
@@ -48,7 +48,7 @@ github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZ
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/jmpsec/osctrl v0.1.9 h1:AyxqZs+XfTaqlsG/b54e2Rlh4mu2+oGd5cUUb1+K97k=
+github.com/jmpsec/osctrl v0.2.0 h1:AyxqZs+XfTaqlsG/b54e2Rlh4mu2+oGd5cUUb1+K97k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/queries/go.mod
+++ b/queries/go.mod
@@ -3,7 +3,7 @@ module github.com/jmpsec/osctrl/queries
 go 1.12
 
 require (
-	github.com/jmpsec/osctrl/nodes v0.1.9
+	github.com/jmpsec/osctrl/nodes v0.2.0
 	github.com/jinzhu/gorm v1.9.8
 )
 

--- a/tls/main.go
+++ b/tls/main.go
@@ -28,7 +28,7 @@ const (
 	// Service name
 	serviceName string = projectName + "-" + settings.ServiceTLS
 	// Service version
-	serviceVersion string = "0.1.9"
+	serviceVersion string = "0.2.0"
 	// Service description
 	serviceDescription string = "TLS service for osctrl"
 	// Application description

--- a/types/go.mod
+++ b/types/go.mod
@@ -2,6 +2,6 @@ module github.com/jmpsec/osctrl/types
 
 go 1.12
 
-require github.com/jmpsec/osctrl/queries v0.1.9
+require github.com/jmpsec/osctrl/queries v0.2.0
 
 replace github.com/jmpsec/osctrl/queries => ../queries


### PR DESCRIPTION
## Overview

Release of `0.2.0`. Lots of changes:

* Fixed Graylog plugin not sending `result`- #25 by @kosborn 
* Adding `osctrl-api` component - #28 
* Log distributed queries results locally - #30 
* Hidding API queries - #31 
* Bugfix: Invalid logging method for api, default to none - #34 
* Refactor: to use struct for html layout pages - #35 by @friedbutter 
* Productionalize `osctrl-api` - #36 
* No more plugins - #37 
* Using custom User Agent for HTTP requests - #39
* Make services wait for backend - #40 
* Preparing for osquery `4.2.0` - #41 
* Compile osctrl statically - #42 

Being the biggest change the introduction of `osctrl-api` and the removal of logging plugins.