### PR TITLE
Fix for binary output on merged commits

### DIFF
--- a/.github/actions/build/binaries/action.yml
+++ b/.github/actions/build/binaries/action.yml
@@ -52,7 +52,7 @@ runs:
     - name: Build osctrl-tls
       run: |
         GOOS=${{ inputs.go_os }} GOARCH=${{ inputs.go_arch }} \
-        go build -o osctrl-${{ inputs.osctrl_component }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
+        go build -o osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
         ./${{ inputs.osctrl_component }}
       shell: bash
 


### PR DESCRIPTION
Binary name was incorrect on `go build` command