### PR TITLE
fix docker-compose build error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,7 @@ services:
     volumes:
       - postgres-db:/var/lib/postgresql/data
     healthcheck:
-      test: ["pg_isready", "-U", "$${POSTGRES_USER}", "-d", "$${POSTGRES_DB}"]
+      test: ["CMD", "pg_isready", "-U", "$${POSTGRES_USER}", "-d", "$${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This fixes the error when running docker-compose build
```
$ docker-compose build
ERROR: Service "postgres" defines an invalid healthcheck: when "test" is a list the first item must be either NONE, CMD or CMD-SHELL
```