### PR TITLE
Get rid of warning when building docker dev environment

### DIFF
--- a/deploy/docker/dockerfiles/Dockerfile-dev-admin
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-admin
@@ -1,5 +1,5 @@
 ######################################## osctrl-dev-base ########################################
-ARG GOLANG_VERSION
+ARG GOLANG_VERSION=${GOLANG_VERSION:-1.23.0-bookworm}
 FROM golang:${GOLANG_VERSION} AS osctrl-admin-dev
 
 WORKDIR /usr/src/app

--- a/deploy/docker/dockerfiles/Dockerfile-dev-api
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-api
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION
+ARG GOLANG_VERSION=${GOLANG_VERSION:-1.23.0-bookworm}
 FROM golang:${GOLANG_VERSION} AS osctrl-api-dev
 
 WORKDIR /usr/src/app

--- a/deploy/docker/dockerfiles/Dockerfile-dev-cli
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-cli
@@ -1,5 +1,5 @@
 #################################################### osctrl-cli-dev ####################################################
-ARG GOLANG_VERSION
+ARG GOLANG_VERSION=${GOLANG_VERSION:-1.23.0-bookworm}
 FROM golang:${GOLANG_VERSION} AS osctrl-cli-dev
 
 WORKDIR /usr/src/app

--- a/deploy/docker/dockerfiles/Dockerfile-dev-tls
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-tls
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION
+ARG GOLANG_VERSION=${GOLANG_VERSION:-1.23.0-bookworm}
 FROM golang:${GOLANG_VERSION} AS osctrl-tls-dev
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
This change makes the `WARN` disappear when building docker images:

```
WARN: InvalidDefaultArgInFrom: Default value for ARG golang:${GOLANG_VERSION} results in empty or invalid base image name
```