### PR TITLE
Adding commands to extend/expire/rotate enroll and remove URLs

### DIFF
--- a/api/handlers-environments.go
+++ b/api/handlers-environments.go
@@ -272,6 +272,7 @@ func apiEnvEnrollActionsHandler(w http.ResponseWriter, r *http.Request) {
 			incMetric(metricAPIEnvsErr)
 			return
 		}
+		msgReturn = "enrollment expired successfully"
 	case settings.ActionRotate:
 		if err := envs.RotateEnroll(env.UUID); err != nil {
 			apiErrorResponse(w, "error rotating enrollment", http.StatusInternalServerError, err)

--- a/cli/api-environment.go
+++ b/cli/api-environment.go
@@ -3,8 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/jmpsec/osctrl/environments"
+	"github.com/jmpsec/osctrl/settings"
+	"github.com/jmpsec/osctrl/types"
 )
 
 // GetEnvironments to retrieve all environments from osctrl
@@ -33,4 +36,58 @@ func (api *OsctrlAPI) GetEnvironment(identifier string) (environments.TLSEnviron
 		return e, fmt.Errorf("can not parse body - %v", err)
 	}
 	return e, nil
+}
+
+// ExtendEnrollment to extend in time the enrollment URL of an environment
+func (api *OsctrlAPI) ExtendEnrollment(identifier string) (string, error) {
+	return api.ActionEnrollmentRemove(identifier, settings.ActionExtend, "enroll", nil)
+}
+
+// RotateEnrollment to rotate the enrollment URL of an environment
+func (api *OsctrlAPI) RotateEnrollment(identifier string) (string, error) {
+	return api.ActionEnrollmentRemove(identifier, settings.ActionRotate, "enroll", nil)
+}
+
+// ExpireEnrollment to expire the enrollment URL of an environment
+func (api *OsctrlAPI) ExpireEnrollment(identifier string) (string, error) {
+	return api.ActionEnrollmentRemove(identifier, settings.ActionExpire, "enroll", nil)
+}
+
+// NotexpireEnrollment to disable expiration for the enrollment URL of an environment
+func (api *OsctrlAPI) NotexpireEnrollment(identifier string) (string, error) {
+	return api.ActionEnrollmentRemove(identifier, settings.ActionNotexpire, "enroll", nil)
+}
+
+// ExtendRemove to extend in time the remove URL of an environment
+func (api *OsctrlAPI) ExtendRemove(identifier string) (string, error) {
+	return api.ActionEnrollmentRemove(identifier, settings.ActionExtend, "remove", nil)
+}
+
+// RotateEnrollment to rotate the remove URL of an environment
+func (api *OsctrlAPI) RotateRemove(identifier string) (string, error) {
+	return api.ActionEnrollmentRemove(identifier, settings.ActionRotate, "remove", nil)
+}
+
+// ExpireRemove to expire the remove URL of an environment
+func (api *OsctrlAPI) ExpireRemove(identifier string) (string, error) {
+	return api.ActionEnrollmentRemove(identifier, settings.ActionExpire, "remove", nil)
+}
+
+// NotexpireRemove to disable expiration for the remove URL of an environment
+func (api *OsctrlAPI) NotexpireRemove(identifier string) (string, error) {
+	return api.ActionEnrollmentRemove(identifier, settings.ActionNotexpire, "remove", nil)
+}
+
+// ExtendEnrollment to extend in time the enrollment URL of an environment
+func (api *OsctrlAPI) ActionEnrollmentRemove(identifier, action, target string, data io.Reader) (string, error) {
+	var res types.ApiGenericResponse
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/%s", api.Configuration.URL, APIPath, APIEnvironments, identifier, target, action)
+	rawE, err := api.PostGeneric(reqURL, data)
+	if err != nil {
+		return "", fmt.Errorf("error api request - %v - %s", err, string(rawE))
+	}
+	if err := json.Unmarshal(rawE, &res); err != nil {
+		return "", fmt.Errorf("can not parse body - %v", err)
+	}
+	return res.Message, nil
 }

--- a/cli/environment.go
+++ b/cli/environment.go
@@ -355,6 +355,110 @@ func quickAddEnvironment(c *cli.Context) error {
 	return nil
 }
 
