### PR TITLE
Enroll one-liners can use proper certificates

### DIFF
--- a/deploy/docker/admin/wait.sh
+++ b/deploy/docker/admin/wait.sh
@@ -32,10 +32,11 @@ fi
 # Generate flag and secret file for enrolling nodes
 FLAGS_FILE="$CONFIG/docker.flags"
 SECRET_FILE="$CONFIG/docker.secret"
+
 # Generating flags and rewriting UUID as identifier for ephemeral, otherwise all the containers
 # will have the same UUID and it will mess things up
-./bin/osctrl-cli -D "$DB_JSON" environment flags -n dev -crt "/$CRT_FILE" -secret "/$SECRET_FILE" | sed 's/=uuid/=ephemeral/g' > "$FLAGS_FILE"
 ./bin/osctrl-cli -D "$DB_JSON" environment secret -n dev > "$SECRET_FILE"
+./bin/osctrl-cli -D "$DB_JSON" environment flags -n dev -crt "/$CRT_FILE" -secret "/$SECRET_FILE" | sed 's/=uuid/=ephemeral/g' > "$FLAGS_FILE"
 
 # Create admin user
 OUTPUT_ADMIN="$(./bin/osctrl-cli -D "$DB_JSON" user add -u admin -p admin -a -n Admin)"

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -79,13 +79,14 @@ services:
     volumes:
       - ./deploy/docker/certs:/etc/certs
       - ./deploy/docker/config:/etc/nginx/conf.d
-  osquery-ubuntu18:
-    container_name: osquery-ubuntu18
+  osquery-ubuntu20:
+    container_name: osquery-ubuntu20
     depends_on:
+      - "osctrl-admin"
       - "osctrl-nginx"
     build:
       context: .
-      dockerfile: "deploy/docker/nodes/ubuntu18/Dockerfile"
+      dockerfile: "deploy/docker/nodes/ubuntu20/Dockerfile"
     links:
       - "osctrl-nginx"
     networks:
@@ -93,6 +94,21 @@ services:
     volumes:
       - ./deploy/docker/config:/config
       - ./deploy/docker/certs:/certs
+  # osquery-ubuntu18:
+  #  container_name: osquery-ubuntu18
+  #  depends_on:
+  #    - "osctrl-admin"
+  #    - "osctrl-nginx"
+  #  build:
+  #    context: .
+  #    dockerfile: "deploy/docker/nodes/ubuntu18/Dockerfile"
+  #  links:
+  #    - "osctrl-nginx"
+  #  networks:
+  #    - public-net
+  #  volumes:
+  #    - ./deploy/docker/config:/config
+  #    - ./deploy/docker/certs:/certs
   # osquery-ubuntu16:
   #   container_name: osquery-ubuntu16
   #   depends_on:

--- a/deploy/docker/nodes/centos6/wait.sh
+++ b/deploy/docker/nodes/centos6/wait.sh
@@ -5,16 +5,19 @@
 # Usage: wait.sh
 
 NAME="osctrl-centos6"
-WAIT=3
+FLAGS_FILE="/config/docker.flags"
+SECRET_FILE="/config/docker.secret"
+WAIT=5
 
 # Check if script to enroll
-while [ ! -f config/docker.flags ] && [ ! -f config/docker.secret ];
+while [ ! -f "$FLAGS_FILE" ] && [ ! -f "$SECRET_FILE" ];
 do
   >&2 echo "osctrl is not ready - Waiting"
   sleep $WAIT
 done
 >&2 echo "osctrl is up - Enrolling $NAME"
+
 sleep $WAIT
 
 # Run osquery
-/usr/bin/osqueryd --flagfile=config/docker.flags --verbose
+/usr/bin/osqueryd --flagfile="$FLAGS_FILE" --verbose

--- a/deploy/docker/nodes/centos7/wait.sh
+++ b/deploy/docker/nodes/centos7/wait.sh
@@ -5,16 +5,19 @@
 # Usage: wait.sh
 
 NAME="osctrl-centos7"
-WAIT=3
+FLAGS_FILE="/config/docker.flags"
+SECRET_FILE="/config/docker.secret"
+WAIT=5
 
 # Check if script to enroll
