### PR TITLE
Extending and rotating one-liners

### DIFF
--- a/admin/handlers/post.go
+++ b/admin/handlers/post.go
@@ -855,12 +855,26 @@ func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Req
 			}
 			adminOKResponse(w, "link expired successfully")
 		case "extend":
-			if err := h.Envs.RotateEnrollPath(env.UUID); err != nil {
+			if err := h.Envs.ExtendEnroll(env.UUID); err != nil {
 				adminErrorResponse(w, "error extending enroll", http.StatusInternalServerError, err)
 				h.Inc(metricAdminErr)
 				return
 			}
 			adminOKResponse(w, "link extended successfully")
+		case "rotate":
+			if err := h.Envs.RotateEnroll(env.UUID); err != nil {
+				adminErrorResponse(w, "error rotating enroll", http.StatusInternalServerError, err)
+				h.Inc(metricAdminErr)
+				return
+			}
+			adminOKResponse(w, "link rotated successfully")
+		case "notexpire":
+			if err := h.Envs.NotExpireEnroll(env.UUID); err != nil {
+				adminErrorResponse(w, "error not expiring enroll", http.StatusInternalServerError, err)
+				h.Inc(metricAdminErr)
+				return
+			}
+			adminOKResponse(w, "link set to not expire successfully")
 		}
 	case "remove":
 		switch e.Action {
@@ -872,12 +886,26 @@ func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Req
 			}
 			adminOKResponse(w, "link expired successfully")
 		case "extend":
-			if err := h.Envs.RotateRemove(env.UUID); err != nil {
+			if err := h.Envs.ExtendRemove(env.UUID); err != nil {
 				adminErrorResponse(w, "error extending remove", http.StatusInternalServerError, err)
 				h.Inc(metricAdminErr)
 				return
 			}
 			adminOKResponse(w, "link extended successfully")
+		case "rotate":
+			if err := h.Envs.RotateRemove(env.UUID); err != nil {
+				adminErrorResponse(w, "error rotating remove", http.StatusInternalServerError, err)
+				h.Inc(metricAdminErr)
+				return
+			}
+			adminOKResponse(w, "link rotated successfully")
+		case "notexpire":
+			if err := h.Envs.NotExpireRemove(env.UUID); err != nil {
+				adminErrorResponse(w, "error not expiring remove", http.StatusInternalServerError, err)
+				h.Inc(metricAdminErr)
+				return
+			}
+			adminOKResponse(w, "link set to not expire successfully")
 		}
 	}
 	// Serialize and send response

--- a/admin/handlers/templates.go
+++ b/admin/handlers/templates.go
@@ -862,6 +862,7 @@ func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request)
 		Title:                 env.Name + " Enroll",
 		Metadata:              h.TemplateMetadata(ctx, h.ServiceVersion),
 		EnvName:               env.Name,
+		OnelinerExpiration:    h.Settings.OnelinerExpiration(),
 		EnrollExpiry:          strings.ToUpper(utils.InFutureTime(env.EnrollExpire)),
 		EnrollExpired:         environments.IsItExpired(env.EnrollExpire),
 		RemoveExpiry:          strings.ToUpper(utils.InFutureTime(env.RemoveExpire)),

