### PR TITLE
Using JSON file for config in provision

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -146,7 +146,7 @@ var (
 	osqueryTablesVersion string
 	loggerFile           string
 	staticFilesFolder    string
-	staticOffline         bool
+	staticOffline        bool
 	carvedFilesFolder    string
 	templatesFolder      string
 )

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -79,19 +79,11 @@ func LoadConfiguration(file, key string) (JSONConfigurationRedis, error) {
 
 // GetRedis to get redis client ready
 func (rm *RedisManager) GetRedis() *redis.Client {
-	options := &redis.Options{
+	return redis.NewClient(&redis.Options{
 		Addr:     PrepareAddr(*rm.Config),
 		Password: rm.Config.Password,
 		DB:       rm.Config.DB,
-	}
-	if rm.Config.Password == "" {
-		options = &redis.Options{
-			Addr: PrepareAddr(*rm.Config),
-			DB:   rm.Config.DB,
-		}
-	}
-	client := redis.NewClient(options)
-	return client
+	})
 }
 
 // Check to verify if connection is open and ready

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -686,7 +686,7 @@ else
     configuration_service "$SOURCE_PATH/deploy/config/$SERVICE_TEMPLATE" "$DEST_PATH/config/$TLS_CONF" "$_T_HOST|$_T_INT_PORT" "$TLS_COMPONENT" "127.0.0.1" "$_T_AUTH" "$_T_LOGGING" "sudo"
 
     # Systemd configuration for TLS service
-    _systemd "osctrl" "osctrl" "osctrl-tls" "$SOURCE_PATH" "$DEST_PATH" "--redis --db"
+    _systemd "osctrl" "osctrl" "osctrl-tls" "$SOURCE_PATH" "$DEST_PATH" "--redis --db --config"
   fi
 
   if [[ "$PART" == "all" ]] || [[ "$PART" == "$ADMIN_COMPONENT" ]]; then
@@ -711,7 +711,7 @@ else
     _static_files "$MODE" "$SOURCE_PATH" "$DEST_PATH" "admin/static" "static"
 
     # Systemd configuration for Admin service
-    _systemd "osctrl" "osctrl" "osctrl-admin" "$SOURCE_PATH" "$DEST_PATH" "--redis --db --jwt"
+    _systemd "osctrl" "osctrl" "osctrl-admin" "$SOURCE_PATH" "$DEST_PATH" "--redis --db --jwt --config"
   fi
 
   if [[ "$PART" == "all" ]] || [[ "$PART" == "$API_COMPONENT" ]]; then
@@ -722,7 +722,7 @@ else
     configuration_service "$SOURCE_PATH/deploy/config/$SERVICE_TEMPLATE" "$DEST_PATH/config/$API_CONF" "$_P_HOST|$_P_INT_PORT" "$API_COMPONENT" "127.0.0.1" "$_P_AUTH" "$_P_LOGGING" "sudo"
 
     # Systemd configuration for API service
-    _systemd "osctrl" "osctrl" "osctrl-api" "$SOURCE_PATH" "$DEST_PATH" "--redis --db --jwt"
+    _systemd "osctrl" "osctrl" "osctrl-api" "$SOURCE_PATH" "$DEST_PATH" "--redis --db --jwt --config"
   fi
 
   # Some needed files

--- a/logging/splunk.go
+++ b/logging/splunk.go
@@ -18,9 +18,6 @@ type SlunkConfiguration struct {
 	Token   string `json:"token"`
 	Host    string `json:"host"`
 	Index   string `json:"index"`
-	Queries string `json:"queries"`
-	Status  string `json:"status"`
-	Results string `json:"results"`
 }
 
 // LoggerSplunk will be used to log data using Splunk

--- a/tls/main.go
+++ b/tls/main.go
@@ -107,9 +107,15 @@ var validAuth = map[string]bool{
 	settings.AuthNone: true,
 }
 var validLogging = map[string]bool{
+	settings.LoggingNone:    true,
+	settings.LoggingStdout:  true,
+	settings.LoggingFile:    true,
 	settings.LoggingDB:      true,
 	settings.LoggingGraylog: true,
 	settings.LoggingSplunk:  true,
+	settings.LoggingKafka:   true,
+	settings.LoggingKinesis: true,
+	settings.LoggingS3:      true,
 }
 
 // Function to load the configuration file and assign to variables

--- a/tls/main.go
+++ b/tls/main.go
@@ -235,7 +235,7 @@ func init() {
 		},
 		&cli.StringFlag{
 			Name:        "redis-pass",
-			Value:       "redis",
+			Value:       "",
 			Usage:       "Password to be used for redis",
 			EnvVars:     []string{"REDIS_PASS"},
 			Destination: &redisConfig.Password,


### PR DESCRIPTION
* Expand list of allowed logging methods for `osctrl-tls`
* Configure systemd service properly to use external JSON for service configuration when using `provision.sh`