### PR TITLE
Remove slider to select hours for status/results

### DIFF
--- a/admin/templates/node.html
+++ b/admin/templates/node.html
@@ -374,8 +374,10 @@
                             <a href="#status-logs" target="_blank">
                               <i class="fas fa-external-link-alt"></i>
                             </a>
+                            <!--
                             <input type="range" class="form-control-range" id="back_hours_status"
                             value="6" min="1" max="24" step="1" oninput="changeBackValue('tableStatusLogs', back_hours_status, back_output_status);">
+                            -->
                             <div class="card-header-actions">
                               <small>Refresh in <span id="status_refresh_seconds">60</span> seconds</small>
                               <button id="status_refresh_pause" class="btn btn-sm btn-outline-dark" data-tooltip="true"
@@ -411,8 +413,10 @@
                             <a href="#result-logs" target="_blank">
                               <i class="fas fa-external-link-alt"></i>
                             </a>
+                            <!--
                             <input type="range" class="form-control-range" id="back_hours_result"
                             value="6" min="1" max="24" step="1" oninput="changeBackValue('tableResultLogs', back_hours_result, back_output_result);">
+                            -->
                             <div class="card-header-actions">
                               <small>Refresh in <span id="result_refresh_seconds">60</span> seconds</small>
                               <button id="result_refresh_pause" class="btn btn-sm btn-outline-dark" data-tooltip="true"


### PR DESCRIPTION
Hiding the slider in the `osctrl-admin` view for status and results logs until that is fully operational in the backend.