### PR TITLE
Severity in status logs can be number or string

### DIFF
--- a/admin/handlers/json-logs.go
+++ b/admin/handlers/json-logs.go
@@ -134,7 +134,7 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 			_l := LogJSON{
 				Created: _c,
 				First:   s.Message,
-				Second:  s.Severity,
+				Second:  strconv.Itoa(int(s.Severity)),
 			}
 			logJSON = append(logJSON, _l)
 		}

--- a/logging/db.go
+++ b/logging/db.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -135,7 +136,7 @@ func (logDB *LoggerDB) Status(data []byte, environment, uuid string, debug bool)
 			Message:     l.Message,
 			Version:     l.Version,
 			Filename:    l.Filename,
-			Severity:    l.Severity,
+			Severity:    strconv.Itoa(int(l.Severity)),
 		}
 		if err := logDB.Database.Conn.Create(&entry).Error; err != nil {
 			log.Printf("Error creating status log entry %s", err)

--- a/types/osquery.go
+++ b/types/osquery.go
@@ -168,7 +168,7 @@ type LogStatusData struct {
 	Message        string         `json:"message"`
 	Version        string         `json:"version"`
 	Filename       string         `json:"filename"`
-	Severity       string         `json:"severity"`
+	Severity       StringInt      `json:"severity"`
 	UnixTime       StringInt      `json:"unixTime"`
 	Decorations    LogDecorations `json:"decorations"`
 	CalendarTime   string         `json:"calendarTime"`


### PR DESCRIPTION
Serialization should be able to handle both types