### PR TITLE
Fix for error generating jwt.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,9 +164,9 @@ docker_down:
 docker_clean:
 	make docker_down
 	./deploy/docker/dockerize.sh -x
+	rm -Rf deploy/docker/certs/*
+	rm -Rf deploy/docker/config/*
 	docker volume rm osctrl_db-data
-	rm -Rf docker/certs/*
-	rm -Rf docker/config/*
 
 # Auto-format and simplify the code
 GOFMT_ARGS = -l -w -s

--- a/deploy/docker/dockerize.sh
+++ b/deploy/docker/dockerize.sh
@@ -233,7 +233,7 @@ JWT_JSON="$CONFIGDIR/jwt.json"
 if [[ -f "$JWT_JSON" && "$_FORCE" == false ]]; then
   log "Using existing $JWT_JSON"
 else
-  cat "$CONFIGDIR/jwt.json" | sed "s|_JWT_SECRET|$_JWT_SECRET|g" | tee "$JWT_JSON"
+  cat "$DEPLOYDIR/config/jwt.json" | sed "s|_JWT_SECRET|$_JWT_SECRET|g" | tee "$JWT_JSON"
 fi
 
 log "Preparing configuration for backend"


### PR DESCRIPTION
## Overview

Fix for #67 when the utility `dockerize.sh` was using the wrong path for the `jwt.json` template and therefore, the deployment using docker was failing. Also there was an error in the path in `make docker_clean` so the generated configuration files were not removed.