-while [ ! -f config/docker.flags ] && [ ! -f config/docker.secret ];
+while [ ! -f "$FLAGS_FILE" ] && [ ! -f "$SECRET_FILE" ];
 do
   >&2 echo "osctrl is not ready - Waiting"
   sleep $WAIT
 done
 >&2 echo "osctrl is up - Enrolling $NAME"
+
 sleep $WAIT
 
 # Run osquery
-/usr/bin/osqueryd --flagfile=config/docker.flags --verbose
+/usr/bin/osqueryd --flagfile="$FLAGS_FILE" --verbose

--- a/deploy/docker/nodes/debian8/wait.sh
+++ b/deploy/docker/nodes/debian8/wait.sh
@@ -5,16 +5,19 @@
 # Usage: wait.sh
 
 NAME="osctrl-debian8"
-WAIT=3
+FLAGS_FILE="/config/docker.flags"
+SECRET_FILE="/config/docker.secret"
+WAIT=5
 
 # Check if script to enroll
-while [ ! -f config/docker.flags ] && [ ! -f config/docker.secret ];
+while [ ! -f "$FLAGS_FILE" ] && [ ! -f "$SECRET_FILE" ];
 do
   >&2 echo "osctrl is not ready - Waiting"
   sleep $WAIT
 done
 >&2 echo "osctrl is up - Enrolling $NAME"
+
 sleep $WAIT
 
 # Run osquery
-/usr/bin/osqueryd --flagfile=config/docker.flags --verbose
+/usr/bin/osqueryd --flagfile="$FLAGS_FILE" --verbose

--- a/deploy/docker/nodes/debian9/wait.sh
+++ b/deploy/docker/nodes/debian9/wait.sh
@@ -5,16 +5,19 @@
 # Usage: wait.sh
 
 NAME="osctrl-debian9"
-WAIT=3
+FLAGS_FILE="/config/docker.flags"
+SECRET_FILE="/config/docker.secret"
+WAIT=5
 
 # Check if script to enroll
-while [ ! -f config/docker.flags ] && [ ! -f config/docker.secret ];
+while [ ! -f "$FLAGS_FILE" ] && [ ! -f "$SECRET_FILE" ];
 do
   >&2 echo "osctrl is not ready - Waiting"
   sleep $WAIT
 done
 >&2 echo "osctrl is up - Enrolling $NAME"
+
 sleep $WAIT
 
 # Run osquery
-/usr/bin/osqueryd --flagfile=config/docker.flags --verbose
+/usr/bin/osqueryd --flagfile="$FLAGS_FILE" --verbose

--- a/deploy/docker/nodes/ubuntu16/wait.sh
+++ b/deploy/docker/nodes/ubuntu16/wait.sh
@@ -5,16 +5,19 @@
 # Usage: wait.sh
 
 NAME="osctrl-ubuntu16"
-WAIT=3
+FLAGS_FILE="/config/docker.flags"
+SECRET_FILE="/config/docker.secret"
+WAIT=5
 
 # Check if script to enroll
-while [ ! -f config/docker.flags ] && [ ! -f config/docker.secret ];
+while [ ! -f "$FLAGS_FILE" ] && [ ! -f "$SECRET_FILE" ];
 do
   >&2 echo "osctrl is not ready - Waiting"
   sleep $WAIT
 done
 >&2 echo "osctrl is up - Enrolling $NAME"
+
 sleep $WAIT
 
 # Run osquery
-/usr/bin/osqueryd --flagfile=config/docker.flags --verbose
+/usr/bin/osqueryd --flagfile="$FLAGS_FILE" --verbose

--- a/deploy/docker/nodes/ubuntu20/Dockerfile
+++ b/deploy/docker/nodes/ubuntu20/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:20.04
+LABEL maintainer="javuto"
+
+RUN apt update && apt install -y curl
+
+RUN curl -# "https://osquery-packages.s3.amazonaws.com/deb/osquery_4.5.1_1.linux.amd64.deb" -o "/tmp/osquery.deb"
+RUN dpkg -i "/tmp/osquery.deb"
+
+COPY deploy/docker/nodes/ubuntu20/wait.sh .
+
+CMD [ "/bin/sh", "wait.sh" ]

