### PR TITLE
Use the values from env variables in `osctrl-tls`

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -271,7 +271,7 @@ func init() {
 		&cli.StringFlag{
 			Name:        "port",
 			Aliases:     []string{"p"},
-			Value:       "9000",
+			Value:       "9001",
 			Usage:       "TCP port for the service",
 			EnvVars:     []string{"SERVICE_PORT"},
 			Destination: &adminConfig.Port,


### PR DESCRIPTION
Values from environment values were not used in the configuration.