### PR TITLE
add redis connection string support (to support tls and more connecti…

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -295,6 +295,13 @@ func init() {
 			Destination: &redisConfigFile,
 		},
 		&cli.StringFlag{
+			Name:        "redis-connection-string",
+			Value:       "",
+			Usage:       "Redis connection string, must include schema (<redis|rediss|unix>://<user>:<pass>@<host>:<port>/<db>?<options>",
+			EnvVars:     []string{"REDIS_CONNECTION_STRING"},
+			Destination: &redisConfig.ConnectionString,
+		},
+		&cli.StringFlag{
 			Name:        "redis-host",
 			Value:       "127.0.0.1",
 			Usage:       "Redis host to be connected to",

--- a/api/main.go
+++ b/api/main.go
@@ -238,6 +238,13 @@ func init() {
 			Destination: &redisConfigFile,
 		},
 		&cli.StringFlag{
+			Name:        "redis-connection-string",
+			Value:       "",
+			Usage:       "Redis connection string, must include schema (<redis|rediss|unix>://<user>:<pass>@<host>:<port>/<db>?<options>",
+			EnvVars:     []string{"REDIS_CONNECTION_STRING"},
+			Destination: &redisConfig.ConnectionString,
+		},
+		&cli.StringFlag{
 			Name:        "redis-host",
 			Value:       "127.0.0.1",
 			Usage:       "Redis host to be connected to",

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -39,6 +39,7 @@ type JSONConfigurationRedis struct {
 	Host                  string `json:"host"`
 	Port                  string `json:"port"`
 	Password              string `json:"password"`
+	ConnectionString      string `json:"connectionstring"`
 	DB                    int    `json:"db"`
 	StatusExpirationHours int    `json:"status_exp_hours"`
 	ResultExpirationHours int    `json:"result_exp_hours"`
@@ -79,11 +80,16 @@ func LoadConfiguration(file, key string) (JSONConfigurationRedis, error) {
 
 // GetRedis to get redis client ready
 func (rm *RedisManager) GetRedis() *redis.Client {
-	return redis.NewClient(&redis.Options{
-		Addr:     PrepareAddr(*rm.Config),
-		Password: rm.Config.Password,
-		DB:       rm.Config.DB,
-	})
+	opt, err := redis.ParseURL(rm.Config.ConnectionString)
+	if err != nil {
+		//use current behavior
+		return redis.NewClient(&redis.Options{
+			Addr:     PrepareAddr(*rm.Config),
+			Password: rm.Config.Password,
+			DB:       rm.Config.DB,
+		})
+	}
+	return redis.NewClient(opt)
 }
 
 // Check to verify if connection is open and ready

--- a/tls/main.go
+++ b/tls/main.go
@@ -247,6 +247,13 @@ func init() {
 			Destination: &redisConfigFile,
 		},
 		&cli.StringFlag{
+			Name:        "redis-connection-string",
+			Value:       "",
+			Usage:       "Redis connection string, must include schema (<redis|rediss|unix>://<user>:<pass>@<host>:<port>/<db>?<options>",
+			EnvVars:     []string{"REDIS_CONNECTION_STRING"},
+			Destination: &redisConfig.ConnectionString,
+		},
+		&cli.StringFlag{
 			Name:        "redis-host",
 			Value:       "127.0.0.1",
 			Usage:       "Redis host to be connected to",


### PR DESCRIPTION
This will add a new cli option "redis-connection-string" to use a redis connection string instead of the current default config format.  This will allow more control over connection options such as TLS connections (rediss://) and setting option parameters.  
