### PR TITLE
Provide session key in configuration

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -161,9 +161,9 @@ var (
 
 // Valid values for auth in configuration
 var validAuth = map[string]bool{
-	settings.AuthDB:      true,
-	settings.AuthSAML:    true,
-	settings.AuthJSON:    true,
+	settings.AuthDB:   true,
+	settings.AuthSAML: true,
+	settings.AuthJSON: true,
 }
 
 // Valid values for logging in configuration
@@ -248,6 +248,13 @@ func init() {
 			Usage:       "Exposed hostname the service uses",
 			EnvVars:     []string{"SERVICE_HOST"},
 			Destination: &adminConfig.Host,
+		},
+		&cli.StringFlag{
+			Name:        "session-key",
+			Value:       "",
+			Usage:       "Session key to generate cookies from it",
+			EnvVars:     []string{"SESSION_KEY"},
+			Destination: &adminConfig.SessionKey,
 		},
 		&cli.StringFlag{
 			Name:        "logging",
@@ -531,7 +538,7 @@ func osctrlAdminService() {
 	log.Println("Initialize carves")
 	carvesmgr = carves.CreateFileCarves(db.Conn)
 	log.Println("Initialize sessions")
-	sessionsmgr = sessions.CreateSessionManager(db.Conn, projectName)
+	sessionsmgr = sessions.CreateSessionManager(db.Conn, projectName, adminConfig.SessionKey)
 	log.Println("Loading service settings")
 	if err := loadingSettings(settingsmgr); err != nil {
 		log.Fatalf("Error loading settings - %v", err)

--- a/api/auth.go
+++ b/api/auth.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/jmpsec/osctrl/settings"
+	"github.com/jmpsec/osctrl/utils"
 )
 
 // contextValue to hold session data in the context
@@ -70,7 +71,7 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 				return
 			}
 			// Update metadata for the user
-			if err := apiUsers.UpdateTokenIPAddress(r.Header.Get("X-Real-IP"), claims.Username); err != nil {
+			if err := apiUsers.UpdateTokenIPAddress(r.Header.Get(utils.XRealIP), claims.Username); err != nil {
 				log.Printf("error updating token for user %s: %v", claims.Username, err)
 			}
 			// Set middleware values

--- a/tls/handlers/handlers.go
+++ b/tls/handlers/handlers.go
@@ -214,7 +214,7 @@ func (h *HandlersTLS) EnrollHandler(w http.ResponseWriter, r *http.Request) {
 	if h.checkValidSecret(t.EnrollSecret, env.Name) {
 		// Generate node_key using UUID as entropy
 		nodeKey = generateNodeKey(t.HostIdentifier, time.Now())
-		newNode = nodeFromEnroll(t, env.Name, r.Header.Get("X-Real-IP"), nodeKey)
+		newNode = nodeFromEnroll(t, env.Name, r.Header.Get(utils.XRealIP), nodeKey)
 		// Check if UUID exists already, if so archive node and enroll new node
 		if h.Nodes.CheckByUUIDEnv(t.HostIdentifier, env.Name) {
 			if err := h.Nodes.Archive(t.HostIdentifier, "exists"); err != nil {
@@ -292,7 +292,7 @@ func (h *HandlersTLS) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Check if provided node_key is valid and if so, update node
 	if h.Nodes.CheckByKey(t.NodeKey) {
-		err = h.Nodes.UpdateIPAddressByKey(r.Header.Get("X-Real-IP"), t.NodeKey)
+		err = h.Nodes.UpdateIPAddressByKey(r.Header.Get(utils.XRealIP), t.NodeKey)
 		if err != nil {
 			h.Inc(metricConfigErr)
 			log.Printf("error updating IP address %v", err)
@@ -380,7 +380,7 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 	if h.Nodes.CheckByKey(t.NodeKey) {
 		nodeInvalid = false
 		// Process logs and update metadata
-		go h.Logs.ProcessLogs(t.Data, t.LogType, env.Name, r.Header.Get("X-Real-IP"), (*h.EnvsMap)[env.Name].DebugHTTP)
+		go h.Logs.ProcessLogs(t.Data, t.LogType, env.Name, r.Header.Get(utils.XRealIP), (*h.EnvsMap)[env.Name].DebugHTTP)
 	} else {
 		nodeInvalid = true
 	}
@@ -434,7 +434,7 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 	// Lookup node by node_key
 	node, err := h.Nodes.GetByKey(t.NodeKey)
 	if err == nil {
-		err = h.Nodes.UpdateIPAddress(r.Header.Get("X-Real-IP"), node)
+		err = h.Nodes.UpdateIPAddress(r.Header.Get(utils.XRealIP), node)
 		if err != nil {
 			h.Inc(metricReadErr)
 			log.Printf("error updating IP Address %v", err)
@@ -509,7 +509,7 @@ func (h *HandlersTLS) QueryWriteHandler(w http.ResponseWriter, r *http.Request) 
 	var nodeInvalid bool
 	// Check if provided node_key is valid and if so, update node
 	if h.Nodes.CheckByKey(t.NodeKey) {
-		if err := h.Nodes.UpdateIPAddressByKey(r.Header.Get("X-Real-IP"), t.NodeKey); err != nil {
+		if err := h.Nodes.UpdateIPAddressByKey(r.Header.Get(utils.XRealIP), t.NodeKey); err != nil {
 			h.Inc(metricWriteErr)
 			log.Printf("error updating IP Address %v", err)
 		}
@@ -650,7 +650,7 @@ func (h *HandlersTLS) CarveInitHandler(w http.ResponseWriter, r *http.Request) {
 	var carveSessionID string
 	// Check if provided node_key is valid and if so, update node
 	if h.Nodes.CheckByKey(t.NodeKey) {
-		if err := h.Nodes.UpdateIPAddressByKey(r.Header.Get("X-Real-IP"), t.NodeKey); err != nil {
+		if err := h.Nodes.UpdateIPAddressByKey(r.Header.Get(utils.XRealIP), t.NodeKey); err != nil {
 			h.Inc(metricInitErr)
 			log.Printf("error updating IP Address %v", err)
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -2,11 +2,12 @@ package types
 
 // JSONConfigurationService to hold all service configuration values
 type JSONConfigurationService struct {
-	Listener string `json:"listener"`
-	Port     string `json:"port"`
-	Host     string `json:"host"`
-	Auth     string `json:"auth"`
-	Logger   string `json:"logger"`
+	Listener   string `json:"listener"`
+	Port       string `json:"port"`
+	Host       string `json:"host"`
+	Auth       string `json:"auth"`
+	Logger     string `json:"logger"`
+	SessionKey string `json:"sessionKey"`
 }
 
 // JSONConfigurationHeaders to keep all headers details for auth

--- a/utils/http-utils.go
+++ b/utils/http-utils.go
@@ -31,6 +31,9 @@ const ContentType string = "Content-Type"
 // UserAgent for header key
 const UserAgent string = "User-Agent"
 
+// XRealIP for header key
+const XRealIP string = "X-Real-IP"
+
 // Authorization for header key
 const Authorization string = "Authorization"
 


### PR DESCRIPTION
- Added configuration parameter for `osctrl-admin` to provide an static session key so sessions won't reset after service restarts.
- Header constant for `X-Real-IP`