### PR TITLE
Migrating native log to zerolog in osctrl-api

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"strings"
 
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // contextValue to hold session data in the context
@@ -70,7 +70,7 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 			}
 			// Update metadata for the user
 			if err := apiUsers.UpdateTokenIPAddress(utils.GetIP(r), claims.Username); err != nil {
-				log.Printf("error updating token for user %s: %v", claims.Username, err)
+				log.Err(err).Msgf("error updating token for user %s", claims.Username)
 			}
 			// Set middleware values
 			s := make(contextValue)

--- a/api/handlers/carves.go
+++ b/api/handlers/carves.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/carves"
@@ -12,6 +11,7 @@ import (
 	"github.com/jmpsec/osctrl/types"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // GET Handler to return a single carve in JSON
@@ -59,7 +59,7 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returned carve %s", name)
+		log.Debug().Msgf("DebugService: Returned carve %s", name)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, carve)
 	h.Inc(metricAPICarvesOK)

--- a/api/handlers/environments.go
+++ b/api/handlers/environments.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/environments"
@@ -11,6 +10,7 @@ import (
 	"github.com/jmpsec/osctrl/types"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // EnvironmentHandler - GET Handler to return one environment as JSON
@@ -44,7 +44,7 @@ func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request)
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returned environment %s", env.Name)
+		log.Debug().Msgf("DebugService: Returned environment %s", env.Name)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, env)
 	h.Inc(metricAPIEnvsOK)
@@ -70,7 +70,7 @@ func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned environments")
+		log.Debug().Msg("DebugService: Returned environments")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, envAll)
 	h.Inc(metricAPIEnvsOK)
@@ -141,7 +141,7 @@ func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returned environment %s", returnData)
+		log.Debug().Msgf("DebugService: Returned environment %s", returnData)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiDataResponse{Data: returnData})
 	h.Inc(metricAPIEnvsOK)
@@ -206,7 +206,7 @@ func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returned environment %s", types.ApiDataResponse{Data: returnData})
+		log.Debug().Msgf("DebugService: Returned environment %s", types.ApiDataResponse{Data: returnData})
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, env)
 	h.Inc(metricAPIEnvsOK)

--- a/api/handlers/login.go
+++ b/api/handlers/login.go
@@ -3,13 +3,13 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // LoginHandler - POST Handler for API login request
@@ -67,7 +67,7 @@ func (h *HandlersApi) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returning token for %s", user.Username)
+		log.Debug().Msgf("DebugService: Returning token for %s", user.Username)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiLoginResponse{Token: user.APIToken})
 	h.Inc(metricAPILoginOK)

--- a/api/handlers/nodes.go
+++ b/api/handlers/nodes.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/nodes"
@@ -11,6 +10,7 @@ import (
 	"github.com/jmpsec/osctrl/types"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // NodeHandler - GET Handler for single JSON nodes
@@ -59,7 +59,7 @@ func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returned node %s", nodeVar)
+		log.Debug().Msgf("DebugService: Returned node %s", nodeVar)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, node)
 	h.Inc(metricAPINodesOK)
@@ -104,7 +104,7 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned nodes")
+		log.Debug().Msg("DebugService: Returned nodes")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, nodes)
 	h.Inc(metricAPINodesOK)
@@ -149,7 +149,7 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned nodes")
+		log.Debug().Msg("DebugService: Returned nodes")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, nodes)
 	h.Inc(metricAPINodesOK)
@@ -194,7 +194,7 @@ func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned nodes")
+		log.Debug().Msg("DebugService: Returned nodes")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, nodes)
 	h.Inc(metricAPINodesOK)
@@ -243,7 +243,7 @@ func (h *HandlersApi) DeleteNodeHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returned node %s", n.UUID)
+		log.Debug().Msgf("DebugService: Returned node %s", n.UUID)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: "node deleted"})
 	h.Inc(metricAPINodesOK)

