### PR TITLE
Prevent logging same data twice

### DIFF
--- a/logging/utils.go
+++ b/logging/utils.go
@@ -1,5 +1,7 @@
 package logging
 
+import "github.com/jmpsec/osctrl/backend"
+
 // Helper to remove duplicates from array of strings
 func uniq(duplicated []string) []string {
 	keys := make(map[string]bool)
@@ -11,4 +13,9 @@ func uniq(duplicated []string) []string {
 		}
 	}
 	return result
+}
+
+// Helper to check if two DB configurations are the same
+func sameConfigDB(loggerOne, loggerTwo backend.JSONConfigurationDB) bool {
+	return (loggerOne.Host == loggerTwo.Host) && (loggerOne.Port == loggerTwo.Port) && (loggerOne.Name == loggerTwo.Name)
 }

--- a/tls/handlers/utils_test.go
+++ b/tls/handlers/utils_test.go
@@ -28,6 +28,7 @@ func TestNodeFromEnroll(t *testing.T) {
 	_ip := "1.2.3.4"
 	_key := "node-key"
 	_rec := 12345
+	_cer := 54321
 	req := types.EnrollRequest{
 		EnrollSecret:   "secret",
 		HostIdentifier: "thisistheuuid",
@@ -94,8 +95,9 @@ func TestNodeFromEnroll(t *testing.T) {
 		Memory:        "memory",
 		BytesReceived: _rec,
 		RawEnrollment: enrollRaw,
+		UserID:        _cer,
 	}
-	resultNode := nodeFromEnroll(req, _env, _ip, _key, _rec)
+	resultNode := nodeFromEnroll(req, _env, _ip, _key, _rec, _cer)
 	assert.Equal(t, node, resultNode)
 }
 

--- a/tls/main.go
+++ b/tls/main.go
@@ -108,7 +108,6 @@ var (
 	tlsKeyFile        string
 	loggerFile        string
 	alwaysLog         bool
-	alwaysLogFile     string
 	carverConfigFile  string
 )
 
@@ -403,14 +402,6 @@ func init() {
 			Destination: &alwaysLog,
 		},
 		&cli.StringFlag{
-			Name:        "always-log-file",
-			Aliases:     []string{"alog"},
-			Value:       defAlwaysLogConfigurationFile,
-			Usage:       "Database logger configuration to always store status and on-demand query logs from nodes",
-			EnvVars:     []string{"ALWAYS_LOG_FILE"},
-			Destination: &alwaysLogFile,
-		},
-		&cli.StringFlag{
 			Name:        "carver-type",
 			Value:       settings.CarverDB,
 			Usage:       "Carver to be used to receive files extracted from nodes",
@@ -475,10 +466,7 @@ func osctrlService() {
 	}
 	// Initialize TLS logger
 	log.Println("Loading TLS logger")
-	if !alwaysLog {
-		alwaysLogFile = ""
-	}
-	loggerTLS, err = logging.CreateLoggerTLS(tlsConfig.Logger, loggerFile, alwaysLogFile, settingsmgr, nodesmgr, queriesmgr, redis)
+	loggerTLS, err = logging.CreateLoggerTLS(tlsConfig.Logger, loggerFile, alwaysLog, dbConfig, settingsmgr, nodesmgr, queriesmgr, redis)
 	if err != nil {
 		log.Fatalf("Error loading logger - %s: %v", tlsConfig.Logger, err)
 	}


### PR DESCRIPTION
* Fix for `osctrl-tls` unit tests.
* Prevent logging the same data twice, when always logging is enabled.
* Reuse the database configuration for always logging settings, so deployment is easier.