+func extendEnrollEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("❌ environment name is required")
+		os.Exit(1)
+	}
+	msg := "enrollment extended successfully"
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		if err := envs.ExtendEnroll(env.UUID); err != nil {
+			return err
+		}
+	} else if apiFlag {
+		msg, err = osctrlAPI.ExtendEnrollment(envName)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("✅ %s\n", msg)
+	return nil
+}
+
+func rotateEnrollEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("❌ environment name is required")
+		os.Exit(1)
+	}
+	msg := "enrollment rotated successfully"
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		if err := envs.ExtendEnroll(env.UUID); err != nil {
+			return err
+		}
+	} else if apiFlag {
+		msg, err = osctrlAPI.ExtendEnrollment(envName)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("✅ %s\n", msg)
+	return nil
+}
+
+func expireEnrollEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("❌ environment name is required")
+		os.Exit(1)
+	}
+	msg := "enrollment expired successfully"
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		if err := envs.ExpireEnroll(env.UUID); err != nil {
+			return err
+		}
+	} else if apiFlag {
+		msg, err = osctrlAPI.ExpireEnrollment(envName)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("✅ %s\n", msg)
+	return nil
+}
+
+func notexpireEnrollEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("❌ environment name is required")
+		os.Exit(1)
+	}
+	msg := "enrollment set to NOT expire"
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		if err := envs.NotExpireEnroll(env.UUID); err != nil {
+			return err
+		}
+	} else if apiFlag {
+		msg, err = osctrlAPI.NotexpireEnrollment(envName)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("✅ %s\n", msg)
+	return nil
+}
+
 func quickRemoveEnvironment(c *cli.Context) error {
 	// Get environment name
 	envName := c.String("name")
@@ -386,6 +490,110 @@ func quickRemoveEnvironment(c *cli.Context) error {
 		os.Exit(1)
 	}
 	fmt.Printf("%s\n", oneLiner)
+	return nil
+}
+
+func extendRemoveEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("❌ environment name is required")
+		os.Exit(1)
+	}
+	msg := "remove extended successfully"
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		if err := envs.ExtendRemove(env.UUID); err != nil {
+			return err
+		}
+	} else if apiFlag {
+		msg, err = osctrlAPI.ExtendRemove(envName)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("✅ %s\n", msg)
+	return nil
+}
+
+func rotateRemoveEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("❌ environment name is required")
+		os.Exit(1)
+	}
+	msg := "remove rotated successfully"
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		if err := envs.RotateRemove(env.UUID); err != nil {
+			return err
+		}
+	} else if apiFlag {
+		msg, err = osctrlAPI.RotateRemove(envName)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("✅ %s\n", msg)
+	return nil
+}
+
+func expireRemoveEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("❌ environment name is required")
+		os.Exit(1)
+	}
+	msg := "remove expired successfully"
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		if err := envs.ExpireRemove(env.UUID); err != nil {
+			return err
+		}
+	} else if apiFlag {
+		msg, err = osctrlAPI.ExpireRemove(envName)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("✅ %s\n", msg)
+	return nil
+}
+
+func notexpireRemoveEnvironment(c *cli.Context) error {
+	// Get environment name
+	envName := c.String("name")
+	if envName == "" {
+		fmt.Println("❌ environment name is required")
+		os.Exit(1)
+	}
+	msg := "remove set to NOT expire"
+	if dbFlag {
+		env, err := envs.Get(envName)
+		if err != nil {
+			return err
+		}
+		if err := envs.NotExpireRemove(env.UUID); err != nil {
+			return err
+		}
+	} else if apiFlag {
+		msg, err = osctrlAPI.NotexpireRemove(envName)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("✅ %s\n", msg)
 	return nil
 }
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -870,6 +870,30 @@ func init() {
 							Action: cliWrapper(quickAddEnvironment),
 						},
 						{
+							Name:    "extend-enroll",
+							Aliases: []string{"f"},
+							Usage:   "Extend the existing enroll URL for a TLS environment",
+							Action:  cliWrapper(extendEnrollEnvironment),
+						},
+						{
+							Name:    "rotate-enroll",
+							Aliases: []string{"f"},
+							Usage:   "Rotate to a new enroll URL for a TLS environment",
+							Action:  cliWrapper(rotateEnrollEnvironment),
+						},
+						{
+							Name:    "expire-enroll",
+							Aliases: []string{"f"},
+							Usage:   "Expire the existing enroll URL for a TLS environment",
+							Action:  cliWrapper(expireEnrollEnvironment),
+						},
+						{
+							Name:    "notexpire-enroll",
+							Aliases: []string{"f"},
+							Usage:   "Set the existing enroll URL for a TLS environment to NOT expire",
+							Action:  cliWrapper(notexpireEnrollEnvironment),
+						},
+						{
 							Name:    "quick-remove",
 							Aliases: []string{"Q"},
 							Usage:   "Generates one-liner for quick removing nodes to a TLS environment",
@@ -888,6 +912,30 @@ func init() {
 								},
 							},
 							Action: cliWrapper(quickRemoveEnvironment),
+						},
+						{
+							Name:    "extend-remove",
+							Aliases: []string{"f"},
+							Usage:   "Extend the existing enroll URL for a TLS environment",
+							Action:  cliWrapper(extendRemoveEnvironment),
+						},
+						{
+							Name:    "rotate-remove",
+							Aliases: []string{"f"},
+							Usage:   "Rotate to a new enroll URL for a TLS environment",
+							Action:  cliWrapper(rotateRemoveEnvironment),
+						},
+						{
+							Name:    "expire-remove",
+							Aliases: []string{"f"},
+							Usage:   "Expire the existing remove URL for a TLS environment",
+							Action:  cliWrapper(expireRemoveEnvironment),
+						},
+						{
+							Name:    "notexpire-remove",
+							Aliases: []string{"f"},
+							Usage:   "Set the existing remove URL for a TLS environment to NOT expire",
+							Action:  cliWrapper(notexpireRemoveEnvironment),
 						},
 						{
 							Name:    "secret",


### PR DESCRIPTION
Implementation of https://github.com/jmpsec/osctrl/issues/470

Adding commands to `osctrl-cli` to perform actions (extend/expire/rotate/notexpire) to enroll and remove URLs for nodes.
Fully supporting `osctrl-api`.