### PR TITLE
Versions bump to go and saml pkg

### DIFF
--- a/admin/auth.go
+++ b/admin/auth.go
@@ -66,7 +66,8 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 			// Access granted
 			h.ServeHTTP(w, r.WithContext(ctx))
 		case settings.AuthSAML:
-			if samlMiddleware.IsAuthorized(r) {
+			_, err := samlMiddleware.Session.GetSession(r)
+			if (err!= nil) {
 				cookiev, err := r.Cookie(samlConfig.TokenName)
 				if err != nil {
 					log.Printf("error extracting JWT data: %v", err)

--- a/admin/auth/go.mod
+++ b/admin/auth/go.mod
@@ -1,3 +1,3 @@
 module github.com/jmpsec/osctrl/admin/auth
 
-go 1.14
+go 1.15

--- a/admin/handlers/go.mod
+++ b/admin/handlers/go.mod
@@ -1,6 +1,6 @@
 module github.com/javuto/osctrl/admin/handlers
 
-go 1.14
+go 1.15
 
 require (
 	github.com/gorilla/mux v1.7.4
@@ -14,7 +14,7 @@ require (
 	github.com/jmpsec/osctrl/nodes v0.2.3
 	github.com/jmpsec/osctrl/queries v0.2.3
 	github.com/jmpsec/osctrl/settings v0.2.3
-	github.com/jmpsec/osctrl/tags v0.0.0-20200527045717-0e3b5d71cf19
+	github.com/jmpsec/osctrl/tags v0.2.3
 	github.com/jmpsec/osctrl/types v0.2.3
 	github.com/jmpsec/osctrl/users v0.2.3
 	github.com/jmpsec/osctrl/utils v0.2.3

--- a/admin/sessions/go.mod
+++ b/admin/sessions/go.mod
@@ -1,3 +1,3 @@
 module github.com/jmpsec/osctrl/admin/sessions
 
-go 1.14
+go 1.15

--- a/api/handlers/go.mod
+++ b/api/handlers/go.mod
@@ -1,3 +1,3 @@
 module github.com/javuto/osctrl/api/handlers
 
-go 1.14
+go 1.15

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmpsec/osctrl/backend
 
-go 1.14
+go 1.15
 
 require (
 	github.com/jinzhu/gorm v1.9.12

--- a/carves/go.mod
+++ b/carves/go.mod
@@ -1,5 +1,5 @@
 module github.com/jmpsec/osctrl/carves
 
-go 1.14
+go 1.15
 
 require github.com/jinzhu/gorm v1.9.8

--- a/environments/go.mod
+++ b/environments/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmpsec/osctrl/environments
 
-go 1.14
+go 1.15
 
 require (
 	github.com/google/uuid v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/jmpsec/osctrl
+module osctrl
 
-go 1.14
+go 1.15
 
 require (
-	github.com/beevik/etree v1.1.0 // indirect
 	github.com/crewjam/saml v0.4.5
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.7.4
@@ -24,7 +23,6 @@ require (
 	github.com/jmpsec/osctrl/users v0.2.3
 	github.com/jmpsec/osctrl/utils v0.2.3
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/russellhaering/goxmldsig v1.1.0 // indirect
 	github.com/spf13/viper v1.6.2
 	github.com/urfave/cli v1.22.4
 )

--- a/go.sum
+++ b/go.sum
@@ -23,9 +23,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/crewjam/httperr v0.0.0-20190612203328-a946449404da h1:WXnT88cFG2davqSFqvaFfzkSMC0lqh/8/rKZ+z7tYvI=
 github.com/crewjam/httperr v0.0.0-20190612203328-a946449404da/go.mod h1:+rmNIXRvYMqLQeR4DHyTvs6y0MEMymTz4vyFpFkKTPs=
-github.com/crewjam/saml v0.0.0-20190508002657-ca21de9dd5b9 h1:fkoDz41YaEsWQOfxO16AsId5KEhxFIniiaJmR7dYBYE=
-github.com/crewjam/saml v0.0.0-20190508002657-ca21de9dd5b9/go.mod h1:w5eu+HNtubx+kRpQL6QFT2F3yIFfYVe6+EzOFVU7Hko=
 github.com/crewjam/saml v0.4.5 h1:H9u+6CZAESUKHxMyxUbVn0IawYvKZn4nt3d4ccV4O/M=
 github.com/crewjam/saml v0.4.5/go.mod h1:qCJQpUtZte9R1ZjUBcW8qtCNlinbO363ooNl02S68bk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -116,6 +115,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
@@ -148,6 +148,7 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -166,8 +167,6 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
-github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7 h1:J4AOUcOh/t1XbQcJfkEqhzgvMJ2tDxdCVvmHxW5QXao=
-github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7/go.mod h1:Oz4y6ImuOQZxynhbSXk7btjEfNBtGlj2dcaOvXl2FSM=
 github.com/russellhaering/goxmldsig v1.1.0 h1:lK/zeJie2sqG52ZAlPNn1oBBqsIsEKypUUBGpYYF6lk=
 github.com/russellhaering/goxmldsig v1.1.0/go.mod h1:QK8GhXPB3+AfuCrfo0oRISa9NfzeCpWmxeGnqEpDF9o=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -199,6 +198,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -252,6 +252,7 @@ golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 h1:rOhMmluY6kLMhdnrivzec6lLgaVbMHMn2ISQXJeJ5EM=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=
@@ -279,6 +280,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
@@ -290,6 +292,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/logging/go.mod
+++ b/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmpsec/osctrl/logging
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go v0.37.4 // indirect

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -1,5 +1,5 @@
 module github.com/jmpsec/osctrl/metrics
 
-go 1.14
+go 1.15
 
 require github.com/spf13/viper v1.4.0

--- a/nodes/go.mod
+++ b/nodes/go.mod
@@ -1,5 +1,5 @@
 module github.com/jmpsec/osctrl/nodes
 
-go 1.14
+go 1.15
 
 require github.com/jinzhu/gorm v1.9.8

--- a/queries/go.mod
+++ b/queries/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmpsec/osctrl/queries
 
-go 1.14
+go 1.15
 
 require (
 	github.com/jinzhu/gorm v1.9.8

--- a/settings/go.mod
+++ b/settings/go.mod
@@ -1,5 +1,5 @@
 module github.com/jmpsec/osctrl/settings
 
-go 1.14
+go 1.15
 
 require github.com/jinzhu/gorm v1.9.8

--- a/tags/go.mod
+++ b/tags/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmpsec/osctrl/tags
 
-go 1.14
+go 1.15
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/tls/handlers/go.mod
+++ b/tls/handlers/go.mod
@@ -1,6 +1,6 @@
 module github.com/javuto/osctrl/tls/handlers
 
-go 1.14
+go 1.15
 
 require (
 	github.com/gorilla/mux v1.6.2
@@ -11,7 +11,7 @@ require (
 	github.com/jmpsec/osctrl/nodes v0.2.3
 	github.com/jmpsec/osctrl/queries v0.2.3
 	github.com/jmpsec/osctrl/settings v0.2.3
-	github.com/jmpsec/osctrl/tags v0.0.0-20200527045717-0e3b5d71cf19
+	github.com/jmpsec/osctrl/tags v0.2.3
 	github.com/jmpsec/osctrl/types v0.2.3
 	github.com/jmpsec/osctrl/utils v0.2.3
 	github.com/segmentio/ksuid v1.0.2

--- a/tls/handlers/go.sum
+++ b/tls/handlers/go.sum
@@ -58,6 +58,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/types/go.mod
+++ b/types/go.mod
@@ -1,3 +1,3 @@
 module github.com/jmpsec/osctrl/types
 
-go 1.14
+go 1.15

--- a/users/go.mod
+++ b/users/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmpsec/osctrl/users
 
-go 1.14
+go 1.15
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -1,5 +1,5 @@
 module github.com/jmpsec/osctrl/utils
 
-go 1.14
+go 1.15
 
 require github.com/stretchr/testify v1.5.1


### PR DESCRIPTION
Bumping version to `go 1.15` in `go.mod` and also the saml package due to CVE. That includes refactoring some code that was changed with the upgrade.