### PR TITLE
Using `osctrl-api` for nodes in `osctrl-cli`

### DIFF
--- a/cli/api-node.go
+++ b/cli/api-node.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jmpsec/osctrl/nodes"
+)
+
+// GetNodes to retrieve nodes from osctrl
+func (api *OsctrlAPI) GetNodes() ([]nodes.OsqueryNode, error) {
+	var nds []nodes.OsqueryNode
+	reqURL := fmt.Sprintf("%s%s%s", api.Configuration.URL, APIPath, APINodes)
+	rawNodes, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return nds, fmt.Errorf("error api request - %v", err)
+	}
+	if err := json.Unmarshal(rawNodes, &nds); err != nil {
+		return nds, fmt.Errorf("can not parse body - %v", err)
+	}
+	return nds, nil
+}
+
+// GetNode to retrieve one node from osctrl
+func (api *OsctrlAPI) GetNode(identifier string) (nodes.OsqueryNode, error) {
+	var node nodes.OsqueryNode
+	reqURL := fmt.Sprintf("%s%s%s/%s", api.Configuration.URL, APIPath, APINodes, identifier)
+	rawNode, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return node, fmt.Errorf("error api request - %v", err)
+	}
+	if err := json.Unmarshal(rawNode, &node); err != nil {
+		return node, fmt.Errorf("can not parse body - %v", err)
+	}
+	return node, nil
+}
+
+// DeleteNode to delete node from osctrl
+func (api *OsctrlAPI) DeleteNode(identifier string) error {
+	return nil
+}

--- a/cli/api.go
+++ b/cli/api.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/jmpsec/osctrl/nodes"
+	"github.com/jmpsec/osctrl/version"
+	"github.com/spf13/viper"
+)
+
+const (
+	// APIPath for the generic API path in osctrl
+	APIPath = "/api/v1"
+	// APINodes for the nodes path
+	APINodes = "/nodes"
+	// JSONApplication for Content-Type headers
+	JSONApplication = "application/json"
+	// JSONApplicationUTF8 for Content-Type headers, UTF charset
+	JSONApplicationUTF8 = JSONApplication + "; charset=UTF-8"
+	// ContentType for header key
+	ContentType = "Content-Type"
+	// UserAgent for header key
+	UserAgent = "User-Agent"
+	// Authorization for header key
+	Authorization = "Authorization"
+	// osctrlUserAgent for customized User-Agent
+	osctrlUserAgent = "osctrl-cli-http-client/" + version.OsctrlVersion
+)
+
+// JSONConfigurationAPI to hold all API configuration values
+type JSONConfigurationAPI struct {
+	URL   string `json:"url"`
+	Token string `json:"token"`
+}
+
+// OsctrlAPI
+type OsctrlAPI struct {
+	Configuration JSONConfigurationAPI
+	Client        *http.Client
+	Headers       map[string]string
+}
+
+// loadAPIConfiguration to load the DB configuration file and assign to variables
+func loadAPIConfiguration(file string) (JSONConfigurationAPI, error) {
+	var config JSONConfigurationAPI
+	// Load file and read config
+	viper.SetConfigFile(file)
+	if err := viper.ReadInConfig(); err != nil {
+		return config, err
+	}
+	// API values
+	apiRaw := viper.Sub(projectName)
+	if apiRaw == nil {
+		return config, fmt.Errorf("could not find key %s", projectName)
+	}
+	if err := apiRaw.Unmarshal(&config); err != nil {
+		return config, err
+	}
+	// No errors!
+	return config, nil
+}
+
+// CreateAPI to initialize the API client and handlers
+func CreateAPI(config JSONConfigurationAPI, insecure bool) *OsctrlAPI {
+	var a *OsctrlAPI
+	// Prepare URL
+	u, err := url.Parse(config.URL)
+	if err != nil {
+		log.Fatalf("invalid url: %v", err)
+	}
+	// Define client with correct TLS settings
+	client := &http.Client{}
+	if u.Scheme == "https" {
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			log.Fatalf("error loading x509 certificate pool: %v", err)
+		}
+		tlsCfg := &tls.Config{RootCAs: certPool}
+		if insecure {
+			tlsCfg.InsecureSkipVerify = true
+		}
+		client.Transport = &http.Transport{TLSClientConfig: tlsCfg}
+	}
+	// Prepare authentication
+	headers := make(map[string]string)
+	headers[Authorization] = fmt.Sprintf("Bearer %s", config.Token)
+	headers[ContentType] = JSONApplicationUTF8
+	a = &OsctrlAPI{
+		Configuration: config,
+		Client:        client,
+		Headers:       headers,
+	}
+	return a
+}
+
+// GetGeneric - Helper function to implement generic retrieval from API
+func (api *OsctrlAPI) GetGeneric(url string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, body)
+	if err != nil {
+		return []byte{}, fmt.Errorf("NewRequest - %v", err)
+	}
+	// Set custom User-Agent
+	req.Header.Set(UserAgent, osctrlUserAgent)
+	// Prepare headers
+	for key, value := range api.Headers {
+		req.Header.Add(key, value)
+	}
+	// Send request
+	resp, err := api.Client.Do(req)
+	if err != nil {
+		return []byte{}, fmt.Errorf("Client.Do - %v", err)
+	}
+	// Check response code
+	if resp.StatusCode != http.StatusOK {
+		return []byte{}, fmt.Errorf("HTTP Code %d", resp.StatusCode)
+	}
+	//defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("failed to close body %v", err)
+		}
+	}()
+	// Read body
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []byte{}, fmt.Errorf("can not read response - %v", err)
+	}
+	return bodyBytes, nil
+}
+
+// GetNodes to retrieve nodes from osctrl
+func (api *OsctrlAPI) GetNodes() ([]nodes.OsqueryNode, error) {
+	var nds []nodes.OsqueryNode
+	reqURL := fmt.Sprintf("%s%s%s", api.Configuration.URL, APIPath, APINodes)
+	rawNodes, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return nds, fmt.Errorf("error api request - %v", err)
+	}
+	if err := json.Unmarshal(rawNodes, &nds); err != nil {
+		return nds, fmt.Errorf("can not parse body - %v", err)
+	}
+	return nds, nil
+}

