### PR TITLE
Bump osctrl to 0.2.3

### DIFF
--- a/admin/handlers/go.mod
+++ b/admin/handlers/go.mod
@@ -6,18 +6,18 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/sessions v1.2.0 // indirect
 	github.com/jinzhu/gorm v1.9.12
-	github.com/jmpsec/osctrl/admin/sessions v0.2.2
-	github.com/jmpsec/osctrl/carves v0.2.2
-	github.com/jmpsec/osctrl/environments v0.2.2
-	github.com/jmpsec/osctrl/logging v0.2.2
-	github.com/jmpsec/osctrl/metrics v0.2.2
-	github.com/jmpsec/osctrl/nodes v0.2.2
-	github.com/jmpsec/osctrl/queries v0.2.2
-	github.com/jmpsec/osctrl/settings v0.2.2
+	github.com/jmpsec/osctrl/admin/sessions v0.2.3
+	github.com/jmpsec/osctrl/carves v0.2.3
+	github.com/jmpsec/osctrl/environments v0.2.3
+	github.com/jmpsec/osctrl/logging v0.2.3
+	github.com/jmpsec/osctrl/metrics v0.2.3
+	github.com/jmpsec/osctrl/nodes v0.2.3
+	github.com/jmpsec/osctrl/queries v0.2.3
+	github.com/jmpsec/osctrl/settings v0.2.3
 	github.com/jmpsec/osctrl/tags v0.0.0-20200527045717-0e3b5d71cf19
-	github.com/jmpsec/osctrl/types v0.2.2
-	github.com/jmpsec/osctrl/users v0.2.2
-	github.com/jmpsec/osctrl/utils v0.2.2
+	github.com/jmpsec/osctrl/types v0.2.3
+	github.com/jmpsec/osctrl/users v0.2.3
+	github.com/jmpsec/osctrl/utils v0.2.3
 )
 
 replace github.com/jmpsec/osctrl/carves => ../../carves

--- a/admin/main.go
+++ b/admin/main.go
@@ -34,7 +34,7 @@ const (
 	// Service name
 	serviceName string = projectName + "-" + settings.ServiceAdmin
 	// Service version
-	serviceVersion string = "0.2.2"
+	serviceVersion string = "0.2.3"
 	// Service description
 	serviceDescription string = "Admin service for osctrl"
 	// Application description

--- a/admin/settings.go
+++ b/admin/settings.go
@@ -27,10 +27,10 @@ func loadingMetrics(mgr *settings.Settings) (*metrics.Metrics, error) {
 		}
 		_m, err := metrics.CreateMetrics(_mCfg.Protocol, _mCfg.Host, _mCfg.Port, serviceName)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to initialize metrics: %v", err)
 			if err := mgr.SetBoolean(false, settings.ServiceAdmin, settings.ServiceMetrics); err != nil {
 				return nil, fmt.Errorf("Failed to disable metrics: %v", err)
 			}
+			return nil, fmt.Errorf("Failed to initialize metrics: %v", err)
 		}
 		return _m, nil
 	}

