### PR TITLE
Fix for #209 with osctrl-admin and osctrl-api using SERVICE_LOGGER

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -261,7 +261,7 @@ func init() {
 			Aliases:     []string{"L"},
 			Value:       settings.LoggingDB,
 			Usage:       "Logging mechanism to handle logs from nodes",
-			EnvVars:     []string{"SERVICE_LOGGING"},
+			EnvVars:     []string{"SERVICE_LOGGER"},
 			Destination: &adminConfig.Logger,
 		},
 		&cli.BoolFlag{

--- a/api/main.go
+++ b/api/main.go
@@ -209,7 +209,7 @@ func init() {
 			Aliases:     []string{"L"},
 			Value:       settings.LoggingNone,
 			Usage:       "Logging mechanism to handle logs from nodes",
-			EnvVars:     []string{"SERVICE_LOGGING"},
+			EnvVars:     []string{"SERVICE_LOGGER"},
 			Destination: &loggerValue,
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
Fix for #209 and the correct env variable is used, `SERVICE_LOGGER`, to prevent the service attempting to load the default logger configuration file `config/logger.json`. Also for loggers that do not require external configuration (`none`, `stdout`, `file`) the error should not happen. Also affects `osctrl-api`.