--- a/deploy/docker/nodes/ubuntu20/wait.sh
+++ b/deploy/docker/nodes/ubuntu20/wait.sh
@@ -4,7 +4,7 @@
 #
 # Usage: wait.sh
 
-NAME="osctrl-ubuntu18"
+NAME="osctrl-ubuntu20"
 FLAGS_FILE="/config/docker.flags"
 SECRET_FILE="/config/docker.secret"
 WAIT=5

--- a/environments/go.mod
+++ b/environments/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/jinzhu/gorm v1.9.8
 	github.com/segmentio/ksuid v1.0.2
+	github.com/stretchr/testify v1.2.2
 )

--- a/environments/go.sum
+++ b/environments/go.sum
@@ -9,6 +9,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20190423183735-731ef375ac02/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
@@ -58,6 +59,7 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
@@ -71,6 +73,7 @@ github.com/segmentio/ksuid v1.0.2 h1:9yBfKyw4ECGTdALaF09Snw3sLJmYIX6AbPJrAy6MrDc
 github.com/segmentio/ksuid v1.0.2/go.mod h1:BXuJDr2byAiHuQaQtSKoXh1J0YmUDurywOXgB2w+OSU=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/environments/oneliners.go
+++ b/environments/oneliners.go
@@ -2,33 +2,53 @@ package environments
 
 import (
 	"bytes"
+	"strings"
 	"text/template"
 )
 
-// QuickAddOneLiner generic to generate quick add one-liners
-func QuickAddOneLiner(oneliner string, environment TLSEnvironment, target string) (string, error) {
-	t, err := template.New(target).Parse(oneliner)
-	if err != nil {
-		return "", err
-	}
-	data := struct {
-		TLSHost     string
-		Environment string
-		SecretPath  string
-	}{
-		TLSHost:     environment.Hostname,
-		Environment: environment.Name,
-		SecretPath:  environment.EnrollSecretPath,
-	}
-	var tpl bytes.Buffer
-	if err := t.Execute(&tpl, data); err != nil {
-		return "", err
-	}
-	return tpl.String(), nil
-}
+const (
+	// InsecureShellTLS for insecure TLS connections in shell oneliners
+	InsecureShellTLS = "k"
+	// InsecurePowershellTLS for insecure TLS connections in powershell onliners
+	InsecurePowershellTLS = "[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};"
+)
 