--- a/api/main.go
+++ b/api/main.go
@@ -29,7 +29,7 @@ const (
 	// Service name
 	serviceName string = projectName + "-" + settings.ServiceAPI
 	// Service version
-	serviceVersion string = "0.2.2"
+	serviceVersion string = "0.2.3"
 	// Service description
 	serviceDescription string = "API service for osctrl"
 	// Application description

--- a/cli/main.go
+++ b/cli/main.go
@@ -25,7 +25,7 @@ const (
 	// Application name
 	appName string = projectName + "-cli"
 	// Application version
-	appVersion string = "0.2.2"
+	appVersion string = "0.2.3"
 	// Application usage
 	appUsage string = "CLI for " + projectName
 	// Application description

--- a/go.mod
+++ b/go.mod
@@ -8,21 +8,21 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.7.4
 	github.com/jinzhu/gorm v1.9.12
-	github.com/jmpsec/osctrl/admin/handlers v0.2.2
-	github.com/jmpsec/osctrl/admin/sessions v0.2.2
-	github.com/jmpsec/osctrl/backend v0.2.2
-	github.com/jmpsec/osctrl/carves v0.2.2
-	github.com/jmpsec/osctrl/environments v0.2.2
-	github.com/jmpsec/osctrl/logging v0.2.2
-	github.com/jmpsec/osctrl/metrics v0.2.2
-	github.com/jmpsec/osctrl/nodes v0.2.2
-	github.com/jmpsec/osctrl/queries v0.2.2
-	github.com/jmpsec/osctrl/settings v0.2.2
-	github.com/jmpsec/osctrl/tags v0.2.2
-	github.com/jmpsec/osctrl/tls/handlers v0.2.2
-	github.com/jmpsec/osctrl/types v0.2.2
-	github.com/jmpsec/osctrl/users v0.2.2
-	github.com/jmpsec/osctrl/utils v0.2.2
+	github.com/jmpsec/osctrl/admin/handlers v0.2.3
+	github.com/jmpsec/osctrl/admin/sessions v0.2.3
+	github.com/jmpsec/osctrl/backend v0.2.3
+	github.com/jmpsec/osctrl/carves v0.2.3
+	github.com/jmpsec/osctrl/environments v0.2.3
+	github.com/jmpsec/osctrl/logging v0.2.3
+	github.com/jmpsec/osctrl/metrics v0.2.3
+	github.com/jmpsec/osctrl/nodes v0.2.3
+	github.com/jmpsec/osctrl/queries v0.2.3
+	github.com/jmpsec/osctrl/settings v0.2.3
+	github.com/jmpsec/osctrl/tags v0.2.3
+	github.com/jmpsec/osctrl/tls/handlers v0.2.3
+	github.com/jmpsec/osctrl/types v0.2.3
+	github.com/jmpsec/osctrl/users v0.2.3
+	github.com/jmpsec/osctrl/utils v0.2.3
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7 // indirect
 	github.com/spf13/viper v1.6.2

--- a/tls/handlers/go.mod
+++ b/tls/handlers/go.mod
@@ -4,16 +4,16 @@ go 1.14
 
 require (
 	github.com/gorilla/mux v1.6.2
-	github.com/jmpsec/osctrl/carves v0.2.2
-	github.com/jmpsec/osctrl/environments v0.2.2
-	github.com/jmpsec/osctrl/logging v0.2.2
-	github.com/jmpsec/osctrl/metrics v0.2.2
-	github.com/jmpsec/osctrl/nodes v0.2.2
-	github.com/jmpsec/osctrl/queries v0.2.2
-	github.com/jmpsec/osctrl/settings v0.2.2
+	github.com/jmpsec/osctrl/carves v0.2.3
+	github.com/jmpsec/osctrl/environments v0.2.3
+	github.com/jmpsec/osctrl/logging v0.2.3
+	github.com/jmpsec/osctrl/metrics v0.2.3
+	github.com/jmpsec/osctrl/nodes v0.2.3
+	github.com/jmpsec/osctrl/queries v0.2.3
+	github.com/jmpsec/osctrl/settings v0.2.3
 	github.com/jmpsec/osctrl/tags v0.0.0-20200527045717-0e3b5d71cf19
-	github.com/jmpsec/osctrl/types v0.2.2
-	github.com/jmpsec/osctrl/utils v0.2.2
+	github.com/jmpsec/osctrl/types v0.2.3
+	github.com/jmpsec/osctrl/utils v0.2.3
 	github.com/segmentio/ksuid v1.0.2
 	github.com/stretchr/testify v1.5.1
 )

--- a/tls/main.go
+++ b/tls/main.go
@@ -30,7 +30,7 @@ const (
 	// Service name
 	serviceName string = projectName + "-" + settings.ServiceTLS
 	// Service version
-	serviceVersion string = "0.2.2"
+	serviceVersion string = "0.2.3"
 	// Service description
 	serviceDescription string = "TLS service for osctrl"
 	// Application description


### PR DESCRIPTION
Release of `0.2.3`. List of changes:

- Fix for #71: Quick enroll using osctrl-admin - #72 
- Fix for #71: Docker quick enroll - #73 
- Implementation of #69: Ability to tag nodes - #74 
- Support for osquery [4.4.0](https://github.com/osquery/osquery/releases/tag/4.4.0) - #80 
- Fix for #82: UUIDs bug when receiving logs - #83 
- Change license from GPLv3 to MIT - #84 
- Upgrade to [Grafana](https://grafana.com/) 6.7.4 - #85 
- Support for osquery [4.5.1](https://github.com/osquery/osquery/releases/tag/4.5.1) - #91 