### PR TITLE
Update Docker setup for v0.3.1

### DIFF
--- a/deploy/cicd/docker/Dockerfile-osctrl-admin
+++ b/deploy/cicd/docker/Dockerfile-osctrl-admin
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG COMPONENT=admin
 ARG GOOS=linux

--- a/deploy/cicd/docker/Dockerfile-osctrl-api
+++ b/deploy/cicd/docker/Dockerfile-osctrl-api
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG COMPONENT=api
 ARG GOOS=linux

--- a/deploy/cicd/docker/Dockerfile-osctrl-cli
+++ b/deploy/cicd/docker/Dockerfile-osctrl-cli
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG COMPONENT=cli
 ARG GOOS=linux

--- a/deploy/cicd/docker/Dockerfile-osctrl-tls
+++ b/deploy/cicd/docker/Dockerfile-osctrl-tls
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG COMPONENT=tls
 ARG GOOS=linux

--- a/deploy/docker/Dockerfile-osctrl-dev
+++ b/deploy/docker/Dockerfile-osctrl-dev
@@ -127,7 +127,7 @@ WORKDIR /opt/osctrl
 ENTRYPOINT [ "/opt/osctrl/bin/osctrl-admin" ]
 
 ######################################## Ubuntu 20.04 node ########################################
-FROM ubuntu:20.04 as osctrl-ubuntu-osquery
+FROM ubuntu:22.04 as osctrl-ubuntu-osquery
 ARG OSCTRL_VERSION
 ARG OSQUERY_VERSION
 ARG POSTGRES_DB_NAME

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -13,7 +13,7 @@ Follow these steps to generate a self-signed certificate that is going to be use
 1. `cp conf/tls/openssl.cnf.example conf/tls/openssl.cnf`
 2. `vim conf/tls/openssl.cnf` and set `emailAddress` with valid e-mail for your org
 3. Replace `osctrl.example.com` in all fields with your domain
-4. `openssl req -x509 -new -nodes -keyout conf/tls/tls.key -out conf/tls/tls.crt -config conf/tls/openssl.cnf`
+4. `openssl req -x509 -new -nodes -days 3650 -keyout conf/tls/tls.key -out conf/tls/tls.crt -config conf/tls/openssl.cnf`
 
 ## Generate JWT secret
 

--- a/deploy/docker/conf/osctrl/cli/entrypoint.sh
+++ b/deploy/docker/conf/osctrl/cli/entrypoint.sh
@@ -13,14 +13,14 @@ if [[ -n "$OSCTRL_PASS_FILE" ]]; then
 fi
 
 ######################################### Wait until DB is up #########################################
-until /opt/osctrl/bin/osctrl-cli check
+until /opt/osctrl/bin/osctrl-cli check-db
 do
   echo "DB is not ready"
   sleep $WAIT
 done
 
 ######################################### Create environment #########################################
-/opt/osctrl/bin/osctrl-cli env add \
+/opt/osctrl/bin/osctrl-cli --db env add \
   --name "${ENV_NAME}" \
   --hostname "${HOST}" \
   --certificate "${CRT_FILE}"
@@ -31,7 +31,7 @@ else
 fi
 
 ######################################### Create admin user #########################################
-/opt/osctrl/bin/osctrl-cli user add \
+/opt/osctrl/bin/osctrl-cli --db user add \
   --admin \
   --username "${OSCTRL_USER}" \
   --password "${OSCTRL_PASS}" \

--- a/deploy/docker/conf/osquery/entrypoint.sh
+++ b/deploy/docker/conf/osquery/entrypoint.sh
@@ -4,31 +4,31 @@ ENV_NAME="${ENV_NAME:=dev}"
 HOST="${HOST:=nginx}"
 
 if [ ! -f "/etc/osquery/osquery.secret" ]; then
-    ######################################### Wait until DB is up #########################################
-    until /opt/osctrl/bin/osctrl-cli check
-    do
-        echo "DB is not ready"
-        sleep 3
-    done
+  ######################################### Wait until DB is up ######################################### 
+  until /opt/osctrl/bin/osctrl-cli check-db
+  do
+    echo "DB is not ready"
+    sleep $WAIT
+  done
 
-    ######################################### Osquery config #########################################
-    # Wait until for env to exist
-    until /opt/osctrl/bin/osctrl-cli env show --name "${ENV_NAME}"
-    do
-        echo "${ENV_NAME} does not exist"
-        sleep 3
-    done
+  ######################################### Osquery config #########################################
+  # Wait until for env to exist
+  until /opt/osctrl/bin/osctrl-cli --db env show --name "${ENV_NAME}"
+  do
+      echo "${ENV_NAME} does not exist"
+      sleep 3
+  done
 
