### PR TITLE
Updated osctrl-cli to support Docker secrets with OSCTRL_PASS_FILE

### DIFF
--- a/deploy/docker/conf/osctrl/cli/entrypoint.sh
+++ b/deploy/docker/conf/osctrl/cli/entrypoint.sh
@@ -7,6 +7,11 @@ OSCTRL_USER="${OSCTRL_USER:=admin}"
 OSCTRL_PASS="${OSCTRL_PASS:=admin}"
 WAIT="${WAIT:=5}"
 
+######################################### OSCTRL_PASS #########################################
+if [[ -n "$OSCTRL_PASS_FILE" ]]; then
+  OSCTRL_PASS=$(cat ${OSCTRL_PASS_FILE})
+fi
+
 ######################################### Wait until DB is up #########################################
 until /opt/osctrl/bin/osctrl-cli check
 do


### PR DESCRIPTION
The `osctrl-cli` component supports passing a password via an ENV var but not Docker secrets. This PR updates the entrypoint to support. 