### PR TITLE
Fix for provision script to support Ubuntu 20.04 and Debian 12

### DIFF
--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -354,7 +354,8 @@ function db_user_postgresql() {
   sudo su - "$__pguser" -c "$__psql -c 'CREATE DATABASE $__pgdb'"
 
   log "Make user owner of database"
-  sudo su - "$__pguser" -c "ALTER DATABASE $__pgdb OWNER TO $__dbuser;"
+  local _dbstatementowner="ALTER DATABASE $__pgdb OWNER TO $__dbuser;"
+  sudo su - "$__pguser" -c "$__psql -c \"$_dbstatementowner\""
 
   log "Granting privileges to user"
   local _dbstatementgrant="GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $__dbuser;"

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -801,13 +801,6 @@ else
     log "Adding host in environment $ENVIRONMENT"
     eval $( "$DEST_PATH"/osctrl-cli --db -D "$__db_conf" environment quick-add -n "$ENVIRONMENT" )
   fi
-
-  # Ascii art is always appreciated
-  if [[ "$DISTRO" == "ubuntu" ]]; then
-    set_motd_ubuntu "$SOURCE_PATH/deploy/motd-osctrl.sh"
-  elif [[ "$DISTRO" == "centos" ]]; then
-    set_motd_centos "$SOURCE_PATH/deploy/motd-osctrl.sh"
-  fi
 fi
 
 echo

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -659,10 +659,10 @@ else
   # Redis - Cache
   if [[ "$REDIS" == true ]]; then
     REDIS_CONF="$SOURCE_PATH/deploy/redis/redis.conf"
-    if [[ "$DISTRO" == "ubuntu" ]]; then
+    REDIS_SERVICE="redis-server.service"
+    REDIS_ETC="/etc/redis/redis.conf"
+    if [[ "$DISTRO" == "ubuntu" || "$DISTRO" == "debian" ]]; then
       package redis-server
-      REDIS_SERVICE="redis-server.service"
-      REDIS_ETC="/etc/redis/redis.conf"
     elif [[ "$DISTRO" == "centos" ]]; then
       log "For CentOS, please install Redis manually"
       exit $OHNOES
@@ -672,7 +672,7 @@ else
 
   # Metrics - InfluxDB + Telegraf + Grafana
   if [[ "$METRICS" == true ]]; then
-    if [[ "$DISTRO" == "ubuntu" ]]; then
+    if [[ "$DISTRO" == "ubuntu" || "$DISTRO" == "debian" ]]; then
       install_influx_telegraf
       configure_influx_telegraf
       install_grafana

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -413,7 +413,7 @@ source "$SOURCE_PATH/deploy/lib.sh"
 
 # Detect Linux distro
 if [[ -f "/etc/debian_version" ]]; then
-  if [[ $(grep -Fxq "Debian" /etc/issue) ]]; then
+  if [[ $(grep "Debian" /etc/issue) ]]; then
     DISTRO="debian"
   else
     DISTRO="ubuntu"


### PR DESCRIPTION
Some fixes for `provision.sh` to be able to deploy osctrl in Ubuntu 20.04 and Debian 12. Related with backend (postgres) and cache (redis).