### PR TITLE
Using single logger and logger config file

### DIFF
--- a/admin/handlers/handlers.go
+++ b/admin/handlers/handlers.go
@@ -35,20 +35,21 @@ const okContent = "✅"
 
 // HandlersAdmin to keep all handlers for TLS
 type HandlersAdmin struct {
-	DB             *gorm.DB
-	Users          *users.UserManager
-	Tags           *tags.TagManager
-	Envs           *environments.Environment
-	Nodes          *nodes.NodeManager
-	Queries        *queries.Queries
-	Carves         *carves.Carves
-	Settings       *settings.Settings
-	Metrics        *metrics.Metrics
-	LoggerDB       *logging.LoggerDB
-	Sessions       *sessions.SessionManager
-	ServiceVersion string
-	OsqueryTables  []types.OsqueryTable
-	AdminConfig    *types.JSONConfigurationService
+	DB              *gorm.DB
+	Users           *users.UserManager
+	Tags            *tags.TagManager
+	Envs            *environments.Environment
+	Nodes           *nodes.NodeManager
+	Queries         *queries.Queries
+	Carves          *carves.Carves
+	Settings        *settings.Settings
+	Metrics         *metrics.Metrics
+	LoggerDB        *logging.LoggerDB
+	Sessions        *sessions.SessionManager
+	ServiceVersion  string
+	TemplatesFolder string
+	OsqueryTables   []types.OsqueryTable
+	AdminConfig     *types.JSONConfigurationService
 }
 
 type HandlersOption func(*HandlersAdmin)
