### PR TITLE
Fix for potentially unsafe external link

### DIFF
--- a/admin/static/js/query.js
+++ b/admin/static/js/query.js
@@ -123,7 +123,10 @@ function confirmDeleteSavedQueries(_names, _url) {
 }
 
 function queryResultLink(link, query, url) {
-  var external_link = '<a href="' + link + '" _target="_blank"><i class="fas fa-external-link-alt"></i></a>';
+  var external_link =
+    '<a href="' +
+    link +
+    '" _target="_blank" rel="noopener noreferrer"><i class="fas fa-external-link-alt"></i></a>';
   return '<span class="query-link"><a href="' + url + '">' + query + '</a> - ' + external_link + '</span> ';
 }
 

--- a/admin/templates/queries-logs.html
+++ b/admin/templates/queries-logs.html
@@ -28,7 +28,7 @@
                 {{ else }}
                   <i class="fas fa-hourglass-half"></i> [ <b>ACTIVE</b> ] - Results for {{ .Name }}
                 {{ end }}
-                 - <a href="{{ queryResultLink .Name $template.EnvUUID }}" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+                 - <a href="{{ queryResultLink .Name $template.EnvUUID }}" target="_blank" rel="noopener noreferrer"><i class="fas fa-external-link-alt"></i></a>
                 <div class="card-header-actions">
                   <button class="btn btn-sm btn-outline-primary" data-tooltip="true"
                     data-placement="bottom" title="Refresh table" onclick="refreshTableNow('tableQueryLogs');">

--- a/admin/templates/queries-run.html
+++ b/admin/templates/queries-run.html
@@ -31,7 +31,7 @@
                     <div class="card mt-2">
                       <div class="card-header">
                         <i class="fas fa-table"></i>
-                          <a href="https://osquery.io/schema/{{ $.TablesVersion }}" target="_blank">
+                          <a href="https://osquery.io/schema/{{ $.TablesVersion }}" target="_blank" rel="noopener noreferrer">
                             osquery {{ $.TablesVersion }}:
                           </a>
                         <div class="card-header-actions">


### PR DESCRIPTION
External links without noopener/noreferrer are a potential security risk.

Specify the link type by adding an attribute`rel="noopener noreferrer"`.