### PR TITLE
Always write on-demand query results to db

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -236,7 +236,17 @@ func (logTLS *LoggerTLS) QueryLog(logType string, data []byte, environment, uuid
 			l.Send(logType, data, environment, uuid, debug)
 		}
 	}
-	// Add logs to cache
+	// If logging is not DB, let's write results to DB anyway
+	if logTLS.Logging != settings.LoggingDB {
+		l, ok := logTLS.Logger.(*LoggerDB)
+		if !ok {
+			log.Printf("error casting logger to %s", settings.LoggingDB)
+		}
+		if l.Enabled {
+			l.Query(data, environment, uuid, name, status, debug)
+		}
+	}
+	// Add logs to cache always
 	if err := logTLS.RedisCache.SetQueryLogs(uuid, name, data); err != nil {
 		log.Printf("error sending %s logs to cache %s", logType, err)
 	}

--- a/tls/main.go
+++ b/tls/main.go
@@ -57,7 +57,7 @@ const (
 	// Default refreshing interval in seconds
 	defaultRefresh int = 300
 	// Default accelerate interval in seconds
-	defaultAccelerate int = 300
+	defaultAccelerate int = 60
 	// Default expiration of oneliners for enroll/expire
 	defaultOnelinerExpiration bool = true
 )


### PR DESCRIPTION
* Always writing on-demand query results to database.
* Reduce accelerated mode to 60 seconds.