### PR TITLE
Install golang depending on architecture

### DIFF
--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -400,7 +400,11 @@ function set_motd_centos() {
 # Install go 1.21.3 from tgz
 function install_go_21() {
   local __version="1.21.3"
-  local __file="go$__version.linux-amd64.tar.gz"
+  local __arch="$(uname -i)"
+  if [[ "$__arch" == "aarch64" ]]; then
+    __arch="arm64"
+  fi
+  local __file="go$__version.linux-$__arch.tar.gz"
   local __url="https://dl.google.com/go/$__file"
   if ! [[ -d "/usr/local/go" ]]; then
     log  "Installing Golang $__version"


### PR DESCRIPTION
When using the `provision.sh` to provision a brand new server, it could fail for ARM due to downloading the wrong golang installer.

This was the error seen:

```line 412: /usr/local/go/bin/go: cannot execute binary file: Exec format error```