### PR TITLE
Fix for #265 in tls, admin and api

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -194,6 +194,9 @@ func loadConfiguration(file, service string) (types.JSONConfigurationAdmin, erro
 	}
 	// Admin values
 	adminRaw := viper.Sub(service)
+	if adminRaw == nil {
+		return cfg, fmt.Errorf("JSON key %s not found in %s", service, file)
+	}
 	if err := adminRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}

--- a/api/main.go
+++ b/api/main.go
@@ -133,7 +133,7 @@ var validAuth = map[string]bool{
 }
 
 // Function to load the configuration file and assign to variables
-func loadConfiguration(file string) (types.JSONConfigurationAPI, error) {
+func loadConfiguration(file, service string) (types.JSONConfigurationAPI, error) {
 	var cfg types.JSONConfigurationAPI
 	log.Printf("Loading %s", file)
 	// Load file and read config
@@ -141,9 +141,12 @@ func loadConfiguration(file string) (types.JSONConfigurationAPI, error) {
 	if err := viper.ReadInConfig(); err != nil {
 		return cfg, err
 	}
-	// TLS endpoint values
-	tlsRaw := viper.Sub(settings.ServiceAPI)
-	if err := tlsRaw.Unmarshal(&cfg); err != nil {
+	// API values
+	apiRaw := viper.Sub(service)
+	if apiRaw == nil {
+		return cfg, fmt.Errorf("JSON key %s not found in %s", service, file)
+	}
+	if err := apiRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
 	// Check if values are valid
@@ -544,7 +547,7 @@ func osctrlAPIService() {
 func cliAction(c *cli.Context) error {
 	// Load configuration if external JSON config file is used
 	if configFlag {
-		apiConfig, err = loadConfiguration(serviceConfigFile)
+		apiConfig, err = loadConfiguration(serviceConfigFile, settings.ServiceAPI)
 		if err != nil {
 			return fmt.Errorf("Failed to load service configuration %s - %s", serviceConfigFile, err)
 		}

--- a/tls/main.go
+++ b/tls/main.go
@@ -139,7 +139,7 @@ var validCarver = map[string]bool{
 }
 
 // Function to load the configuration file and assign to variables
-func loadConfiguration(file string) (types.JSONConfigurationTLS, error) {
+func loadConfiguration(file, service string) (types.JSONConfigurationTLS, error) {
 	var cfg types.JSONConfigurationTLS
 	log.Printf("Loading %s", file)
 	// Load file and read config
@@ -148,7 +148,10 @@ func loadConfiguration(file string) (types.JSONConfigurationTLS, error) {
 		return cfg, err
 	}
 	// TLS endpoint values
-	tlsRaw := viper.Sub(settings.ServiceTLS)
+	tlsRaw := viper.Sub(service)
+	if tlsRaw == nil {
+		return cfg, fmt.Errorf("JSON key %s not found in %s", service, file)
+	}
 	if err := tlsRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
@@ -642,7 +645,7 @@ func osctrlService() {
 func cliAction(c *cli.Context) error {
 	// Load configuration if external JSON config file is used
 	if configFlag {
-		tlsConfig, err = loadConfiguration(serviceConfigFile)
+		tlsConfig, err = loadConfiguration(serviceConfigFile, settings.ServiceTLS)
 		if err != nil {
 			return fmt.Errorf("Error loading %s - %s", serviceConfigFile, err)
 		}


### PR DESCRIPTION
Fix for #265 in `osctrl-tls`, `osctrl-admin` and `osctrl-api`