### PR TITLE
Fix for provision using own certificate

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -540,13 +540,16 @@ else
     # Own certificates should copy them
     if [[ "$TYPE" == "own" ]]; then
       # Check if certificates exist
-      if [[ -f "$CERTFILE" ]] && [[ -f "$KEYFILE" ]]; then
+      if sudo test -f "$CERTFILE" && sudo test -f "$KEYFILE" ; then
         log "Using existing certificate"
         sudo cp "$CERTFILE" "$_cert_file"
         sudo cp "$CERTFILE" "$_cert_file_a"
         log "Using existing key"
         sudo cp "$KEYFILE" "$_key_file"
         sudo cp "$KEYFILE" "$_key_file_a"
+      else
+        _log "Certificate or key are missing"
+        exit $OHNOES
       fi
     fi
 


### PR DESCRIPTION
When using `provision.sh` using own certificates, which is with the parameter `-t own`, if the certificate and the key are only readable by root, their existence can not be verified and the provision will fail. 