### PR TITLE
Fix to prevent nil DBLogger in osctrl-admin

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -736,10 +736,10 @@ func osctrlAdminService() {
 	}()
 
 	var loggerDBConfig *backend.JSONConfigurationDB
-	loggerFile = ""
 	// Set the logger configuration file if we have a DB logger
 	if adminConfig.Logger == settings.LoggingDB {
 		if loggerDbSame {
+			loggerFile = ""
 			loggerDBConfig = &dbConfig
 		}
 	}


### PR DESCRIPTION
By default, the `DBLogger` was `nil` and was triggering a panic error.