### PR TITLE
Using 1.23 format for go.mod

### DIFF
--- a/admin/auth/go.mod
+++ b/admin/auth/go.mod
@@ -1,6 +1,6 @@
 module admin/auth
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/admin/sessions => ../../admin/sessions
 

--- a/admin/handlers/go.mod
+++ b/admin/handlers/go.mod
@@ -1,6 +1,6 @@
 module admin/handlers
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/admin/sessions => ../../admin/sessions
 

--- a/admin/sessions/go.mod
+++ b/admin/sessions/go.mod
@@ -1,6 +1,6 @@
 module admin/sessions
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/environments => ../../environments
 

--- a/api/handlers/go.mod
+++ b/api/handlers/go.mod
@@ -1,3 +1,3 @@
 module api/handlers
 
-go 1.21.3
+go 1.21

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module backend
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/spf13/viper v1.18.2

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -1,6 +1,6 @@
 module cache
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/nodes => ../nodes
 

--- a/carves/go.mod
+++ b/carves/go.mod
@@ -1,6 +1,6 @@
 module carves
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/nodes => ../nodes
 

--- a/environments/go.mod
+++ b/environments/go.mod
@@ -1,6 +1,6 @@
 module environments
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/nodes => ../nodes
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module osctrl
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/admin/auth => ./admin/auth
 

--- a/logging/go.mod
+++ b/logging/go.mod
@@ -1,6 +1,6 @@
 module logging
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/backend => ../backend
 

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -1,6 +1,6 @@
 module metrics
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/types => ../types
 

--- a/nodes/go.mod
+++ b/nodes/go.mod
@@ -1,6 +1,6 @@
 module nodes
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/jinzhu/gorm v1.9.16

--- a/queries/go.mod
+++ b/queries/go.mod
@@ -1,6 +1,6 @@
 module queries
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/nodes => ../nodes
 

--- a/settings/go.mod
+++ b/settings/go.mod
@@ -1,6 +1,6 @@
 module settings
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/nodes => ../nodes
 

--- a/tags/go.mod
+++ b/tags/go.mod
@@ -1,6 +1,6 @@
 module tags
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/nodes => ../nodes
 

--- a/tls/handlers/go.mod
+++ b/tls/handlers/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmpsec/osctrl/tls/handlers
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/backend => ../../backend
 

--- a/types/go.mod
+++ b/types/go.mod
@@ -1,6 +1,6 @@
 module types
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/nodes => ../nodes
 

--- a/users/go.mod
+++ b/users/go.mod
@@ -1,6 +1,6 @@
 module users
 
-go 1.21.3
+go 1.21
 
 replace github.com/jmpsec/osctrl/nodes => ../nodes
 

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -1,6 +1,6 @@
 module utils
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/google/uuid v1.6.0

--- a/version/go.mod
+++ b/version/go.mod
@@ -1,6 +1,6 @@
 module version
 
-go 1.21.3
+go 1.21
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
Until the migration to `1.22` let's keep the previous format.