### PR TITLE
Logger for docker environment is set to db

### DIFF
--- a/admin/handlers/handlers.go
+++ b/admin/handlers/handlers.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/jmpsec/osctrl/admin/sessions"
+	"github.com/jmpsec/osctrl/backend"
 	"github.com/jmpsec/osctrl/cache"
 	"github.com/jmpsec/osctrl/carves"
 	"github.com/jmpsec/osctrl/environments"
@@ -172,10 +173,20 @@ func WithAdminConfig(config *types.JSONConfigurationAdmin) HandlersOption {
 	}
 }
 
-func WithDBLogger(dbfile string) HandlersOption {
+func WithDBLogger(dbfile string, config *backend.JSONConfigurationDB) HandlersOption {
 	return func(h *HandlersAdmin) {
 		if dbfile == "" {
-			h.DBLogger = nil
+			if config == nil {
+				h.DBLogger = nil
+				return
+			}
+			logger, err := logging.CreateLoggerDBConfig(*config)
+			if err != nil {
+				log.Printf("error creating DB logger %v", err)
+				logger.Enabled = false
+				logger.Database = nil
+			}
+			h.DBLogger = logger
 			return
 		}
 		logger, err := logging.CreateLoggerDBFile(dbfile)

--- a/deploy/docker/dockerfiles/Dockerfile-dev-admin
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-admin
@@ -23,7 +23,6 @@ RUN go mod verify
 ### Copy osctrl-admin bin and configs ###
 RUN mkdir -p /opt/osctrl/bin
 RUN mkdir -p /opt/osctrl/config
-RUN mkdir -p /opt/osctrl/script
 RUN mkdir -p /opt/osctrl/carved_files
 
 ### Copy osctrl-admin web templates ###

--- a/deploy/docker/dockerfiles/Dockerfile-dev-api
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-api
@@ -8,7 +8,7 @@ ENV GOOS="linux"
 ENV CGO_ENABLED=0
 
 # Hot reloading mod
-RUN go install github.com/cosmtrek/air@v1.41.0 
+RUN go install github.com/cosmtrek/air@v1.41.0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.1
 
 # Copy code
@@ -21,7 +21,6 @@ RUN go mod verify
 ### Copy osctrl-api bin and configs ###
 RUN mkdir -p /opt/osctrl/bin
 RUN mkdir -p /opt/osctrl/config
-RUN mkdir -p /opt/osctrl/script
 RUN go build -o /opt/osctrl/bin/osctrl-api api/*.go
 
 EXPOSE 9002

--- a/deploy/docker/dockerfiles/Dockerfile-dev-tls
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-tls
@@ -8,7 +8,7 @@ ENV GOOS="linux"
 ENV CGO_ENABLED=0
 
 # Hot reloading mod
-RUN go install github.com/cosmtrek/air@v1.41.0 
+RUN go install github.com/cosmtrek/air@v1.41.0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.1
 
 # Copy code
@@ -21,7 +21,6 @@ RUN go mod verify
 ### Copy osctrl-api bin and configs ###
 RUN mkdir -p /opt/osctrl/bin
 RUN mkdir -p /opt/osctrl/config
-RUN mkdir -p /opt/osctrl/script
 RUN go build -o /opt/osctrl/bin/osctrl-tls tls/*.go
 
 EXPOSE 9000

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -32,7 +32,7 @@ services:
   ######################################### osctrl-tls #########################################
   osctrl-tls:
     container_name: 'osctrl-tls-dev'
-    image: 'osctrl-tls-dev:v${OSCTRL_VERSION}'
+    image: 'osctrl-tls-dev:${OSCTRL_VERSION}'
     restart: unless-stopped
     build:
       context: .
@@ -40,12 +40,13 @@ services:
       args:
         GOLANG_VERSION: ${GOLANG_VERSION}
     environment:
-      #### TLS settings ####
+      #### osctrl-tls configuration settings ####
       - SERVICE_LISTENER=0.0.0.0
       - SERVICE_PORT=9000
       - SERVICE_HOST=0.0.0.0
       - SERVICE_AUTH=none
-      - SERVICE_LOGGER=stdout
+      - SERVICE_LOGGER=db
+      - LOGGER_DB_SAME=true
       #### Database settings ####
       - DB_HOST=osctrl-postgres
       - DB_NAME=${POSTGRES_DB_NAME}
@@ -67,7 +68,7 @@ services:
   ######################################### osctrl-admin #########################################
   osctrl-admin:
     container_name: 'osctrl-admin-dev'
-    image: 'osctrl-admin-dev:v${OSCTRL_VERSION}'
+    image: 'osctrl-admin-dev:${OSCTRL_VERSION}'
     restart: unless-stopped
     build:
       context: .
@@ -76,13 +77,14 @@ services:
         GOLANG_VERSION: ${GOLANG_VERSION}
         OSQUERY_VERSION: ${OSQUERY_VERSION}
     environment:
-      #### TLS settings ####
+      #### osctrl-admin configuration settings ####
       - SERVICE_LISTENER=0.0.0.0
       - SERVICE_PORT=9001
       - SERVICE_HOST=0.0.0.0
       - SERVICE_AUTH=db
       - JWT_SECRET=${JWT_SECRET}
-      - SERVICE_LOGGER=stdout
+      - SERVICE_LOGGER=db
+      - LOGGER_DB_SAME=true
       #### Database settings ####
       - DB_HOST=osctrl-postgres
       - DB_NAME=${POSTGRES_DB_NAME}
@@ -104,7 +106,7 @@ services:
   ######################################### osctrl-api #########################################
   osctrl-api:
     container_name: 'osctrl-api-dev'
-    image: 'osctrl-api-dev:v${OSCTRL_VERSION}'
+    image: 'osctrl-api-dev:${OSCTRL_VERSION}'
     restart: unless-stopped
     build:
       context: .
@@ -113,13 +115,13 @@ services:
         GOLANG_VERSION: ${GOLANG_VERSION}
         OSQUERY_VERSION: ${OSQUERY_VERSION}
     environment:
-      #### TLS settings ####
+      #### osctrl-api configuration settings ####
       - SERVICE_LISTENER=0.0.0.0
       - SERVICE_PORT=9002
       - SERVICE_HOST=0.0.0.0
       - SERVICE_AUTH=jwt
       - JWT_SECRET=${JWT_SECRET}
-      - SERVICE_LOGGER=stdout
+      - SERVICE_LOGGER=db
       #### Database settings ####
       - DB_HOST=osctrl-postgres
       - DB_NAME=${POSTGRES_DB_NAME}
@@ -183,7 +185,7 @@ services:
   ##############################################################################################
   osctrl-cli:
     container_name: 'osctrl-cli-dev'
-    image: 'osctrl-cli-dev:v${OSCTRL_VERSION}'
+    image: 'osctrl-cli-dev:${OSCTRL_VERSION}'
     restart: unless-stopped
     build:
       context: .
@@ -221,7 +223,7 @@ services:
   ######################################### osquery #########################################
   osquery:
     container_name: 'osctrl-osquery-dev'
-    image: 'osctrl-osquery-dev:v${OSCTRL_VERSION}'
+    image: 'osctrl-osquery-dev:${OSCTRL_VERSION}'
     restart: unless-stopped
     build:
       context: .

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -25,7 +25,7 @@ type LoggerTLS struct {
 }
 
 // CreateLoggerTLS to instantiate a new logger for the TLS endpoint
-func CreateLoggerTLS(logging, loggingFile string, s3Conf types.S3Configuration, alwaysLog bool, dbConf backend.JSONConfigurationDB, mgr *settings.Settings, nodes *nodes.NodeManager, queries *queries.Queries) (*LoggerTLS, error) {
+func CreateLoggerTLS(logging, loggingFile string, s3Conf types.S3Configuration, loggerSame, alwaysLog bool, dbConf backend.JSONConfigurationDB, mgr *settings.Settings, nodes *nodes.NodeManager, queries *queries.Queries) (*LoggerTLS, error) {
 	l := &LoggerTLS{
 		Logging: logging,
 		Nodes:   nodes,
@@ -47,12 +47,21 @@ func CreateLoggerTLS(logging, loggingFile string, s3Conf types.S3Configuration, 
 		g.Settings(mgr)
 		l.Logger = g
 	case settings.LoggingDB:
-		d, err := CreateLoggerDBFile(loggingFile)
-		if err != nil {
-			return nil, err
+		if loggerSame {
+			d, err := CreateLoggerDBConfig(dbConf)
+			if err != nil {
+				return nil, err
+			}
+			d.Settings(mgr)
+			l.Logger = d
+		} else {
+			d, err := CreateLoggerDBFile(loggingFile)
+			if err != nil {
+				return nil, err
+			}
+			d.Settings(mgr)
+			l.Logger = d
 		}
-		d.Settings(mgr)
-		l.Logger = d
 	case settings.LoggingStdout:
 		d, err := CreateLoggerStdout()
 		if err != nil {

--- a/tls/main.go
+++ b/tls/main.go
@@ -111,6 +111,7 @@ var (
 	tlsKeyFile        string
 	loggerFlag        bool
 	loggerFile        string
+	loggerDbSame      bool
 	alwaysLog         bool
 	carverConfigFile  string
 )
@@ -422,6 +423,13 @@ func init() {
 			Destination: &loggerFile,
 		},
 		&cli.BoolFlag{
+			Name:        "logger-db-same",
+			Value:       false,
+			Usage:       "Use the same DB configuration for the logger",
+			EnvVars:     []string{"LOGGER_DB_SAME"},
+			Destination: &loggerDbSame,
+		},
+		&cli.BoolFlag{
 			Name:        "always-log",
 			Aliases:     []string{"a", "always"},
 			Value:       false,
@@ -569,11 +577,11 @@ func osctrlService() {
 	ingestedMetrics = metrics.CreateIngested(db.Conn)
 	// Initialize TLS logger
 	log.Println("Loading TLS logger")
-	loggerTLS, err = logging.CreateLoggerTLS(tlsConfig.Logger, loggerFile, s3LogConfig, alwaysLog, dbConfig, settingsmgr, nodesmgr, queriesmgr)
+	loggerTLS, err = logging.CreateLoggerTLS(
+		tlsConfig.Logger, loggerFile, s3LogConfig, loggerDbSame, alwaysLog, dbConfig, settingsmgr, nodesmgr, queriesmgr)
 	if err != nil {
 		log.Fatalf("Error loading logger - %s: %v", tlsConfig.Logger, err)
 	}
-
 	// Sleep to reload environments
 	// FIXME Implement Redis cache
 	// FIXME splay this?


### PR DESCRIPTION
Several things in this PR:

- Making sure the logger for the docker dev environment is set to `db`.
- Adding new parameter (`logger-db-same`) and env variable (`LOGGER_DB_SAME `) to use the same configuration for the logger than the backend access.
- Some small changes in the dockerfiles.