### PR TITLE
Fix for empty IP address when `X-Real-IP` not present

### DIFF
--- a/admin/sessions/sessions.go
+++ b/admin/sessions/sessions.go
@@ -134,7 +134,7 @@ func (sm *SessionManager) GetByUsername(username string) ([]UserSession, error) 
 func (sm *SessionManager) New(r *http.Request, username, level string) (UserSession, error) {
 	session := UserSession{
 		Username:  username,
-		IPAddress: r.Header.Get(utils.XRealIP),
+		IPAddress: utils.GetIP(r),
 		UserAgent: r.Header.Get(utils.UserAgent),
 		ExpiresAt: time.Now().Add(time.Duration(defaultMaxAge) * time.Second),
 	}

--- a/api/auth.go
+++ b/api/auth.go
@@ -71,7 +71,7 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 				return
 			}
 			// Update metadata for the user
-			if err := apiUsers.UpdateTokenIPAddress(r.Header.Get(utils.XRealIP), claims.Username); err != nil {
+			if err := apiUsers.UpdateTokenIPAddress(utils.GetIP(r), claims.Username); err != nil {
 				log.Printf("error updating token for user %s: %v", claims.Username, err)
 			}
 			// Set middleware values

--- a/tls/handlers/handlers.go
+++ b/tls/handlers/handlers.go
@@ -214,7 +214,7 @@ func (h *HandlersTLS) EnrollHandler(w http.ResponseWriter, r *http.Request) {
 	if h.checkValidSecret(t.EnrollSecret, env.Name) {
 		// Generate node_key using UUID as entropy
 		nodeKey = generateNodeKey(t.HostIdentifier, time.Now())
-		newNode = nodeFromEnroll(t, env.Name, r.Header.Get(utils.XRealIP), nodeKey)
+		newNode = nodeFromEnroll(t, env.Name, utils.GetIP(r), nodeKey)
 		// Check if UUID exists already, if so archive node and enroll new node
 		if h.Nodes.CheckByUUIDEnv(t.HostIdentifier, env.Name) {
 			if err := h.Nodes.Archive(t.HostIdentifier, "exists"); err != nil {
@@ -292,7 +292,7 @@ func (h *HandlersTLS) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Check if provided node_key is valid and if so, update node
 	if h.Nodes.CheckByKey(t.NodeKey) {
-		err = h.Nodes.UpdateIPAddressByKey(r.Header.Get(utils.XRealIP), t.NodeKey)
+		err = h.Nodes.UpdateIPAddressByKey(utils.GetIP(r), t.NodeKey)
 		if err != nil {
 			h.Inc(metricConfigErr)
 			log.Printf("error updating IP address %v", err)
@@ -380,7 +380,7 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 	if h.Nodes.CheckByKey(t.NodeKey) {
 		nodeInvalid = false
 		// Process logs and update metadata
-		go h.Logs.ProcessLogs(t.Data, t.LogType, env.Name, r.Header.Get(utils.XRealIP), (*h.EnvsMap)[env.Name].DebugHTTP)
+		go h.Logs.ProcessLogs(t.Data, t.LogType, env.Name, utils.GetIP(r), (*h.EnvsMap)[env.Name].DebugHTTP)
 	} else {
 		nodeInvalid = true
 	}
@@ -434,7 +434,7 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 	// Lookup node by node_key
 	node, err := h.Nodes.GetByKey(t.NodeKey)
 	if err == nil {
-		err = h.Nodes.UpdateIPAddress(r.Header.Get(utils.XRealIP), node)
+		err = h.Nodes.UpdateIPAddress(utils.GetIP(r), node)
 		if err != nil {
 			h.Inc(metricReadErr)
 			log.Printf("error updating IP Address %v", err)
@@ -509,7 +509,7 @@ func (h *HandlersTLS) QueryWriteHandler(w http.ResponseWriter, r *http.Request) 
 	var nodeInvalid bool
 	// Check if provided node_key is valid and if so, update node
 	if h.Nodes.CheckByKey(t.NodeKey) {
-		if err := h.Nodes.UpdateIPAddressByKey(r.Header.Get(utils.XRealIP), t.NodeKey); err != nil {
+		if err := h.Nodes.UpdateIPAddressByKey(utils.GetIP(r), t.NodeKey); err != nil {
 			h.Inc(metricWriteErr)
 			log.Printf("error updating IP Address %v", err)
 		}
@@ -650,7 +650,7 @@ func (h *HandlersTLS) CarveInitHandler(w http.ResponseWriter, r *http.Request) {
 	var carveSessionID string
 	// Check if provided node_key is valid and if so, update node
 	if h.Nodes.CheckByKey(t.NodeKey) {
-		if err := h.Nodes.UpdateIPAddressByKey(r.Header.Get(utils.XRealIP), t.NodeKey); err != nil {
+		if err := h.Nodes.UpdateIPAddressByKey(utils.GetIP(r), t.NodeKey); err != nil {
 			h.Inc(metricInitErr)
 			log.Printf("error updating IP Address %v", err)
 		}

--- a/utils/http-utils.go
+++ b/utils/http-utils.go
@@ -34,6 +34,8 @@ const UserAgent string = "User-Agent"
 // XRealIP for header key
 const XRealIP string = "X-Real-IP"
 
+const XForwardedFor string = "X-Forwarded-For"
+
 // Authorization for header key
 const Authorization string = "Authorization"
 
@@ -108,6 +110,19 @@ func DebugHTTPDump(r *http.Request, debugCheck bool, showBody bool) {
 	if debugCheck {
 		log.Println(DebugHTTP(r, debugCheck, showBody))
 	}
+}
+
+// GetIP - Helper to get the IP address from a HTTP request
+func GetIP(r *http.Request) string {
+	realIP := r.Header.Get(XRealIP)
+	if realIP != "" {
+		return realIP
+	}
+	forwarded := r.Header.Get(XForwardedFor)
+	if forwarded != "" {
+		return forwarded
+	}
+	return r.RemoteAddr
 }
 
 // HTTPResponse - Helper to send HTTP response


### PR DESCRIPTION
Fix for #229 when using `osctrl` directly for TLS termination, without using nginx and `X-Real-IP` header is not present. Now it will check for `X-Real-IP`, `X-Forwarded-For` and of none of those are present, it will just capture the raw IP.