### PR TITLE
Add support for arm64 docker builds

### DIFF
--- a/.github/actions/build/docker/action.yml
+++ b/.github/actions/build/docker/action.yml
@@ -13,9 +13,6 @@ inputs:
   commit_sha:
     required: true
     description: Define the SHA1 git commit hash
-  docker_tag:
-    required: true
-    description: Define the Docker tag
   docker_hub_org:
     required: true
     description: Pass DockerHub org to action
@@ -54,12 +51,28 @@ runs:
         osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
         osctrl-${{ inputs.osctrl_component }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 
+    ########################### Add meta data for containers ###########################
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}
+        labels: |
+          org.opencontainers.image.title=osctrl-${{ inputs.osctrl_component }}
+        tags: |
+            type=sha,prefix=,format=short
+            type=match,pattern=v(.*),group=1
+
     ########################### Log into Dockerhub ###########################
     - name: Login to Docker Hub
       uses: docker/login-action@v3.0.0
       with:
         username: ${{ inputs.docker_hub_username }}
         password: ${{ inputs.docker_hub_access_token }}
+
+    # ########################### Setup QEMU ###########################
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     ########################### Setup Docker ###########################
     - name: Set up Docker Buildx
@@ -73,8 +86,27 @@ runs:
         context: .
         file: ./deploy/cicd/docker/Dockerfile-osctrl-${{ inputs.osctrl_component }}
         push: true
-        tags: ${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}:${{ inputs.docker_tag }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: "${{ inputs.go_os }}/${{ inputs.go_arch  }}"
+        outputs: type=image,name=${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }},push-by-digest=true,name-canonical=true,push=true
         build-args: |
           COMPONENT=${{ inputs.osctrl_component }}
           GOOS=${{ inputs.go_os }}
           GOARCH=${{ inputs.go_arch }}
+
+    ########################### Export image digest to tmp ###########################
+    - name: Export digest
+      shell: bash
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.docker_build.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+
+    ########################### Upload digest ###########################
+    - name: Upload digest
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: digests-osctrl-${{ inputs.osctrl_component }}-${{ inputs.go_os }}-${{ inputs.go_arch }}
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/actions/build/dpkg/action.yml
+++ b/.github/actions/build/dpkg/action.yml
@@ -48,6 +48,7 @@ runs:
         OSCTRL_VERSION: ${{ inputs.commit_sha }}
 
     - name: Create DEB package contents for tagged version
+      id: create_deb_tagged_pkgs
       uses: jiro4989/build-deb-action@v3.0.0
       if: startsWith(github.ref, 'refs/tags/')
       with:
@@ -59,6 +60,7 @@ runs:
         desc: "DEB package for osctrl-${OSCTRL_COMPONENT}-${OSCTRL_VERSION} Commit SHA: ${COMMIT_SHA}"
 
     - name: Create DEB package contents
+      id: create_deb_pkgs
       uses: jiro4989/build-deb-action@v3.0.0
       with:
         package: osctrl-${{ inputs.osctrl_component }}