--- a/api/handlers/platforms.go
+++ b/api/handlers/platforms.go
@@ -2,12 +2,12 @@ package handlers
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // PlatformsHandler - GET Handler for multiple JSON platforms
@@ -30,7 +30,7 @@ func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned platforms")
+		log.Debug().Msg("DebugService: Returned platforms")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, platforms)
 	h.Inc(metricAPIPlatformsOK)
@@ -74,7 +74,7 @@ func (h *HandlersApi) PlatformsEnvHandler(w http.ResponseWriter, r *http.Request
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned platforms")
+		log.Debug().Msg("DebugService: Returned platforms")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, platforms)
 	h.Inc(metricAPIPlatformsOK)

--- a/api/handlers/queries.go
+++ b/api/handlers/queries.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/queries"
@@ -11,6 +10,7 @@ import (
 	"github.com/jmpsec/osctrl/types"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // QueryShowHandler - GET Handler to return a single query in JSON
@@ -58,7 +58,7 @@ func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returned query %s", name)
+		log.Debug().Msgf("DebugService: Returned query %s", name)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, query)
 	h.Inc(metricAPIQueriesOK)

--- a/api/handlers/settings.go
+++ b/api/handlers/settings.go
@@ -2,12 +2,12 @@ package handlers
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // SettingsHandler - GET Handler for all settings including JSON
@@ -30,7 +30,7 @@ func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned settings")
+		log.Debug().Msg("DebugService: Returned settings")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 	h.Inc(metricAPISettingsOK)
@@ -69,7 +69,7 @@ func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Requ
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned settings")
+		log.Debug().Msg("DebugService: Returned settings")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 	h.Inc(metricAPISettingsOK)
@@ -126,7 +126,7 @@ func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.R
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned settings")
+		log.Debug().Msg("DebugService: Returned settings")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 	h.Inc(metricAPISettingsOK)
@@ -165,7 +165,7 @@ func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned settings")
+		log.Debug().Msg("DebugService: Returned settings")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 	h.Inc(metricAPISettingsOK)
@@ -222,7 +222,7 @@ func (h *HandlersApi) SettingsServiceEnvJSONHandler(w http.ResponseWriter, r *ht
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned settings")
+		log.Debug().Msg("DebugService: Returned settings")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 	h.Inc(metricAPISettingsOK)

--- a/api/handlers/tags.go
+++ b/api/handlers/tags.go
@@ -2,12 +2,12 @@ package handlers
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // TagsHandler - GET Handler for multiple JSON tags
@@ -30,7 +30,7 @@ func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned tags")
+		log.Debug().Msg("DebugService: Returned tags")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, tags)
 	h.Inc(metricAPITagsOK)
@@ -74,7 +74,7 @@ func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned tags")
+		log.Debug().Msg("DebugService: Returned tags")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, tags)
 	h.Inc(metricAPITagsOK)

--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -2,12 +2,12 @@ package handlers
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/users"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // UserHandler - GET Handler for single JSON nodes
@@ -37,7 +37,7 @@ func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Printf("DebugService: Returned user %s", usernameVar)
+		log.Debug().Msgf("DebugService: Returned user %s", usernameVar)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, user)
 	h.Inc(metricAPIUsersOK)
@@ -68,7 +68,7 @@ func (h *HandlersApi) UsersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize and serve JSON
 	if h.Settings.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Returned users")
+		log.Debug().Msg("DebugService: Returned users")
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, users)
 	h.Inc(metricAPIUsersOK)

--- a/api/handlers/utils.go
+++ b/api/handlers/utils.go
@@ -1,12 +1,12 @@
 package handlers
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/logging"
 	"github.com/jmpsec/osctrl/types"
 	"github.com/jmpsec/osctrl/utils"
+	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
 
