### PR TITLE
Sending TLS logs to logstash via tcp, udp or http

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	// Default file to store logs
+	// DefaultFileLog file to store logs
 	DefaultFileLog = "osctrl.log"
 )
 
@@ -104,6 +104,13 @@ func CreateLoggerTLS(logging, loggingFile string, s3Conf types.S3Configuration, 
 			if err != nil {
 				return nil, err
 			}
+		}
+		d.Settings(mgr)
+		l.Logger = d
+	case settings.LoggingLogstash:
+		d, err := CreateLoggerLogstash(loggingFile)
+		if err != nil {
+			return nil, err
 		}
 		d.Settings(mgr)
 		l.Logger = d

--- a/logging/logstash.go
+++ b/logging/logstash.go
@@ -1,0 +1,158 @@
+package logging
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+
+	"github.com/jmpsec/osctrl/settings"
+	"github.com/jmpsec/osctrl/utils"
+	"github.com/spf13/viper"
+)
+
+const (
+	// LogstashTCP for TCP inputs
+	LogstashTCP = "tcp"
+	// LogstashUDP for UDP inputs
+	LogstashUDP = "udp"
+	// LogstashHTTP for HTTP inputs
+	LogstashHTTP = "http"
+)
+
+// LogstashConfiguration to hold all logstash configuration values
+type LogstashConfiguration struct {
+	Host     string `json:"host"`
+	Port     string `json:"port"`
+	Protocol string `json:"protocol"`
+	Path     string `json:"path"`
+}
+
+// LoggerLogstash will be used to log data using Logstash
+type LoggerLogstash struct {
+	Configuration LogstashConfiguration
+	Headers       map[string]string
+	Enabled       bool
+}
+
+// CreateLoggerLogstash to initialize the logger
+func CreateLoggerLogstash(logstashFile string) (*LoggerLogstash, error) {
+	config, err := LoadLogstash(logstashFile)
+	if err != nil {
+		return nil, err
+	}
+	l := &LoggerLogstash{
+		Configuration: config,
+		Headers: map[string]string{
+			utils.ContentType: utils.JSONApplicationUTF8,
+		},
+		Enabled: true,
+	}
+	return l, nil
+}
+
+// LoadLogstash - Function to load the Logstash configuration from JSON file
+func LoadLogstash(file string) (LogstashConfiguration, error) {
+	var _logstashCfg LogstashConfiguration
+	log.Printf("Loading %s", file)
+	// Load file and read config
+	viper.SetConfigFile(file)
+	if err := viper.ReadInConfig(); err != nil {
+		return _logstashCfg, err
+	}
+	cfgRaw := viper.Sub(settings.LoggingLogstash)
+	if err := cfgRaw.Unmarshal(&_logstashCfg); err != nil {
+		return _logstashCfg, err
+	}
+	// No errors!
+	return _logstashCfg, nil
+}
+
+const (
+	// LogstashMethod Method to send requests
+	LogstashMethod = "POST"
+	// LogstashContentType Content Type for requests
+	LogstashContentType = "application/json"
+	// LogstashConnStr Connection string for Logstash
+	LogstashConnStr = "%s:%s"
+)
+
+// LogstashMessage to handle log format to be sent to Logstash
+type LogstashMessage struct {
+	Time        int64       `json:"time"`
+	LogType     string      `json:"log_type"`
+	UUID        string      `json:"uuid"`
+	Environment string      `json:"environment"`
+	Data        interface{} `json:"data"`
+}
+
+// Settings - Function to prepare settings for the logger
+func (logLS *LoggerLogstash) Settings(mgr *settings.Settings) {
+	log.Printf("Setting Logstash logging settings\n")
+}
+
+// SendHTTP - Function that sends JSON logs to Logstash via HTTP
+func (logLS *LoggerLogstash) SendHTTP(logType string, data []byte, environment, uuid string, debug bool) {
+	if debug {
+		log.Printf("DebugService: Send %s via Logstash HTTP", logType)
+	}
+	jsonData := strings.NewReader(string(data))
+	if debug {
+		log.Printf("DebugService: Sending %d bytes to Logstash HTTP for %s - %s", len(data), environment, uuid)
+	}
+	httpURL := fmt.Sprintf("http://%s:%s", logLS.Configuration.Host, logLS.Configuration.Port)
+	// Send log with a POST to the Splunk URL
+	resp, body, err := utils.SendRequest(LogstashMethod, httpURL, jsonData, logLS.Headers)
+	if err != nil {
+		log.Printf("Error sending request %s", err)
+	}
+	if debug {
+		log.Printf("DebugService: HTTP %d %s", resp, body)
+	}
+}
+
+// SendUDP - Function that sends data to Logstash via UDP
+func (logLS *LoggerLogstash) SendUDP(logType string, data []byte, environment, uuid string, debug bool) {
+	if debug {
+		log.Printf("DebugService: Send %s via Logstash TCP", logType)
+	}
+	if debug {
+		log.Printf("DebugService: Sending %d bytes to Logstash TCP for %s - %s", len(data), environment, uuid)
+	}
+	connAddr := fmt.Sprintf(LogstashConnStr, logLS.Configuration.Host, logLS.Configuration.Port)
+	conn, err := net.Dial("udp", connAddr)
+	if err != nil {
+		log.Printf("Error connecting to Logstash %s", err)
+	}
+	defer conn.Close()
+	_, err = conn.Write(data)
+	if err != nil {
+		log.Printf("Error writing to Logstash %s", err)
+	}
+	if debug {
+		log.Printf("DebugService: Sent data to Logstash TCP")
+	}
+}
+
+// SendTCP - Function that sends data to Logstash via TCP
+func (logLS *LoggerLogstash) SendTCP(logType string, data []byte, environment, uuid string, debug bool) {
+	if debug {
+		log.Printf("DebugService: Send %s via Logstash UDP", logType)
+	}
+	if debug {
+		log.Printf("DebugService: Sending %d bytes to Logstash UDP for %s - %s", len(data), environment, uuid)
+	}
+	connAddr := fmt.Sprintf(LogstashConnStr, logLS.Configuration.Host, logLS.Configuration.Port)
+	conn, err := net.Dial("tcp", connAddr)
+	if err != nil {
+		log.Printf("Error connecting to Logstash %s", err)
+	}
+	defer conn.Close()
+	_, err = conn.Write(data)
+	if err != nil {
+		log.Printf("Error writing to Logstash %s", err)
+	}
+	if debug {
+		log.Printf("DebugService: Sent data to Logstash UDP")
+	}
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -34,16 +34,15 @@ const (
 
 // Types of logging
 const (
-	LoggingNone    string = "none"
-	LoggingStdout  string = "stdout"
-	LoggingFile    string = "file"
-	LoggingDB      string = "db"
-	LoggingGraylog string = "graylog"
-	LoggingSplunk  string = "splunk"
-	LoggingELK     string = "elk"
-	LoggingKafka   string = "kafka"
-	LoggingKinesis string = "kinesis"
-	LoggingS3      string = "s3"
+	LoggingNone     string = "none"
+	LoggingStdout   string = "stdout"
+	LoggingFile     string = "file"
+	LoggingDB       string = "db"
+	LoggingGraylog  string = "graylog"
+	LoggingSplunk   string = "splunk"
+	LoggingLogstash string = "logstash"
+	LoggingKinesis  string = "kinesis"
+	LoggingS3       string = "s3"
 )
 
 // Types of carver

--- a/tls/main.go
+++ b/tls/main.go
@@ -122,15 +122,15 @@ var validAuth = map[string]bool{
 
 // Valid values for logging in configuration
 var validLogging = map[string]bool{
-	settings.LoggingNone:    true,
-	settings.LoggingStdout:  true,
-	settings.LoggingFile:    true,
-	settings.LoggingDB:      true,
-	settings.LoggingGraylog: true,
-	settings.LoggingSplunk:  true,
-	settings.LoggingKafka:   true,
-	settings.LoggingKinesis: true,
-	settings.LoggingS3:      true,
+	settings.LoggingNone:     true,
+	settings.LoggingStdout:   true,
+	settings.LoggingFile:     true,
+	settings.LoggingDB:       true,
+	settings.LoggingGraylog:  true,
+	settings.LoggingSplunk:   true,
+	settings.LoggingLogstash: true,
+	settings.LoggingKinesis:  true,
+	settings.LoggingS3:       true,
 }
 
 // Valid values for carver in configuration

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/google/uuid v1.5.0
 	github.com/segmentio/ksuid v1.0.4
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -1,9 +1,11 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
@@ -13,6 +15,9 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/utils/http-utils.go
+++ b/utils/http-utils.go
@@ -38,8 +38,8 @@ const XForwardedFor string = "X-Forwarded-For"
 // Authorization for header key
 const Authorization string = "Authorization"
 
-// osctrlUserAgent for customized User-Agent
-const osctrlUserAgent string = "osctrl-http-client/1.1"
+// OsctrlUserAgent for customized User-Agent
+const OsctrlUserAgent string = "osctrl-http-client/1.1"
 
 // SendRequest - Helper function to send HTTP requests
 func SendRequest(reqType, reqURL string, params io.Reader, headers map[string]string) (int, []byte, error) {
@@ -61,7 +61,7 @@ func SendRequest(reqType, reqURL string, params io.Reader, headers map[string]st
 		return 0, []byte("Cound not prepare request"), err
 	}
 	// Set custom User-Agent
-	req.Header.Set(UserAgent, osctrlUserAgent)
+	req.Header.Set(UserAgent, OsctrlUserAgent)
 	// Prepare headers
 	for key, value := range headers {
 		req.Header.Add(key, value)
@@ -71,18 +71,15 @@ func SendRequest(reqType, reqURL string, params io.Reader, headers map[string]st
 	if err != nil {
 		return 0, []byte("Error sending request"), err
 	}
-	//defer resp.Body.Close()
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			log.Printf("Failed to close body %v", err)
 		}
 	}()
-
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, []byte("Can not read response"), err
 	}
-
 	return resp.StatusCode, bodyBytes, nil
 }
 


### PR DESCRIPTION
Adding new logger to `osctrl-tls` to send logs to Logstash via `tcp`, `udp` or `http`. The configuration would be like this:

```
{
  "host": "127.0.0.1",
  "port": "1234",
  "protocol": "http",
  "path": "/logging"
}
```