-    # Get enroll secret
-    /opt/osctrl/bin/osctrl-cli env secret --name "${ENV_NAME}" > /etc/osquery/osquery.secret
+  # Get enroll secret
+  /opt/osctrl/bin/osctrl-cli --db env secret --name "${ENV_NAME}" > /etc/osquery/osquery.secret
 
-    # Get server cert
-    echo "" | openssl s_client -connect ${HOST}:443 2>/dev/null | sed -n -e '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p' > /etc/osquery/osctrl.crt
+  # Get server cert
+  echo "" | openssl s_client -connect ${HOST}:443 2>/dev/null | sed -n -e '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p' > /etc/osquery/osctrl.crt
 
-    # Get and set Osquery flags
-    /opt/osctrl/bin/osctrl-cli env show-flags --name "${ENV_NAME}" > /etc/osquery/osquery.flags
-    sed -i "s#__SECRET_FILE__#/etc/osquery/osquery.secret#g" /etc/osquery/osquery.flags
-    echo "--tls_server_certs=/etc/osquery/osctrl.crt" >> /etc/osquery/osquery.flags
+  # Get and set Osquery flags
+  /opt/osctrl/bin/osctrl-cli --db env show-flags --name "${ENV_NAME}" > /etc/osquery/osquery.flags
+  sed -i "s#__SECRET_FILE__#/etc/osquery/osquery.secret#g" /etc/osquery/osquery.flags
+  echo "--tls_server_certs=/etc/osquery/osctrl.crt" >> /etc/osquery/osquery.flags
 fi
 
 # Run Osquery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,29 @@
-version: "2.2"
+version: "2.4"
 services:
   ######################################### NGINX #########################################
   nginx:
     container_name: 'osctrl-nginx'
+    image: nginx:${NGINX_VERSION}
     restart: unless-stopped
-    build:
-      context: .
-      dockerfile: deploy/docker/Dockerfile-nginx
-      args:
-        NGINX_VERSION: ${NGINX_VERSION}
-    networks:
-      - default
-      - osctrl-backend
     ports:
       - 8000:80
       - 8443:443
+    networks:
+      - default
+      - osctrl-backend
+    volumes:
+      - type: bind
+        source: ./deploy/docker/conf/nginx/nginx.conf
+        target: /etc/nginx/nginx.conf
+      - type: bind
+        source: ./deploy/docker/conf/nginx/osctrl.conf
+        target: /etc/nginx/conf.d/osctrl.conf
+      - type: bind
+        source: ./deploy/docker/conf/tls/tls.crt
+        target: /etc/ssl/certs/osctrl.crt
+      - type: bind
+        source: ./deploy/docker/conf/tls/tls.key
+        target: /etc/ssl/private/osctrl.key
     depends_on:
       - osctrl-tls
       - osctrl-admin
@@ -25,6 +34,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    cpus: 2
+    mem_limit: 150M
 
   ######################################### osctrl-tls #########################################
   osctrl-tls:
@@ -55,6 +66,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    cpus: 2
+    mem_limit: 150M
 
   ######################################### osctrl-admin #########################################
   osctrl-admin:
@@ -86,6 +99,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    cpus: 2
+    mem_limit: 150M
 
   ######################################### osctrl-api #########################################
   osctrl-api:
@@ -117,6 +132,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    cpus: 2
+    mem_limit: 150M
 
   ######################################### PostgreSQL #########################################
   postgres:
@@ -136,6 +153,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    cpus: 2
+    mem_limit: 1G
 
   ######################################### Redis #########################################
   redis:
@@ -146,6 +165,8 @@ services:
       - osctrl-backend
     volumes:
       - redis-data:/data
+    cpus: 1
+    mem_limit: 100M
 
   ######################################### osctrl-cli #########################################
   # osctrl-cli is the component that creates the osctrl env and admin user
@@ -178,10 +199,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    cpus: 1
+    mem_limit: 100M
 
   ######################################### osquery #########################################
   ubuntu-osquery:
-    container_name: 'osctrl-osquery-ubuntu'
     restart: unless-stopped
     build:
       context: .
@@ -213,6 +235,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    cpus: 1
+    mem_limit: 150M
 
 networks:
   osctrl-backend:


### PR DESCRIPTION
Updates:
- Update docker base image to ubuntu:22.04, 
- update osctrl-cli commands to use `osctrl-cli --db`, 
- updated entrypoint scripts