--- a/cli/api.go
+++ b/cli/api.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/version"
 	"github.com/spf13/viper"
 )
@@ -134,18 +132,4 @@ func (api *OsctrlAPI) GetGeneric(url string, body io.Reader) ([]byte, error) {
 		return []byte{}, fmt.Errorf("can not read response - %v", err)
 	}
 	return bodyBytes, nil
-}
-
-// GetNodes to retrieve nodes from osctrl
-func (api *OsctrlAPI) GetNodes() ([]nodes.OsqueryNode, error) {
-	var nds []nodes.OsqueryNode
-	reqURL := fmt.Sprintf("%s%s%s", api.Configuration.URL, APIPath, APINodes)
-	rawNodes, err := api.GetGeneric(reqURL, nil)
-	if err != nil {
-		return nds, fmt.Errorf("error api request - %v", err)
-	}
-	if err := json.Unmarshal(rawNodes, &nds); err != nil {
-		return nds, fmt.Errorf("can not parse body - %v", err)
-	}
-	return nds, nil
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -19,8 +19,6 @@ import (
 )
 
 const (
-	// DB configuration file
-	defDBConfigurationFile string = "config/db.json"
 	// Project name
 	projectName string = "osctrl"
 	// Application name
@@ -38,6 +36,7 @@ var (
 	err         error
 	app         *cli.App
 	dbConfig    backend.JSONConfigurationDB
+	apiConfig   JSONConfigurationAPI
 	flags       []cli.Flag
 	commands    []*cli.Command
 	settingsmgr *settings.Settings
@@ -47,12 +46,19 @@ var (
 	tagsmgr     *tags.TagManager
 	envs        *environments.Environment
 	db          *backend.DBManager
+	osctrlAPI   *OsctrlAPI
 )
 
 // Variables for flags
 var (
-	dbFlag       bool
-	dbConfigFile string
+	dbFlag        bool
+	apiFlag       bool
+	jsonFlag      bool
+	csvFlag       bool
+	prettyFlag    bool
+	insecureFlag  bool
+	dbConfigFile  string
+	apiConfigFile string
 )
 
 // Initialization code
@@ -63,15 +69,45 @@ func init() {
 			Name:        "db",
 			Aliases:     []string{"d"},
 			Value:       false,
-			Usage:       "Provide DB configuration via JSON file",
+			Usage:       "Connect to local osctrl DB using JSON config file",
 			EnvVars:     []string{"DB_CONFIG"},
 			Destination: &dbFlag,
+		},
+		&cli.BoolFlag{
+			Name:        "api",
+			Aliases:     []string{"a"},
+			Value:       true,
+			Usage:       "Connect to remote osctrl using JSON config file",
+			EnvVars:     []string{"API_CONFIG"},
+			Destination: &apiFlag,
+		},
+		&cli.StringFlag{
+			Name:        "api-file",
+			Aliases:     []string{"A"},
+			Value:       "",
+			Usage:       "Load API JSON configuration from `FILE`",
+			EnvVars:     []string{"API_CONFIG_FILE"},
+			Destination: &apiConfigFile,
+		},
+		&cli.StringFlag{
+			Name:        "api-url",
+			Aliases:     []string{"U"},
+			Usage:       "The URL for osctrl API to be used",
+			EnvVars:     []string{"API_URL"},
+			Destination: &apiConfig.URL,
+		},
+		&cli.StringFlag{
+			Name:        "api-token",
+			Aliases:     []string{"T"},
+			Usage:       "Token to authenticate with the osctrl API",
+			EnvVars:     []string{"API_TOKEN"},
+			Destination: &apiConfig.Token,
 		},
 		&cli.StringFlag{
 			Name:        "db-file",
 			Aliases:     []string{"D"},
-			Value:       defDBConfigurationFile,
-			Usage:       "Load DB configuration from `FILE`",
+			Value:       "",
+			Usage:       "Load DB JSON configuration from `FILE`",
 			EnvVars:     []string{"DB_CONFIG_FILE"},
 			Destination: &dbConfigFile,
 		},
@@ -130,6 +166,34 @@ func init() {
 			Usage:       "Maximum amount of time a connection may be reused",
 			EnvVars:     []string{"DB_CONN_MAX_LIFETIME"},
 			Destination: &dbConfig.ConnMaxLifetime,
+		},
+		&cli.BoolFlag{
+			Name:        "insecure",
+			Aliases:     []string{"i"},
+			Value:       false,
+			Usage:       "Allow insecure server connections when using SSL",
+			Destination: &insecureFlag,
+		},
+		&cli.BoolFlag{
+			Name:        "json",
+			Aliases:     []string{"j"},
+			Value:       false,
+			Usage:       "Print output in JSON format",
+			Destination: &jsonFlag,
+		},
+		&cli.BoolFlag{
+			Name:        "csv",
+			Aliases:     []string{"c"},
+			Value:       false,
+			Usage:       "Print output in CSV format",
+			Destination: &csvFlag,
+		},
+		&cli.BoolFlag{
+			Name:        "pretty",
+			Aliases:     []string{"p"},
+			Value:       true,
+			Usage:       "Print output in pretty format (table)",
+			Destination: &prettyFlag,
 		},
 	}
 	// Initialize CLI flags commands
@@ -1088,9 +1152,14 @@ func init() {
 			},
 		},
 		{
-			Name:   "check",
+			Name:   "check-db",
 			Usage:  "Checks DB connection",
 			Action: checkDB,
+		},
+		{
+			Name:   "check-api",
+			Usage:  "Checks API token",
+			Action: cliWrapper(checkAPI),
 		},
 	}
 }
