### PR TITLE
Perform actions to enroll-remove nodes in osctrl-api

### DIFF
--- a/admin/handlers/post.go
+++ b/admin/handlers/post.go
@@ -911,28 +911,28 @@ func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Req
 		}
 	case settings.ScriptRemove:
 		switch e.Action {
-		case "expire":
+		case settings.ActionExpire:
 			if err := h.Envs.ExpireRemove(env.UUID); err != nil {
 				adminErrorResponse(w, "error expiring remove", http.StatusInternalServerError, err)
 				h.Inc(metricAdminErr)
 				return
 			}
 			adminOKResponse(w, "link expired successfully")
-		case "extend":
+		case settings.ActionExtend:
 			if err := h.Envs.ExtendRemove(env.UUID); err != nil {
 				adminErrorResponse(w, "error extending remove", http.StatusInternalServerError, err)
 				h.Inc(metricAdminErr)
 				return
 			}
 			adminOKResponse(w, "link extended successfully")
-		case "rotate":
+		case settings.ActionRotate:
 			if err := h.Envs.RotateRemove(env.UUID); err != nil {
 				adminErrorResponse(w, "error rotating remove", http.StatusInternalServerError, err)
 				h.Inc(metricAdminErr)
 				return
 			}
 			adminOKResponse(w, "link rotated successfully")
-		case "notexpire":
+		case settings.ActionNotexpire:
 			if err := h.Envs.NotExpireRemove(env.UUID); err != nil {
 				adminErrorResponse(w, "error not expiring remove", http.StatusInternalServerError, err)
 				h.Inc(metricAdminErr)

--- a/api/main.go
+++ b/api/main.go
@@ -549,7 +549,9 @@ func osctrlAPIService() {
 	// API: environments by environment
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(apiEnvironmentHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{target}", handlerAuthCheck(http.HandlerFunc(apiEnvEnrollHandler)))
+	muxAPI.Handle("POST "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{action}", handlerAuthCheck(http.HandlerFunc(apiEnvEnrollActionsHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}/remove/{target}", handlerAuthCheck(http.HandlerFunc(apiEnvironmentHandler)))
+	muxAPI.Handle("POST "+_apiPath(apiEnvironmentsPath)+"/{env}/remove/{action}", handlerAuthCheck(http.HandlerFunc(apiEnvRemoveActionsHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath), handlerAuthCheck(http.HandlerFunc(apiEnvironmentsHandler)))
 	// API: tags
 	muxAPI.Handle("GET "+_apiPath(apiTagsPath), handlerAuthCheck(http.HandlerFunc(apiTagsHandler)))

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -59,6 +59,18 @@ const (
 	ScriptRemove string = "remove"
 )
 
+// Types of enroll/remove actions
+const (
+	ActionExpire    string = "expire"
+	ActionExtend    string = "extend"
+	ActionRotate    string = "rotate"
+	ActionNotexpire string = "notexpire"
+	SetMacPackage   string = "set_pkg"
+	SetMsiPackage   string = "set_msi"
+	SetDebPackage   string = "set_deb"
+	SetRpmPackage   string = "set_rpm"
+)
+
 // Types of package
 const (
 	PackageDeb string = "deb"

--- a/types/types.go
+++ b/types/types.go
@@ -97,12 +97,12 @@ type ScriptRequest struct {
 
 // ApiDistributedQueryRequest to receive query requests
 type ApiDistributedQueryRequest struct {
-	UUIDs  []string `json:"uuid_list"`
-	Platforms  []string `json:"platform_list"`
-	Environments  []string `json:"environment_list"`
-	Hosts  []string `json:"host_list"`
-	Query  string   `json:"query"`
-	Hidden bool     `json:"hidden"`
+	UUIDs        []string `json:"uuid_list"`
+	Platforms    []string `json:"platform_list"`
+	Environments []string `json:"environment_list"`
+	Hosts        []string `json:"host_list"`
+	Query        string   `json:"query"`
+	Hidden       bool     `json:"hidden"`
 }
 
 // ApiDistributedCarveRequest to receive query requests
@@ -145,4 +145,13 @@ type ApiDataResponse struct {
 // ApiLoginResponse to be returned to API login requests with the generated token
 type ApiLoginResponse struct {
 	Token string `json:"token"`
+}
+
+// ApiActionsRequest to receive action requests
+type ApiActionsRequest struct {
+	Certificate string `json:"certificate"`
+	MacPkgURL   string `json:"url_mac_pkg"`
+	MsiPkgURL   string `json:"url_msi_pkg"`
+	RpmPkgURL   string `json:"url_rpm_pkg"`
+	DebPkgURL   string `json:"url_deb_pkg"`
 }


### PR DESCRIPTION
Adding the ability to extend/expire/rotate/notexpire actions for enroll/remove nodes in `osctrl-api`