### PR TITLE
Limit local status and result logs and queries

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -135,6 +135,7 @@ func loadConfiguration(file string) (types.JSONConfigurationService, error) {
 
 // Initialization code
 func init() {
+	log.Printf("==================== Initializing %s v%s", serviceName, serviceVersion)
 	var err error
 	// Command line flags
 	flag.Usage = apiUsage
@@ -168,6 +169,7 @@ func init() {
 
 // Go go!
 func main() {
+	log.Printf("==================== Starting %s v%s", serviceName, serviceVersion)
 	// Database handler
 	dbConfig, err := backend.LoadConfiguration(*dbFlag, backend.DBKey)
 	if err != nil {
@@ -285,15 +287,8 @@ func main() {
 	routerAPI.Handle(_apiPath(apiEnvironmentsPath), handlerAuthCheck(http.HandlerFunc(apiEnvironmentsHandler))).Methods("GET")
 	routerAPI.Handle(_apiPath(apiEnvironmentsPath)+"/", handlerAuthCheck(http.HandlerFunc(apiEnvironmentsHandler))).Methods("GET")
 
-	// multiple listeners channel
-	finish := make(chan bool)
-
 	// Launch HTTP server for TLS endpoint
-	go func() {
-		serviceListener := apiConfig.Listener + ":" + apiConfig.Port
-		log.Printf("%s v%s - HTTP listening %s", serviceName, serviceVersion, serviceListener)
-		log.Fatal(http.ListenAndServe(serviceListener, routerAPI))
-	}()
-
-	<-finish
+	serviceListener := apiConfig.Listener + ":" + apiConfig.Port
+	log.Printf("%s v%s - HTTP listening %s", serviceName, serviceVersion, serviceListener)
+	log.Fatal(http.ListenAndServe(serviceListener, routerAPI))
 }

--- a/environments/environments.go
+++ b/environments/environments.go
@@ -322,7 +322,7 @@ func (environment *Environment) ExpireEnroll(name string) error {
 	return nil
 }
 
-// RotateRemove to replace Secret and SecrtPath for enrolling in an environment
+// RotateRemove to replace Secret and SecretPath for enrolling in an environment
 func (environment *Environment) RotateRemove(name string) error {
 	env, err := environment.Get(name)
 	if err != nil {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -60,9 +60,15 @@ const (
 
 // Names for setting values for logging
 const (
-	QueryResultLink string = "query_result_link"
-	StatusLogsLink  string = "status_logs_link"
-	ResultLogsLink  string = "result_logs_link"
+	QueryResultLink     string = "query_result_link"
+	StatusLogsLink      string = "status_logs_link"
+	ResultLogsLink      string = "result_logs_link"
+	CleanStatusLogs     string = "clean_status_logs"
+	CleanStatusInterval string = "clean_status_interval"
+	CleanResultLogs     string = "clean_result_logs"
+	CleanResultInterval string = "clean_result_interval"
+	CleanQueryLogs      string = "clean_query_logs"
+	CleanQueryEntries   string = "clean_query_entries"
 )
 
 // Default values for the setting values for logging
@@ -104,9 +110,9 @@ type Settings struct {
 
 // ValidTypes to check validity of settings type
 var ValidTypes = map[string]struct{}{
-  TypeString: struct{}{},
-  TypeBoolean: struct{}{},
-  TypeInteger: struct{}{},
+	TypeString:  struct{}{},
+	TypeBoolean: struct{}{},
+	TypeInteger: struct{}{},
 }
 
 // NewSettings to initialize the access to settings and table
@@ -192,7 +198,7 @@ func (conf *Settings) NewIntegerValue(service, name string, value int64) error {
 // VerifyType to make sure type is valid
 func (conf *Settings) VerifyType(sType string) bool {
 	_, ok := ValidTypes[sType]
-  return ok
+	return ok
 }
 
 // DeleteValue deletes an existing settings value
@@ -515,6 +521,60 @@ func (conf *Settings) ResultLogsLink() string {
 		return ""
 	}
 	return value.String
+}
+
+// CleanStatusLogs checks if status logs cleanup is enabled
+func (conf *Settings) CleanStatusLogs() bool {
+	value, err := conf.RetrieveValue(ServiceAdmin, CleanStatusLogs)
+	if err != nil {
+		return false
+	}
+	return value.Boolean
+}
+
+// CleanStatusInterval gets the interval in seconds to cleanup status logs
+func (conf *Settings) CleanStatusInterval() int64 {
+	value, err := conf.RetrieveValue(ServiceAdmin, CleanStatusInterval)
+	if err != nil {
+		return 0
+	}
+	return value.Integer
+}
+
+// CleanResultLogs checks if result logs cleanup is enabled
+func (conf *Settings) CleanResultLogs() bool {
+	value, err := conf.RetrieveValue(ServiceAdmin, CleanResultLogs)
+	if err != nil {
+		return false
+	}
+	return value.Boolean
+}
+
+// CleanResultInterval gets the interval in seconds to cleanup result logs
+func (conf *Settings) CleanResultInterval() int64 {
+	value, err := conf.RetrieveValue(ServiceAdmin, CleanResultInterval)
+	if err != nil {
+		return 0
+	}
+	return value.Integer
+}
+
+// CleanQueryLogs checks if query logs cleanup is enabled
+func (conf *Settings) CleanQueryLogs() bool {
+	value, err := conf.RetrieveValue(ServiceAdmin, CleanQueryLogs)
+	if err != nil {
+		return false
+	}
+	return value.Boolean
+}
+
+// CleanQueryEntries gets the number of entries to cleanup in query logs
+func (conf *Settings) CleanQueryEntries() int64 {
+	value, err := conf.RetrieveValue(ServiceAdmin, CleanQueryEntries)
+	if err != nil {
+		return 0
+	}
+	return value.Integer
 }
 
 // DefaultEnv gets the default environment

--- a/tls/main.go
+++ b/tls/main.go
@@ -116,6 +116,7 @@ func loadConfiguration(file string) (types.JSONConfigurationService, error) {
 
 // Initialization code
 func init() {
+	log.Printf("==================== Initializing %s v%s", serviceName, serviceVersion)
 	// Command line flags
 	flag.Usage = tlsUsage
 	// Define flags
@@ -138,6 +139,7 @@ func init() {
 
 // Go go!
 func main() {
+	log.Printf("==================== Starting %s v%s", serviceName, serviceVersion)
 	// Backend configuration
 	dbConfig, err := backend.LoadConfiguration(*dbFlag, backend.DBKey)
 	if err != nil {


### PR DESCRIPTION
## Overview

Implementing #19 to keep logs locally in the database for a number of hours or number of entries.

* Added option to enable the removal of status logs, called `clean_status_logs` and also `clean_status_interval` as integer which will have the number of *seconds* to hold status logs for in the backend.
* Added option to enable the removal of result logs, called `clean_result_logs` and also `clean_result_interval` as integer which will have the number of *seconds* to hold result logs for in the backend.
* Added option to enable the removal of queries, query logs, query executions and query targets, called `clean_query_logs` and also `clean_query_entries` as integer which will have the number of *entries* to hold queries in the backend.

⚠️  If you enable this settings, and you do not have an additional logging mechanism (splunk, graylog) enabled, the logs will be removed from the backend and therefore lost. ⚠️ 
