### PR TITLE
Missing query results and `osctrl-admin` panics

### DIFF
--- a/admin/handlers/json-logs.go
+++ b/admin/handlers/json-logs.go
@@ -190,7 +190,7 @@ func (h *HandlersAdmin) JSONQueryLogsHandler(w http.ResponseWriter, r *http.Requ
 	// Iterate through targets to get logs
 	queryLogJSON := []QueryLogJSON{}
 	// Get logs
-	if h.RedisCache != nil {
+	if h.DBLogger != nil {
 		queryLogs, err := h.DBLogger.QueryLogs(name)
 		if err != nil {
 			log.Printf("error getting logs %v", err)

--- a/admin/handlers/templates.go
+++ b/admin/handlers/templates.go
@@ -722,14 +722,15 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 	}
 	// Prepare template data
 	templateData := QueryLogsTemplateData{
-		Title:        "Query logs " + query.Name,
-		EnvUUID:      env.UUID,
-		Metadata:     h.TemplateMetadata(ctx, h.ServiceVersion),
-		LeftMetadata: leftMetadata,
-		Environments: h.allowedEnvironments(ctx[sessions.CtxUser], envAll),
-		Platforms:    platforms,
-		Query:        query,
-		QueryTargets: targets,
+		Title:         "Query logs " + query.Name,
+		EnvUUID:       env.UUID,
+		Metadata:      h.TemplateMetadata(ctx, h.ServiceVersion),
+		LeftMetadata:  leftMetadata,
+		Environments:  h.allowedEnvironments(ctx[sessions.CtxUser], envAll),
+		Platforms:     platforms,
+		Query:         query,
+		QueryTargets:  targets,
+		ServiceConfig: *h.AdminConfig,
 	}
 	if err := t.Execute(w, templateData); err != nil {
 		h.Inc(metricAdminErr)
@@ -1115,18 +1116,19 @@ func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Prepare template data
 	templateData := NodeTemplateData{
-		Title:        "Node View " + node.Hostname,
-		EnvUUID:      env.UUID,
-		Metadata:     h.TemplateMetadata(ctx, h.ServiceVersion),
-		LeftMetadata: leftMetadata,
-		Node:         node,
-		NodeTags:     nodeTags,
-		TagsForNode:  tags,
-		Environments: h.allowedEnvironments(ctx[sessions.CtxUser], envAll),
-		Platforms:    platforms,
-		Dashboard:    dashboardEnabled,
-		Packs:        packs,
-		Schedule:     schedule,
+		Title:         "Node View " + node.Hostname,
+		EnvUUID:       env.UUID,
+		Metadata:      h.TemplateMetadata(ctx, h.ServiceVersion),
+		LeftMetadata:  leftMetadata,
+		Node:          node,
+		NodeTags:      nodeTags,
+		TagsForNode:   tags,
+		Environments:  h.allowedEnvironments(ctx[sessions.CtxUser], envAll),
+		Platforms:     platforms,
+		Dashboard:     dashboardEnabled,
+		Packs:         packs,
+		Schedule:      schedule,
+		ServiceConfig: *h.AdminConfig,
 	}
 	if err := t.Execute(w, templateData); err != nil {
 		h.Inc(metricAdminErr)

--- a/admin/handlers/types-templates.go
+++ b/admin/handlers/types-templates.go
@@ -143,14 +143,15 @@ type CarvesDetailsTemplateData struct {
 
 // QueryLogsTemplateData for passing data to the query template
 type QueryLogsTemplateData struct {
-	Title        string
-	EnvUUID      string
-	Environments []environments.TLSEnvironment
-	Platforms    []string
-	Query        queries.DistributedQuery
-	QueryTargets []queries.DistributedQueryTarget
-	Metadata     TemplateMetadata
-	LeftMetadata AsideLeftMetadata
+	Title         string
+	EnvUUID       string
+	Environments  []environments.TLSEnvironment
+	Platforms     []string
+	Query         queries.DistributedQuery
+	QueryTargets  []queries.DistributedQueryTarget
+	Metadata      TemplateMetadata
+	LeftMetadata  AsideLeftMetadata
+	ServiceConfig types.JSONConfigurationAdmin
 }
 
 // EnvironmentsTemplateData for passing data to the environments template
@@ -216,16 +217,17 @@ type TagsTemplateData struct {
 
 // NodeTemplateData for passing data to the query template
 type NodeTemplateData struct {
-	Title        string
-	EnvUUID      string
-	Node         nodes.OsqueryNode
-	NodeTags     []tags.AdminTag
-	TagsForNode  []tags.AdminTagForNode
-	Environments []environments.TLSEnvironment
-	Platforms    []string
-	Metadata     TemplateMetadata
-	LeftMetadata AsideLeftMetadata
-	Dashboard    bool
-	Schedule     environments.ScheduleConf
-	Packs        environments.PacksEntries
+	Title         string
+	EnvUUID       string
+	Node          nodes.OsqueryNode
+	NodeTags      []tags.AdminTag
+	TagsForNode   []tags.AdminTagForNode
+	Environments  []environments.TLSEnvironment
+	Platforms     []string
+	Metadata      TemplateMetadata
+	LeftMetadata  AsideLeftMetadata
+	Dashboard     bool
+	Schedule      environments.ScheduleConf
+	Packs         environments.PacksEntries
+	ServiceConfig types.JSONConfigurationAdmin
 }

--- a/admin/handlers/utils.go
+++ b/admin/handlers/utils.go
@@ -168,6 +168,12 @@ func toJSONConfigurationService(values []settings.SettingValue) types.JSONConfig
 		if v.Name == settings.JSONAuth {
 			cfg.Auth = v.String
 		}
+		if v.Name == settings.JSONLogger {
+			cfg.Logger = v.String
+		}
+		if v.Name == settings.JSONCarver {
+			cfg.Carver = v.String
+		}
 		if v.Name == settings.JSONSessionKey {
 			cfg.SessionKey = v.String
 		}

--- a/admin/templates/node.html
+++ b/admin/templates/node.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
   {{ $metadata := .Metadata }}
+  {{ $serviceConfig := .ServiceConfig }}
 
   {{ template "page-head" . }}
 
@@ -390,6 +391,7 @@
                               </button>
                             </div>
                           </div>
+                        {{ if eq $serviceConfig.Logger "db" }}
                           <div id="status-table" class="card-body table-responsive">
                             <table id="tableStatusLogs" class="table table-bordered table-striped" style="width:100%">
                               <input type="hidden" id="status_refresh_value" value="yes">
@@ -402,6 +404,11 @@
                               </thead>
                             </table>
                           </div>
+                        {{ else }}
+                          <div class="alert alert-warning" role="alert">
+                            <i class="fas fa-exclamation-triangle"></i> The logger is set to <b>{{ $serviceConfig.Logger }}</b> in the service configuration. No logs to display.
+                          </div>
+                        {{ end }}
                         </div>
                       </div>
 
@@ -429,6 +436,7 @@
                               </button>
                             </div>
                           </div>
+                        {{ if eq $serviceConfig.Logger "db" }}
                           <div id="results-table" class="card-body table-responsive">
                             <table id="tableResultLogs" class="table table-bordered table-striped" style="width:100%">
                               <input type="hidden" id="result_refresh_value" value="yes">
@@ -441,6 +449,11 @@
                               </thead>
                             </table>
                           </div>
+                        {{ else }}
+                          <div class="alert alert-warning" role="alert">
+                            <i class="fas fa-exclamation-triangle"></i> The logger is set to <b>{{ $serviceConfig.Logger }}</b> in the service configuration. No logs to display.
+                          </div>
+                        {{ end }}
                         </div>
                       </div>
 

--- a/admin/templates/queries-logs.html
+++ b/admin/templates/queries-logs.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
   {{ $metadata := .Metadata }}
+  {{ $serviceConfig := .ServiceConfig }}
 
   {{ template "page-head" . }}
 
@@ -71,6 +72,7 @@
                   </tbody>
                 </table>
                 <br>
+              {{ if eq $serviceConfig.Logger "db" }}
                 <table id="tableQueryLogs" class="table table-bordered table-striped" style="width:100%">
                   <input type="hidden" id="refresh_value" value="yes">
                   <thead>
@@ -81,6 +83,11 @@
                     </tr>
                   </thead>
                 </table>
+              {{ else }}
+                <div class="alert alert-warning" role="alert">
+                  <i class="fas fa-exclamation-triangle"></i> The logger is set to <b>{{ $serviceConfig.Logger }}</b> in the service configuration.
+                </div>
+              {{ end }}
 
               </div>
             </div>

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -255,6 +255,10 @@ func (r *RedisManager) SetLogs(logType, hostID, envOrName string, data []byte) e
 	if err := r.Client.Set(ctx, hKey, data, tExpire).Err(); err != nil {
 		return fmt.Errorf("%s Set: %s", logType, err)
 	}
+	// Make sure we expire the key
+	if err := r.Client.Expire(ctx, hKey, tExpire).Err(); err != nil {
+		return fmt.Errorf("%s Expire: %s", logType, err)
+	}
 	return nil
 }
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -337,7 +337,7 @@ func (conf *Settings) SetAdminJSON(cfg types.JSONConfigurationAdmin, envID uint)
 	if err := conf.SetJSON(ServiceAdmin, JSONAuth, cfg.Auth, envID); err != nil {
 		return err
 	}
-	if err := conf.SetJSON(ServiceTLS, JSONLogger, cfg.Logger, envID); err != nil {
+	if err := conf.SetJSON(ServiceAdmin, JSONLogger, cfg.Logger, envID); err != nil {
 		return err
 	}
 	if err := conf.SetJSON(ServiceAdmin, JSONSessionKey, cfg.SessionKey, envID); err != nil {


### PR DESCRIPTION
When trying to retrieve on-demand query results, or any other results that may be stored in the DB, the `osctrl-admin` service was invoking a `nil` pointer, causing a panic. This PR fixes several issues, including #438:

- Display a message when the logger is not configured to `db`, and there are no logs to display. 
- Making sure keys in redis are expired.
- The JSON setting for logger was not stored in the DB correctly.