@@ -40,7 +40,7 @@ func postgresQueryLogs(db *gorm.DB, name string) (APIQueryData, error) {
 
 // Helper to handle API error responses
 func apiErrorResponse(w http.ResponseWriter, msg string, code int, err error) {
-	log.Printf("apiErrorResponse %s: %v", msg, err)
+	log.Debug().Msgf("apiErrorResponse %s: %v", msg, err)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, code, types.ApiErrorResponse{Error: msg})
 }
 

--- a/api/jwt.go
+++ b/api/jwt.go
@@ -1,17 +1,16 @@
 package main
 
 import (
-	"log"
-
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 )
 
 // Function to load the configuration file
 func loadJWTConfiguration(file string) (types.JSONConfigurationJWT, error) {
 	var cfg types.JSONConfigurationJWT
-	log.Printf("Loading %s", file)
+	log.Info().Msgf("Loading %s", file)
 	// Load file and read config
 	viper.SetConfigFile(file)
 	if err := viper.ReadInConfig(); err != nil {

--- a/api/settings.go
+++ b/api/settings.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/jmpsec/osctrl/metrics"
 	"github.com/jmpsec/osctrl/settings"
+	"github.com/rs/zerolog/log"
 )
 
 // Function to load the metrics settings
@@ -13,7 +13,7 @@ func loadingMetrics(mgr *settings.Settings) (*metrics.Metrics, error) {
 	// Check if service settings for metrics is ready, initialize if so
 	if !mgr.IsValue(settings.ServiceAPI, settings.ServiceMetrics, settings.NoEnvironmentID) {
 		if err := mgr.NewBooleanValue(settings.ServiceAPI, settings.ServiceMetrics, false, settings.NoEnvironmentID); err != nil {
-			log.Printf("Failed to add %s to configuration: %v", settings.ServiceMetrics, err)
+			log.Err(err).Msgf("Failed to add %s to configuration", settings.ServiceMetrics)
 		}
 	}
 	if mgr.ServiceMetrics(settings.ServiceAPI) {
@@ -40,7 +40,7 @@ func loadingMetrics(mgr *settings.Settings) (*metrics.Metrics, error) {
 func loadingSettings(mgr *settings.Settings) error {
 	// Check if service settings for debug service is ready
 	if mgr.DebugService(settings.ServiceAPI) {
-		log.Println("DebugService: Initializing settings")
+		log.Debug().Msg("DebugService: Initializing settings")
 	}
 	// Check if service settings for debug service is ready
 	if !mgr.IsValue(settings.ServiceAPI, settings.DebugService, settings.NoEnvironmentID) {

--- a/api/utils.go
+++ b/api/utils.go
@@ -3,19 +3,19 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/jmpsec/osctrl/environments"
 	"github.com/jmpsec/osctrl/settings"
+	"github.com/rs/zerolog/log"
 )
 
 // Helper to refresh the environments map until cache/Redis support is implemented
 func refreshEnvironments() environments.MapEnvironments {
-	log.Printf("Refreshing environments...\n")
+	log.Info().Msg("Refreshing environments...")
 	_envsmap, err := envs.GetMap()
 	if err != nil {
-		log.Printf("error refreshing environments %v\n", err)
+		log.Err(err).Msg("error refreshing environments")
 		return environments.MapEnvironments{}
 	}
 	return _envsmap
@@ -23,10 +23,10 @@ func refreshEnvironments() environments.MapEnvironments {
 
 // Helper to refresh the settings until cache/Redis support is implemented
 func refreshSettings() settings.MapSettings {
-	log.Printf("Refreshing settings...\n")
+	log.Info().Msg("Refreshing settings...")
 	_settingsmap, err := settingsmgr.GetMap(settings.ServiceAPI, settings.NoEnvironmentID)
 	if err != nil {
-		log.Printf("error refreshing settings %v\n", err)
+		log.Err(err).Msg("error refreshing settings")
 		return settings.MapSettings{}
 	}
 	return _settingsmap


### PR DESCRIPTION
Migrating `osctrl-api` to zerolog so logs are better formatted.