### PR TITLE
replicate logic used for admin to run queris on multiple UUIDs, Envs,…

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -65,11 +65,7 @@ func _apiPath(target string) string {
 }
 
 // Helper to verify if a platform is valid
-func checkValidPlatform(platform string) bool {
-	platforms, err := nodesmgr.GetAllPlatforms()
-	if err != nil {
-		return false
-	}
+func checkValidPlatform(platforms []string, platform string) bool {
 	for _, p := range platforms {
 		if p == platform {
 			return true

--- a/cli/api-query.go
+++ b/cli/api-query.go
@@ -51,7 +51,7 @@ func (api *OsctrlAPI) CompleteQuery(env, identifier string) error {
 // RunQuery to initiate a query in osctrl
 func (api *OsctrlAPI) RunQuery(env, uuid, query string, hidden bool) (types.ApiQueriesResponse, error) {
 	q := types.ApiDistributedQueryRequest{
-		UUID:   uuid,
+		UUIDs:   []string{uuid},
 		Query:  query,
 		Hidden: hidden,
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -97,9 +97,12 @@ type ScriptRequest struct {
 
 // ApiDistributedQueryRequest to receive query requests
 type ApiDistributedQueryRequest struct {
-	UUID   string `json:"uuid"`
-	Query  string `json:"query"`
-	Hidden bool   `json:"hidden"`
+	UUIDs  []string `json:"uuid_list"`
+	Platforms  []string `json:"platform_list"`
+	Environments  []string `json:"environment_list"`
+	Hosts  []string `json:"host_list"`
+	Query  string   `json:"query"`
+	Hidden bool     `json:"hidden"`
 }
 
 // ApiDistributedCarveRequest to receive query requests


### PR DESCRIPTION
Tested locally: 

```
        response = self.session.post(
            f"{self.base_url}/queries/qa", json={"uuid_list": uuids, "query": "SELECT * FROM sudoers;"}
        )
        response.raise_for_status()
```

![image](https://github.com/user-attachments/assets/9d2b0063-3d2f-43f6-a8a3-57dc6f33ac15)


Let me know if there are any tests I should update or anything else
tests have passed in my fork [here](https://github.com/peterbogdan/osctrl/pull/3)

I have replicated the logic from [QueryRunPOSTHandler](https://github.com/jmpsec/osctrl/blob/main/admin/handlers/post.go#L93) in Admin for this