### PR TITLE
Fix `osctrl-cli` syntax

### DIFF
--- a/deploy/docker/conf/osctrl/cli/entrypoint.sh
+++ b/deploy/docker/conf/osctrl/cli/entrypoint.sh
@@ -13,7 +13,7 @@ if [[ -n "$OSCTRL_PASS_FILE" ]]; then
 fi
 
 ######################################### Wait until DB is up #########################################
-until /opt/osctrl/bin/osctrl-cli check-db
+until /opt/osctrl/bin/osctrl-cli --db check-db
 do
   echo "DB is not ready"
   sleep $WAIT

--- a/deploy/docker/conf/osquery/entrypoint.sh
+++ b/deploy/docker/conf/osquery/entrypoint.sh
@@ -4,8 +4,8 @@ ENV_NAME="${ENV_NAME:=dev}"
 HOST="${HOST:=nginx}"
 
 if [ ! -f "/etc/osquery/osquery.secret" ]; then
-  ######################################### Wait until DB is up ######################################### 
-  until /opt/osctrl/bin/osctrl-cli check-db
+  ######################################### Wait until DB is up #########################################
+  until /opt/osctrl/bin/osctrl-cli --db check-db
   do
     echo "DB is not ready"
     sleep $WAIT

--- a/deploy/docker/conf/osquery/wait-cli.sh
+++ b/deploy/docker/conf/osquery/wait-cli.sh
@@ -12,14 +12,14 @@ _USER="${_USER:=admin}"
 WAIT=${WAIT:=5}
 
 # Wait until DB is up
-until /opt/osctrl/bin/osctrl-cli -D "$DB_JSON" check
+until /opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" check
 do
   echo "DB is not ready"
   sleep $WAIT
 done
 
 # Create environment dev
-/opt/osctrl/bin/osctrl-cli -D "$DB_JSON" env add -name "$ENV_NAME" -host "$_HOST" -crt "$CRT_FILE"
+/opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" env add -name "$ENV_NAME" -host "$_HOST" -crt "$CRT_FILE"
 if [ $? -eq 0 ]; then
   echo "Created environment dev"
 else
@@ -27,17 +27,17 @@ else
 fi
 
 # Decrease intervals in dev
-/opt/osctrl/bin/osctrl-cli -D "$DB_JSON" env update -n "$ENV_NAME" -l 75 -c 45 -q 60
+/opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" env update -n "$ENV_NAME" -l 75 -c 45 -q 60
 
 # Enable verbose mode
-/opt/osctrl/bin/osctrl-cli -D "$DB_JSON" env add-osquery-option -n dev -o "verbose" -t bool -b true
+/opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" env add-osquery-option -n dev -o "verbose" -t bool -b true
 # Disable splay for schedule
-/opt/osctrl/bin/osctrl-cli -D "$DB_JSON" env add-osquery-option -n dev -o "schedule_splay_percent" -t int -i 0
+/opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" env add-osquery-option -n dev -o "schedule_splay_percent" -t int -i 0
 # Add uptime query to schedule
-/opt/osctrl/bin/osctrl-cli -D "$DB_JSON" env add-scheduled-query -n dev -q "SELECT * FROM uptime;" -Q "uptime" -i 60
+/opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" env add-scheduled-query -n dev -q "SELECT * FROM uptime;" -Q "uptime" -i 60
 
 # Create admin user
-/opt/osctrl/bin/osctrl-cli -D "$DB_JSON" user add -u "$_USER" -p "$_USER" -a -E "$ENV_NAME" -n "$_USER"
+/opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" user add -u "$_USER" -p "$_USER" -a -E "$ENV_NAME" -n "$_USER"
 if [ $? -eq 0 ]; then
   echo "Created $_USER user"
 else

--- a/deploy/docker/conf/osquery/wait.sh
+++ b/deploy/docker/conf/osquery/wait.sh
@@ -12,13 +12,13 @@ ENV_NAME="dev"
 WAIT=5
 
 # Wait until DB is up
-until /opt/osctrl/bin/osctrl-cli -D "$DB_JSON" check
+until /opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" check
 do
   sleep $WAIT
 done
 
 # Wait until osctrl environment is up
-until /opt/osctrl/bin/osctrl-cli -D "$DB_JSON" env show --name "$ENV_NAME"
+until /opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" env show --name "$ENV_NAME"
 do
   sleep $WAIT
 done
