### PR TITLE
Edit environment hostname from `osctrl-admin`

### DIFF
--- a/admin/handlers/post.go
+++ b/admin/handlers/post.go
@@ -1019,6 +1019,15 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 		adminOKResponse(w, "debug changed successfully")
+	case "edit":
+		if h.Envs.Exists(c.UUID) {
+			if err := h.Envs.UpdateHostname(c.UUID, c.Hostname); err != nil {
+				adminErrorResponse(w, "error updating hostname", http.StatusInternalServerError, err)
+				h.Inc(metricAdminErr)
+				return
+			}
+		}
+		adminOKResponse(w, "debug changed successfully")
 	}
 	// Serialize and send response
 	if h.Settings.DebugService(settings.ServiceAdmin) {

--- a/admin/handlers/types-requests.go
+++ b/admin/handlers/types-requests.go
@@ -98,6 +98,7 @@ type ExpirationRequest struct {
 type EnvironmentsRequest struct {
 	CSRFToken string `json:"csrftoken"`
 	Action    string `json:"action"`
+	UUID      string `json:"uuid"`
 	Name      string `json:"name"`
 	Hostname  string `json:"hostname"`
 	Type      string `json:"type"`

--- a/admin/templates/environments.html
+++ b/admin/templates/environments.html
@@ -55,7 +55,9 @@
                     <tr>
                       <td><b>{{ $e.Name }}</b></td>
                       <td>{{ $e.Type }}</td>
-                      <td>{{ $e.Hostname }}</td>
+                      <td>
+                        <p id="hostname" data-tooltip="true" data-uuid="{{ $e.UUID }}" class="editable-field" role="button" tabindex="0" title="Click to edit...">{{ $e.Hostname }}</p>
+                      </td>
                       <td>
                         <label class="switch switch-label switch-pill switch-success switch-sm">
                           <input id="{{ $e.Name }}_debug_check" class="switch-input" type="checkbox" onclick="changeDebugHTTP('{{ $e.Name }}');" {{ if $e.DebugHTTP }} checked {{ end }}>
@@ -144,6 +146,37 @@
     <script src="/static/js/environments.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {
+        // Editable fields
+        $(".editable-field").editable(function(value, settings) {
+			    var data = {
+            csrftoken: $("#csrftoken").val(),
+            action: 'edit',
+            uuid: $(this).attr('data-uuid'),
+          };
+          var type_edit = $(this).attr('id');
+          if (type_edit === 'hostname') {
+            data.hostname = value;
+          }
+          console.log(settings);
+          sendPostRequest(data, window.location.pathname, '', false);
+          return value;
+		    }, {
+          indicator : "<img src='/static/img/spinner.svg' />",
+          type : "text",
+          onedit : function() { return true;},
+          cancel : 'Cancel',
+          cssclass : 'editable-class',
+          cancelcssclass : 'btn btn-danger',
+          submitcssclass : 'btn btn-success',
+          maxlength : 200,
+          // select all text
+          select : true,
+          label : '',
+          showfn : function(elem) { elem.fadeIn('slow') },
+          submit : 'Save',
+          tooltip : "Click to edit...",
+          width : 160
+        });
         // Update icon on environment creation modal
         $('#environment_icon').on('input', function() {
           $("#environment_show_icon").removeClass();

--- a/environments/environments.go
+++ b/environments/environments.go
@@ -287,7 +287,15 @@ func (environment *Environment) UpdateCertificate(idEnv, certificate string) err
 // UpdateFlags to update flags for an environment
 func (environment *Environment) UpdateFlags(idEnv, flags string) error {
 	if err := environment.DB.Model(&TLSEnvironment{}).Where("name = ? OR uuid = ?", idEnv, idEnv).Update("flags", flags).Error; err != nil {
-		return fmt.Errorf("Update %v", err)
+		return fmt.Errorf("Update flags %v", err)
+	}
+	return nil
+}
+
+// UpdateHostname to update hostname for an environment
+func (environment *Environment) UpdateHostname(idEnv, hostname string) error {
+	if err := environment.DB.Model(&TLSEnvironment{}).Where("name = ? OR uuid = ?", idEnv, idEnv).Update("hostname", hostname).Error; err != nil {
+		return fmt.Errorf("Update hostname %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Implementation of #119 and now the hostname for an existing environment is editable from `osctrl-admin`