@@ -74,12 +76,12 @@ runs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}-${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
-        path: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}-${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
+        path: ${{ steps.create_deb_tagged_pkgs.outputs.file_name }}
         retention-days: 10
 
     - name: Upload osctrl DEBs
       uses: actions/upload-artifact@v4.3.1
       with:
         name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
-        path: osctrl-${{ inputs.osctrl_component }}_${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
+        path: ${{ steps.create_deb_pkgs.outputs.file_name }}
         retention-days: 10

--- a/.github/actions/tagged_release/docker/codesign/action.yml
+++ b/.github/actions/tagged_release/docker/codesign/action.yml
@@ -4,10 +4,10 @@ inputs:
   osctrl_component:
     required: true
     description: Define the osctrl component to compile
-  docker_tag:
+  docker_tags:
     required: true
     description: Define the Docker tag
-  docker_image_digest:
+  docker_image_digests:
     required: true
     description: Dockerhub image digest
   docker_hub_org:
@@ -58,16 +58,28 @@ runs:
       env:
         COSIGN_PASSWORD: "${{ inputs.codesign_password }}"
       run: |
-        IMAGE_NAME="${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}:${{ inputs.docker_tag }}"
         echo "${{ inputs.codesign_private_key }}" > cosign.key
-        cosign sign --key cosign.key docker.io/$IMAGE_NAME@${{ inputs.docker_image_digest }}
+        for tag in ${{ inputs.docker_tags }}
+        do
+          IMAGE_NAME="${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}:$tag"
+          for digest in ${{ inputs.docker_image_digest }}
+          do
+            cosign sign --key cosign.key docker.io/$IMAGE_NAME@sha256:$digest
+          done
+        done
         rm -f cosign.key
 
     ########################### Verify signed image using cosign ###########################
     - name: Verify the signed published Docker image
       shell: bash
       run: |
-        IMAGE_NAME="${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}:${{ inputs.docker_tag }}"
         echo "${{ inputs.codesign_public_cert }}" > cosign.key
-        cosign verify --key cosign.key docker.io/$IMAGE_NAME@${{ inputs.docker_image_digest }}
+        for tag in ${{ inputs.docker_tags }}
+        do
+          IMAGE_NAME="${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}:$tag"
+          for digest in ${{ inputs.docker_image_digest }}
+          do
+            cosign verify --key cosign.key docker.io/$IMAGE_NAME@sha256:$digest
+          done
+        done
         rm -f cosign.key

--- a/.github/actions/tagged_release/github/action.yml
+++ b/.github/actions/tagged_release/github/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
       run: |
         cp \
-        osctrl-${{ inputs.osctrl_component }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
+        osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
         osctrl-${{ inputs.osctrl_component }}-${{ inputs.release_version_tag }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 
     - name: Copy windows binary
@@ -47,7 +47,7 @@ runs:
       shell: bash
       run: |
         cp \
-        osctrl-${{ inputs.osctrl_component }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
+        osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin \
         osctrl-${{ inputs.osctrl_component }}-${{ inputs.release_version_tag }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.exe
 
     ########################### Download osctrl DEB package ###########################

--- a/.github/workflows/build_and_test_main_merge.yml
+++ b/.github/workflows/build_and_test_main_merge.yml
@@ -103,7 +103,7 @@ jobs:
       matrix:
         components: ['tls', 'admin', 'api', 'cli']
         goos: ['linux']
-        goarch: ['amd64']
+        goarch: ['amd64', 'arm64']
     steps:
       ########################### Checkout code ###########################
       - name: Checkout code
@@ -131,8 +131,59 @@ jobs:
           #### Build vars ####
           osctrl_component: ${{ matrix.components }}
           commit_sha: ${{ steps.vars.outputs.sha_short }}
-          docker_tag: ${{ steps.vars.outputs.sha_short }}
           #### Dockerhub creds ####
           docker_hub_org: ${{ secrets.DOCKER_HUB_ORG }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           docker_hub_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+
+  push_docker_images:
+      needs: [create_docker_images]
+      runs-on: ubuntu-22.04
+      strategy:
+        matrix:
+          components: ['tls', 'admin', 'api', 'cli']
+      steps:
+        ########################### Get digests from build ###########################
+        - name: Download digests
+          uses: actions/download-artifact@v4.1.2
+          with:
+            pattern: digests-osctrl-${{ matrix.components }}-*
+            merge-multiple: true
+            path: /tmp/digests
+
+        ########################### Setup Docker ###########################
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3.0.0
+
+        ########################### Add meta data for containers ###########################
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v5
+          with:
+            images: ${{ secrets.DOCKER_HUB_ORG }}/osctrl-${{ matrix.components }}
+            labels: |
+              org.opencontainers.image.title=osctrl-${{ matrix.components }}
+            tags: |
+                type=sha,prefix=,format=short
+                type=match,pattern=v(.*),group=1
+
+
+        ########################### Log into Dockerhub ###########################
+        - name: Login to Docker Hub
+          uses: docker/login-action@v3.0.0
+          with:
+            username: ${{ secrets.DOCKER_HUB_USERNAME }}
+            password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+        ########################### Create and push images ###########################
+        - name: Create manifest list and push
+          working-directory: /tmp/digests
+          run: |
+            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+              $(printf '${{ secrets.DOCKER_HUB_ORG }}/osctrl-${{ matrix.components }}@sha256:%s ' *)
+
+        ########################### Inspect new image ###########################
+        - name: Inspect image
+          run: |
+            docker buildx imagetools inspect ${{ secrets.DOCKER_HUB_ORG }}/osctrl-${{ matrix.components }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/create_tagged_releases.yml
+++ b/.github/workflows/create_tagged_releases.yml
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+          echo "branch=$(echo ${GITHUB_REF_NAME})" >> $GITHUB_OUTPUT
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       ########################### Build DEB packages ###########################
@@ -96,6 +96,7 @@ jobs:
           osctrl_component: ${{ matrix.components }}
           commit_sha: ${{ steps.vars.outputs.sha_short }}
           osquery_version: ${{ env.OSQUERY_VERSION }}
+          release_version_tag:  ${{ steps.vars.outputs.branch }}
 
   create_docker_images:
     needs: [build_and_test]
@@ -104,7 +105,7 @@ jobs:
       matrix:
         components: ['tls', 'admin', 'api', 'cli']
         goos: ['linux']
-        goarch: ['amd64']
+        goarch: ['amd64', 'arm64']
     steps:
       ########################### Checkout code ###########################
       - name: Checkout code
@@ -133,31 +134,96 @@ jobs:
           #### Build vars ####
           osctrl_component: ${{ matrix.components }}
           commit_sha: ${{ steps.vars.outputs.sha_short }}
-          docker_tag: ${{ steps.vars.outputs.RELEASE_VERSION }}
           #### Dockerhub creds ####
           docker_hub_org: ${{ secrets.DOCKER_HUB_ORG }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           docker_hub_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      ########################### Sign Docker images ###########################
-      - name: Sign osctrl Docker containers
-        uses: ./.github/actions/tagged_release/docker/codesign
-        with:
-          #### Docker vars ####
-          osctrl_component: ${{ matrix.components }}
-          docker_tag: ${{ steps.vars.outputs.RELEASE_VERSION }}
-          docker_image_digest: ${{ steps.build_docker_containers.outputs.docker_image_digest }}
-          #### Dockerhub creds ####
-          docker_hub_org: ${{ secrets.DOCKER_HUB_ORG }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          docker_hub_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          #### Codesign secrets ####
-          codesign_password: ${{ secrets.COSIGN_PASSWORD }}
-          codesign_private_key: ${{ secrets.COSIGN_PRIVATE }}
-          codesign_public_cert: ${{ secrets.COSIGN_PUBLIC }}
+
+  push_docker_images:
+      needs: [create_docker_images]
+      runs-on: ubuntu-22.04
+      strategy:
+        matrix:
+          components: ['tls', 'admin', 'api', 'cli']
+      steps:
+        ########################### Checkout code ###########################
+        - name: Checkout code
+          uses: actions/checkout@v4.1.1
+          with:
+            fetch-depth: 2
+
+        ########################### Get digests from build ###########################
+        - name: Download digests
+          uses: actions/download-artifact@v4.1.2
+          with:
+            pattern: digests-osctrl-${{ matrix.components }}-*
+            merge-multiple: true
+            path: /tmp/digests
+
+        ########################### Setup Docker ###########################
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3.0.0
+
+        ########################### Add meta data for containers ###########################
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v5
+          with:
+            images: ${{ secrets.DOCKER_HUB_ORG }}/osctrl-${{ matrix.components }}
+            labels: |
+              org.opencontainers.image.title=osctrl-${{ matrix.components }}
+            tags: |
+                type=sha,prefix=,format=short
+                type=match,pattern=v(.*),group=1
+
+
+        ########################### Log into Dockerhub ###########################
+        - name: Login to Docker Hub
+          uses: docker/login-action@v3.0.0
+          with:
+            username: ${{ secrets.DOCKER_HUB_USERNAME }}
+            password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+        ########################### Create and push images ###########################
+        - name: Create manifest list and push
+          working-directory: /tmp/digests
+          run: |
+            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+              $(printf '${{ secrets.DOCKER_HUB_ORG }}/osctrl-${{ matrix.components }}@sha256:%s ' *)
+
+        ########################### Generate image tags and digests ###########################
+        - name: Export digests and tags for cosign
+          id: docker_vars
+          working-directory: /tmp/digests
+          run: |
+              echo "digests=$(printf '%s ' *)" >> $GITHUB_OUTPUT
+              echo "tags=$(jq -cr '.tags | map(\"-t \" + .) | join(\" \")' <<< \"$DOCKER_METADATA_OUTPUT_JSON\")" >> $GITHUB_OUTPUT
+
+        ########################### Sign Docker images ###########################
+        - name: Sign osctrl Docker containers
+          uses: ./.github/actions/tagged_release/docker/codesign
+          with:
+            #### Docker vars ####
+            osctrl_component: ${{ matrix.components }}
+            docker_tags: ${{ steps.docker_vars.outputs.tags }}
+            docker_image_digests: ${{ steps.digests.outputs.digests }}
+            #### Dockerhub creds ####
+            docker_hub_org: ${{ secrets.DOCKER_HUB_ORG }}
+            docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+            docker_hub_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+            #### Codesign secrets ####
+            codesign_password: ${{ secrets.COSIGN_PASSWORD }}
+            codesign_private_key: ${{ secrets.COSIGN_PRIVATE }}
+            codesign_public_cert: ${{ secrets.COSIGN_PUBLIC }}
+
+        ########################### Inspect new image ###########################
+        - name: Inspect image
+          run: |
+            docker buildx imagetools inspect ${{ secrets.DOCKER_HUB_ORG }}/osctrl-${{ matrix.components }}:${{ steps.meta.outputs.version }}
 
   create_release:
-    needs: [build_and_test,create_deb_packages,create_docker_images]
+    needs: [build_and_test,create_deb_packages,push_docker_images]
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -184,7 +250,6 @@ jobs:
       ########################### Create release ###########################
       - name: Create a new release with binaries and packages
         uses: ./.github/actions/tagged_release/github
-        id: build_docker_containers
         with:
           go_os: "${{ matrix.goos }}"
           go_arch: "${{ matrix.goarch }}"


### PR DESCRIPTION
Add support for arm64 docker builds

- Split building images into 2 steps: one to build all images for all platforms and export the digests upstream; create the new image using all digests with `docker buildx imagetools create` as recommended in [multi-platform.md](https://github.com/crazy-max/docker-docs/blob/6aa26f53aeecf40013a3a255b36a8f21a08b0ac9/build/ci/github-actions/multi-platform.md)
- updated `.github/actions/tagged_release/docker/codesign/action.yml` to sign all images and digests pushed to docker hub
- Push `latest` tag on new tagged_releases
- use `docker/metadata-action` to tag the images 
- fixed bug in `.github/actions/tagged_release/github/action.yml` where `inputs.commit_sha` was missing from file name
- fixed bug in `.github/actions/build/dpkg/action.yml` where the artifact could not be found and uploaded

Tagged release workflow tested [here](https://github.com/peterbogdan/osctrl/actions/runs/9825678719)
Normal release workflow tested [here](https://github.com/peterbogdan/osctrl/actions/runs/9825476763)

Tested uploading the new images in my docker hub:
- [osctrl-tls](https://hub.docker.com/r/peterbbb/osctrl-tls/tags)
- [osctrl-cli](https://hub.docker.com/r/peterbbb/osctrl-cli/tags)
- [osctrl-admin](https://hub.docker.com/r/peterbbb/osctrl-admin/tags)
- [osctrl-api](https://hub.docker.com/r/peterbbb/osctrl-api/tags)