### PR TITLE
Build osctrl components for arm64 + darwin. Build osctr-cli for Windows

### DIFF
--- a/.github/actions/tagged_release/github/action.yml
+++ b/.github/actions/tagged_release/github/action.yml
@@ -30,24 +30,36 @@ runs:
       shell: bash
       run: "ls -la"
 
-    - name: Rename binary
+    - name: Rename Linux or darwin binary
+      if: go_os == 'linux' || go_os == 'darwin'
       shell: bash
       run: |
         mv \
         osctrl-${{ inputs.osctrl_component }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
         osctrl-${{ inputs.osctrl_component }}-${{ inputs.release_version_tag }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 
+    - name: Rename Windows binary
+      if: go_os == 'windows'
+      shell: bash
+      run: |
+        mv \
+        osctrl-${{ inputs.osctrl_component }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
+        osctrl-${{ inputs.osctrl_component }}-${{ inputs.release_version_tag }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.exe
+
     ########################### Download osctrl DEB package ###########################
     - name: Download a osctrl binaries
+      if: go_os == 'linux'
       uses: actions/download-artifact@v3
       with:
         name: osctrl-${{ inputs.osctrl_component }}_0.0.${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
 
     - name: LS
+      if: go_os == 'linux'
       shell: bash
       run: "ls -la"
 
     - name: Rename DEB package
+      if: go_os == 'linux'
       shell: bash
       run: |
         mv \
@@ -62,4 +74,5 @@ runs:
         files: |
           osctrl-*.bin
           osctrl-*.deb
+          osctrl-*.exe
         body_path: ./CHANGELOG.md

--- a/.github/workflows/build_and_test_main_merge.yml
+++ b/.github/workflows/build_and_test_main_merge.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build osctrl binaries
         # Build all osctrl components for linux for all archs
         # Build all osctrl components for darwin for all archs
-        # Build all osctrl cli for windows for all archs
+        # Build osctrl cli for windows for all archs
         if: matrix.goos == 'linux' || matrix.goos == 'darwin' || (matrix.goos == 'windows' && matrix.components == 'cli')
         uses: ./.github/actions/build/binaries
         with:

--- a/.github/workflows/build_and_test_main_merge.yml
+++ b/.github/workflows/build_and_test_main_merge.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         components: ['tls', 'admin', 'api', 'cli']
-        goos: ['linux']
-        goarch: ['amd64']
+        goos: ['linux', 'darwin', 'windows']
+        goarch: ['amd64', 'arm64']
     steps:
       ########################### Checkout code ###########################
       - name: Checkout code
@@ -36,6 +36,10 @@ jobs:
 
       ########################### Build osctrl ###########################
       - name: Build osctrl binaries
+        # Build all osctrl components for linux for all archs
+        # Build all osctrl components for darwin for all archs
+        # Build all osctrl cli for windows for all archs
+        if: matrix.goos == 'linux' || matrix.goos == 'darwin' || (matrix.goos == 'windows' && matrix.components == 'cli')
         uses: ./.github/actions/build/binaries
         with:
           go_os: "${{ matrix.goos }}"
@@ -58,6 +62,7 @@ jobs:
       #     golang_version: "${{ env.GOLANG_VERSION }}"
 
   create_deb_packages:
+    if: matrix.goos == 'linux'
     needs: [build_and_test]
     runs-on: ubuntu-22.04
     strategy:
@@ -93,6 +98,7 @@ jobs:
           osquery_version: ${{ env.OSQUERY_VERSION }}
 
   create_docker_images:
+    if: matrix.goos == 'linux'
     needs: [build_and_test]
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/build_and_test_pr.yml
+++ b/.github/workflows/build_and_test_pr.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build osctrl binaries
         # Build all osctrl components for linux for all archs
         # Build all osctrl components for darwin for all archs
-        # Build all osctrl cli for windows for all archs
+        # Build osctrl cli for windows for all archs
         if: matrix.goos == 'linux' || matrix.goos == 'darwin' || (matrix.goos == 'windows' && matrix.components == 'cli')
         uses: ./.github/actions/build/binaries
         with:

--- a/.github/workflows/build_and_test_pr.yml
+++ b/.github/workflows/build_and_test_pr.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         components: ['tls', 'admin', 'api', 'cli']
-        goos: ['linux']
-        goarch: ['amd64']
+        goos: ['linux', 'darwin', 'windows']
+        goarch: ['amd64', 'arm64']
     steps:
       ########################### Checkout code ###########################
       - name: Checkout code
@@ -33,6 +33,7 @@ jobs:
 
       ########################### Build osctrl ###########################
       - name: Build osctrl binaries
+        if: matrix.goos == 'linux' || matrix.goos == 'darwin' || (matrix.goos == 'windows' && matrix.components == 'cli')
         uses: ./.github/actions/build/binaries
         with:
           go_os: "${{ matrix.goos }}"

--- a/.github/workflows/build_and_test_pr.yml
+++ b/.github/workflows/build_and_test_pr.yml
@@ -33,6 +33,9 @@ jobs:
 
       ########################### Build osctrl ###########################
       - name: Build osctrl binaries
+        # Build all osctrl components for linux for all archs
+        # Build all osctrl components for darwin for all archs
+        # Build all osctrl cli for windows for all archs
         if: matrix.goos == 'linux' || matrix.goos == 'darwin' || (matrix.goos == 'windows' && matrix.components == 'cli')
         uses: ./.github/actions/build/binaries
         with:

--- a/.github/workflows/create_tagged_releases.yml
+++ b/.github/workflows/create_tagged_releases.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build osctrl binaries
         # Build all osctrl components for linux for all archs
         # Build all osctrl components for darwin for all archs
-        # Build all osctrl cli for windows for all archs
+        # Build osctrl cli for windows for all archs
         if: matrix.goos == 'linux' || matrix.goos == 'darwin' || (matrix.goos == 'windows' && matrix.components == 'cli')
         uses: ./.github/actions/build/binaries
         with:

--- a/.github/workflows/create_tagged_releases.yml
+++ b/.github/workflows/create_tagged_releases.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         components: ['tls', 'admin', 'api', 'cli']
-        goos: ['linux']
-        goarch: ['amd64']
+        goos: ['linux', 'darwin', 'windows']
+        goarch: ['amd64', 'arm64']
     steps:
       ########################### Checkout code ###########################
       - name: Checkout code
@@ -37,6 +37,10 @@ jobs:
 
       ########################### Build osctrl ###########################
       - name: Build osctrl binaries
+        # Build all osctrl components for linux for all archs
+        # Build all osctrl components for darwin for all archs
+        # Build all osctrl cli for windows for all archs
+        if: matrix.goos == 'linux' || matrix.goos == 'darwin' || (matrix.goos == 'windows' && matrix.components == 'cli')
         uses: ./.github/actions/build/binaries
         with:
           go_os: "${{ matrix.goos }}"
@@ -59,6 +63,7 @@ jobs:
       #     golang_version: "${{ env.GOLANG_VERSION }}"
 
   create_deb_packages:
+    if: matrix.goos == 'linux'
     needs: [build_and_test]
     runs-on: ubuntu-22.04
     strategy:
@@ -94,6 +99,7 @@ jobs:
           osquery_version: ${{ env.OSQUERY_VERSION }}
 
   create_docker_images:
+    if: matrix.goos == 'linux'
     needs: [build_and_test]
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
Background

Our CI/CD pipeline is not building Docker containers for Darwin arm64 (M1 macbooks). 

Changes
This PR instructs the CI/CD pipeline to build osctrl component for Linux (amd64, arm64), darwin (amd64, arm64), and osctrl-cli for Windows. 
