### PR TITLE
Regenerate flags and save them

### DIFF
--- a/cli/environment.go
+++ b/cli/environment.go
@@ -205,6 +205,23 @@ func showFlagsEnvironment(c *cli.Context) error {
 	return nil
 }
 
+func genFlagsEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("Environment name is required")
+		os.Exit(1)
+	}
+	flags, err := envs.GenerateFlagsEnv(envName, "", "")
+	if err != nil {
+		return err
+	}
+	if err := envs.UpdateFlags(envName, flags); err != nil {
+		return err
+	}
+	return nil
+}
+
 func listEnvironment(c *cli.Context) error {
 	envAll, err := envs.All()
 	if err != nil {

--- a/cli/main.go
+++ b/cli/main.go
@@ -836,6 +836,19 @@ func init() {
 					Action: cliWrapper(showFlagsEnvironment),
 				},
 				{
+					Name:    "gen-flags",
+					Aliases: []string{"g"},
+					Usage:   "Generate and save the flags for a TLS environment",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    "name",
+							Aliases: []string{"n"},
+							Usage:   "Environment name to be displayed",
+						},
+					},
+					Action: cliWrapper(genFlagsEnvironment),
+				},
+				{
 					Name:    "list",
 					Aliases: []string{"l"},
 					Usage:   "List all existing TLS environments",


### PR DESCRIPTION
Adding command in `osctrl-cli` to re-generate flags, based on the values for the environment, and save them:
```
   gen-flags, g            Generate and save the flags for a TLS environment
```