### PR TITLE
Retry connection for Redis/cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -44,6 +44,7 @@ type JSONConfigurationRedis struct {
 	StatusExpirationHours int    `json:"status_exp_hours"`
 	ResultExpirationHours int    `json:"result_exp_hours"`
 	QueryExpirationHours  int    `json:"query_exp_hours"`
+	ConnRetry             int    `json:"conn_retry"`
 }
 
 // CachedQueryWriteData to store in cache query logs


### PR DESCRIPTION
New parameter for `osctrl-tls` to enable retry the connection to Redis/cache if it fails:

```
--redis-conn-retry value         Time in seconds to retry the connection to the cache, if set to 0 the service will stop if the connection fails (default: 7) [$REDIS_CONN_RETRY]
```