### PR TITLE
Handle online or offline static files for `osctrl-admin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,6 @@ dhparam.pem
 # Customization
 #brand.png
 
-# Admin generated files
-page-head.html
-page-js.html
-
 # Random notes for debug
 notes.txt
 

--- a/admin/handlers/handlers.go
+++ b/admin/handlers/handlers.go
@@ -49,6 +49,7 @@ type HandlersAdmin struct {
 	ServiceVersion  string
 	OsqueryVersion  string
 	TemplatesFolder string
+	StaticLocation  string
 	CarvesFolder    string
 	OsqueryTables   []types.OsqueryTable
 	AdminConfig     *types.JSONConfigurationService
@@ -143,6 +144,15 @@ func WithOsqueryVersion(version string) HandlersOption {
 func WithTemplates(templates string) HandlersOption {
 	return func(h *HandlersAdmin) {
 		h.TemplatesFolder = templates
+	}
+}
+
+func WithStaticLocation(offline bool) HandlersOption {
+	return func(h *HandlersAdmin) {
+		h.StaticLocation = "online"
+		if offline {
+			h.StaticLocation = "offline"
+		}
 	}
 }
 

--- a/admin/handlers/templates.go
+++ b/admin/handlers/templates.go
@@ -38,11 +38,11 @@ func (h *HandlersAdmin) TemplateMetadata(ctx sessions.ContextValue, version stri
 }
 
 // NewTemplateFiles defines based on layout and default static pages
-func NewTemplateFiles(base string, layoutFilename string) *TemplateFiles {
+func (h *HandlersAdmin) NewTemplateFiles(base string, layoutFilename string) *TemplateFiles {
 	paths := []string{
 		base + "/" + layoutFilename,
-		base + "/components/page-head.html",
-		base + "/components/page-js.html",
+		base + "/components/page-head-" + h.StaticLocation + ".html",
+		base + "/components/page-js-" + h.StaticLocation + ".html",
 		base + "/components/page-header.html",
 		base + "/components/page-aside-left.html",
 		base + "/components/page-aside-right.html",
@@ -59,8 +59,8 @@ func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	// Prepare template
 	t, err := template.ParseFiles(
 		h.TemplatesFolder+"/login.html",
-		h.TemplatesFolder+"/components/page-head.html",
-		h.TemplatesFolder+"/components/page-js.html")
+		h.TemplatesFolder+"/components/page-head-"+h.StaticLocation+".html",
+		h.TemplatesFolder+"/components/page-js-" + h.StaticLocation + ".html")
 	if err != nil {
 		h.Inc(metricAdminErr)
 		log.Printf("error getting login template: %v", err)
@@ -118,7 +118,7 @@ func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "table.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "table.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -200,8 +200,8 @@ func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) 
 	// Prepare template
 	t, err := template.ParseFiles(
 		h.TemplatesFolder+"/table.html",
-		h.TemplatesFolder+"/components/page-head.html",
-		h.TemplatesFolder+"/components/page-js.html",
+		h.TemplatesFolder+"/components/page-head-" + h.StaticLocation + ".html",
+		h.TemplatesFolder+"/components/page-js-" + h.StaticLocation + ".html",
 		h.TemplatesFolder+"/components/page-aside-right.html",
 		h.TemplatesFolder+"/components/page-aside-left.html",
 		h.TemplatesFolder+"/components/page-header.html",
@@ -269,8 +269,8 @@ func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Reques
 	// Prepare template
 	t, err := template.ParseFiles(
 		h.TemplatesFolder+"/queries-run.html",
-		h.TemplatesFolder+"/components/page-head.html",
-		h.TemplatesFolder+"/components/page-js.html",
+		h.TemplatesFolder+"/components/page-head-" + h.StaticLocation + ".html",
+		h.TemplatesFolder+"/components/page-js-" + h.StaticLocation + ".html",
 		h.TemplatesFolder+"/components/page-aside-right.html",
 		h.TemplatesFolder+"/components/page-aside-left.html",
 		h.TemplatesFolder+"/components/page-header.html",
@@ -343,7 +343,7 @@ func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "queries.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "queries.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -396,7 +396,7 @@ func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "saved.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "saved.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -449,7 +449,7 @@ func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "carves-run.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "carves-run.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -519,7 +519,7 @@ func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "carves.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "carves.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -584,7 +584,7 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 		"queryResultLink": h.queryResultLink,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "queries-logs.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "queries-logs.html").filepaths
 	t, err := template.New("queries-logs.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -660,7 +660,7 @@ func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "carves-details.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "carves-details.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -764,7 +764,7 @@ func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "conf.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "conf.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -832,7 +832,7 @@ func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "enroll.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "enroll.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -905,7 +905,7 @@ func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 		"jsonRawIndent":   jsonRawIndent,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "node.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "node.html").filepaths
 	t, err := template.New("node.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1018,7 +1018,7 @@ func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "environments.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "environments.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1084,7 +1084,7 @@ func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "settings.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "settings.html").filepaths
 	t, err := template.ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1156,7 +1156,7 @@ func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) 
 		"inFutureTime":    utils.InFutureTime,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "users.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "users.html").filepaths
 	t, err := template.New("users.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1221,7 +1221,7 @@ func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
 		"inFutureTime":    utils.InFutureTime,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "tags.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "tags.html").filepaths
 	t, err := template.New("tags.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)
@@ -1285,7 +1285,7 @@ func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Req
 		"pastFutureTimes": utils.PastFutureTimes,
 	}
 	// Prepare template
-	tempateFiles := NewTemplateFiles(h.TemplatesFolder, "profile.html").filepaths
+	tempateFiles := h.NewTemplateFiles(h.TemplatesFolder, "profile.html").filepaths
 	t, err := template.New("profile.html").Funcs(funcMap).ParseFiles(tempateFiles...)
 	if err != nil {
 		h.Inc(metricAdminErr)

--- a/admin/main.go
+++ b/admin/main.go
@@ -146,6 +146,7 @@ var (
 	osqueryTablesVersion string
 	loggerFile           string
 	staticFilesFolder    string
+	staticOffline         bool
 	carvedFilesFolder    string
 	templatesFolder      string
 )
@@ -493,6 +494,14 @@ func init() {
 			EnvVars:     []string{"STATIC_FILES"},
 			Destination: &staticFilesFolder,
 		},
+		&cli.BoolFlag{
+			Name:        "static-offline",
+			Aliases:     []string{"S"},
+			Value:       false,
+			Usage:       "Use offline static files (js and css). Default is online files.",
+			EnvVars:     []string{"STATIC_ONLINE"},
+			Destination: &staticOffline,
+		},
 		&cli.StringFlag{
 			Name:        "templates",
 			Value:       defTemplatesFolder,
@@ -613,6 +622,7 @@ func osctrlAdminService() {
 		handlers.WithVersion(serviceVersion),
 		handlers.WithOsqueryVersion(osqueryTablesVersion),
 		handlers.WithTemplates(templatesFolder),
+		handlers.WithStaticLocation(staticOffline),
 		handlers.WithOsqueryTables(osqueryTables),
 		handlers.WithAdminConfig(&adminConfig),
 	)

--- a/admin/templates/carves-run.html
+++ b/admin/templates/carves-run.html
@@ -171,7 +171,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/carves.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/admin/templates/carves.html
+++ b/admin/templates/carves.html
@@ -68,7 +68,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/query.js"></script>
     <script src="/static/js/carves.js"></script>
     <script src="/static/js/tables.js"></script>

--- a/admin/templates/conf.html
+++ b/admin/templates/conf.html
@@ -290,7 +290,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/configuration.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/admin/templates/enroll.html
+++ b/admin/templates/enroll.html
@@ -273,7 +273,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/enrolls.js"></script>
     <script type="text/javascript">
       // Highlight.js code element initialization

--- a/admin/templates/environments.html
+++ b/admin/templates/environments.html
@@ -142,7 +142,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/environments.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/admin/templates/login.html
+++ b/admin/templates/login.html
@@ -68,7 +68,6 @@
 
     <!-- custom JS -->
     <script src="/static/js/functions.js"></script>
-    <script src="/static/js/login.js"></script>
 
   </body>
 

--- a/admin/templates/profile.html
+++ b/admin/templates/profile.html
@@ -142,7 +142,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/profile.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/admin/templates/queries-run.html
+++ b/admin/templates/queries-run.html
@@ -255,7 +255,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/query.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/admin/templates/queries.html
+++ b/admin/templates/queries.html
@@ -68,7 +68,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/query.js"></script>
     <script src="/static/js/tables.js"></script>
     <script type="text/javascript">

--- a/admin/templates/saved.html
+++ b/admin/templates/saved.html
@@ -65,7 +65,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/query.js"></script>
     <script src="/static/js/tables.js"></script>
     <script type="text/javascript">

--- a/admin/templates/table.html
+++ b/admin/templates/table.html
@@ -108,7 +108,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/nodeactions.js"></script>
     <script src="/static/js/tables.js"></script>
     <script type="text/javascript">

--- a/admin/templates/tags.html
+++ b/admin/templates/tags.html
@@ -138,7 +138,6 @@
     {{ template "page-js" . }}
 
     <!-- custom JS -->
-    <script src="/static/js/login.js"></script>
     <script src="/static/js/tags.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/admin/templates/users.html
+++ b/admin/templates/users.html
@@ -350,7 +350,6 @@
 
     <!-- custom JS -->
     <script src="/static/js/users.js"></script>
-    <script src="/static/js/login.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {
         // Editable fields

--- a/deploy/docker/Dockerfile-osctrl-dev
+++ b/deploy/docker/Dockerfile-osctrl-dev
@@ -116,8 +116,6 @@ RUN chown osctrl-admin:osctrl-admin -R /opt/osctrl/config
 
 ### Copy osctrl-admin web templates ###
 COPY /go/src/osctrl/admin/templates/ /opt/osctrl/tmpl_admin
-COPY /go/src/osctrl/admin/templates/components/page-head-online.html /opt/osctrl/tmpl_admin/components/page-head.html
-COPY /go/src/osctrl/admin/templates/components/page-js-online.html /opt/osctrl/tmpl_admin/components/page-js.html
 COPY /go/src/osctrl/admin/static/ /opt/osctrl/static
 COPY /go/src/osctrl/deploy/osquery/data/${OSQUERY_VERSION}.json /opt/osctrl/data/${OSQUERY_VERSION}.json
 

--- a/deploy/docker/Dockerfile-osctrl-prod
+++ b/deploy/docker/Dockerfile-osctrl-prod
@@ -114,8 +114,6 @@ RUN chown osctrl-admin:osctrl-admin -R /opt/osctrl/config
 
 ### Copy osctrl-admin web templates ###
 COPY --from=osctrl-base /go/src/osctrl/admin/templates/ /opt/osctrl/tmpl_admin
-COPY --from=osctrl-base /go/src/osctrl/admin/templates/components/page-head-online.html /opt/osctrl/tmpl_admin/components/page-head.html
-COPY --from=osctrl-base /go/src/osctrl/admin/templates/components/page-js-online.html /opt/osctrl/tmpl_admin/components/page-js.html
 COPY --from=osctrl-base /go/src/osctrl/admin/static/ /opt/osctrl/static
 COPY --from=osctrl-base /go/src/osctrl/deploy/osquery/data/${OSQUERY_VERSION}.json /opt/osctrl/data/${OSQUERY_VERSION}.json
 

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -470,15 +470,6 @@ if [[ "$UPGRADE" == true ]]; then
     _static_files "$MODE" "$SOURCE_PATH" "$DEST_PATH" "admin/templates" "tmpl_admin"
     _static_files "$MODE" "$SOURCE_PATH" "$DEST_PATH" "admin/static" "static"
 
-    # Static files will require internet connection (CSS + JS)
-    if [[ "$MODE" == "dev" ]]; then
-      sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
-      sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
-    else
-      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
-      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
-    fi
-
     # Restart service with new binary
     make install_admin
   fi
@@ -723,15 +714,6 @@ else
     # Prepare static files for Admin service
     _static_files "$MODE" "$SOURCE_PATH" "$DEST_PATH" "admin/templates" "tmpl_admin"
     _static_files "$MODE" "$SOURCE_PATH" "$DEST_PATH" "admin/static" "static"
-
-    # Static files will require internet connection (CSS + JS)
-    if [[ "$MODE" == "dev" ]]; then
-      sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
-      sudo ln -fs "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
-    else
-      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-head-online.html" "$DEST_PATH/tmpl_admin/components/page-head.html"
-      sudo rsync -av "$SOURCE_PATH/admin/templates/components/page-js-online.html" "$DEST_PATH/tmpl_admin/components/page-js.html"
-    fi
 
     # Systemd configuration for Admin service
     _systemd "osctrl" "osctrl" "osctrl-admin" "$SOURCE_PATH" "$DEST_PATH"


### PR DESCRIPTION
Fix for #219 where online/offline static files (CSS and JS) had to be sym linked while provisioning. Now a new flag (`--static-offline`) is added to `osctrl-admin` to use offline assets, by default online assets are used. 