### PR TITLE
Provide IP address as ENV variables for `Vagrantfile`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
-IP_ADDRESS = "10.10.10.5"
+IP_ADDRESS = ENV["OSCTRL_IP_ADDRESS"] || "10.10.10.5"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/focal64"
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell" do |s|
     s.path = "deploy/provision.sh"
     s.args = [
-      "--nginx", "--postgres", "-E", "--metrics", "--all-hostname",
+      "--nginx", "--postgres", "--enroll", "--all-hostname",
       IP_ADDRESS, "--password", "admin"
     ]
     privileged = false


### PR DESCRIPTION
The IP address when deploying `osctrl` using vagrant was static and was possible to change only editing the `Vagrantfile`. Now you can provide the ENV variable `OSCTRL_IP_ADDRESS` and it will be set, or defaults to the previous value that was `10.10.10.5`.

It can be utilized with the following command:

```
OSCTRL_IP_ADDRESS="10.10.10.6" vagrant up
```
...
```
...
    default:
    default: [+]  -> https://10.10.10.6:8443
    default:
...
```

Also metrics have been disable in vagrant deployment.