### PR TITLE
Using RegisteredClaims in JWT to avoid deprecated code

### DIFF
--- a/admin/handlers/post.go
+++ b/admin/handlers/post.go
@@ -1268,7 +1268,7 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		if u.Token {
-			token, exp, err := h.Users.CreateToken(newUser.Username)
+			token, exp, err := h.Users.CreateToken(newUser.Username, h.AdminConfig.Host)
 			if err != nil {
 				adminErrorResponse(w, "error creating token", http.StatusInternalServerError, err)
 				h.Inc(metricAdminErr)
@@ -1348,7 +1348,7 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 						return
 					}
 				*/
-				token, exp, err := h.Users.CreateToken(u.Username)
+				token, exp, err := h.Users.CreateToken(u.Username, h.AdminConfig.Host)
 				if err != nil {
 					adminErrorResponse(w, "error creating token", http.StatusInternalServerError, err)
 					h.Inc(metricAdminErr)

--- a/admin/handlers/tokens.go
+++ b/admin/handlers/tokens.go
@@ -102,7 +102,7 @@ func (h *HandlersAdmin) TokensPOSTHandler(w http.ResponseWriter, r *http.Request
 	if h.Settings.DebugService(settings.ServiceAdmin) {
 		log.Println("DebugService: Creating token")
 	}
-	token, exp, err := h.Users.CreateToken(user.Username)
+	token, exp, err := h.Users.CreateToken(user.Username, h.AdminConfig.Host)
 	if err != nil {
 		adminErrorResponse(w, "error creating token", http.StatusInternalServerError, err)
 		h.Inc(metricAdminErr)

--- a/api/handlers-login.go
+++ b/api/handlers-login.go
@@ -58,7 +58,7 @@ func apiLoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Do we have a token already?
 	if user.APIToken == "" {
-		token, exp, err := apiUsers.CreateToken(l.Username)
+		token, exp, err := apiUsers.CreateToken(l.Username, serviceName)
 		if err != nil {
 			apiErrorResponse(w, "error creating token", http.StatusInternalServerError, err)
 			incMetric(metricAPILoginErr)

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -77,7 +77,7 @@ func TestUserManager(t *testing.T) {
 		assert.Equal(t, 123, int(user.EnvironmentID))
 	})
 	t.Run("CreateCheckToken", func(t *testing.T) {
-		token, tt, err := manager.CreateToken("testUsername")
+		token, tt, err := manager.CreateToken("testUsername", "issuer")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, token)
 		now := time.Now()


### PR DESCRIPTION
`jwt.StandardClaims` is deprecated so using `jwt.RegisteredClaims` instead. Also passing the token issuer as parameter.