### PR TITLE
Environment ID added to queries

### DIFF
--- a/queries/queries.go
+++ b/queries/queries.go
@@ -55,19 +55,20 @@ const (
 // DistributedQuery as abstraction of a distributed query
 type DistributedQuery struct {
 	gorm.Model
-	Name       string `gorm:"not null;unique;index"`
-	Creator    string
-	Query      string
-	Expected   int
-	Executions int
-	Errors     int
-	Active     bool
-	Hidden     bool
-	Protected  bool
-	Completed  bool
-	Deleted    bool
-	Type       string
-	Path       string
+	Name          string `gorm:"not null;unique;index"`
+	Creator       string
+	Query         string
+	Expected      int
+	Executions    int
+	Errors        int
+	Active        bool
+	Hidden        bool
+	Protected     bool
+	Completed     bool
+	Deleted       bool
+	Type          string
+	Path          string
+	EnvironmentID uint
 }
 
 // DistributedQueryTarget to keep target logic for queries

--- a/queries/saved.go
+++ b/queries/saved.go
@@ -9,9 +9,10 @@ import (
 // SavedQuery as abstraction of a saved query to be used in distributed, schedule or packs
 type SavedQuery struct {
 	gorm.Model
-	Name    string
-	Creator string
-	Query   string
+	Name          string
+	Creator       string
+	Query         string
+	EnvironmentID uint
 }
 
 // GetSavedByCreator to get a saved query by creator


### PR DESCRIPTION
Adding `environment_id` to saved and on-demand queries.