### PR TITLE
Migration from gorilla mux to the native mux in osctrl-admin

### DIFF
--- a/admin/handlers/go.mod
+++ b/admin/handlers/go.mod
@@ -33,7 +33,6 @@ replace github.com/jmpsec/osctrl/utils => ../../utils
 replace github.com/jmpsec/osctrl/version => ../../version
 
 require (
-	github.com/gorilla/mux v1.8.1
 	github.com/jmpsec/osctrl/admin/sessions v0.3.8
 	github.com/jmpsec/osctrl/carves v0.3.8
 	github.com/jmpsec/osctrl/environments v0.0.0-20240819084417-5d0c74745216

--- a/admin/handlers/json-carves.go
+++ b/admin/handlers/json-carves.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/carves"
 	"github.com/jmpsec/osctrl/queries"
@@ -63,10 +62,9 @@ func (h *HandlersAdmin) JSONCarvesHandler(w http.ResponseWriter, r *http.Request
 		h.Inc(metricJSONErr)
 		return
 	}
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		log.Println("environment is missing")
 		h.Inc(metricJSONErr)
 		return
@@ -79,8 +77,8 @@ func (h *HandlersAdmin) JSONCarvesHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Extract target
-	target, ok := vars["target"]
-	if !ok {
+	target := r.PathValue("target")
+	if target == "" {
 		h.Inc(metricJSONErr)
 		log.Println("error getting target")
 		return

--- a/admin/handlers/json-logs.go
+++ b/admin/handlers/json-logs.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
@@ -62,10 +61,9 @@ type QueryLogJSON struct {
 func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricJSONReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract type
-	logType, ok := vars["type"]
-	if !ok {
+	logType := r.PathValue("type")
+	if logType == "" {
 		log.Println("error getting log type")
 		h.Inc(metricJSONErr)
 		return
@@ -77,8 +75,8 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		log.Println("environment is missing")
 		h.Inc(metricJSONErr)
 		return
@@ -100,8 +98,8 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	// Extract UUID
 	// FIXME verify UUID
-	UUID, ok := vars["uuid"]
-	if !ok {
+	UUID := r.PathValue("uuid")
+	if UUID == "" {
 		log.Println("error getting UUID")
 		h.Inc(metricJSONErr)
 		return
@@ -188,11 +186,10 @@ func (h *HandlersAdmin) JSONQueryLogsHandler(w http.ResponseWriter, r *http.Requ
 		h.Inc(metricJSONErr)
 		return
 	}
-	vars := mux.Vars(r)
 	// Extract query name
 	// FIXME verify name
-	name, ok := vars["name"]
-	if !ok {
+	name := r.PathValue("name")
+	if name == "" {
 		log.Println("error getting name")
 		h.Inc(metricJSONErr)
 		return

--- a/admin/handlers/json-nodes.go
+++ b/admin/handlers/json-nodes.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/users"
@@ -43,10 +42,9 @@ type NodeJSON struct {
 func (h *HandlersAdmin) JSONEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricJSONReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		log.Println("error getting environment")
 		h.Inc(metricJSONErr)
 		return
@@ -73,8 +71,8 @@ func (h *HandlersAdmin) JSONEnvironmentHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Extract target
-	target, ok := vars["target"]
-	if !ok {
+	target := r.PathValue("target")
+	if target == "" {
 		log.Println("error getting target")
 		h.Inc(metricJSONErr)
 		return
@@ -133,17 +131,16 @@ func (h *HandlersAdmin) JSONPlatformHandler(w http.ResponseWriter, r *http.Reque
 		h.Inc(metricJSONErr)
 		return
 	}
-	vars := mux.Vars(r)
 	// Extract platform
-	platform, ok := vars["platform"]
-	if !ok {
+	platform := r.PathValue("platform")
+	if platform == "" {
 		log.Println("error getting platform")
 		h.Inc(metricJSONErr)
 		return
 	}
 	// Extract target
-	target, ok := vars["target"]
-	if !ok {
+	target := r.PathValue("target")
+	if target == "" {
 		log.Println("error getting target")
 		h.Inc(metricJSONErr)
 		return

--- a/admin/handlers/json-queries.go
+++ b/admin/handlers/json-queries.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/queries"
 	"github.com/jmpsec/osctrl/settings"
@@ -133,10 +132,9 @@ func (h *HandlersAdmin) JSONQueryHandler(w http.ResponseWriter, r *http.Request)
 		h.Inc(metricJSONErr)
 		return
 	}
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		log.Println("environment is missing")
 		h.Inc(metricJSONErr)
 		return
@@ -149,8 +147,8 @@ func (h *HandlersAdmin) JSONQueryHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Extract target
-	target, ok := vars["target"]
-	if !ok {
+	target := r.PathValue("target")
+	if target == "" {
 		log.Println("error getting target")
 		h.Inc(metricJSONErr)
 		return

--- a/admin/handlers/json-stats.go
+++ b/admin/handlers/json-stats.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/settings"
@@ -26,10 +25,9 @@ func (h *HandlersAdmin) JSONStatsHandler(w http.ResponseWriter, r *http.Request)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
-	vars := mux.Vars(r)
 	// Extract stats target
-	target, ok := vars["target"]
-	if !ok {
+	target := r.PathValue("target")
+	if target == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting target")
 		return
@@ -41,8 +39,8 @@ func (h *HandlersAdmin) JSONStatsHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Extract identifier
-	identifier, ok := vars["identifier"]
-	if !ok {
+	identifier := r.PathValue("identifier")
+	if identifier == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting target identifier")
 		return

--- a/admin/handlers/post.go
+++ b/admin/handlers/post.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/queries"
@@ -93,10 +92,9 @@ func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request
 func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		log.Println("environment is missing")
 		h.Inc(metricAdminErr)
 		return
@@ -246,10 +244,9 @@ func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Reque
 func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		log.Println("environment is missing")
 		h.Inc(metricAdminErr)
 		return
@@ -403,10 +400,9 @@ func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Requ
 func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		log.Println("environment is missing")
 		h.Inc(metricAdminErr)
 		return
@@ -542,10 +538,9 @@ func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.
 func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["environment"]
-	if !ok {
+	envVar := r.PathValue("environment")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -775,10 +770,9 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract environment and verify
-	envVar, ok := vars["environment"]
-	if !ok || !h.Envs.Exists(envVar) {
+	envVar := r.PathValue("environment")
+	if envVar == "" || !h.Envs.Exists(envVar) {
 		adminErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAdminErr)
 		return
@@ -845,10 +839,9 @@ func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Requ
 func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["environment"]
-	if !ok {
+	envVar := r.PathValue("environment")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -1122,10 +1115,9 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract service
-	serviceVar, ok := vars["service"]
-	if !ok {
+	serviceVar := r.PathValue("service")
+	if serviceVar == "" {
 		adminErrorResponse(w, "error getting service", http.StatusInternalServerError, nil)
 		h.Inc(metricAdminErr)
 		return
@@ -1547,10 +1539,9 @@ func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Reque
 func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract username and verify
-	usernameVar, ok := vars["username"]
-	if !ok || !h.Users.Exists(usernameVar) {
+	usernameVar := r.PathValue("username")
+	if usernameVar == "" || !h.Users.Exists(usernameVar) {
 		adminErrorResponse(w, "error getting username", http.StatusInternalServerError, nil)
 		h.Inc(metricAdminErr)
 		return
@@ -1618,10 +1609,9 @@ func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Re
 func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), true)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["environment"]
-	if !ok {
+	envVar := r.PathValue("environment")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return

--- a/admin/handlers/templates.go
+++ b/admin/handlers/templates.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/carves"
 	"github.com/jmpsec/osctrl/environments"
@@ -100,10 +99,9 @@ func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
 func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -125,8 +123,8 @@ func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Reques
 	}
 	// Extract target
 	// FIXME verify target
-	target, ok := vars["target"]
-	if !ok {
+	target := r.PathValue("target")
+	if target == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting target")
 		return
@@ -187,19 +185,18 @@ func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Reques
 func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract platform
 	// FIXME verify platform
-	platform, ok := vars["platform"]
-	if !ok {
+	platform := r.PathValue("platform")
+	if platform == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting platform")
 		return
 	}
 	// Extract target
 	// FIXME verify target
-	target, ok := vars["target"]
-	if !ok {
+	target := r.PathValue("target")
+	if target == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting target")
 		return
@@ -273,10 +270,9 @@ func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) 
 func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -365,10 +361,9 @@ func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Reques
 func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -434,10 +429,9 @@ func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Reque
 func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -503,10 +497,9 @@ func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Re
 func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -589,10 +582,9 @@ func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Reque
 func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -658,10 +650,9 @@ func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Requ
 func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -682,8 +673,8 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Extract name
-	name, ok := vars["name"]
-	if !ok {
+	name := r.PathValue("name")
+	if name == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting name")
 		return
@@ -760,10 +751,9 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["env"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		log.Println("environment is missing")
 		h.Inc(metricAdminErr)
 		return
@@ -784,8 +774,8 @@ func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Extract name
-	name, ok := vars["name"]
-	if !ok {
+	name := r.PathValue("name")
+	if name == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting name")
 		return
@@ -877,10 +867,9 @@ func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Requ
 func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["environment"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -945,10 +934,9 @@ func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
 func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["environment"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -1039,10 +1027,9 @@ func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request)
 func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract environment
-	envVar, ok := vars["environment"]
-	if !ok {
+	envVar := r.PathValue("env")
+	if envVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting environment")
 		return
@@ -1055,8 +1042,8 @@ func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// Get download target
-	targetVar, ok := vars["target"]
-	if !ok {
+	targetVar := r.PathValue("target")
+	if targetVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting download target")
 		return
@@ -1123,10 +1110,9 @@ func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Req
 func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Extract uuid
-	uuid, ok := vars["uuid"]
-	if !ok {
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting uuid")
 		return
@@ -1303,7 +1289,6 @@ func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
 func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAdminReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAdmin, settings.NoEnvironmentID), false)
-	vars := mux.Vars(r)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1313,8 +1298,8 @@ func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Extract service
-	serviceVar, ok := vars["service"]
-	if !ok {
+	serviceVar := r.PathValue("service")
+	if serviceVar == "" {
 		h.Inc(metricAdminErr)
 		log.Println("error getting service")
 		return

--- a/admin/handlers/tokens.go
+++ b/admin/handlers/tokens.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/users"
@@ -32,10 +31,9 @@ func (h *HandlersAdmin) TokensGETHandler(w http.ResponseWriter, r *http.Request)
 		h.Inc(metricAdminErr)
 		return
 	}
-	vars := mux.Vars(r)
 	// Extract username
-	username, ok := vars["username"]
-	if !ok {
+	username := r.PathValue("username")
+	if username == "" {
 		adminErrorResponse(w, "error getting username", http.StatusInternalServerError, nil)
 		h.Inc(metricAdminErr)
 		return
@@ -72,10 +70,9 @@ func (h *HandlersAdmin) TokensPOSTHandler(w http.ResponseWriter, r *http.Request
 		h.Inc(metricTokenErr)
 		return
 	}
-	vars := mux.Vars(r)
 	// Extract username and verify
-	username, ok := vars["username"]
-	if !ok || !h.Users.Exists(username) {
+	username := r.PathValue("username")
+	if username == "" || !h.Users.Exists(username) {
 		adminErrorResponse(w, "error getting username", http.StatusInternalServerError, nil)
 		h.Inc(metricAdminErr)
 		return

--- a/admin/main.go
+++ b/admin/main.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/crewjam/saml/samlsp"
-	"github.com/gorilla/mux"
 	"github.com/jmpsec/osctrl/admin/handlers"
 	"github.com/jmpsec/osctrl/admin/sessions"
 	"github.com/jmpsec/osctrl/backend"
@@ -773,7 +772,7 @@ func osctrlAdminService() {
 		log.Println("DebugService: Creating router")
 	}
 	// Create router for admin
-	routerAdmin := mux.NewRouter()
+	adminMux := http.NewServeMux()
 
 	// ///////////////////////// UNAUTHENTICATED CONTENT
 	if settingsmgr.DebugService(settings.ServiceAdmin) {
@@ -782,119 +781,118 @@ func osctrlAdminService() {
 	// Admin: login only if local auth is enabled
 	if adminConfig.Auth != settings.AuthNone && adminConfig.Auth != settings.AuthSAML {
 		// login
-		routerAdmin.HandleFunc(loginPath, handlersAdmin.LoginHandler).Methods("GET")
-		routerAdmin.HandleFunc(loginPath, handlersAdmin.LoginPOSTHandler).Methods("POST")
-		routerAdmin.HandleFunc(logoutPath, func(w http.ResponseWriter, r *http.Request) {
+		adminMux.HandleFunc("GET "+loginPath, handlersAdmin.LoginHandler)
+		adminMux.HandleFunc("POST "+loginPath, handlersAdmin.LoginPOSTHandler)
+		adminMux.HandleFunc("GET "+logoutPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, loginPath, http.StatusFound)
-		}).Methods("GET")
+		})
 	}
 	// Admin: health of service
-	routerAdmin.HandleFunc(healthPath, handlersAdmin.HealthHandler).Methods("GET")
+	adminMux.HandleFunc("GET "+healthPath, handlersAdmin.HealthHandler)
 	// Admin: error
-	routerAdmin.HandleFunc(errorPath, handlersAdmin.ErrorHandler).Methods("GET")
+	adminMux.HandleFunc("GET "+errorPath, handlersAdmin.ErrorHandler)
 	// Admin: forbidden
-	routerAdmin.HandleFunc(forbiddenPath, handlersAdmin.ForbiddenHandler).Methods("GET")
+	adminMux.HandleFunc("GET "+forbiddenPath, handlersAdmin.ForbiddenHandler)
 	// Admin: favicon
-	routerAdmin.HandleFunc(faviconPath, handlersAdmin.FaviconHandler)
+	adminMux.HandleFunc(faviconPath, handlersAdmin.FaviconHandler)
 	// Admin: static
-	routerAdmin.PathPrefix("/static/").Handler(
-		http.StripPrefix("/static", http.FileServer(http.Dir(staticFilesFolder))))
+	adminMux.Handle("/static/", http.StripPrefix("/static", http.FileServer(http.Dir(staticFilesFolder))))
 
 	// ///////////////////////// AUTHENTICATED CONTENT
 	if settingsmgr.DebugService(settings.ServiceAdmin) {
 		log.Println("DebugService: Authenticated content")
 	}
 	// Admin: JSON data for environments
-	routerAdmin.Handle("/json/environment/{env}/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONEnvironmentHandler))).Methods("GET")
+	adminMux.Handle("GET /json/environment/{env}/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONEnvironmentHandler)))
 	// Admin: JSON data for platforms
-	routerAdmin.Handle("/json/platform/{platform}/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONPlatformHandler))).Methods("GET")
+	adminMux.Handle("GET /json/platform/{platform}/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONPlatformHandler)))
 	// Admin: JSON data for logs
-	routerAdmin.Handle("/json/logs/{type}/{env}/{uuid}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONLogsHandler))).Methods("GET")
+	adminMux.Handle("GET /json/logs/{type}/{env}/{uuid}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONLogsHandler)))
 	// Admin: JSON data for query logs
-	routerAdmin.Handle("/json/query/{name}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONQueryLogsHandler))).Methods("GET")
+	adminMux.Handle("GET /json/query/{name}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONQueryLogsHandler)))
 	// Admin: JSON data for sidebar stats
-	routerAdmin.Handle("/json/stats/{target}/{identifier}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONStatsHandler))).Methods("GET")
+	adminMux.Handle("GET /json/stats/{target}/{identifier}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONStatsHandler)))
 	// Admin: JSON data for tags
-	routerAdmin.Handle("/json/tags", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONTagsHandler))).Methods("GET")
+	adminMux.Handle("GET /json/tags", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONTagsHandler)))
 	// Admin: table for environments
-	routerAdmin.Handle("/environment/{env}/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnvironmentHandler))).Methods("GET")
+	adminMux.Handle("GET /environment/{env}/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnvironmentHandler)))
 	// Admin: table for platforms
-	routerAdmin.Handle("/platform/{platform}/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.PlatformHandler))).Methods("GET")
+	adminMux.Handle("GET /platform/{platform}/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.PlatformHandler)))
 	// Admin: root
-	routerAdmin.Handle("/", handlerAuthCheck(http.HandlerFunc(handlersAdmin.RootHandler))).Methods("GET")
+	adminMux.Handle("GET /", handlerAuthCheck(http.HandlerFunc(handlersAdmin.RootHandler)))
 	// Admin: node view
-	routerAdmin.Handle("/node/{uuid}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.NodeHandler))).Methods("GET")
+	adminMux.Handle("GET /node/{uuid}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.NodeHandler)))
 	// Admin: multi node action
-	routerAdmin.Handle("/node/actions", handlerAuthCheck(http.HandlerFunc(handlersAdmin.NodeActionsPOSTHandler))).Methods("POST")
+	adminMux.Handle("POST /node/actions", handlerAuthCheck(http.HandlerFunc(handlersAdmin.NodeActionsPOSTHandler)))
 	// Admin: run queries
-	routerAdmin.Handle("/query/{env}/run", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryRunGETHandler))).Methods("GET")
-	routerAdmin.Handle("/query/{env}/run", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryRunPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /query/{env}/run", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryRunGETHandler)))
+	adminMux.Handle("POST /query/{env}/run", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryRunPOSTHandler)))
 	// Admin: list queries
-	routerAdmin.Handle("/query/{env}/list", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryListGETHandler))).Methods("GET")
+	adminMux.Handle("GET /query/{env}/list", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryListGETHandler)))
 	// Admin: saved queries
-	routerAdmin.Handle("/query/{env}/saved", handlerAuthCheck(http.HandlerFunc(handlersAdmin.SavedQueriesGETHandler))).Methods("GET")
+	adminMux.Handle("GET /query/{env}/saved", handlerAuthCheck(http.HandlerFunc(handlersAdmin.SavedQueriesGETHandler)))
 	// Admin: query actions
-	routerAdmin.Handle("/query/{env}/actions", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryActionsPOSTHandler))).Methods("POST")
+	adminMux.Handle("POST /query/{env}/actions", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryActionsPOSTHandler)))
 	// Admin: query JSON
-	routerAdmin.Handle("/query/{env}/json/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONQueryHandler))).Methods("GET")
+	adminMux.Handle("GET /query/{env}/json/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONQueryHandler)))
 	// Admin: query logs
-	routerAdmin.Handle("/query/{env}/logs/{name}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryLogsHandler))).Methods("GET")
+	adminMux.Handle("GET /query/{env}/logs/{name}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.QueryLogsHandler)))
 	// Admin: carve files
-	routerAdmin.Handle("/carves/{env}/run", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesRunGETHandler))).Methods("GET")
-	routerAdmin.Handle("/carves/{env}/run", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesRunPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /carves/{env}/run", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesRunGETHandler)))
+	adminMux.Handle("POST /carves/{env}/run", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesRunPOSTHandler)))
 	// Admin: list carves
-	routerAdmin.Handle("/carves/{env}/list", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesListGETHandler))).Methods("GET")
+	adminMux.Handle("GET /carves/{env}/list", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesListGETHandler)))
 	// Admin: carves actions
-	routerAdmin.Handle("/carves/{env}/actions", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesActionsPOSTHandler))).Methods("POST")
+	adminMux.Handle("POST /carves/{env}/actions", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesActionsPOSTHandler)))
 	// Admin: carves JSON
-	routerAdmin.Handle("/carves/{env}/json/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONCarvesHandler))).Methods("GET")
+	adminMux.Handle("GET /carves/{env}/json/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONCarvesHandler)))
 	// Admin: carves details
-	routerAdmin.Handle("/carves/{env}/details/{name}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesDetailsHandler))).Methods("GET")
+	adminMux.Handle("GET /carves/{env}/details/{name}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesDetailsHandler)))
 	// Admin: carves download
-	routerAdmin.Handle("/carves/{env}/download/{sessionid}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesDownloadHandler))).Methods("GET")
+	adminMux.Handle("GET /carves/{env}/download/{sessionid}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.CarvesDownloadHandler)))
 	// Admin: nodes configuration
-	routerAdmin.Handle("/conf/{environment}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.ConfGETHandler))).Methods("GET")
-	routerAdmin.Handle("/conf/{environment}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.ConfPOSTHandler))).Methods("POST")
-	routerAdmin.Handle("/intervals/{environment}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.IntervalsPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /conf/{env}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.ConfGETHandler)))
+	adminMux.Handle("POST /conf/{env}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.ConfPOSTHandler)))
+	adminMux.Handle("POST /intervals/{env}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.IntervalsPOSTHandler)))
 	// Admin: nodes enroll
-	routerAdmin.Handle("/enroll/{environment}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnrollGETHandler))).Methods("GET")
-	routerAdmin.Handle("/enroll/{environment}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnrollPOSTHandler))).Methods("POST")
-	routerAdmin.Handle("/enroll/{environment}/download/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnrollDownloadHandler))).Methods("GET")
-	routerAdmin.Handle("/expiration/{environment}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.ExpirationPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /enroll/{env}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnrollGETHandler)))
+	adminMux.Handle("POST /enroll/{env}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnrollPOSTHandler)))
+	adminMux.Handle("GET /enroll/{env}/download/{target}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnrollDownloadHandler)))
+	adminMux.Handle("POST /expiration/{env}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.ExpirationPOSTHandler)))
 	// Admin: server settings
-	routerAdmin.Handle("/settings/{service}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.SettingsGETHandler))).Methods("GET")
-	routerAdmin.Handle("/settings/{service}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.SettingsPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /settings/{service}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.SettingsGETHandler)))
+	adminMux.Handle("POST /settings/{service}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.SettingsPOSTHandler)))
 	// Admin: manage environments
-	routerAdmin.Handle("/environments", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnvsGETHandler))).Methods("GET")
-	routerAdmin.Handle("/environments", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnvsPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /environments", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnvsGETHandler)))
+	adminMux.Handle("POST /environments", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EnvsPOSTHandler)))
 	// Admin: manage users
-	routerAdmin.Handle("/users", handlerAuthCheck(http.HandlerFunc(handlersAdmin.UsersGETHandler))).Methods("GET")
-	routerAdmin.Handle("/users", handlerAuthCheck(http.HandlerFunc(handlersAdmin.UsersPOSTHandler))).Methods("POST")
-	routerAdmin.Handle("/users/permissions/{username}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.PermissionsGETHandler))).Methods("GET")
-	routerAdmin.Handle("/users/permissions/{username}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.PermissionsPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /users", handlerAuthCheck(http.HandlerFunc(handlersAdmin.UsersGETHandler)))
+	adminMux.Handle("POST /users", handlerAuthCheck(http.HandlerFunc(handlersAdmin.UsersPOSTHandler)))
+	adminMux.Handle("GET /users/permissions/{username}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.PermissionsGETHandler)))
+	adminMux.Handle("POST /users/permissions/{username}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.PermissionsPOSTHandler)))
 	// Admin: manage tags
-	routerAdmin.Handle("/tags", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TagsGETHandler))).Methods("GET")
-	routerAdmin.Handle("/tags", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TagsPOSTHandler))).Methods("POST")
-	routerAdmin.Handle("/tags/nodes", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TagNodesPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /tags", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TagsGETHandler)))
+	adminMux.Handle("POST /tags", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TagsPOSTHandler)))
+	adminMux.Handle("POST /tags/nodes", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TagNodesPOSTHandler)))
 	// Admin: manage tokens
-	routerAdmin.Handle("/tokens/{username}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TokensGETHandler))).Methods("GET")
-	routerAdmin.Handle("/tokens/{username}/refresh", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TokensPOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /tokens/{username}", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TokensGETHandler)))
+	adminMux.Handle("POST /tokens/{username}/refresh", handlerAuthCheck(http.HandlerFunc(handlersAdmin.TokensPOSTHandler)))
 	// Admin: edit profile
-	routerAdmin.Handle("/profile", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EditProfileGETHandler))).Methods("GET")
-	routerAdmin.Handle("/profile", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EditProfilePOSTHandler))).Methods("POST")
+	adminMux.Handle("GET /profile", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EditProfileGETHandler)))
+	adminMux.Handle("POST /profile", handlerAuthCheck(http.HandlerFunc(handlersAdmin.EditProfilePOSTHandler)))
 	// Admin: dashboard and search bar
-	routerAdmin.Handle("/dashboard", handlerAuthCheck(http.HandlerFunc(handlersAdmin.DashboardGETHandler))).Methods("GET")
+	adminMux.Handle("GET /dashboard", handlerAuthCheck(http.HandlerFunc(handlersAdmin.DashboardGETHandler)))
 	// Admin: logout
-	routerAdmin.Handle(logoutPath, handlerAuthCheck(http.HandlerFunc(handlersAdmin.LogoutPOSTHandler))).Methods("POST")
+	adminMux.Handle("POST "+logoutPath, handlerAuthCheck(http.HandlerFunc(handlersAdmin.LogoutPOSTHandler)))
 	// SAML ACS
 	if adminConfig.Auth == settings.AuthSAML {
-		routerAdmin.PathPrefix("/saml/").Handler(samlMiddleware)
-		routerAdmin.HandleFunc(loginPath, func(w http.ResponseWriter, r *http.Request) {
+		adminMux.Handle("/saml/", samlMiddleware)
+		adminMux.HandleFunc("GET "+loginPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
-		}).Methods("GET")
-		routerAdmin.HandleFunc(logoutPath, func(w http.ResponseWriter, r *http.Request) {
+		})
+		adminMux.HandleFunc("GET "+logoutPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, samlConfig.LogoutURL, http.StatusFound)
-		}).Methods("GET")
+		})
 	}
 	// Launch HTTP server for admin
 	serviceAdmin := adminConfig.Listener + ":" + adminConfig.Port
@@ -912,7 +910,7 @@ func osctrlAdminService() {
 		}
 		srv := &http.Server{
 			Addr:         serviceAdmin,
-			Handler:      routerAdmin,
+			Handler:      adminMux,
 			TLSConfig:    cfg,
 			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
 		}
@@ -920,7 +918,7 @@ func osctrlAdminService() {
 		log.Fatal(srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile))
 	} else {
 		log.Printf("%s v%s - HTTP listening %s", serviceName, serviceVersion, serviceAdmin)
-		log.Fatal(http.ListenAndServe(serviceAdmin, routerAdmin))
+		log.Fatal(http.ListenAndServe(serviceAdmin, adminMux))
 	}
 }
 

--- a/admin/main.go
+++ b/admin/main.go
@@ -794,9 +794,9 @@ func osctrlAdminService() {
 	// Admin: forbidden
 	adminMux.HandleFunc("GET "+forbiddenPath, handlersAdmin.ForbiddenHandler)
 	// Admin: favicon
-	adminMux.HandleFunc(faviconPath, handlersAdmin.FaviconHandler)
+	adminMux.HandleFunc("GET " + faviconPath, handlersAdmin.FaviconHandler)
 	// Admin: static
-	adminMux.Handle("/static/", http.StripPrefix("/static", http.FileServer(http.Dir(staticFilesFolder))))
+	adminMux.Handle("GET /static/", http.StripPrefix("/static", http.FileServer(http.Dir(staticFilesFolder))))
 
 	// ///////////////////////// AUTHENTICATED CONTENT
 	if settingsmgr.DebugService(settings.ServiceAdmin) {
@@ -886,7 +886,7 @@ func osctrlAdminService() {
 	adminMux.Handle("POST "+logoutPath, handlerAuthCheck(http.HandlerFunc(handlersAdmin.LogoutPOSTHandler)))
 	// SAML ACS
 	if adminConfig.Auth == settings.AuthSAML {
-		adminMux.Handle("/saml/", samlMiddleware)
+		adminMux.Handle("GET /saml/", samlMiddleware)
 		adminMux.HandleFunc("GET "+loginPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
 		})


### PR DESCRIPTION
Using the new `http.NewServeMux()` introduced in go `1.22` and skip using third party dependencies such as gorilla/mux