-// QuickRemoveOneLiner generic to generate quick remove one-liners
-func QuickRemoveOneLiner(oneliner string, environment TLSEnvironment, target string) (string, error) {
+const (
+	// ShellTarget for shell extension
+	ShellTarget = ".sh"
+	// PowershellTarget for powershell extension
+	PowershellTarget = ".ps1"
+	// EnrollTarget for enroll target
+	EnrollTarget = "enroll"
+	// RemoveTarget for remove target
+	RemoveTarget = "remove"
+	// EnrollShell for enroll shell
+	EnrollShell = EnrollTarget + ShellTarget
+	// RemoveShell for remove shell
+	RemoveShell = RemoveTarget + ShellTarget
+	// EnrollPowershell for enroll powershell
+	EnrollPowershell = EnrollTarget + PowershellTarget
+	// RemovePowershell for remove powershell
+	RemovePowershell = RemoveTarget + PowershellTarget
+)
+
+// PrepareOneLiner generic to generate  one-liners
+func PrepareOneLiner(oneliner string, environment TLSEnvironment, target string) (string, error) {
+	// Determine if insecure TLS is on
+	insecureTLS := ""
+	if environment.Certificate != "" {
+		if strings.HasSuffix(target, ShellTarget) {
+			insecureTLS = InsecureShellTLS
+		} else if strings.HasSuffix(target, PowershellTarget) {
+			insecureTLS = InsecurePowershellTLS
+		}
+	}
+	// Determine if this is to enroll or remove
+	secretPath := environment.RemoveSecretPath
+	if strings.HasPrefix(target, EnrollTarget) {
+		secretPath = environment.EnrollSecretPath
+	}
+	// Prepare template for oneliner
 	t, err := template.New(target).Parse(oneliner)
 	if err != nil {
 		return "", err
@@ -37,10 +57,12 @@ func QuickRemoveOneLiner(oneliner string, environment TLSEnvironment, target str
 		TLSHost     string
 		Environment string
 		SecretPath  string
+		InsecureTLS string
 	}{
 		TLSHost:     environment.Hostname,
 		Environment: environment.Name,
-		SecretPath:  environment.RemoveSecretPath,
+		SecretPath:  secretPath,
+		InsecureTLS: insecureTLS,
 	}
 	var tpl bytes.Buffer
 	if err := t.Execute(&tpl, data); err != nil {
@@ -51,30 +73,30 @@ func QuickRemoveOneLiner(oneliner string, environment TLSEnvironment, target str
 
 // QuickAddOneLinerShell to get the quick add one-liner for Linux/OSX nodes
 func QuickAddOneLinerShell(environment TLSEnvironment) (string, error) {
-	s := `curl -sk https://{{ .TLSHost }}/{{ .Environment }}/{{ .SecretPath }}/enroll.sh | sh`
-	return QuickAddOneLiner(s, environment, "enroll.sh")
+	s := `curl -s{{ .InsecureTLS }} https://{{ .TLSHost }}/{{ .Environment }}/{{ .SecretPath }}/enroll.sh | sh`
+	return PrepareOneLiner(s, environment, EnrollShell)
 }
 
 // QuickRemoveOneLinerShell to get the quick remove one-liner for Linux/OSX nodes
 func QuickRemoveOneLinerShell(environment TLSEnvironment) (string, error) {
-	s := `curl -sk https://{{ .TLSHost }}/{{ .Environment }}/{{ .SecretPath }}/remove.sh | sh`
-	return QuickRemoveOneLiner(s, environment, "remove.sh")
+	s := `curl -s{{ .InsecureTLS }} https://{{ .TLSHost }}/{{ .Environment }}/{{ .SecretPath }}/remove.sh | sh`
+	return PrepareOneLiner(s, environment, RemoveShell)
 }
 
 // QuickAddOneLinerPowershell to get the quick add one-liner for Windows nodes
 func QuickAddOneLinerPowershell(environment TLSEnvironment) (string, error) {
 	s := `Set-ExecutionPolicy Bypass -Scope Process -Force;
-[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};
+{{ .InsecureTLS }}
 iex ((New-Object System.Net.WebClient).DownloadString('https://{{ .TLSHost }}/{{ .Environment }}/{{ .SecretPath }}/enroll.ps1'))`
-	return QuickAddOneLiner(s, environment, "enroll.ps1")
+	return PrepareOneLiner(s, environment, EnrollPowershell)
 }
 
 // QuickRemoveOneLinerPowershell to get the quick remove one-liner for Windows nodes
 func QuickRemoveOneLinerPowershell(environment TLSEnvironment) (string, error) {
 	s := `Set-ExecutionPolicy Bypass -Scope Process -Force;
-[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};
+{{ .InsecureTLS }}
 iex ((New-Object System.Net.WebClient).DownloadString('https://{{ .TLSHost }}/{{ .Environment }}/{{ .SecretPath }}/remove.ps1'))`
-	return QuickRemoveOneLiner(s, environment, "remove.ps1")
+	return PrepareOneLiner(s, environment, RemovePowershell)
 }
 
 // QuickAddScript to get a quick add script for a environment
@@ -82,16 +104,16 @@ func QuickAddScript(project, script string, environment TLSEnvironment) (string,
 	var templateName, templatePath string
 	// What script is it?
 	switch script {
-	case "enroll.sh":
+	case EnrollShell:
 		templateName = "quick-add.sh"
 		templatePath = "scripts/quick-add.sh"
-	case "enroll.ps1":
+	case EnrollPowershell:
 		templateName = "quick-add.ps1"
 		templatePath = "scripts/quick-add.ps1"
-	case "remove.sh":
+	case RemoveShell:
 		templateName = "quick-remove.sh"
 		templatePath = "scripts/quick-remove.sh"
-	case "remove.ps1":
+	case RemovePowershell:
 		templateName = "quick-remove.ps1"
 		templatePath = "scripts/quick-remove.ps1"
 	}

--- a/environments/oneliners_test.go
+++ b/environments/oneliners_test.go
@@ -1,0 +1,56 @@
+package environments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepareOneLiner(t *testing.T) {
+	envTest := TLSEnvironment{
+		Certificate:      "certificate",
+		Hostname:         "hostname",
+		Name:             "name",
+		RemoveSecretPath: "rPath",
+		EnrollSecretPath: "ePath",
+	}
+	tmpl := "oneliner {{ .InsecureTLS }} 1 {{ .TLSHost }} 2 {{ .Environment }} 3 {{ .SecretPath }}"
+	t.Run("empty", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner("", TLSEnvironment{}, "")
+		assert.Equal(t, oneliner, "")
+	})
+	t.Run("not empty insecure enroll.sh", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner(tmpl, envTest, "enroll.sh")
+		assert.Equal(t, oneliner, "oneliner k 1 hostname 2 name 3 ePath")
+	})
+	t.Run("not empty insecure remove.sh", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner(tmpl, envTest, "remove.sh")
+		assert.Equal(t, oneliner, "oneliner k 1 hostname 2 name 3 rPath")
+	})
+	t.Run("not empty insecure enroll.ps1", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner(tmpl, envTest, "enroll.ps1")
+		assert.Equal(t, oneliner, "oneliner [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; 1 hostname 2 name 3 ePath")
+	})
+	t.Run("not empty insecure remove.ps1", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner(tmpl, envTest, "remove.ps1")
+		assert.Equal(t, oneliner, "oneliner [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; 1 hostname 2 name 3 rPath")
+	})
+	// Empty certificate means secure TLS
+	envTest.Certificate = ""
+	t.Run("not empty secure enroll.sh", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner(tmpl, envTest, "enroll.sh")
+		assert.Equal(t, oneliner, "oneliner  1 hostname 2 name 3 ePath")
+	})
+	t.Run("not empty secure remove.sh", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner(tmpl, envTest, "remove.sh")
+		assert.Equal(t, oneliner, "oneliner  1 hostname 2 name 3 rPath")
+	})
+	t.Run("not empty secure enroll.ps1", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner(tmpl, envTest, "enroll.ps1")
+		assert.Equal(t, oneliner, "oneliner  1 hostname 2 name 3 ePath")
+	})
+	t.Run("not empty secure remove.ps1", func(t *testing.T) {
+		oneliner, _ := PrepareOneLiner(tmpl, envTest, "remove.ps1")
+		assert.Equal(t, oneliner, "oneliner  1 hostname 2 name 3 rPath")
+	})
+}

--- a/tls/handlers/handlers.go
+++ b/tls/handlers/handlers.go
@@ -532,13 +532,13 @@ func (h *HandlersTLS) QuickEnrollHandler(w http.ResponseWriter, r *http.Request)
 	if strings.HasPrefix(script, "enroll") {
 		if !h.checkValidEnrollSecretPath(env, secretPath) {
 			h.Inc(metricOnelinerErr)
-			log.Println("Invalid Path")
+			log.Println("Invalid secret path for enrolling")
 			return
 		}
 	} else if strings.HasPrefix(script, "remove") {
 		if !h.checkValidRemoveSecretPath(env, secretPath) {
 			h.Inc(metricOnelinerErr)
-			log.Println("Invalid Path")
+			log.Println("Invalid secret path for removing")
 			return
 		}
 	}


### PR DESCRIPTION
The enroll one-liners that were generated with `osctrl` were forced to use insecure TLS connections which is not great. Now if the certificate for a new environment is empty, which happens when certificates like Let's Encrypt are used, no need to force insecure TLS with `curl -k` in shell or `[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};` in PowerShell.

Also added `ubuntu20` docker container for the dockerized dev environment and some improvements to the `wait.sh`.