### PR TITLE
Support for env variables for parameters in `osctrl-api`

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -131,6 +131,7 @@ var (
 	loggingValue         cli.StringSlice
 	dbFlag               bool
 	dbConfigFile         string
+	dbConfigFileLogger   string
 	tlsServer            bool
 	tlsCertFile          string
 	tlsKeyFile           string

--- a/api/main.go
+++ b/api/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"crypto/tls"
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/jmpsec/osctrl/backend"
@@ -19,6 +19,7 @@ import (
 	"github.com/jmpsec/osctrl/types"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/version"
+	"github.com/urfave/cli/v2"
 
 	"github.com/gorilla/mux"
 	"github.com/jinzhu/gorm"
@@ -37,15 +38,15 @@ const (
 	// Application description
 	appDescription string = serviceDescription + ", a fast and efficient osquery management"
 	// Default service configuration file
-	configurationFile string = "config/" + settings.ServiceAPI + ".json"
+	defConfigurationFile string = "config/" + settings.ServiceAPI + ".json"
 	// Default DB configuration file
-	dbConfigurationFile string = "config/db.json"
-	// Default JWT configuration file
-	jwtConfigurationFile string = "config/jwt.json"
+	defDBConfigurationFile string = "config/db.json"
 	// Default TLS certificate file
-	tlsCertificateFile string = "config/tls.crt"
+	defTLSCertificateFile string = "config/tls.crt"
 	// Default TLS private key file
-	tlsKeyFile string = "config/tls.key"
+	defTLSKeyFile string = "config/tls.key"
+	// Default JWT configuration file
+	defJWTConfigurationFile string = "config/jwt.json"
 	// Default refreshing interval in seconds
 	defaultRefresh int = 300
 )
@@ -84,7 +85,9 @@ var (
 
 // Global variables
 var (
+	err         error
 	apiConfig   types.JSONConfigurationService
+	dbConfig    backend.JSONConfigurationDB
 	jwtConfig   types.JSONConfigurationJWT
 	db          *gorm.DB
 	apiUsers    *users.UserManager
@@ -97,17 +100,22 @@ var (
 	queriesmgr  *queries.Queries
 	filecarves  *carves.Carves
 	_metrics    *metrics.Metrics
+	app         *cli.App
+	flags       []cli.Flag
 )
 
 // Variables for flags
 var (
-	versionFlag *bool
-	configFlag  *string
-	dbFlag      *string
-	jwtFlag     *string
-	tlsServer   *bool
-	tlsCert     *string
-	tlsKey      *string
+	configFlag    bool
+	configFile    string
+	loggingValue  cli.StringSlice
+	dbFlag        bool
+	dbConfigFile  string
+	jwtFlag       bool
+	jwtConfigFile string
+	tlsServer     bool
+	tlsCertFile   string
+	tlsKeyFile    string
 )
 
 // Valid values for auth and logging in configuration
@@ -148,49 +156,196 @@ func loadConfiguration(file string) (types.JSONConfigurationService, error) {
 
 // Initialization code
 func init() {
-	log.Printf("==================== Initializing %s v%s", serviceName, serviceVersion)
-	var err error
-	// Command line flags
-	flag.Usage = apiUsage
-	// Define flags
-	versionFlag = flag.Bool("v", false, "Displays the binary version.")
-	configFlag = flag.String("c", configurationFile, "Service configuration JSON file to use.")
-	dbFlag = flag.String("D", dbConfigurationFile, "DB configuration JSON file to use.")
-	jwtFlag = flag.String("J", jwtConfigurationFile, "JWT configuration JSON file to use.")
-	tlsServer = flag.Bool("tls", false, "TLS termination is enabled. It requires certificate and key.")
-	tlsCert = flag.String("cert", tlsCertificateFile, "Certificate file to be used for TLS.")
-	tlsKey = flag.String("key", tlsKeyFile, "Private key file to be used for TLS.")
-	// Parse all flags
-	flag.Parse()
-	if *versionFlag {
-		apiVersion()
+	// Initialize CLI flags
+	flags = []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "config",
+			Aliases:     []string{"c"},
+			Value:       false,
+			Usage:       "Provide service configuration via JSON file",
+			EnvVars:     []string{"SERVICE_CONFIG"},
+			Destination: &configFlag,
+		},
+		&cli.StringFlag{
+			Name:        "config-file",
+			Aliases:     []string{"C"},
+			Value:       defDBConfigurationFile,
+			Usage:       "Load service configuration from `FILE`",
+			EnvVars:     []string{"SERVICE_CONFIG_FILE"},
+			Destination: &dbConfigFile,
+		},
+		&cli.StringFlag{
+			Name:        "listener",
+			Aliases:     []string{"l"},
+			Value:       "0.0.0.0",
+			Usage:       "Listener for the service",
+			EnvVars:     []string{"SERVICE_LISTENER"},
+			Destination: &apiConfig.Listener,
+		},
+		&cli.StringFlag{
+			Name:        "port",
+			Aliases:     []string{"p"},
+			Value:       "9000",
+			Usage:       "TCP port for the service",
+			EnvVars:     []string{"SERVICE_PORT"},
+			Destination: &apiConfig.Port,
+		},
+		&cli.StringFlag{
+			Name:        "auth",
+			Aliases:     []string{"A"},
+			Value:       settings.AuthNone,
+			Usage:       "Authentication mechanism for the service",
+			EnvVars:     []string{"SERVICE_AUTH"},
+			Destination: &apiConfig.Auth,
+		},
+		&cli.StringFlag{
+			Name:        "host",
+			Aliases:     []string{"H"},
+			Value:       "0.0.0.0",
+			Usage:       "Exposed hostname the service uses",
+			EnvVars:     []string{"SERVICE_HOST"},
+			Destination: &apiConfig.Host,
+		},
+		&cli.StringSliceFlag{
+			Name:        "logging",
+			Aliases:     []string{"L"},
+			Value:       &cli.StringSlice{},
+			Usage:       "Logging mechanism to handle logs from nodes",
+			EnvVars:     []string{"SERVICE_LOGGING"},
+			Destination: &loggingValue,
+		},
+		&cli.BoolFlag{
+			Name:        "db",
+			Aliases:     []string{"d"},
+			Value:       false,
+			Usage:       "Provide DB configuration via JSON file",
+			EnvVars:     []string{"DB_CONFIG"},
+			Destination: &dbFlag,
+		},
+		&cli.StringFlag{
+			Name:        "db-file",
+			Aliases:     []string{"D"},
+			Value:       defConfigurationFile,
+			Usage:       "Load DB configuration from `FILE`",
+			EnvVars:     []string{"DB_CONFIG_FILE"},
+			Destination: &configFile,
+		},
+		&cli.StringFlag{
+			Name:        "db-host",
+			Value:       "127.0.0.1",
+			Usage:       "Backend host to be connected to",
+			EnvVars:     []string{"DB_HOST"},
+			Destination: &dbConfig.Host,
+		},
+		&cli.StringFlag{
+			Name:        "db-port",
+			Value:       "5432",
+			Usage:       "Backend port to be connected to",
+			EnvVars:     []string{"DB_PORT"},
+			Destination: &dbConfig.Port,
+		},
+		&cli.StringFlag{
+			Name:        "db-name",
+			Value:       "postgres",
+			Usage:       "Backend port to be connected to",
+			EnvVars:     []string{"DB_NAME"},
+			Destination: &dbConfig.Name,
+		},
+		&cli.StringFlag{
+			Name:        "db-user",
+			Value:       "postgres",
+			Usage:       "Username to be used for the backend",
+			EnvVars:     []string{"DB_USER"},
+			Destination: &dbConfig.Username,
+		},
+		&cli.StringFlag{
+			Name:        "db-pass",
+			Value:       "postgres",
+			Usage:       "Password to be used for the backend",
+			EnvVars:     []string{"DB_PASS"},
+			Destination: &dbConfig.Password,
+		},
+		&cli.IntFlag{
+			Name:        "db-max-idle-conns",
+			Value:       20,
+			Usage:       "Maximum number of connections in the idle connection pool",
+			EnvVars:     []string{"DB_MAX_IDLE_CONNS"},
+			Destination: &dbConfig.MaxIdleConns,
+		},
+		&cli.IntFlag{
+			Name:        "db-max-open-conns",
+			Value:       100,
+			Usage:       "Maximum number of open connections to the database",
+			EnvVars:     []string{"DB_MAX_OPEN_CONNS"},
+			Destination: &dbConfig.MaxOpenConns,
+		},
+		&cli.IntFlag{
+			Name:        "db-conn-max-lifetime",
+			Value:       30,
+			Usage:       "Maximum amount of time a connection may be reused",
+			EnvVars:     []string{"DB_CONN_MAX_LIFETIME"},
+			Destination: &dbConfig.ConnMaxLifetime,
+		},
+		&cli.BoolFlag{
+			Name:        "tls",
+			Aliases:     []string{"t"},
+			Value:       false,
+			Usage:       "Enable TLS termination. It requires certificate and key",
+			EnvVars:     []string{"TLS_SERVER"},
+			Destination: &tlsServer,
+		},
+		&cli.StringFlag{
+			Name:        "cert",
+			Aliases:     []string{"T"},
+			Value:       defTLSCertificateFile,
+			Usage:       "TLS termination certificate from `FILE`",
+			EnvVars:     []string{"TLS_CERTIFICATE"},
+			Destination: &tlsCertFile,
+		},
+		&cli.StringFlag{
+			Name:        "key",
+			Aliases:     []string{"K"},
+			Value:       defTLSKeyFile,
+			Usage:       "TLS termination private key from `FILE`",
+			EnvVars:     []string{"TLS_KEY"},
+			Destination: &tlsKeyFile,
+		},
+		&cli.BoolFlag{
+			Name:        "jwt",
+			Aliases:     []string{"j"},
+			Value:       false,
+			Usage:       "Provide JWT configuration via JSON file",
+			EnvVars:     []string{"JWT_CONFIG"},
+			Destination: &jwtFlag,
+		},
+		&cli.StringFlag{
+			Name:        "jwt-file",
+			Value:       defJWTConfigurationFile,
+			Usage:       "Load JWT configuration from `FILE`",
+			EnvVars:     []string{"JWT_CONFIG_FILE"},
+			Destination: &jwtConfigFile,
+		},
+		&cli.StringFlag{
+			Name:        "jwt-secret",
+			Usage:       "Password to be used for the backend",
+			EnvVars:     []string{"JWT_SECRET"},
+			Destination: &jwtConfig.JWTSecret,
+		},
+		&cli.IntFlag{
+			Name:        "jwt-expire",
+			Value:       3,
+			Usage:       "Maximum amount of hours for the tokens to expire",
+			EnvVars:     []string{"JWT_EXPIRE"},
+			Destination: &jwtConfig.HoursToExpire,
+		},
 	}
 	// Logging format flags
 	log.SetFlags(log.Lshortfile)
-	// Load API configuration
-	apiConfig, err = loadConfiguration(*configFlag)
-	if err != nil {
-		log.Fatalf("Error loading %s - %s", *configFlag, err)
-	}
-	// Load JWT configuration
-	// Load configuration for JWT if enabled
-	if apiConfig.Auth == settings.AuthJWT {
-		jwtConfig, err = loadJWTConfiguration(*jwtFlag)
-		if err != nil {
-			log.Fatalf("Error loading %s - %s", *jwtFlag, err)
-		}
-		return
-	}
 }
 
 // Go go!
-func main() {
-	log.Printf("==================== Starting %s v%s", serviceName, serviceVersion)
-	// Database handler
-	dbConfig, err := backend.LoadConfiguration(*dbFlag, backend.DBKey)
-	if err != nil {
-		log.Fatalf("Failed to load DB configuration - %v", err)
-	}
+func osctrlAPIService() {
+	log.Println("Initializing backend...")
 	for {
 		db, err = backend.GetDB(dbConfig)
 		if db != nil {
@@ -209,21 +364,21 @@ func main() {
 			log.Fatalf("Failed to close Database handler - %v", err)
 		}
 	}()
-	// Initialize users
+	log.Println("Initialize users")
 	apiUsers = users.CreateUserManager(db, &jwtConfig)
-	// Initialize tags
+	log.Println("Initialize tags")
 	tagsmgr = tags.CreateTagManager(db)
-	// Initialize environment
+	log.Println("Initialize environment")
 	envs = environments.CreateEnvironment(db)
 	// Initialize settings
+	log.Println("Initialize settings")
 	settingsmgr = settings.NewSettings(db)
-	// Initialize nodes
+	log.Println("Initialize nodes")
 	nodesmgr = nodes.CreateNodes(db)
-	// Initialize queries
+	log.Println("Initialize queries")
 	queriesmgr = queries.CreateQueries(db)
-	// Initialize carves
+	log.Println("Initialize carves")
 	filecarves = carves.CreateFileCarves(db)
-	// Initialize service settings
 	log.Println("Loading service settings")
 	loadingSettings()
 
@@ -309,7 +464,7 @@ func main() {
 
 	// Launch listeners for API server
 	serviceListener := apiConfig.Listener + ":" + apiConfig.Port
-	if *tlsServer {
+	if tlsServer {
 		cfg := &tls.Config{
 			MinVersion:               tls.VersionTLS12,
 			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
@@ -328,9 +483,64 @@ func main() {
 			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
 		}
 		log.Printf("%s v%s - HTTPS listening %s", serviceName, serviceVersion, serviceListener)
-		log.Fatal(srv.ListenAndServeTLS(*tlsCert, *tlsKey))
+		log.Fatal(srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile))
 	} else {
 		log.Printf("%s v%s - HTTP listening %s", serviceName, serviceVersion, serviceListener)
 		log.Fatal(http.ListenAndServe(serviceListener, routerAPI))
 	}
+}
+
+// Action to run when no flags are provided to run checks and prepare data
+func cliAction(c *cli.Context) error {
+	// Load configuration if external service JSON config file is used
+	if configFlag {
+		apiConfig, err = loadConfiguration(configFile)
+		if err != nil {
+			return fmt.Errorf("Failed to load service configuration %s - %s", configFile, err)
+		}
+	} else {
+		apiConfig.Logging = loggingValue.Value()
+	}
+	// Load DB configuration if external db JSON config file is used
+	if dbFlag {
+		dbConfig, err = backend.LoadConfiguration(dbConfigFile, backend.DBKey)
+		if err != nil {
+			return fmt.Errorf("Failed to load DB configuration - %v", err)
+		}
+	}
+	// Load JWT configuration if external JWT JSON config file is used
+	if jwtFlag {
+		jwtConfig, err = loadJWTConfiguration(jwtConfigFile)
+		if err != nil {
+			return fmt.Errorf("Failed to load JWT configuration - %v", err)
+		}
+	}
+	return nil
+}
+
+func main() {
+	// Initiate CLI and parse arguments
+	app = cli.NewApp()
+	app.Name = serviceName
+	app.Usage = appDescription
+	app.Version = serviceVersion
+	app.Description = appDescription
+	app.Flags = flags
+	// Define this command for help to exit when help flag is passed
+	app.Commands = []*cli.Command{
+		{
+			Name: "help",
+			Action: func(c *cli.Context) error {
+				cli.ShowAppHelpAndExit(c, 0)
+				return nil
+			},
+		},
+	}
+	app.Action = cliAction
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Service starts!
+	osctrlAPIService()
 }


### PR DESCRIPTION
Using https://github.com/urfave/cli v2 adding support to use environment variables for all parameters that were loaded with JSON files.