### PR TITLE
Show target for on-demand query results

### DIFF
--- a/admin/templates/queries-logs.html
+++ b/admin/templates/queries-logs.html
@@ -76,6 +76,7 @@
                   <thead>
                     <tr>
                       <th>Created</th>
+                      <th>Target</th>
                       <th>Data</th>
                     </tr>
                   </thead>
@@ -129,14 +130,26 @@
                 sort: "created.timestamp"
               }
             },
+            {"data" : "target"},
             {"data" : "data"}
           ],
           order: [[ 0, "desc" ]],
           columnDefs: [
             { width: '10%', targets: 0 },
             {
-              width: '90%',
+              width: '15%',
               targets: 1,
+              render: function (data, type, row, meta) {
+                if (type === 'display') {
+                  return '<a href="/node/'+data.uuid+'">' + data.name + '</a>';
+                } else {
+                  return data;
+                }
+              }
+            },
+            {
+              width: '75%',
+              targets: 2,
               render: function (data, type, row, meta) {
                 if (type === 'display') {
                   return '<pre>' + JSON.stringify(JSON.parse(data),null,2) + '</pre>';


### PR DESCRIPTION
Implementation of #125 where system name nor `UUID` was shown on the results page for on-demand query that applied to multiple targets. For example using an environment or a platform.

Now results are shown with the localname and a link to the node:

<img width="1163" alt="Screen Shot 2021-01-20 at 2 47 36 PM" src="https://user-images.githubusercontent.com/1271349/105193299-54b79b00-5aed-11eb-93fb-2f5c9255cd56.png">
