### PR TITLE
Using only UUID to identify environment in osctrl-api

### DIFF
--- a/api/handlers/carves.go
+++ b/api/handlers/carves.go
@@ -28,12 +28,12 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPICarvesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPICarvesErr)
@@ -72,12 +72,12 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPICarvesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPICarvesErr)
@@ -150,12 +150,12 @@ func (h *HandlersApi) apiCarvesShowHandler(w http.ResponseWriter, r *http.Reques
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPICarvesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPICarvesErr)

--- a/api/handlers/environments.go
+++ b/api/handlers/environments.go
@@ -20,12 +20,12 @@ func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
@@ -83,12 +83,12 @@ func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
@@ -108,7 +108,7 @@ func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract target
 	targetVar := r.PathValue("target")
 	if targetVar == "" {
-		apiErrorResponse(w, "error getting target", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting target", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
@@ -154,12 +154,12 @@ func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
@@ -219,12 +219,12 @@ func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Req
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
@@ -244,7 +244,7 @@ func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Req
 	// Extract action
 	actionVar := r.PathValue("action")
 	if actionVar == "" {
-		apiErrorResponse(w, "error getting action", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting action", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
@@ -330,12 +330,12 @@ func (h *HandlersApi) EnvRemoveActionsHandler(w http.ResponseWriter, r *http.Req
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
@@ -355,7 +355,7 @@ func (h *HandlersApi) EnvRemoveActionsHandler(w http.ResponseWriter, r *http.Req
 	// Extract action
 	actionVar := r.PathValue("action")
 	if actionVar == "" {
-		apiErrorResponse(w, "error getting action", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting action", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}

--- a/api/handlers/login.go
+++ b/api/handlers/login.go
@@ -19,12 +19,12 @@ func (h *HandlersApi) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPILoginErr)
 		return
 	}
-	// Get environment
-	env, err := h.Envs.Get(envVar)
+	// Get environment by UUID
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPILoginErr)

--- a/api/handlers/nodes.go
+++ b/api/handlers/nodes.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/jmpsec/osctrl/nodes"
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
 	"github.com/jmpsec/osctrl/users"
@@ -19,12 +20,12 @@ func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPINodesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPINodesErr)
@@ -40,7 +41,7 @@ func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract host identifier for node
 	nodeVar := r.PathValue("node")
 	if nodeVar == "" {
-		apiErrorResponse(w, "error getting node", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting node", http.StatusBadRequest, nil)
 		h.Inc(metricAPINodesErr)
 		return
 	}
@@ -71,12 +72,12 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPINodesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPINodesErr)
@@ -90,7 +91,7 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Get nodes
-	nodes, err := h.Nodes.Gets("active", 24)
+	nodes, err := h.Nodes.Gets(nodes.ActiveNodes, 24)
 	if err != nil {
 		apiErrorResponse(w, "error getting nodes", http.StatusInternalServerError, err)
 		h.Inc(metricAPINodesErr)
@@ -116,12 +117,12 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPINodesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPINodesErr)
@@ -135,7 +136,7 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Get nodes
-	nodes, err := h.Nodes.Gets("inactive", 24)
+	nodes, err := h.Nodes.Gets(nodes.InactiveNodes, 24)
 	if err != nil {
 		apiErrorResponse(w, "error getting nodes", http.StatusInternalServerError, err)
 		h.Inc(metricAPINodesErr)
@@ -161,14 +162,14 @@ func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPINodesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPINodesErr)
 		return
 	}
@@ -180,7 +181,7 @@ func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get nodes
-	nodes, err := h.Nodes.Gets("all", 0)
+	nodes, err := h.Nodes.Gets(nodes.AllNodes, 0)
 	if err != nil {
 		apiErrorResponse(w, "error getting nodes", http.StatusInternalServerError, err)
 		h.Inc(metricAPINodesErr)
@@ -206,12 +207,12 @@ func (h *HandlersApi) DeleteNodeHandler(w http.ResponseWriter, r *http.Request) 
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPINodesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPINodesErr)

--- a/api/handlers/platforms.go
+++ b/api/handlers/platforms.go
@@ -43,12 +43,12 @@ func (h *HandlersApi) PlatformsEnvHandler(w http.ResponseWriter, r *http.Request
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)

--- a/api/handlers/queries.go
+++ b/api/handlers/queries.go
@@ -20,19 +20,19 @@ func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract name
 	name := r.PathValue("name")
 	if name == "" {
-		apiErrorResponse(w, "error getting name", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting name", http.StatusBadRequest, nil)
 		h.Inc(metricAPIQueriesErr)
 		return
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIQueriesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPIQueriesErr)
@@ -71,12 +71,12 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIQueriesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPIQueriesErr)
@@ -99,7 +99,7 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 	// FIXME check validity of query
 	// Query can not be empty
 	if q.Query == "" {
-		apiErrorResponse(w, "query can not be empty", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "query can not be empty", http.StatusBadRequest, nil)
 		h.Inc(metricAPIQueriesErr)
 		return
 	}
@@ -216,12 +216,12 @@ func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Reque
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIQueriesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPIQueriesErr)
@@ -258,12 +258,12 @@ func (h *HandlersApi) HiddenQueriesShowHandler(w http.ResponseWriter, r *http.Re
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error with environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIQueriesErr)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPIQueriesErr)
@@ -300,7 +300,7 @@ func (h *HandlersApi) QueryResultsHandler(w http.ResponseWriter, r *http.Request
 	// Extract name
 	name := r.PathValue("name")
 	if name == "" {
-		apiErrorResponse(w, "error getting name", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting name", http.StatusBadRequest, nil)
 		h.Inc(metricAPIQueriesErr)
 		return
 	}
@@ -312,7 +312,7 @@ func (h *HandlersApi) QueryResultsHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Get environment
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
 		h.Inc(metricAPIQueriesErr)

--- a/api/handlers/settings.go
+++ b/api/handlers/settings.go
@@ -43,7 +43,7 @@ func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Requ
 	// Extract service
 	service := r.PathValue("service")
 	if service == "" {
-		apiErrorResponse(w, "error getting service", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting service", http.StatusBadRequest, nil)
 		h.Inc(metricAPISettingsErr)
 		return
 	}
@@ -82,7 +82,7 @@ func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.R
 	// Extract service
 	service := r.PathValue("service")
 	if service == "" {
-		apiErrorResponse(w, "error getting service", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting service", http.StatusBadRequest, nil)
 		h.Inc(metricAPISettingsErr)
 		return
 	}
@@ -95,12 +95,12 @@ func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.R
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
@@ -139,7 +139,7 @@ func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.
 	// Extract environment
 	service := r.PathValue("service")
 	if service == "" {
-		apiErrorResponse(w, "error getting service", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting service", http.StatusBadRequest, nil)
 		h.Inc(metricAPISettingsErr)
 		return
 	}
@@ -178,7 +178,7 @@ func (h *HandlersApi) SettingsServiceEnvJSONHandler(w http.ResponseWriter, r *ht
 	// Extract environment
 	service := r.PathValue("service")
 	if service == "" {
-		apiErrorResponse(w, "error getting service", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting service", http.StatusBadRequest, nil)
 		h.Inc(metricAPISettingsErr)
 		return
 	}
@@ -191,12 +191,12 @@ func (h *HandlersApi) SettingsServiceEnvJSONHandler(w http.ResponseWriter, r *ht
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)

--- a/api/handlers/tags.go
+++ b/api/handlers/tags.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TagsHandler - GET Handler for multiple JSON tags
-func (h *HandlersApi) TagsHandler(w http.ResponseWriter, r *http.Request) {
+func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAPITagsReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAPI, settings.NoEnvironmentID), false)
 	// Get context data and check access
@@ -43,12 +43,12 @@ func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
-		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error getting environment", http.StatusBadRequest, nil)
 		h.Inc(metricAPIEnvsErr)
 		return
 	}
 	// Get environment by name
-	env, err := h.Envs.Get(envVar)
+	env, err := h.Envs.GetByUUID(envVar)
 	if err != nil {
 		if err.Error() == "record not found" {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)

--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -17,7 +17,7 @@ func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract username
 	usernameVar := r.PathValue("username")
 	if usernameVar == "" {
-		apiErrorResponse(w, "error with username", http.StatusInternalServerError, nil)
+		apiErrorResponse(w, "error with username", http.StatusBadRequest, nil)
 		h.Inc(metricAPIUsersErr)
 		return
 	}

--- a/api/main.go
+++ b/api/main.go
@@ -565,21 +565,21 @@ func osctrlAPIService() {
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesRunHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
-	// API: users by environment
+	// API: users
 	muxAPI.Handle("GET "+_apiPath(apiUsersPath)+"/{username}", handlerAuthCheck(http.HandlerFunc(handlersApi.UserHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiUsersPath), handlerAuthCheck(http.HandlerFunc(handlersApi.UsersHandler)))
 	// API: platforms
 	muxAPI.Handle("GET "+_apiPath(apiPlatformsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.PlatformsHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiPlatformsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.PlatformsEnvHandler)))
-	// API: environments by environment
+	// API: environments
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvEnrollHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{action}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvEnrollActionsHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}/remove/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiEnvironmentsPath)+"/{env}/remove/{action}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvRemoveActionsHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentsHandler)))
-	// API: tags
-	muxAPI.Handle("GET "+_apiPath(apiTagsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.TagsHandler)))
+	// API: tags by environment
+	muxAPI.Handle("GET "+_apiPath(apiTagsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.AllTagsHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiTagsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.TagsEnvHandler)))
 	// API: settings by environment
 	muxAPI.Handle("GET "+_apiPath(apiSettingsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsHandler)))

--- a/nodes/nodes.go
+++ b/nodes/nodes.go
@@ -9,6 +9,15 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	// ActiveNodes to represent active nodes
+	ActiveNodes = "active"
+	// InactiveNodes to represent inactive nodes
+	InactiveNodes = "inactive"
+	// AllNodes to represent all nodes
+	AllNodes = "all"
+)
+
 // OsqueryNode as abstraction of a node
 type OsqueryNode struct {
 	gorm.Model
@@ -210,16 +219,16 @@ func (n *NodeManager) GetBySelector(stype, selector, target string, hours int64)
 		s = "platform"
 	}
 	switch target {
-	case "all":
+	case AllNodes:
 		if err := n.DB.Where(s+" = ?", selector).Find(&nodes).Error; err != nil {
 			return nodes, err
 		}
-	case "active":
+	case ActiveNodes:
 		//if err := n.DB.Where(s+" = ?", selector).Where("updated_at > ?", time.Now().AddDate(0, 0, -3)).Find(&nodes).Error; err != nil {
 		if err := n.DB.Where(s+" = ?", selector).Where("updated_at > ?", time.Now().Add(time.Duration(hours)*time.Hour)).Find(&nodes).Error; err != nil {
 			return nodes, err
 		}
-	case "inactive":
+	case InactiveNodes:
 		//if err := n.DB.Where(s+" = ?", selector).Where("updated_at < ?", time.Now().AddDate(0, 0, -3)).Find(&nodes).Error; err != nil {
 		if err := n.DB.Where(s+" = ?", selector).Where("updated_at < ?", time.Now().Add(time.Duration(hours)*time.Hour)).Find(&nodes).Error; err != nil {
 			return nodes, err
@@ -232,16 +241,16 @@ func (n *NodeManager) GetBySelector(stype, selector, target string, hours int64)
 func (n *NodeManager) Gets(target string, hours int64) ([]OsqueryNode, error) {
 	var nodes []OsqueryNode
 	switch target {
-	case "all":
+	case AllNodes:
 		if err := n.DB.Find(&nodes).Error; err != nil {
 			return nodes, err
 		}
-	case "active":
+	case ActiveNodes:
 		//if err := n.DB.Where("updated_at > ?", time.Now().AddDate(0, 0, -3)).Find(&nodes).Error; err != nil {
 		if err := n.DB.Where("updated_at > ?", time.Now().Add(time.Duration(hours)*time.Hour)).Find(&nodes).Error; err != nil {
 			return nodes, err
 		}
-	case "inactive":
+	case InactiveNodes:
 		//if err := n.DB.Where("updated_at < ?", time.Now().AddDate(0, 0, -3)).Find(&nodes).Error; err != nil {
 		if err := n.DB.Where("updated_at < ?", time.Now().Add(time.Duration(hours)*time.Hour)).Find(&nodes).Error; err != nil {
 			return nodes, err

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -76,6 +76,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/OsqueryNode"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -120,6 +126,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/OsqueryNode"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -164,6 +176,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/OsqueryNode"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -206,6 +224,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OsqueryNode"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -253,6 +277,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiGenericResponse"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -297,6 +327,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/DistributedQuery"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -336,6 +372,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiQueriesResponse"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -384,6 +426,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DistributedQuery"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -1148,7 +1196,7 @@ paths:
         - tags
       summary: Get tags
       description: Returns all osctrl tags for enrolled nodes
-      operationId: TagsHandler
+      operationId: AllTagsHandler
       responses:
         200:
           description: successful operation
@@ -1196,6 +1244,12 @@ paths:
                 type: array
                 items:
                   type: string
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -1271,6 +1325,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/SettingValue"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -1315,6 +1375,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/SettingValue"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:
@@ -1397,6 +1463,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/SettingValue"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:


### PR DESCRIPTION
Using only the `UUID` identifier to be exposed via `osctrl-api`