### PR TITLE
Using different cookie name to avoid conflicts

### DIFF
--- a/admin/auth.go
+++ b/admin/auth.go
@@ -16,10 +16,8 @@ const (
 	carveLevel string = "carve"
 )
 
-// Using the default name for the cookie in SAML:
-// https://github.com/crewjam/saml/blob/main/samlsp/session_cookie.go#L11
 const (
-	authCookieName = "token"
+	authCookieName = "osctrl-admin-session"
 )
 
 // Handler to check access to a resource based on the authentication enabled


### PR DESCRIPTION
Using the same cookie name than the samlsp library was causing some issues when `saml` was configured as authentication method in `osctrl-admin`.