### PR TITLE
Skip using underscore in DB JSON configuration file

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -31,10 +31,10 @@ type JSONConfigurationDB struct {
 	Name            string `json:"name"`
 	Username        string `json:"username"`
 	Password        string `json:"password"`
-	MaxIdleConns    int    `json:"max_idle_conns"`
-	MaxOpenConns    int    `json:"max_open_conns"`
-	ConnMaxLifetime int    `json:"conn_max_lifetime"`
-	ConnRetry       int    `json:"conn_retry"`
+	MaxIdleConns    int    `json:"maxIdleConns"`
+	MaxOpenConns    int    `json:"maxOpenConns"`
+	ConnMaxLifetime int    `json:"connMaxLifetime"`
+	ConnRetry       int    `json:"connRetry"`
 }
 
 // LoadConfiguration to load the DB configuration file and assign to variables

--- a/deploy/config/db.json
+++ b/deploy/config/db.json
@@ -5,9 +5,9 @@
     "name": "_DB_NAME",
     "username": "_DB_USERNAME",
     "password": "_DB_PASSWORD",
-    "max_idle_conns": 20,
-    "max_open_conns": 100,
-    "conn_max_lifetime": 30,
-    "conn_retry": 10
+    "maxIdleConns": 20,
+    "maxOpenConns": 100,
+    "connMaxLifetime": 30,
+    "connRetry": 10
   }
 }


### PR DESCRIPTION
Change underscore to camel case capitalization for the `db.json` configuration file. Here is the actual issue with the JSON parsing library:

https://github.com/spf13/viper/issues/678