@@ -122,6 +123,12 @@ func WithSessions(sessions *sessions.SessionManager) HandlersOption {
 func WithVersion(version string) HandlersOption {
 	return func(h *HandlersAdmin) {
 		h.ServiceVersion = version
+	}
+}
+
+func WithTemplates(templates string) HandlersOption {
+	return func(h *HandlersAdmin) {
+		h.TemplatesFolder = templates
 	}
 }
 

--- a/admin/handlers/templates.go
+++ b/admin/handlers/templates.go
@@ -15,10 +15,6 @@ import (
 	"github.com/jmpsec/osctrl/utils"
 )
 
-const (
-	templatesFilesFolder string = "tmpl_admin"
-)
-
 // TemplateFiles for building UI layout
 type TemplateFiles struct {
 	filepaths []string
@@ -61,9 +57,9 @@ func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin), false)
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder+"/login.html",
-		templatesFilesFolder+"/components/page-head.html",
-		templatesFilesFolder+"/components/page-js.html")
+		h.TemplatesFolder+"/login.html",
+		h.TemplatesFolder+"/components/page-head.html",
+		h.TemplatesFolder+"/components/page-js.html")
 	if err != nil {
 		h.Inc(metricAdminErr)
 		log.Printf("error getting login template: %v", err)
@@ -127,7 +123,7 @@ func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "table.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "table.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -208,13 +204,13 @@ func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder+"/table.html",
-		templatesFilesFolder+"/components/page-head.html",
-		templatesFilesFolder+"/components/page-js.html",
-		templatesFilesFolder+"/components/page-aside-right.html",
-		templatesFilesFolder+"/components/page-aside-left.html",
-		templatesFilesFolder+"/components/page-header.html",
-		templatesFilesFolder+"/components/page-modals.html")
+		h.TemplatesFolder+"/table.html",
+		h.TemplatesFolder+"/components/page-head.html",
+		h.TemplatesFolder+"/components/page-js.html",
+		h.TemplatesFolder+"/components/page-aside-right.html",
+		h.TemplatesFolder+"/components/page-aside-left.html",
+		h.TemplatesFolder+"/components/page-header.html",
+		h.TemplatesFolder+"/components/page-modals.html")
 	if err != nil {
 		h.Inc(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -277,13 +273,13 @@ func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Reques
 	}
 	// Prepare template
 	t, err := template.ParseFiles(
-		templatesFilesFolder+"/queries-run.html",
-		templatesFilesFolder+"/components/page-head.html",
-		templatesFilesFolder+"/components/page-js.html",
-		templatesFilesFolder+"/components/page-aside-right.html",
-		templatesFilesFolder+"/components/page-aside-left.html",
-		templatesFilesFolder+"/components/page-header.html",
-		templatesFilesFolder+"/components/page-modals.html")
+		h.TemplatesFolder+"/queries-run.html",
+		h.TemplatesFolder+"/components/page-head.html",
+		h.TemplatesFolder+"/components/page-js.html",
+		h.TemplatesFolder+"/components/page-aside-right.html",
+		h.TemplatesFolder+"/components/page-aside-left.html",
+		h.TemplatesFolder+"/components/page-header.html",
+		h.TemplatesFolder+"/components/page-modals.html")
 	if err != nil {
 		h.Inc(metricAdminErr)
 		log.Printf("error getting table template: %v", err)
@@ -352,7 +348,7 @@ func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "queries.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "queries.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -405,7 +401,7 @@ func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "saved.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "saved.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -458,7 +454,7 @@ func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "carves-run.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "carves-run.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -528,7 +524,7 @@ func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "carves.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "carves.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -593,7 +589,7 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 		"queryResultLink": h.queryResultLink,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "queries-logs.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "queries-logs.html").filepaths
 	t, err := template.New("queries-logs.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -669,7 +665,7 @@ func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "carves-details.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "carves-details.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -772,7 +768,7 @@ func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "conf.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "conf.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -846,7 +842,7 @@ func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "enroll.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "enroll.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -928,7 +924,7 @@ func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 		"resultLogsLink":  h.resultLogsLink,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "node.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "node.html").filepaths
 	t, err := template.New("node.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1041,7 +1037,7 @@ func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "environments.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "environments.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1107,7 +1103,7 @@ func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "settings.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "settings.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1179,7 +1175,7 @@ func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) 
 		"inFutureTime":    utils.InFutureTime,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "users.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "users.html").filepaths
 	t, err := template.New("users.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1244,7 +1240,7 @@ func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
 		"inFutureTime":    utils.InFutureTime,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "tags.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "tags.html").filepaths
 	t, err := template.New("tags.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1308,7 +1304,7 @@ func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Req
 		"pastFutureTimes": utils.PastFutureTimes,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(templatesFilesFolder, "profile.html").filepaths
+	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "profile.html").filepaths
 	t, err := template.New("profile.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)

--- a/admin/handlers/utils.go
+++ b/admin/handlers/utils.go
@@ -179,7 +179,7 @@ func toJSONConfigurationService(values []settings.SettingValue) types.JSONConfig
 			cfg.Auth = v.String
 		}
 		if v.Name == settings.JSONLogging {
-			cfg.Logging = strings.Split(v.String, ",")
+			cfg.Logger = v.String
 		}
 	}
 	return cfg

--- a/admin/main.go
+++ b/admin/main.go
@@ -81,7 +81,9 @@ const (
 // Random
 const (
 	// Static files folder
-	staticFilesFolder string = "./static"
+	defStaticFilesFolder string = "./static"
+	// Default templates folder
+	defTemplatesFolder string = "./tmpl_admin"
 	// Default refreshing interval in seconds
 	defaultRefresh int = 300
 	// Default hours to classify nodes as inactive
@@ -132,7 +134,6 @@ var (
 	configFile           string
 	dbFlag               bool
 	dbConfigFile         string
-	dbConfigFileLogger   string
 	tlsServer            bool
 	tlsCertFile          string
 	tlsKeyFile           string
@@ -143,6 +144,8 @@ var (
 	osqueryTablesFile    string
 	osqueryTablesVersion string
 	loggerFile           string
+	staticFilesFolder    string
+	templatesFolder      string
 )
 
 // SAML variables
@@ -240,7 +243,7 @@ func init() {
 		&cli.StringFlag{
 			Name:        "auth",
 			Aliases:     []string{"A"},
-			Value:       settings.AuthNone,
+			Value:       settings.AuthDB,
 			Usage:       "Authentication mechanism for the service",
 			EnvVars:     []string{"SERVICE_AUTH"},
 			Destination: &adminConfig.Auth,
@@ -421,6 +424,21 @@ func init() {
 			EnvVars:     []string{"LOGGER_FILE"},
 			Destination: &loggerFile,
 		},
+		&cli.StringFlag{
+			Name:        "static",
+			Aliases:     []string{"s"},
+			Value:       defStaticFilesFolder,
+			Usage:       "Directory with all the static files needed for the osctrl-admin UI",
+			EnvVars:     []string{"STATIC_FILES"},
+			Destination: &staticFilesFolder,
+		},
+		&cli.StringFlag{
+			Name:        "templates",
+			Value:       defTemplatesFolder,
+			Usage:       "Directory with all the static files needed for the osctrl-admin UI",
+			EnvVars:     []string{"STATIC_FILES"},
+			Destination: &templatesFolder,
+		},
 	}
 	// Logging format flags
 	log.SetFlags(log.Lshortfile)
@@ -473,7 +491,7 @@ func osctrlAdminService() {
 		log.Fatalf("Error loading metrics - %v", err)
 	}
 	// Initialize DB logger
-	loggerDB, err = logging.CreateLoggerDB(dbConfigFile)
+	loggerDB, err = logging.CreateLoggerDB(loggerFile)
 	if err != nil {
 		log.Fatalf("Error loading logger - %v", err)
 	}
@@ -566,6 +584,7 @@ func osctrlAdminService() {
 		ahandlers.WithLoggerDB(loggerDB),
 		ahandlers.WithSessions(sessionsmgr),
 		ahandlers.WithVersion(serviceVersion),
+		ahandlers.WithTemplates(templatesFolder),
 		ahandlers.WithOsqueryTables(osqueryTables),
 		ahandlers.WithAdminConfig(&adminConfig),
 	)

--- a/admin/settings.go
+++ b/admin/settings.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/jmpsec/osctrl/metrics"
 	"github.com/jmpsec/osctrl/settings"
@@ -106,8 +105,7 @@ func loadingSettings(mgr *settings.Settings) error {
 		return fmt.Errorf("Failed to load logging settings: %v", err)
 	}
 	// Write JSON config to settings
-	logging := strings.Join(adminConfig.Logging, ",")
-	if err := mgr.SetAllJSON(settings.ServiceAdmin, adminConfig.Listener, adminConfig.Port, adminConfig.Host, adminConfig.Auth, logging); err != nil {
+	if err := mgr.SetAllJSON(settings.ServiceAdmin, adminConfig.Listener, adminConfig.Port, adminConfig.Host, adminConfig.Auth, adminConfig.Logger); err != nil {
 		return fmt.Errorf("Failed to add JSON values to configuration: %v", err)
 	}
 	return nil

--- a/admin/utils.go
+++ b/admin/utils.go
@@ -75,7 +75,7 @@ func toJSONConfigurationService(values []settings.SettingValue) types.JSONConfig
 			cfg.Auth = v.String
 		}
 		if v.Name == settings.JSONLogging {
-			cfg.Logging = strings.Split(v.String, ",")
+			cfg.Logger = v.String
 		}
 	}
 	return cfg

--- a/api/main.go
+++ b/api/main.go
@@ -108,7 +108,7 @@ var (
 var (
 	configFlag    bool
 	configFile    string
-	loggingValue  cli.StringSlice
+	loggerValue   string
 	dbFlag        bool
 	dbConfigFile  string
 	jwtFlag       bool
@@ -183,7 +183,7 @@ func init() {
 		&cli.StringFlag{
 			Name:        "port",
 			Aliases:     []string{"p"},
-			Value:       "9000",
+			Value:       "9002",
 			Usage:       "TCP port for the service",
 			EnvVars:     []string{"SERVICE_PORT"},
 			Destination: &apiConfig.Port,
@@ -204,13 +204,13 @@ func init() {
 			EnvVars:     []string{"SERVICE_HOST"},
 			Destination: &apiConfig.Host,
 		},
-		&cli.StringSliceFlag{
+		&cli.StringFlag{
 			Name:        "logging",
 			Aliases:     []string{"L"},
-			Value:       &cli.StringSlice{},
+			Value:       settings.LoggingNone,
 			Usage:       "Logging mechanism to handle logs from nodes",
 			EnvVars:     []string{"SERVICE_LOGGING"},
-			Destination: &loggingValue,
+			Destination: &loggerValue,
 		},
 		&cli.BoolFlag{
 			Name:        "db",

--- a/api/main.go
+++ b/api/main.go
@@ -145,10 +145,8 @@ func loadConfiguration(file string) (types.JSONConfigurationService, error) {
 	if !validAuth[cfg.Auth] {
 		return cfg, fmt.Errorf("Invalid auth method: '%s'", cfg.Auth)
 	}
-	for _, _l := range cfg.Logging {
-		if !validLogging[_l] {
-			return cfg, fmt.Errorf("Invalid logging method")
-		}
+	if !validLogging[cfg.Logger] {
+		return cfg, fmt.Errorf("Invalid logging method")
 	}
 	// No errors!
 	return cfg, nil
@@ -498,8 +496,6 @@ func cliAction(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("Failed to load service configuration %s - %s", configFile, err)
 		}
-	} else {
-		apiConfig.Logging = loggingValue.Value()
 	}
 	// Load DB configuration if external db JSON config file is used
 	if dbFlag {

--- a/api/settings.go
+++ b/api/settings.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"strings"
 
 	"github.com/jmpsec/osctrl/metrics"
 	"github.com/jmpsec/osctrl/settings"
@@ -85,8 +84,7 @@ func loadingSettings() {
 	// Metrics
 	loadingMetrics()
 	// Write JSON config to settings
-	logging := strings.Join(apiConfig.Logging, ",")
-	if err := settingsmgr.SetAllJSON(settings.ServiceAPI, apiConfig.Listener, apiConfig.Port, apiConfig.Host, apiConfig.Auth, logging); err != nil {
+	if err := settingsmgr.SetAllJSON(settings.ServiceAPI, apiConfig.Listener, apiConfig.Port, apiConfig.Host, apiConfig.Auth, apiConfig.Logger); err != nil {
 		log.Fatalf("Failed to add JSON values to configuration: %v", err)
 	}
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -49,7 +49,6 @@ var (
 
 // Variables for flags
 var (
-	configFile   string
 	dbFlag       bool
 	dbConfigFile string
 )
@@ -72,7 +71,7 @@ func init() {
 			Value:       defDBConfigurationFile,
 			Usage:       "Load DB configuration from `FILE`",
 			EnvVars:     []string{"DB_CONFIG_FILE"},
-			Destination: &configFile,
+			Destination: &dbConfigFile,
 		},
 	}
 	// Initialize CLI flags commands

--- a/deploy/config/service.json
+++ b/deploy/config/service.json
@@ -4,6 +4,6 @@
     "port": "_SERVICE_PORT",
     "host": "_SERVICE_HOST",
     "auth": "_SERVICE_AUTH",
-    "logging": "_SERVICE_LOGGING"
+    "logger": "_SERVICE_LOGGING"
   }
 }

--- a/deploy/docker/Dockerfile-osctrl-dev
+++ b/deploy/docker/Dockerfile-osctrl-dev
@@ -30,6 +30,7 @@ COPY deploy/docker/conf/osctrl/db.json /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_NAME }}#${POSTGRES_DB_NAME}#g" /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_USERNAME }}#${POSTGRES_DB_USERNAME}#g" /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_PASSWORD }}#${POSTGRES_DB_PASSWORD}#g" /opt/osctrl/config/db.json
+RUN cp /opt/osctrl/config/db.json /opt/osctrl/config/logger.json
 
 USER osctrl-tls
 EXPOSE 9000
@@ -107,11 +108,12 @@ RUN go build -o /opt/osctrl/bin/osctrl-cli cli/*.go
 COPY /go/src/osctrl/deploy/docker/conf/osctrl/admin/admin.json /opt/osctrl/config/admin.json
 COPY /go/src/osctrl/deploy/docker/conf/osctrl/jwt.json /opt/osctrl/config/jwt.json
 RUN sed -i "s#{{ JWT_SECRET }}#${JWT_SECRET}#g" /opt/osctrl/config/jwt.json
-
 COPY /go/src/osctrl/deploy/docker/conf/osctrl/db.json /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_NAME }}#${POSTGRES_DB_NAME}#g" /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_USERNAME }}#${POSTGRES_DB_USERNAME}#g" /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_PASSWORD }}#${POSTGRES_DB_PASSWORD}#g" /opt/osctrl/config/db.json
+RUN cp /opt/osctrl/config/db.json /opt/osctrl/config/logger.json
+
 RUN chown osctrl-admin:osctrl-admin -R /opt/osctrl/config
 
 ### Copy osctrl-admin web templates ###

--- a/deploy/docker/Dockerfile-osctrl-prod
+++ b/deploy/docker/Dockerfile-osctrl-prod
@@ -45,6 +45,7 @@ COPY deploy/docker/conf/osctrl/db.json /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_NAME }}#${POSTGRES_DB_NAME}#g" /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_USERNAME }}#${POSTGRES_DB_USERNAME}#g" /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_PASSWORD }}#${POSTGRES_DB_PASSWORD}#g" /opt/osctrl/config/db.json
+RUN cp /opt/osctrl/config/db.json /opt/osctrl/config/logger.json
 
 USER osctrl-tls
 EXPOSE 9000
@@ -110,6 +111,7 @@ COPY deploy/docker/conf/osctrl/db.json /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_NAME }}#${POSTGRES_DB_NAME}#g" /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_USERNAME }}#${POSTGRES_DB_USERNAME}#g" /opt/osctrl/config/db.json
 RUN sed -i "s#{{ POSTGRES_DB_PASSWORD }}#${POSTGRES_DB_PASSWORD}#g" /opt/osctrl/config/db.json
+RUN cp /opt/osctrl/config/db.json /opt/osctrl/config/logger.json
 RUN chown osctrl-admin:osctrl-admin -R /opt/osctrl/config
 
 ### Copy osctrl-admin web templates ###

--- a/deploy/docker/conf/osctrl/admin/admin.json
+++ b/deploy/docker/conf/osctrl/admin/admin.json
@@ -4,6 +4,6 @@
       "port": "9001",
       "host": "0.0.0.0",
       "auth": "db",
-      "logging": "db"
+      "logger": "db"
     }
 }

--- a/deploy/docker/conf/osctrl/api/api.json
+++ b/deploy/docker/conf/osctrl/api/api.json
@@ -4,6 +4,6 @@
     "port": "9002",
     "host": "localhost",
     "auth": "jwt",
-    "logging": "none"
+    "logger": "none"
   }
 }

--- a/deploy/docker/conf/osctrl/tls/tls.json
+++ b/deploy/docker/conf/osctrl/tls/tls.json
@@ -4,6 +4,6 @@
       "port": "9000",
       "host": "0.0.0.0",
       "auth": "none",
-      "logging": "db"
+      "logger": "db"
     }
 }

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -141,6 +141,7 @@ ADMIN_CONF="$ADMIN_COMPONENT.json"
 API_CONF="$API_COMPONENT.json"
 DB_CONF="db.json"
 JWT_CONF="jwt.json"
+LOGGER_CONF="logger.json"
 SERVICE_TEMPLATE="service.json"
 DB_TEMPLATE="db.json"
 JWT_TEMPLATE="jwt.json"
@@ -644,6 +645,9 @@ else
 
   # Generate DB configuration file for services
   configuration_db "$SOURCE_PATH/deploy/config/$DB_TEMPLATE" "$DEST_PATH/config/$DB_CONF" "$_DB_HOST" "$_DB_PORT" "$_DB_NAME" "$_DB_USER" "$_DB_PASS" "sudo"
+
+  # Prepare DB logger configuration for services
+  sudo cp "$DEST_PATH/config/$DB_CONF" "$DEST_PATH/config/$LOGGER_CONF"
 
   # JWT configuration
   cat "$SOURCE_PATH/deploy/config/$JWT_TEMPLATE" | sed "s|_JWT_SECRET|$_JWT_SECRET|g" | sudo tee "$DEST_PATH/config/$JWT_CONF"

--- a/logging/db.go
+++ b/logging/db.go
@@ -61,9 +61,9 @@ type LoggerDB struct {
 	Enabled       bool
 }
 
-func CreateLoggerDB(dbfile, dbname string) (*LoggerDB, error) {
+func CreateLoggerDB(dbfile string) (*LoggerDB, error) {
 	// Load DB configuration
-	config, err := backend.LoadConfiguration(dbfile, dbname)
+	config, err := backend.LoadConfiguration(dbfile, settings.LoggingDB)
 	if err != nil {
 		return nil, err
 	}

--- a/logging/graylog.go
+++ b/logging/graylog.go
@@ -12,13 +12,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-const (
-	// GraylogName as JSON key for configuration
-	GraylogName string = "graylog"
-	// GraylogFile as default file for configuration
-	GraylogFile string = "config/" + GraylogName + ".json"
-)
-
 // GraylogConfiguration to hold all graylog configuration values
 type GraylogConfiguration struct {
 	URL     string `json:"url"`
@@ -38,7 +31,7 @@ func LoadGraylog(file string) (GraylogConfiguration, error) {
 	if err != nil {
 		return _graylogCfg, err
 	}
-	cfgRaw := viper.Sub(GraylogName)
+	cfgRaw := viper.Sub(settings.LoggingGraylog)
 	err = cfgRaw.Unmarshal(&_graylogCfg)
 	if err != nil {
 		return _graylogCfg, err
@@ -54,8 +47,8 @@ type LoggerGraylog struct {
 	Enabled       bool
 }
 
-func CreateLoggerGraylog() (*LoggerGraylog, error) {
-	config, err := LoadGraylog(GraylogFile)
+func CreateLoggerGraylog(graylogFile string) (*LoggerGraylog, error) {
+	config, err := LoadGraylog(graylogFile)
 	if err != nil {
 		return nil, err
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,104 +1,111 @@
 package logging
 
 import (
+	"log"
+
 	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/queries"
 	"github.com/jmpsec/osctrl/settings"
 )
 
-const (
-	// DBName as JSON key for configuration
-	DBName string = "db"
-	// DBFile as default file for configuration
-	DBFile string = "config/" + DBName + ".json"
-)
-
 // LoggerTLS will be used to handle logging for the TLS endpoint
 type LoggerTLS struct {
-	DB      *LoggerDB
-	Graylog *LoggerGraylog
-	Splunk  *LoggerSplunk
-	Logging []string
+	Logging string
+	Logger  interface{}
 	Nodes   *nodes.NodeManager
 	Queries *queries.Queries
 }
 
 // CreateLoggerTLS to instantiate a new logger for the TLS endpoint
-func CreateLoggerTLS(logging []string, mgr *settings.Settings, nodes *nodes.NodeManager, queries *queries.Queries) (*LoggerTLS, error) {
+func CreateLoggerTLS(logging, loggingFile string, mgr *settings.Settings, nodes *nodes.NodeManager, queries *queries.Queries) (*LoggerTLS, error) {
 	l := &LoggerTLS{
-		DB:      &LoggerDB{},
-		Splunk:  &LoggerSplunk{},
 		Logging: logging,
-		Graylog: &LoggerGraylog{},
 		Nodes:   nodes,
 		Queries: queries,
 	}
-	for _, _l := range logging {
-		switch _l {
-		case settings.LoggingSplunk:
-			s, err := CreateLoggerSplunk()
-			if err != nil {
-				return nil, err
-			}
-			s.Settings(mgr)
-			l.Splunk = s
-		case settings.LoggingGraylog:
-			g, err := CreateLoggerGraylog()
-			if err != nil {
-				return nil, err
-			}
-			g.Settings(mgr)
-			l.Graylog = g
+	switch logging {
+	case settings.LoggingSplunk:
+		s, err := CreateLoggerSplunk(loggingFile)
+		if err != nil {
+			return nil, err
 		}
+		s.Settings(mgr)
+		l.Logger = s
+	case settings.LoggingGraylog:
+		g, err := CreateLoggerGraylog(loggingFile)
+		if err != nil {
+			return nil, err
+		}
+		g.Settings(mgr)
+		l.Logger = g
+	case settings.LoggingDB:
+		d, err := CreateLoggerDB(loggingFile)
+		if err != nil {
+			return nil, err
+		}
+		d.Settings(mgr)
+		l.Logger = d
 	}
 	// Initialize the DB logger anyway
-	d, err := CreateLoggerDB(DBFile, DBName)
-	if err != nil {
-		return nil, err
-	}
-	d.Settings(mgr)
-	l.DB = d
 	return l, nil
 }
 
 // Log will send status/result logs via the configured method of logging
 func (logTLS *LoggerTLS) Log(logType string, data []byte, environment, uuid string, debug bool) {
-	for _, _l := range logTLS.Logging {
-		switch _l {
-		case settings.LoggingSplunk:
-			if logTLS.Splunk.Enabled {
-				logTLS.Splunk.Send(logType, data, environment, uuid, debug)
-			}
-		case settings.LoggingGraylog:
-			if logTLS.Graylog.Enabled {
-				logTLS.Graylog.Send(logType, data, environment, uuid, debug)
-			}
+	switch logTLS.Logging {
+	case settings.LoggingSplunk:
+		l, ok := logTLS.Logger.(LoggerSplunk)
+		if !ok {
+			log.Printf("error casting logger to %s", settings.LoggingSplunk)
 		}
-	}
-	// TODO: Log to db to keep 24 hours of logs locally
-	// https://github.com/jmpsec/osctrl/issues/19
-	// Logging to DB happens anyway
-	if logTLS.DB.Enabled {
-		logTLS.DB.Log(logType, data, environment, uuid, debug)
+		if l.Enabled {
+			l.Send(logType, data, environment, uuid, debug)
+		}
+	case settings.LoggingGraylog:
+		l, ok := logTLS.Logger.(LoggerGraylog)
+		if !ok {
+			log.Printf("error casting logger to %s", settings.LoggingGraylog)
+		}
+		if l.Enabled {
+			l.Send(logType, data, environment, uuid, debug)
+		}
+	case settings.LoggingDB:
+		l, ok := logTLS.Logger.(LoggerDB)
+		if !ok {
+			log.Printf("error casting logger to %s", settings.LoggingDB)
+		}
+		if l.Enabled {
+			l.Log(logType, data, environment, uuid, debug)
+		}
 	}
 }
 
 // LogQuery will send query result logs via the configured method of logging
 func (logTLS *LoggerTLS) QueryLog(logType string, data []byte, environment, uuid, name string, status int, debug bool) {
-	for _, _l := range logTLS.Logging {
-		switch _l {
-		case settings.LoggingSplunk:
-			if logTLS.Splunk.Enabled {
-				logTLS.Splunk.Send(logType, data, environment, uuid, debug)
-			}
-		case settings.LoggingGraylog:
-			if logTLS.Graylog.Enabled {
-				logTLS.Graylog.Send(logType, data, environment, uuid, debug)
-			}
+	switch logTLS.Logging {
+	case settings.LoggingSplunk:
+		l, ok := logTLS.Logger.(LoggerSplunk)
+		if !ok {
+			log.Printf("error casting logger to %s", settings.LoggingSplunk)
 		}
-	}
-	// Logging to DB happens anyway
-	if logTLS.DB.Enabled {
-		logTLS.DB.Query(data, environment, uuid, name, status, debug)
+		if l.Enabled {
+			l.Send(logType, data, environment, uuid, debug)
+		}
+	case settings.LoggingGraylog:
+		l, ok := logTLS.Logger.(LoggerGraylog)
+		if !ok {
+			log.Printf("error casting logger to %s", settings.LoggingGraylog)
+		}
+		if l.Enabled {
+			l.Send(logType, data, environment, uuid, debug)
+		}
+	case settings.LoggingDB:
+		l, ok := logTLS.Logger.(LoggerDB)
+		if !ok {
+			log.Printf("error casting logger to %s", settings.LoggingDB)
+		}
+		if l.Enabled {
+			l.Query(data, environment, uuid, name, status, debug)
+		}
 	}
 }

--- a/logging/splunk.go
+++ b/logging/splunk.go
@@ -12,13 +12,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-const (
-	// SplunkName as JSON key for configuration
-	SplunkName string = "splunk"
-	// SplunkFile as default file for configuration
-	SplunkFile string = "config/" + SplunkName + ".json"
-)
-
 // SlunkConfiguration to hold all splunk configuration values
 type SlunkConfiguration struct {
 	URL     string `json:"url"`
@@ -37,15 +30,15 @@ type LoggerSplunk struct {
 	Enabled       bool
 }
 
-func CreateLoggerSplunk() (*LoggerSplunk, error) {
-	config, err := LoadSplunk(SplunkFile)
+func CreateLoggerSplunk(splunkFile string) (*LoggerSplunk, error) {
+	config, err := LoadSplunk(splunkFile)
 	if err != nil {
 		return nil, err
 	}
 	l := &LoggerSplunk{
 		Configuration: config,
 		Headers: map[string]string{
-			"Authorization":   "Splunk " + config.Token,
+			utils.Authorization:   "Splunk " + config.Token,
 			utils.ContentType: utils.JSONApplicationUTF8,
 		},
 		Enabled: true,
@@ -62,7 +55,7 @@ func LoadSplunk(file string) (SlunkConfiguration, error) {
 	if err := viper.ReadInConfig(); err != nil {
 		return _splunkCfg, err
 	}
-	cfgRaw := viper.Sub(SplunkName)
+	cfgRaw := viper.Sub(settings.LoggingSplunk)
 	if err := cfgRaw.Unmarshal(&_splunkCfg); err != nil {
 		return _splunkCfg, err
 	}

--- a/tls/settings.go
+++ b/tls/settings.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/jmpsec/osctrl/metrics"
 	"github.com/jmpsec/osctrl/settings"
@@ -62,8 +61,7 @@ func loadingSettings(mgr *settings.Settings) error {
 		}
 	}
 	// Write JSON config to settings
-	logging := strings.Join(tlsConfig.Logging, ",")
-	if err := mgr.SetAllJSON(settings.ServiceTLS, tlsConfig.Listener, tlsConfig.Port, tlsConfig.Host, tlsConfig.Auth, logging); err != nil {
+	if err := mgr.SetAllJSON(settings.ServiceTLS, tlsConfig.Listener, tlsConfig.Port, tlsConfig.Host, tlsConfig.Auth, tlsConfig.Logger); err != nil {
 		return fmt.Errorf("Failed to add JSON values to configuration: %v", err)
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -2,11 +2,11 @@ package types
 
 // JSONConfigurationService to hold all service configuration values
 type JSONConfigurationService struct {
-	Listener string   `json:"listener"`
-	Port     string   `json:"port"`
-	Host     string   `json:"host"`
-	Auth     string   `json:"auth"`
-	Logging  []string `json:"logging"`
+	Listener string `json:"listener"`
+	Port     string `json:"port"`
+	Host     string `json:"host"`
+	Auth     string `json:"auth"`
+	Logger   string `json:"logger"`
 }
 
 // JSONConfigurationHeaders to keep all headers details for auth

--- a/utils/http-utils.go
+++ b/utils/http-utils.go
@@ -31,6 +31,9 @@ const ContentType string = "Content-Type"
 // UserAgent for header key
 const UserAgent string = "User-Agent"
 
+// Authorization for header key
+const Authorization string = "Authorization"
+
 // osctrlUserAgent for customized User-Agent
 const osctrlUserAgent string = "osctrl-http-client/1.1"
 


### PR DESCRIPTION
- Using new environment variable to specify the location for the logger configuration.
- Using single logger for status/result logs coming from nodes.
- Don't log to db logger regardless, only if it is enabled.
- Updated `provision.sh` to use the new configuration file.
- Updated docker configurations to use the new configuration file.