### PR TITLE
Fix for upgrading existing osctrl

### DIFF
--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -301,7 +301,7 @@ function _static_files() {
       sudo ln -s "$__path/$__from" "$__dest/$__target"
     fi
   else
-    sudo cp -R "$__path/$__from" "$__dest/$__target"
+    sudo rsync -av "$__path/$__from" "$__dest/$__target"
   fi
 }
 

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -414,6 +414,7 @@ package make
 package openssl
 package tmux
 package bc
+package rsync
 
 # Golang
 # package golang-go
@@ -461,8 +462,8 @@ if [[ "$UPGRADE" == true ]]; then
       sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
       sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
     else
-      sudo cp "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
-      sudo cp "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
+      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
+      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
     fi
 
     # Restart service with new binary
@@ -476,6 +477,12 @@ if [[ "$UPGRADE" == true ]]; then
     # Restart service with new binary
     make install_api
   fi
+
+  # Compile CLI
+  make cli
+
+  # Install CLI
+  DEST="$DEST_PATH" make install_cli
 else
   # We are provisioning a new machine
   log ""
@@ -691,8 +698,8 @@ else
       sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
       sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
     else
-      sudo cp "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
-      sudo cp "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
+      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
+      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
     fi
 
     # Systemd configuration for Admin service


### PR DESCRIPTION
When using `provision.sh` to upgrade an existing deployment of `osctrl`, copying existing files in `-m prod` was not working properly so this PR uses `rsync` instead.