### PR TITLE
Fix for updating existing osctrl

### DIFF
--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -301,7 +301,7 @@ function _static_files() {
       sudo ln -s "$__path/$__from" "$__dest/$__target"
     fi
   else
-    sudo rsync -v "$__path/$__from/" "$__dest/$__target/"
+    sudo rsync -av "$__path/$__from/" "$__dest/$__target"
   fi
 }
 

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -462,8 +462,8 @@ if [[ "$UPGRADE" == true ]]; then
       sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
       sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
     else
-      sudo rsync -v "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
-      sudo rsync -v "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
+      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
+      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
     fi
 
     # Restart service with new binary
@@ -698,8 +698,8 @@ else
       sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
       sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
     else
-      sudo rsync -v "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
-      sudo rsync -v "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
+      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
+      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
     fi
 
     # Systemd configuration for Admin service


### PR DESCRIPTION
The command `rsync` was not issued recursively so some files were not getting updated.