--- a/admin/handlers/types-templates.go
+++ b/admin/handlers/types-templates.go
@@ -56,6 +56,7 @@ type ConfTemplateData struct {
 type EnrollTemplateData struct {
 	Title                 string
 	EnvName               string
+	OnelinerExpiration    bool
 	EnrollExpiry          string
 	EnrollExpired         bool
 	RemoveExpiry          string

--- a/admin/static/js/enrolls.js
+++ b/admin/static/js/enrolls.js
@@ -17,12 +17,28 @@ function expireEnrollLink() {
   genericLinkAction('enroll', 'expire');
 }
 
+function rotateEnrollLink() {
+  genericLinkAction('enroll', 'rotate');
+}
+
+function notexpireEnrollLink() {
+  genericLinkAction('enroll', 'notexpire');
+}
+
 function extendRemoveLink() {
   genericLinkAction('remove', 'extend');
 }
 
 function expireRemoveLink() {
   genericLinkAction('remove', 'expire');
+}
+
+function rotateRemoveLink() {
+  genericLinkAction('remove', 'rotate');
+}
+
+function notexpireRemoveLink() {
+  genericLinkAction('remove', 'notexpire');
 }
 
 function confirmUploadCertificate() {

--- a/admin/templates/enroll.html
+++ b/admin/templates/enroll.html
@@ -28,20 +28,32 @@
                       <span class="align-self-center mr-1"><b>{{ .EnrollExpiry }}</b></span>
                     {{ if eq $metadata.Level "admin" }}
                       {{ if not .EnrollExpired }}
-                      <div class="card-header-action mr-3">
+                      <div class="card-header-action mr-1">
                         <button id="enroll_expire" class="btn btn-sm btn-block btn-danger"
                           data-tooltip="true" data-placement="bottom" title="Expire" onclick="expireEnrollLink();">
                           <i class="far fa-times-circle"></i>
                         </button>
                       </div>
                       {{ end }}
-                      {{ if .EnrollExpired }}
-                      <div class="card-header-action mr-3">
-                          <button id="enroll_extend" class="btn btn-sm btn-block btn-success"
-                            data-tooltip="true" data-placement="bottom" title="Extend 24 hours" onclick="extendEnrollLink();">
-                            <i class="far fa-clock"></i>
-                          </button>
+                      <div class="card-header-action mr-1">
+                        <button id="enroll_extend" class="btn btn-sm btn-block btn-success"
+                          data-tooltip="true" data-placement="bottom" title="Extend 24 hours" onclick="extendEnrollLink();">
+                          <i class="far fa-clock"></i>
+                        </button>
                       </div>
+                      <div class="card-header-action mr-1">
+                        <button id="remove_rotate" class="btn btn-sm btn-block btn-warning"
+                          data-tooltip="true" data-placement="bottom" title="Rotate link" onclick="rotateEnrollLink();">
+                          <i class="fas fa-sync-alt"></i>
+                        </button>
+                      </div>
+                      {{ if and (not .OnelinerExpiration) (ne .EnrollExpiry "NEVER EXPIRES") }}
+                        <div class="card-header-action mr-1">
+                          <button id="enroll_notexpire" class="btn btn-sm btn-block btn-info"
+                            data-tooltip="true" data-placement="bottom" title="Disable Expiration" onclick="notexpireEnrollLink();">
+                            <i class="fas fa-stopwatch"></i>
+                          </button>
+                        </div>
                       {{ end }}
                     {{end }}
 
@@ -103,20 +115,32 @@
                     <span class="align-self-center mr-1"><b>{{ .RemoveExpiry }}</b></span>
                   {{ if eq $metadata.Level "admin" }}
                     {{ if not .RemoveExpired }}
-                    <div class="card-header-action mr-3">
+                    <div class="card-header-action mr-1">
                       <button id="remove_expire" class="btn btn-sm btn-block btn-danger"
                         data-tooltip="true" data-placement="bottom" title="Expire" onclick="expireRemoveLink();">
                         <i class="far fa-times-circle"></i>
                       </button>
                     </div>
                     {{ end }}
-                    {{ if .RemoveExpired }}
-                    <div class="card-header-action mr-3">
+                    <div class="card-header-action mr-1">
                       <button id="remove_extend" class="btn btn-sm btn-block btn-success"
                         data-tooltip="true" data-placement="bottom" title="Extend 24 hours" onclick="extendRemoveLink();">
                         <i class="far fa-clock"></i>
                       </button>
                     </div>
+                    <div class="card-header-action mr-1">
+                      <button id="remove_rotate" class="btn btn-sm btn-block btn-warning"
+                        data-tooltip="true" data-placement="bottom" title="Rotate link" onclick="rotateRemoveLink();">
+                        <i class="fas fa-sync-alt"></i>
+                      </button>
+                    </div>
+                    {{ if and (not .OnelinerExpiration) (ne .RemoveExpiry "NEVER EXPIRES") }}
+                      <div class="card-header-action mr-1">
+                        <button id="remove_notexpire" class="btn btn-sm btn-block btn-info"
+                          data-tooltip="true" data-placement="bottom" title="Disable Expiration" onclick="notexpireRemoveLink();">
+                          <i class="fas fa-stopwatch"></i>
+                        </button>
+                      </div>
                     {{ end }}
                   {{ end }}
 

--- a/environments/util.go
+++ b/environments/util.go
@@ -21,6 +21,9 @@ func ReadExternalFile(path string) string {
 
 // IsItExpired to determine if a time has expired, which makes it in the past
 func IsItExpired(t time.Time) bool {
+	if t.IsZero() {
+		return false
+	}
 	now := time.Now()
 	return (int(t.Sub(now).Seconds()) <= 0)
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -23,11 +23,11 @@ const (
 
 // Types of authentication
 const (
-	AuthNone    string = "none"
-	AuthJSON    string = "json"
-	AuthDB      string = "db"
-	AuthSAML    string = "saml"
-	AuthJWT     string = "jwt"
+	AuthNone string = "none"
+	AuthJSON string = "json"
+	AuthDB   string = "db"
+	AuthSAML string = "saml"
+	AuthJWT  string = "jwt"
 )
 
 // Types of logging
@@ -59,6 +59,7 @@ const (
 	InactiveHours      string = "inactive_hours"
 	AcceleratedSeconds string = "accelerated_seconds"
 	NodeDashboard      string = "node_dashboard"
+	OnelinerExpiration string = "oneliner_expiration"
 )
 
 // Names for the values that are read from the JSON config file
@@ -484,6 +485,15 @@ func (conf *Settings) DefaultEnv(service string) string {
 // NodeDashboard checks if display dashboard per node is enabled
 func (conf *Settings) NodeDashboard() bool {
 	value, err := conf.RetrieveValue(ServiceAdmin, NodeDashboard)
+	if err != nil {
+		return false
+	}
+	return value.Boolean
+}
+
+// OnelinerExpiration checks if enrolling links will expire
+func (conf *Settings) OnelinerExpiration() bool {
+	value, err := conf.RetrieveValue(ServiceTLS, OnelinerExpiration)
 	if err != nil {
 		return false
 	}

--- a/tls/main.go
+++ b/tls/main.go
@@ -58,6 +58,8 @@ const (
 	defaultRefresh int = 300
 	// Default accelerate interval in seconds
 	defaultAccelerate int = 300
+	// Default expiration of oneliners for enroll/expire
+	defaultOnelinerExpiration bool = true
 )
 
 var (

--- a/tls/settings.go
+++ b/tls/settings.go
@@ -54,16 +54,15 @@ func loadingSettings(mgr *settings.Settings) error {
 			return fmt.Errorf("Failed to add %s to configuration: %v", settings.RefreshEnvs, err)
 		}
 	}
-	// Check if service settings for settings refresh is ready
-	if !mgr.IsValue(settings.ServiceTLS, settings.RefreshSettings) {
-		if err := mgr.NewIntegerValue(settings.ServiceTLS, settings.RefreshSettings, int64(defaultRefresh)); err != nil {
-			return fmt.Errorf("Failed to add %s to configuration: %v", settings.RefreshSettings, err)
+	// Check if service settings for enroll/remove oneliner links is ready
+	if !mgr.IsValue(settings.ServiceTLS, settings.OnelinerExpiration) {
+		if err := mgr.NewBooleanValue(settings.ServiceTLS, settings.OnelinerExpiration, defaultOnelinerExpiration); err != nil {
+			return fmt.Errorf("Failed to add %s to configuration: %v", settings.OnelinerExpiration, err)
 		}
 	}
 	// Write JSON config to settings
 	if err := mgr.SetAllJSON(settings.ServiceTLS, tlsConfig.Listener, tlsConfig.Port, tlsConfig.Host, tlsConfig.Auth, tlsConfig.Logger); err != nil {
 		return fmt.Errorf("Failed to add JSON values to configuration: %v", err)
 	}
-
 	return nil
 }

--- a/utils/time-utils.go
+++ b/utils/time-utils.go
@@ -86,7 +86,7 @@ func PastTimeAgo(t time.Time) string {
 // InFutureTime - Helper to format future times only returning one value (minute, hour, day)
 func InFutureTime(t time.Time) string {
 	if t.IsZero() {
-		return "Never"
+		return "Never Expires"
 	}
 	now := time.Now()
 	seconds := int(t.Sub(now).Seconds())


### PR DESCRIPTION
* Ability to extend one-liners, for add and remove nodes, without changing them.
* Ability to rotate one-liners.
* Added new setting (`oneliner_expiration `) to `osctrl-tls` to allow one-liners never expire. 