@@ -1116,36 +1185,65 @@ func checkDB(c *cli.Context) error {
 	return nil
 }
 
+// Action for the API check
+func checkAPI(c *cli.Context) error {
+	if apiFlag {
+		nds, err := osctrlAPI.GetNodes()
+		if err != nil {
+			return err
+		}
+		log.Printf("Received %d nodes", len(nds))
+	}
+	// Should be good
+	return nil
+}
+
 // Function to wrap actions
 func cliWrapper(action func(*cli.Context) error) func(*cli.Context) error {
 	return func(c *cli.Context) error {
-		// Load DB configuration if external JSON config file is used
+		// DB connection will be used
 		if dbFlag {
 			// Initialize backend
-			db, err = backend.CreateDBManagerFile(dbConfigFile)
-			if err != nil {
-				return fmt.Errorf("Failed to create backend - %v", err)
+			if dbConfigFile != "" {
+				db, err = backend.CreateDBManagerFile(dbConfigFile)
+				if err != nil {
+					return fmt.Errorf("CreateDBManagerFile - %v", err)
+				}
+			} else {
+				db, err = backend.CreateDBManager(dbConfig)
+				if err != nil {
+					return fmt.Errorf("CreateDBManager - %v", err)
+				}
 			}
-		} else {
-			db, err = backend.CreateDBManager(dbConfig)
-			if err != nil {
-				return fmt.Errorf("Failed to create backend - %v", err)
-			}
+			// Initialize users
+			adminUsers = users.CreateUserManager(db.Conn, &types.JSONConfigurationJWT{JWTSecret: appName})
+			// Initialize environment
+			envs = environments.CreateEnvironment(db.Conn)
+			// Initialize settings
+			settingsmgr = settings.NewSettings(db.Conn)
+			// Initialize nodes
+			nodesmgr = nodes.CreateNodes(db.Conn)
+			// Initialize queries
+			queriesmgr = queries.CreateQueries(db.Conn)
+			// Initialize tags
+			tagsmgr = tags.CreateTagManager(db.Conn)
+			// Execute action
+			return action(c)
 		}
-		// Initialize users
-		adminUsers = users.CreateUserManager(db.Conn, &types.JSONConfigurationJWT{JWTSecret: appName})
-		// Initialize environment
-		envs = environments.CreateEnvironment(db.Conn)
-		// Initialize settings
-		settingsmgr = settings.NewSettings(db.Conn)
-		// Initialize nodes
-		nodesmgr = nodes.CreateNodes(db.Conn)
-		// Initialize queries
-		queriesmgr = queries.CreateQueries(db.Conn)
-		// Initialize tags
-		tagsmgr = tags.CreateTagManager(db.Conn)
-		// Execute action
-		return action(c)
+		if apiFlag {
+			if apiConfigFile != "" {
+				apiConfig, err = loadAPIConfiguration(apiConfigFile)
+				if err != nil {
+					return fmt.Errorf("loadAPIConfiguration - %v", err)
+				}
+			}
+			// Initialize API
+			osctrlAPI = CreateAPI(apiConfig, insecureFlag)
+			// Execute action
+			return action(c)
+		}
+		// If we are here, nor DB or API has been enabled
+		return nil
 	}
 }
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -969,16 +969,17 @@ func init() {
 					Usage:   "List enrolled nodes",
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
-							Name:    "all, v",
-							Aliases: []string{"v"},
-							Hidden:  false,
-							Usage:   "Show all nodes",
-						},
-						&cli.BoolFlag{
 							Name:    "active",
 							Aliases: []string{"a"},
-							Hidden:  true,
+							Hidden:  false,
+							Value:   true,
 							Usage:   "Show active nodes",
+						},
+						&cli.BoolFlag{
+							Name:    "all, A",
+							Aliases: []string{"A"},
+							Hidden:  false,
+							Usage:   "Show all nodes",
 						},
 						&cli.BoolFlag{
 							Name:    "inactive, i",
@@ -988,6 +989,19 @@ func init() {
 						},
 					},
 					Action: cliWrapper(listNodes),
+				},
+				{
+					Name:    "show",
+					Aliases: []string{"s"},
+					Usage:   "Show an existing node",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    "uuid",
+							Aliases: []string{"u"},
+							Usage:   "Node UUID to be shown",
+						},
+					},
+					Action: cliWrapper(showNode),
 				},
 			},
 		},
