### PR TITLE
Adding eviction policy to redis to avoid OOM issues

### DIFF
--- a/deploy/redis/redis.conf
+++ b/deploy/redis/redis.conf
@@ -2,3 +2,21 @@ bind 127.0.0.1
 daemonize no
 supervised systemd
 requirepass REDIS_PASSWORD
+
+# This limit will depend on the memory available in your system
+maxmemory 1G
+
+# MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
+# is reached. You can select one from the following behaviors:
+#
+# volatile-lru -> Evict using approximated LRU, only keys with an expire set.
+# allkeys-lru -> Evict any key using approximated LRU.
+# volatile-lfu -> Evict using approximated LFU, only keys with an expire set.
+# allkeys-lfu -> Evict any key using approximated LFU.
+# volatile-random -> Remove a random key having an expire set.
+# allkeys-random -> Remove a random key, any key.
+# volatile-ttl -> Remove the key with the nearest expire time (minor TTL)
+# noeviction -> Don't evict anything, just return an error on write operations.
+# LRU means Least Recently Used
+# LFU means Least Frequently Used
+maxmemory-policy allkeys-lfu


### PR DESCRIPTION
Adding an eviction policy to the default redis configuration, to avoid OOM issues.