### PR TITLE
Adding db connection retry

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -34,6 +34,7 @@ type JSONConfigurationDB struct {
 	MaxIdleConns    int    `json:"max_idle_conns"`
 	MaxOpenConns    int    `json:"max_open_conns"`
 	ConnMaxLifetime int    `json:"conn_max_lifetime"`
+	ConnRetry       int    `json:"conn_retry"`
 }
 
 // LoadConfiguration to load the DB configuration file and assign to variables

--- a/deploy/config/db.json
+++ b/deploy/config/db.json
@@ -7,6 +7,7 @@
     "password": "_DB_PASSWORD",
     "max_idle_conns": 20,
     "max_open_conns": 100,
-    "conn_max_lifetime": 30
+    "conn_max_lifetime": 30,
+    "conn_retry": 10
   }
 }


### PR DESCRIPTION
New parameter for `osctrl-tls` to enable retry the connection to the DB if it fails:

```
--db-conn-retry value            Time in seconds to retry the connection to the database, if set to 0 the service will stop if the connection fails (default: 7) [$DB_CONN_RETRY]
```