@@ -1159,7 +1173,7 @@ func init() {
 		{
 			Name:   "check-api",
 			Usage:  "Checks API token",
-			Action: cliWrapper(checkAPI),
+			Action: checkAPI,
 		},
 	}
 }
@@ -1188,11 +1202,14 @@ func checkDB(c *cli.Context) error {
 // Action for the API check
 func checkAPI(c *cli.Context) error {
 	if apiFlag {
-		nds, err := osctrlAPI.GetNodes()
-		if err != nil {
-			return err
+		if apiConfigFile != "" {
+			apiConfig, err = loadAPIConfiguration(apiConfigFile)
+			if err != nil {
+				return fmt.Errorf("loadAPIConfiguration - %v", err)
+			}
 		}
-		log.Printf("Received %d nodes", len(nds))
+		// Initialize API
+		osctrlAPI = CreateAPI(apiConfig, insecureFlag)
 	}
 	// Should be good
 	return nil

--- a/cli/node.go
+++ b/cli/node.go
@@ -1,17 +1,49 @@
 package main
 
 import (
+	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/jmpsec/osctrl/nodes"
-	"github.com/jmpsec/osctrl/utils"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 )
 
+// Helper function to convert a slice of nodes into the data expected for output
+func nodesToData(nds []nodes.OsqueryNode, header []string) [][]string {
+	var data [][]string
+	if header != nil {
+		data = append(data, header)
+	}
+	for _, n := range nds {
+		data = append(data, nodeToData(n, nil)...)
+	}
+	return data
+}
+
+func nodeToData(n nodes.OsqueryNode, header []string) [][]string {
+	var data [][]string
+	if header != nil {
+		data = append(data, header)
+	}
+	_n := []string{
+		n.Hostname,
+		n.UUID,
+		n.Platform,
+		n.PlatformVersion,
+		n.Environment,
+		nodeLastSeen(n),
+		n.IPAddress,
+		n.OsqueryVersion,
+	}
+	data = append(data, _n)
+	return data
+}
+
 func listNodes(c *cli.Context) error {
-	// Get values from flags
+	// Get flag values for this command
 	target := "active"
 	if c.Bool("all") {
 		target = "all"
@@ -19,6 +51,7 @@ func listNodes(c *cli.Context) error {
 	if c.Bool("inactive") {
 		target = "inactive"
 	}
+	// Retrieve data
 	var nds []nodes.OsqueryNode
 	if dbFlag {
 		nds, err = nodesmgr.Gets(target, settingsmgr.InactiveHours())
@@ -31,35 +64,40 @@ func listNodes(c *cli.Context) error {
 			return err
 		}
 	}
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{
+	header := []string{
 		"Hostname",
 		"UUID",
 		"Platform",
+		"PlatformVersion",
 		"Environment",
-		"Last Status",
+		"Last Seen",
 		"IPAddress",
-		"Version",
-	})
-	if len(nds) > 0 {
-		data := [][]string{}
-		fmt.Printf("Existing %s nodes (%d):\n", target, len(nds))
-		for _, n := range nds {
-			_n := []string{
-				n.Hostname,
-				n.UUID,
-				n.Platform,
-				n.Environment,
-				utils.PastFutureTimes(n.LastStatus),
-				n.IPAddress,
-				n.OsqueryVersion,
-			}
-			data = append(data, _n)
+		"OsqueryVersion",
+	}
+	// Prepare output
+	if jsonFlag {
+		jsonRaw, err := json.Marshal(nds)
+		if err != nil {
+			return err
 		}
-		table.AppendBulk(data)
+		fmt.Println(string(jsonRaw))
+	} else if csvFlag {
+		data := nodesToData(nds, header)
+		w := csv.NewWriter(os.Stdout)
+		if err := w.WriteAll(data); err != nil {
+			return err
+		}
+	} else if prettyFlag {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader(header)
+		if len(nds) > 0 {
+			fmt.Printf("Existing %s nodes (%d):\n", target, len(nds))
+			data := nodesToData(nds, nil)
+			table.AppendBulk(data)
+		} else {
+			fmt.Printf("No %s nodes\n", target)
+		}
 		table.Render()
-	} else {
-		fmt.Printf("No nodes\n")
 	}
 	return nil
 }
@@ -71,5 +109,65 @@ func deleteNode(c *cli.Context) error {
 		fmt.Println("uuid is required")
 		os.Exit(1)
 	}
-	return nodesmgr.ArchiveDeleteByUUID(uuid)
+	if dbFlag {
+		if err := nodesmgr.ArchiveDeleteByUUID(uuid); err != nil {
+			return err
+		}
+	} else if apiFlag {
+
+	}
+	fmt.Println("✅ Node has been deleted")
+	return nil
+}
+
+func showNode(c *cli.Context) error {
+	// Get values from flags
+	uuid := c.String("uuid")
+	if uuid == "" {
+		fmt.Println("UUID is required")
+		os.Exit(1)
+	}
+	var node nodes.OsqueryNode
+	if dbFlag {
+		node, err = nodesmgr.GetByUUID(uuid)
+		if err != nil {
+			return err
+		}
+	} else if apiFlag {
+		node, err = osctrlAPI.GetNode(uuid)
+		if err != nil {
+			return err
+		}
+	}
+	header := []string{
+		"Hostname",
+		"UUID",
+		"Platform",
+		"PlatformVersion",
+		"Environment",
+		"Last Seen",
+		"IPAddress",
+		"OsqueryVersion",
+	}
+	// Prepare output
+	if jsonFlag {
+		jsonRaw, err := json.Marshal(node)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(jsonRaw))
+	} else if csvFlag {
+		data := nodeToData(node, header)
+		w := csv.NewWriter(os.Stdout)
+		if err := w.WriteAll(data); err != nil {
+			return err
+		}
+	} else if prettyFlag {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader(header)
+		data := nodeToData(node, header)
+		table.AppendBulk(data)
+		table.Render()
+	}
+	return nil
 }

--- a/cli/node.go
+++ b/cli/node.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/utils"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
@@ -18,9 +19,17 @@ func listNodes(c *cli.Context) error {
 	if c.Bool("inactive") {
 		target = "inactive"
 	}
-	nodes, err := nodesmgr.Gets(target, settingsmgr.InactiveHours())
-	if err != nil {
-		return err
+	var nds []nodes.OsqueryNode
+	if dbFlag {
+		nds, err = nodesmgr.Gets(target, settingsmgr.InactiveHours())
+		if err != nil {
+			return err
+		}
+	} else if apiFlag {
+		nds, err = osctrlAPI.GetNodes()
+		if err != nil {
+			return err
+		}
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{
@@ -32,10 +41,10 @@ func listNodes(c *cli.Context) error {
 		"IPAddress",
 		"Version",
 	})
-	if len(nodes) > 0 {
+	if len(nds) > 0 {
 		data := [][]string{}
-		fmt.Printf("Existing %s nodes (%d):\n", target, len(nodes))
-		for _, n := range nodes {
+		fmt.Printf("Existing %s nodes (%d):\n", target, len(nds))
+		for _, n := range nds {
 			_n := []string{
 				n.Hostname,
 				n.UUID,

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"time"
 	"unicode/utf8"
 
+	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/users"
+	"github.com/jmpsec/osctrl/utils"
 )
 
 // Helper to truncate a string
@@ -50,6 +53,51 @@ func stringifyUserAccess(perms users.UserAccess) string {
 	for e, p := range perms {
 		env, _ := envs.Get(e)
 		res += fmt.Sprintf("%s [%s]\n", env.Name, stringifyEnvAccess(p))
+	}
+	return res
+}
+
+// Helper to get what is the last seen time for a node
+func nodeLastSeen(n nodes.OsqueryNode) string {
+	now := time.Now()
+	var diff float64
+	var res string
+	// Status if not empty/zero
+	if !n.LastStatus.IsZero() {
+		diff = n.LastStatus.Sub(now).Seconds()
+		res = utils.PastFutureTimes(n.LastStatus) + " (status)"
+	}
+	// Result if not empty/zero
+	if n.LastResult.Year() == now.Year() {
+		diffResult := n.LastResult.Sub(now).Seconds()
+		if diffResult < diff {
+			res = utils.PastFutureTimes(n.LastResult) + " (result)"
+			diff = diffResult
+		}
+	}
+	// Config if not empty/zero
+	if n.LastConfig.Year() == now.Year() {
+		diffConfig := n.LastConfig.Sub(now).Seconds()
+		if diffConfig < diff {
+			res = utils.PastFutureTimes(n.LastConfig) + " (config)"
+			diff = diffConfig
+		}
+	}
+	// Query read if not empty/zero
+	if n.LastQueryRead.Year() == now.Year() {
+		diffRead := n.LastQueryRead.Sub(now).Seconds()
+		if diffRead < diff {
+			res = utils.PastFutureTimes(n.LastQueryRead) + " (query)"
+			diff = diffRead
+		}
+	}
+	// Query write if not empty/zero
+	if n.LastQueryWrite.Year() == now.Year() {
+		diffWrite := n.LastQueryWrite.Sub(now).Seconds()
+		if diffWrite < diff {
+			res = utils.PastFutureTimes(n.LastQueryWrite) + " (write)"
+			diff = diffWrite
+		}
 	}
 	return res
 }


### PR DESCRIPTION
Extend `osctrl-cli` to be used remotely via `osctrl-api` and authenticating via JWT tokens:
- Adding JSON output
- Adding CSV output