### PR TITLE
Fix for docker enroll

### DIFF
--- a/deploy/docker/dockerize.sh
+++ b/deploy/docker/dockerize.sh
@@ -78,7 +78,7 @@ mkdir -p "$CERTSDIR"
 mkdir -p "$CONFIGDIR"
 
 # Secret for API JWT
-_JWT_SECRET="$(head -c64 < /dev/random | base64 | head -n 1 | openssl dgst -sha256 | cut -d " " -f1)"
+_JWT_SECRET="$(head -c64 < /dev/random | base64 | head -n 1 | openssl dgst -sha256 | cut -d " " -f2)"
 
 # Default values for arguments
 SHOW_USAGE=true

--- a/deploy/docker/tls/Dockerfile
+++ b/deploy/docker/tls/Dockerfile
@@ -10,6 +10,8 @@ WORKDIR /osctrl-tls
 
 COPY . .
 
+COPY tls/scripts/ scripts
+
 RUN go build -o bin/osctrl-tls tls/*.go
 RUN go build -o bin/osctrl-cli cli/*.go
 


### PR DESCRIPTION
## Overview

Second attempt to fix #71 where the files needed for the quick enroll were missing in the `osctrl-tls` container. This was only affecting the docker deployment.