### PR TITLE
Adding always logger

### DIFF
--- a/logging/db.go
+++ b/logging/db.go
@@ -28,7 +28,7 @@ type OsqueryResultData struct {
 	Name        string
 	Action      string
 	Epoch       int64
-	Columns     []byte
+	Columns     string
 	Counter     int
 }
 
@@ -50,7 +50,7 @@ type OsqueryQueryData struct {
 	UUID        string `gorm:"index"`
 	Environment string
 	Name        string
-	Data        []byte
+	Data        string
 	Status      int
 }
 
@@ -158,7 +158,7 @@ func (logDB *LoggerDB) Result(data []byte, environment, uuid string, debug bool)
 			Name:        l.Name,
 			Action:      l.Action,
 			Epoch:       l.Epoch,
-			Columns:     l.Columns,
+			Columns:     string(l.Columns),
 			Counter:     l.Counter,
 		}
 		if err := logDB.Database.Conn.Create(&entry).Error; err != nil {
@@ -174,7 +174,7 @@ func (logDB *LoggerDB) Query(data []byte, environment, uuid, name string, status
 		UUID:        strings.ToUpper(uuid),
 		Environment: environment,
 		Name:        name,
-		Data:        data,
+		Data:        string(data),
 		Status:      status,
 	}
 	// Insert in DB

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/queries"
 	"github.com/jmpsec/osctrl/settings"
+	"github.com/jmpsec/osctrl/types"
 )
 
 const (
@@ -178,7 +179,7 @@ func (logTLS *LoggerTLS) Log(logType string, data []byte, environment, uuid stri
 		}
 	}
 	// If logs are status, write via always logger
-	if logTLS.AlwaysLogger != nil && logTLS.AlwaysLogger.Enabled {
+	if logTLS.AlwaysLogger != nil && logTLS.AlwaysLogger.Enabled && logType == types.StatusLog {
 		logTLS.AlwaysLogger.Log(logType, data, environment, uuid, debug)
 	}
 	// Add logs to cache

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -32,7 +32,6 @@ func CreateLoggerTLS(logging, loggingFile, alwaysLogger string, mgr *settings.Se
 		Queries:    queries,
 		RedisCache: redis,
 	}
-	log.Printf("Always log to %s", alwaysLogger)
 	switch logging {
 	case settings.LoggingSplunk:
 		s, err := CreateLoggerSplunk(loggingFile)

--- a/tls/main.go
+++ b/tls/main.go
@@ -50,6 +50,8 @@ const (
 	defRedisConfigurationFile string = "config/redis.json"
 	// Default Logger configuration file
 	defLoggerConfigurationFile string = "config/logger.json"
+	// Default Logger configuration file
+	defAlwaysLoggerConfigurationFile string = "config/always.json"
 	// Default TLS certificate file
 	defTLSCertificateFile string = "config/tls.crt"
 	// Default TLS private key file
@@ -102,6 +104,7 @@ var (
 	tlsCertFile       string
 	tlsKeyFile        string
 	loggerFile        string
+	alwaysLoggerFile  string
 )
 
 // Valid values for auth and logging in configuration
@@ -374,6 +377,14 @@ func init() {
 			EnvVars:     []string{"LOGGER_FILE"},
 			Destination: &loggerFile,
 		},
+		&cli.StringFlag{
+			Name:        "always-logger",
+			Aliases:     []string{"A"},
+			Value:       defAlwaysLoggerConfigurationFile,
+			Usage:       "Logger configuration to always store status and on-demand query logs from nodes",
+			EnvVars:     []string{"ALWAYS_LOGGER_FILE"},
+			Destination: &alwaysLoggerFile,
+		},
 	}
 	// Logging format flags
 	log.SetFlags(log.Lshortfile)
@@ -425,7 +436,7 @@ func osctrlService() {
 	}
 	// Initialize TLS logger
 	log.Println("Loading TLS logger")
-	loggerTLS, err = logging.CreateLoggerTLS(tlsConfig.Logger, loggerFile, settingsmgr, nodesmgr, queriesmgr, redis)
+	loggerTLS, err = logging.CreateLoggerTLS(tlsConfig.Logger, loggerFile, alwaysLoggerFile, settingsmgr, nodesmgr, queriesmgr, redis)
 	if err != nil {
 		log.Fatalf("Error loading logger - %s: %v", tlsConfig.Logger, err)
 	}

--- a/tls/main.go
+++ b/tls/main.go
@@ -50,8 +50,8 @@ const (
 	defRedisConfigurationFile string = "config/redis.json"
 	// Default Logger configuration file
 	defLoggerConfigurationFile string = "config/logger.json"
-	// Default Logger configuration file
-	defAlwaysLoggerConfigurationFile string = "config/always.json"
+	// Default always DB logger configuration file
+	defAlwaysLogConfigurationFile string = "config/always.json"
 	// Default TLS certificate file
 	defTLSCertificateFile string = "config/tls.crt"
 	// Default TLS private key file
@@ -104,7 +104,8 @@ var (
 	tlsCertFile       string
 	tlsKeyFile        string
 	loggerFile        string
-	alwaysLoggerFile  string
+	alwaysLog         bool
+	alwaysLogFile     string
 )
 
 // Valid values for auth and logging in configuration
@@ -377,13 +378,21 @@ func init() {
 			EnvVars:     []string{"LOGGER_FILE"},
 			Destination: &loggerFile,
 		},
+		&cli.BoolFlag{
+			Name:        "always-log",
+			Aliases:     []string{"a", "always"},
+			Value:       false,
+			Usage:       "Always log status and on-demand query logs from nodes in database",
+			EnvVars:     []string{"ALWAYS_LOG"},
+			Destination: &alwaysLog,
+		},
 		&cli.StringFlag{
-			Name:        "always-logger",
-			Aliases:     []string{"A"},
-			Value:       defAlwaysLoggerConfigurationFile,
-			Usage:       "Logger configuration to always store status and on-demand query logs from nodes",
-			EnvVars:     []string{"ALWAYS_LOGGER_FILE"},
-			Destination: &alwaysLoggerFile,
+			Name:        "always-log-file",
+			Aliases:     []string{"alog"},
+			Value:       defAlwaysLogConfigurationFile,
+			Usage:       "Database logger configuration to always store status and on-demand query logs from nodes",
+			EnvVars:     []string{"ALWAYS_LOG_FILE"},
+			Destination: &alwaysLogFile,
 		},
 	}
 	// Logging format flags
@@ -436,7 +445,10 @@ func osctrlService() {
 	}
 	// Initialize TLS logger
 	log.Println("Loading TLS logger")
-	loggerTLS, err = logging.CreateLoggerTLS(tlsConfig.Logger, loggerFile, alwaysLoggerFile, settingsmgr, nodesmgr, queriesmgr, redis)
+	if !alwaysLog {
+		alwaysLogFile = ""
+	}
+	loggerTLS, err = logging.CreateLoggerTLS(tlsConfig.Logger, loggerFile, alwaysLogFile, settingsmgr, nodesmgr, queriesmgr, redis)
 	if err != nil {
 		log.Fatalf("Error loading logger - %s: %v", tlsConfig.Logger, err)
 	}


### PR DESCRIPTION
Adding ability to always log on-demand query logs and status.

This is configurable via parameters/environment variables:

```
--always-log, -a, --always             Always log status and on-demand query logs from nodes in database (default: false) [$ALWAYS_LOG]
--always-log-file value, --alog value  Database logger configuration to always store status and on-demand query logs from nodes (default: "config/always.json") [$ALWAYS_LOG_FILE]```