@@ -26,8 +26,8 @@ done
 # To enroll, check existance for flags and secret and they are not empty
 while [ ! -f "$FLAGS_FILE" ] && [ ! -s "$FLAGS_FILE" ] && [ ! -f "$SECRET_FILE" ] && [ ! -s "$SECRET_FILE" ];
 do
-    /opt/osctrl/bin/osctrl-cli -D "$DB_JSON" env secret --name "$ENV_NAME" > ${SECRET_FILE}
-    /opt/osctrl/bin/osctrl-cli -D "$DB_JSON" env show-flags --name "$ENV_NAME" | sed 's/=uuid/=ephemeral/g' > ${FLAGS_FILE}
+    /opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" env secret --name "$ENV_NAME" > ${SECRET_FILE}
+    /opt/osctrl/bin/osctrl-cli --db -D "$DB_JSON" env show-flags --name "$ENV_NAME" | sed 's/=uuid/=ephemeral/g' > ${FLAGS_FILE}
     sed -i "s#--enroll_secret_path=.*#--enroll_secret_path=${SECRET_FILE}#g" ${FLAGS_FILE}
     sed -i "s#--enroll_secret_path=.*#--enroll_secret_path=${SECRET_FILE}#g" ${FLAGS_FILE}
     sed -i "s#--distributed_interval=.*#--distributed_interval=60#g" ${FLAGS_FILE}

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -736,27 +736,27 @@ else
 
   # Create initial environment to enroll machines
   log "Creating environment $ENVIRONMENT"
-  "$DEST_PATH"/osctrl-cli -D "$__db_conf" environment add -n "$ENVIRONMENT" -host "$_T_HOST" -crt "$__osctrl_crt"
+  "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" environment add -n "$ENVIRONMENT" -host "$_T_HOST" -crt "$__osctrl_crt"
 
   # Create admin user
   log "Creating admin user"
-  "$DEST_PATH"/osctrl-cli -D "$__db_conf" user add -u "$_ADMIN_USER" -p "$_ADMIN_PASS" -a -E "$ENVIRONMENT" -n "Admin"
+  "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" user add -u "$_ADMIN_USER" -p "$_ADMIN_PASS" -a -e "$ENVIRONMENT" -n "Admin"
 
   # If we are in dev, lower intervals
   if [[ "$MODE" == "dev" ]]; then
     log "Decrease intervals for environment $ENVIRONMENT"
-    "$DEST_PATH"/osctrl-cli -D "$__db_conf" environment update -n "$ENVIRONMENT" -l "75" -c "45" -q "60"
+    "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" environment update -n "$ENVIRONMENT" -l "75" -c "45" -q "60"
     log "Enable verbose mode"
-    "$DEST_PATH"/osctrl-cli -D "$__db_conf" environment add-osquery-option -n "$ENVIRONMENT" -o "verbose" -t bool -b true
+    "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" environment add-osquery-option -n "$ENVIRONMENT" -o "verbose" -t bool -b true
     log "Disable splay for schedule"
-    "$DEST_PATH"/osctrl-cli -D "$__db_conf" environment add-osquery-option -n "$ENVIRONMENT" -o "schedule_splay_percent" -t int -i 0
+    "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" environment add-osquery-option -n "$ENVIRONMENT" -o "schedule_splay_percent" -t int -i 0
     log "Add uptime query to schedule"
-    "$DEST_PATH"/osctrl-cli -D "$__db_conf" environment add-scheduled-query -n "$ENVIRONMENT" -q "SELECT * FROM uptime;" -Q "uptime" -i 60
+    "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" environment add-scheduled-query -n "$ENVIRONMENT" -q "SELECT * FROM uptime;" -Q "uptime" -i 60
   fi
 
   # Make newly created environment as default
   log "Making environment $ENVIRONMENT as default"
-  "$DEST_PATH"/osctrl-cli -D "$__db_conf" settings add -n default_env -s admin --type string --string "$ENVIRONMENT"
+  "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" settings add -n default_env -s admin --type string --string "$ENVIRONMENT"
 
   log "Checking if service is ready"
   while true; do
@@ -773,7 +773,7 @@ else
   # Enroll host in environment
   if [[ "$ENROLL" == true ]]; then
     log "Adding host in environment $ENVIRONMENT"
-    eval $( "$DEST_PATH"/osctrl-cli -D "$__db_conf" environment quick-add -n "$ENVIRONMENT" )
+    eval $( "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" environment quick-add -n "$ENVIRONMENT" )
   fi
 
   # Ascii art is always appreciated


### PR DESCRIPTION
Using the newest syntax for `osctrl-cli`