### PR TITLE
Check JWT secret is not empty for `osctrl-admin` and `osctrl-api`

### DIFF
--- a/users/users.go
+++ b/users/users.go
@@ -47,6 +47,10 @@ type UserManager struct {
 
 // CreateUserManager to initialize the users struct and tables
 func CreateUserManager(backend *gorm.DB, jwtconfig *types.JSONConfigurationJWT) *UserManager {
+	// Check if JWT is not empty
+	if jwtconfig.JWTSecret == "" {
+		log.Fatalf("JWT Secret can not be empty")
+	}
 	var u *UserManager
 	u = &UserManager{DB: backend, JWTConfig: jwtconfig}
 	// table admin_users


### PR DESCRIPTION
Implementation for #226 when both `osctrl-admin` and `osctrl-api` will not start if the JWT secret is not set properly.