### PR TITLE
TLS 1.2 and 1.3

### DIFF
--- a/deploy/nginx/ssl.conf
+++ b/deploy/nginx/ssl.conf
@@ -13,7 +13,7 @@ server {
     ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
 
     # Disable SSLv3
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     # Diffie-Hellman parameter for DHE ciphersuites
     # $ sudo openssl dhparam -out /etc/ssl/certs/dhparam.pem 4096


### PR DESCRIPTION
Following https://github.com/osquery/osquery/pull/6910 and making sure that TLS 1.2 and 1.3 are default in `osctrl-nginx` because that is where the TLS termination happens.