### PR TITLE
Display last 100 entries for status and result logs

### DIFF
--- a/admin/handlers/json-logs.go
+++ b/admin/handlers/json-logs.go
@@ -108,18 +108,28 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	// Extract parameter for seconds
 	// If parameter is not present or invalid, it defaults to 6 hours back
-	secondsBack := int64(utils.SixHours)
-	seconds, ok := r.URL.Query()["seconds"]
+	// secondsBack := int64(utils.SixHours)
+	// seconds, ok := r.URL.Query()["seconds"]
+	// if ok {
+	// 	s, err := strconv.ParseInt(seconds[0], 10, 64)
+	// 	if err == nil {
+	// 		secondsBack = s
+	// 	}
+	// }
+	// Extract parameter for limit
+	// If parameter is not present or invalid, it defaults to 100 items
+	limitItems := 100
+	limit, ok := r.URL.Query()["limit"]
 	if ok {
-		s, err := strconv.ParseInt(seconds[0], 10, 64)
+		l, err := strconv.ParseInt(limit[0], 10, 64)
 		if err == nil {
-			secondsBack = s
+			limitItems = int(l)
 		}
 	}
 	// Get logs
 	logJSON := []LogJSON{}
 	if logType == types.StatusLog && h.AdminConfig.Logger == settings.LoggingDB {
-		statusLogs, err := h.DBLogger.StatusLogs(UUID, env.Name, secondsBack)
+		statusLogs, err := h.DBLogger.StatusLogsLimit(UUID, env.Name, limitItems)
 		if err != nil {
 			log.Printf("error getting logs %v", err)
 			h.Inc(metricJSONErr)
@@ -138,8 +148,8 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 			}
 			logJSON = append(logJSON, _l)
 		}
-	} else if logType == types.ResultLog && h.RedisCache != nil {
-		resultLogs, err := h.RedisCache.ResultLogs(UUID, env.Name, secondsBack)
+	} else if logType == types.ResultLog && h.AdminConfig.Logger == settings.LoggingDB {
+		resultLogs, err := h.DBLogger.ResultLogsLimit(UUID, env.Name, limitItems)
 		if err != nil {
 			log.Printf("error getting logs %v", err)
 			h.Inc(metricJSONErr)
@@ -149,8 +159,8 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 		for _, r := range resultLogs {
 			_l := LogJSON{
 				Created: CreationTimes{
-					Display:   utils.PastFutureTimesEpoch(int64(r.UnixTime)),
-					Timestamp: strconv.Itoa(int(r.UnixTime)),
+					Display:   utils.PastFutureTimes(r.CreatedAt),
+					Timestamp: strconv.Itoa(int(r.CreatedAt.Unix())),
 				},
 				First:  r.Name,
 				Second: string(r.Columns),

--- a/admin/templates/node.html
+++ b/admin/templates/node.html
@@ -371,7 +371,8 @@
                         <div class="card mt-2">
                           <div id="status-card-header" class="card-header">
                             <i class="fas fa-stream"></i>
-                            <label for="back_hours_status">Last <b><output id="back_output_status">6</output></b> hours of status logs for node {{ .UUID }}</label>
+                            <!-- <label for="back_hours_status">Last <b><output id="back_output_status">6</output></b> hours of status logs for node {{ .UUID }}</label> -->
+                            <label for="back_hours_status">Last <b><output>100</output id="back_output_status"></b> entries of status logs for node {{ .UUID }}</label>
                             <a href="#status-logs" target="_blank">
                               <i class="fas fa-external-link-alt"></i>
                             </a>
@@ -416,7 +417,8 @@
                         <div class="card mt-2">
                           <div id="result-card-header" class="card-header">
                             <i class="fas fa-stream"></i>
-                            <label for="back_hours_result">Last <b><output id="back_output_result">6</output></b> hours of status logs for node {{ .UUID }}</label>
+                            <!-- <label for="back_hours_result">Last <b><output id="back_output_result">6</output></b> hours of result logs for node {{ .UUID }}</label> -->
+                            <label for="back_hours_result">Last <b><output id="back_output_result">100</output></b> entries of result logs for node {{ .UUID }}</label>
                             <a href="#result-logs" target="_blank">
                               <i class="fas fa-external-link-alt"></i>
                             </a>

--- a/logging/db.go
+++ b/logging/db.go
@@ -197,7 +197,16 @@ func (logDB *LoggerDB) QueryLogs(name string) ([]OsqueryQueryData, error) {
 func (logDB *LoggerDB) StatusLogs(uuid, environment string, seconds int64) ([]OsqueryStatusData, error) {
 	var logs []OsqueryStatusData
 	minusSeconds := time.Now().Add(time.Duration(-seconds) * time.Second)
-	if err := logDB.Database.Conn.Where("uuid = ? AND environment = ?", strings.ToUpper(uuid), environment).Where("created_at > ?", minusSeconds).Find(&logs).Error; err != nil {
+	if err := logDB.Database.Conn.Where("uuid = ? AND environment = ?", strings.ToUpper(uuid), environment).Where("created_at < ?", minusSeconds).Find(&logs).Error; err != nil {
+		return logs, err
+	}
+	return logs, nil
+}
+
+// StatusLogsLimit will retrieve a limited number of status logs
+func (logDB *LoggerDB) StatusLogsLimit(uuid, environment string, limit int) ([]OsqueryStatusData, error) {
+	var logs []OsqueryStatusData
+	if err := logDB.Database.Conn.Where("uuid = ? AND environment = ?", strings.ToUpper(uuid), environment).Order("created_at desc").Limit(limit).Find(&logs).Error; err != nil {
 		return logs, err
 	}
 	return logs, nil
@@ -207,7 +216,16 @@ func (logDB *LoggerDB) StatusLogs(uuid, environment string, seconds int64) ([]Os
 func (logDB *LoggerDB) ResultLogs(uuid, environment string, seconds int64) ([]OsqueryResultData, error) {
 	var logs []OsqueryResultData
 	minusSeconds := time.Now().Add(time.Duration(-seconds) * time.Second)
-	if err := logDB.Database.Conn.Where("uuid = ? AND environment = ?", strings.ToUpper(uuid), environment).Where("created_at > ?", minusSeconds).Find(&logs).Error; err != nil {
+	if err := logDB.Database.Conn.Where("uuid = ? AND environment = ?", strings.ToUpper(uuid), environment).Where("created_at < ?", minusSeconds).Find(&logs).Error; err != nil {
+		return logs, err
+	}
+	return logs, nil
+}
+
+// ResultLogsLimit will retrieve a limited number of result logs
+func (logDB *LoggerDB) ResultLogsLimit(uuid, environment string, limit int) ([]OsqueryResultData, error) {
+	var logs []OsqueryResultData
+	if err := logDB.Database.Conn.Where("uuid = ? AND environment = ?", strings.ToUpper(uuid), environment).Order("created_at").Limit(limit).Find(&logs).Error; err != nil {
 		return logs, err
 	}
 	return logs, nil


### PR DESCRIPTION
Fix to display the last 100 entries for status and result logs in `osctrl-admin`.