### PR TITLE
Improvements to `osctrl-cli`

### DIFF
--- a/cli/carve.go
+++ b/cli/carve.go
@@ -94,19 +94,19 @@ func listCarves(c *cli.Context) error {
 		"ArchivePath",
 	}
 	// Prepare output
-	if jsonFlag {
+	if formatFlag == jsonFormat {
 		jsonRaw, err := json.Marshal(cs)
 		if err != nil {
 			return err
 		}
 		fmt.Println(string(jsonRaw))
-	} else if csvFlag {
+	} else if formatFlag == csvFormat {
 		data := carvesToData(cs, header)
 		w := csv.NewWriter(os.Stdout)
 		if err := w.WriteAll(data); err != nil {
 			return err
 		}
-	} else if prettyFlag {
+	} else if formatFlag == prettyFormat {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader(header)
 		if len(cs) > 0 {

--- a/cli/node.go
+++ b/cli/node.go
@@ -80,19 +80,19 @@ func listNodes(c *cli.Context) error {
 		"OsqueryVersion",
 	}
 	// Prepare output
-	if jsonFlag {
+	if formatFlag == jsonFormat {
 		jsonRaw, err := json.Marshal(nds)
 		if err != nil {
 			return fmt.Errorf("❌ error marshaling - %s", err)
 		}
 		fmt.Println(string(jsonRaw))
-	} else if csvFlag {
+	} else if formatFlag == csvFormat {
 		data := nodesToData(nds, header)
 		w := csv.NewWriter(os.Stdout)
 		if err := w.WriteAll(data); err != nil {
 			return fmt.Errorf("❌ error writting csv - %s", err)
 		}
-	} else if prettyFlag {
+	} else if formatFlag == prettyFormat {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader(header)
 		if len(nds) > 0 {
@@ -211,19 +211,19 @@ func showNode(c *cli.Context) error {
 		"OsqueryVersion",
 	}
 	// Prepare output
-	if jsonFlag {
+	if formatFlag == jsonFormat {
 		jsonRaw, err := json.Marshal(node)
 		if err != nil {
 			return fmt.Errorf("❌ error marshaling - %s", err)
 		}
 		fmt.Println(string(jsonRaw))
-	} else if csvFlag {
+	} else if formatFlag == csvFormat {
 		data := nodeToData(node, nil)
 		w := csv.NewWriter(os.Stdout)
 		if err := w.WriteAll(data); err != nil {
 			return fmt.Errorf("❌ error writting csv - %s", err)
 		}
-	} else if prettyFlag {
+	} else if formatFlag == prettyFormat {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader(header)
 		data := nodeToData(node, nil)

--- a/cli/permission.go
+++ b/cli/permission.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/jmpsec/osctrl/users"
+	"github.com/olekukonko/tablewriter"
+	"github.com/urfave/cli/v2"
+)
+
+// Helper function to convert user permissions into the data expected for output
+func permissionsToData(perms users.UserAccess, header []string) [][]string {
+	var data [][]string
+	if header != nil {
+		data = append(data, header)
+	}
+	for e, p := range perms {
+		_p := []string{
+			e,
+			stringifyBool(p.User),
+			stringifyBool(p.Admin),
+			stringifyBool(p.Query),
+			stringifyBool(p.Carve),
+		}
+		data = append(data, _p)
+	}
+	return data
+}
+
+// Helper function
+func accessToData(access users.EnvAccess, env string, header []string) [][]string {
+	var data [][]string
+	if header != nil {
+		data = append(data, header)
+	}
+	_p := []string{
+		env,
+		stringifyBool(access.User),
+		stringifyBool(access.Admin),
+		stringifyBool(access.Query),
+		stringifyBool(access.Carve),
+	}
+	data = append(data, _p)
+	return data
+}
+
+func changePermissions(c *cli.Context) error {
+	// Get values from flags
+	username := c.String("username")
+	if username == "" {
+		fmt.Println("❌ username is required")
+		os.Exit(1)
+	}
+	envName := c.String("environment")
+	if envName == "" {
+		fmt.Println("❌ environment is required")
+		os.Exit(1)
+	}
+	admin := c.Bool("admin")
+	user := c.Bool("user")
+	carve := c.Bool("carve")
+	query := c.Bool("query")
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return fmt.Errorf("❌ error getting environment - %s", err)
+		}
+		// If admin, then all permissions follow
+		if admin {
+			user = true
+			query = true
+			carve = true
+		}
+		// Reset permissions to regular user access
+		if user {
+			if err := adminUsers.SetEnvUser(username, env.UUID, user); err != nil {
+				return fmt.Errorf("❌ error setting user - %s", err)
+			}
+		}
+		if admin {
+			if err := adminUsers.SetEnvAdmin(username, env.UUID, admin); err != nil {
+				return fmt.Errorf("❌ error setting admin - %s", err)
+			}
+		}
+		if carve {
+			if err := adminUsers.SetEnvCarve(username, env.UUID, carve); err != nil {
+				return fmt.Errorf("❌ error setting carve - %s", err)
+			}
+		}
+		if query {
+			if err := adminUsers.SetEnvQuery(username, env.UUID, query); err != nil {
+				return fmt.Errorf("❌ error setting query - %s", err)
+			}
+		}
+	} else if apiFlag {
+	}
+	if !silentFlag {
+		fmt.Printf("✅ permissions changed for user %s successfully\n", username)
+	}
+	return nil
+}
+
+func showPermissions(c *cli.Context) error {
+	// Get values from flags
+	username := c.String("username")
+	if username == "" {
+		fmt.Println("❌ username is required")
+		os.Exit(1)
+	}
+	envName := c.String("environment")
+	if envName == "" {
+		fmt.Println("❌ environment is required")
+		os.Exit(1)
+	}
+	// Retrieve data
+	var userAccess users.EnvAccess
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return fmt.Errorf("❌ error env get - %s", err)
+		}
+		// Show is just display user existing permissions and return
+		userAccess, err = adminUsers.GetEnvAccess(username, env.UUID)
+		if err != nil {
+			return fmt.Errorf("❌ error getting access - %s", err)
+		}
+	} else if apiFlag {
+	}
+	header := []string{
+		"Environment",
+		"User access",
+		"Admin access",
+		"Query access",
+		"Carve access",
+	}
+	// Prepare output
+	if formatFlag == jsonFormat {
+		jsonRaw, err := json.Marshal(userAccess)
+		if err != nil {
+			return fmt.Errorf("❌ error serializing - %s", err)
+		}
+		fmt.Println(string(jsonRaw))
+	} else if formatFlag == csvFormat {
+		data := accessToData(userAccess, envName, header)
+		w := csv.NewWriter(os.Stdout)
+		if err := w.WriteAll(data); err != nil {
+			return fmt.Errorf("❌ error WriteAll - %s", err)
+		}
+	} else if formatFlag == prettyFormat {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader(header)
+		data := accessToData(userAccess, envName, nil)
+		table.AppendBulk(data)
+		table.Render()
+	}
+	return nil
+}
+
+func resetPermissions(c *cli.Context) error {
+	// Get values from flags
+	username := c.String("username")
+	if username == "" {
+		fmt.Println("❌ username is required")
+		os.Exit(1)
+	}
+	envName := c.String("environment")
+	if envName == "" {
+		fmt.Println("❌ environment is required")
+		os.Exit(1)
+	}
+	admin := c.Bool("admin")
+	user := c.Bool("user")
+	carve := c.Bool("carve")
+	query := c.Bool("query")
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		// If admin, then all permissions follow
+		if admin {
+			user = true
+			query = true
+			carve = true
+		}
+		if err := adminUsers.DeletePermissions(username, env.UUID); err != nil {
+			return err
+		}
+		access := adminUsers.GenEnvUserAccess([]string{env.UUID}, user, query, carve, admin)
+		perms := adminUsers.GenPermissions(username, appName, access)
+		if err := adminUsers.CreatePermissions(perms); err != nil {
+			return err
+		}
+	} else if apiFlag {
+	}
+	if !silentFlag {
+		fmt.Printf("✅ permissions reset for user %s successfully\n", username)
+	}
+	return nil
+}
+
+func allPermissions(c *cli.Context) error {
+	// Get values from flags
+	username := c.String("username")
+	if username == "" {
+		fmt.Println("❌ username is required")
+		os.Exit(1)
+	}
+	var existingAccess users.UserAccess
+	if dbFlag {
+		// Show is just display user existing permissions and return
+		existingAccess, err = adminUsers.GetAccess(username)
+		if err != nil {
+			return fmt.Errorf("❌ error getting access - %s", err)
+		}
+	} else if apiFlag {
+	}
+	header := []string{
+		"Environment",
+		"User access",
+		"Admin access",
+		"Query access",
+		"Carve access",
+	}
+	// Prepare output
+	if formatFlag == jsonFormat {
+		jsonRaw, err := json.Marshal(existingAccess)
+		if err != nil {
+			return fmt.Errorf("❌ error serializing - %s", err)
+		}
+		fmt.Println(string(jsonRaw))
+	} else if formatFlag == csvFormat {
+		data := permissionsToData(existingAccess, header)
+		w := csv.NewWriter(os.Stdout)
+		if err := w.WriteAll(data); err != nil {
+			return fmt.Errorf("❌ error WriteAll - %s", err)
+		}
+	} else if formatFlag == prettyFormat {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader(header)
+		data := permissionsToData(existingAccess, nil)
+		table.AppendBulk(data)
+		table.Render()
+	}
+	return nil
+}

--- a/cli/query.go
+++ b/cli/query.go
@@ -98,19 +98,19 @@ func listQueries(c *cli.Context) error {
 		"Deleted",
 	}
 	// Prepare output
-	if jsonFlag {
+	if formatFlag == jsonFormat {
 		jsonRaw, err := json.Marshal(qs)
 		if err != nil {
 			return fmt.Errorf("❌ error json marshal - %s", err)
 		}
 		fmt.Println(string(jsonRaw))
-	} else if csvFlag {
+	} else if formatFlag == csvFormat {
 		data := queriesToData(qs, header)
 		w := csv.NewWriter(os.Stdout)
 		if err := w.WriteAll(data); err != nil {
 			return fmt.Errorf("❌ error csv writeall - %s", err)
 		}
-	} else if prettyFlag {
+	} else if formatFlag == prettyFormat {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader(header)
 		if len(qs) > 0 {


### PR DESCRIPTION
* Better handling for permissions
* Using `-o / --output-format` for `json`, `csv` or `pretty` outputs
* Prepare `osctrl-cli` to utilize API for permissions