### PR TITLE
Adding flag to utilize the SSL support for the backend connection

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -416,6 +416,13 @@ func init() {
 			EnvVars:     []string{"DB_PASS"},
 			Destination: &dbConfigValues.Password,
 		},
+		&cli.StringFlag{
+			Name:        "db-sslmode",
+			Value:       "disable",
+			Usage:       "SSL native support to encrypt the connection to the backend",
+			EnvVars:     []string{"DB_SSLMODE"},
+			Destination: &dbConfigValues.SSLMode,
+		},
 		&cli.IntFlag{
 			Name:        "db-max-idle-conns",
 			Value:       20,

--- a/api/main.go
+++ b/api/main.go
@@ -337,6 +337,13 @@ func init() {
 			EnvVars:     []string{"DB_PASS"},
 			Destination: &dbConfigValues.Password,
 		},
+		&cli.StringFlag{
+			Name:        "db-sslmode",
+			Value:       "disable",
+			Usage:       "SSL native support to encrypt the connection to the backend",
+			EnvVars:     []string{"DB_SSLMODE"},
+			Destination: &dbConfigValues.SSLMode,
+		},
 		&cli.IntFlag{
 			Name:        "db-max-idle-conns",
 			Value:       20,

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// DBString to format connection string to database for postgres
-	DBString = "host=%s port=%s dbname=%s user=%s password=%s sslmode=disable"
+	DBString = "host=%s port=%s dbname=%s user=%s password=%s sslmode=%s"
 	// DBKey to identify the configuration JSON key
 	DBKey = "db"
 )
@@ -31,6 +31,7 @@ type JSONConfigurationDB struct {
 	Name            string `json:"name"`
 	Username        string `json:"username"`
 	Password        string `json:"password"`
+	SSLMode         string `json:"sslmode"`
 	MaxIdleConns    int    `json:"maxIdleConns"`
 	MaxOpenConns    int    `json:"maxOpenConns"`
 	ConnMaxLifetime int    `json:"connMaxLifetime"`
@@ -57,7 +58,7 @@ func LoadConfiguration(file, key string) (JSONConfigurationDB, error) {
 // PrepareDSN to generate DB connection string
 func PrepareDSN(config JSONConfigurationDB) string {
 	return fmt.Sprintf(
-		DBString, config.Host, config.Port, config.Name, config.Username, config.Password)
+		DBString, config.Host, config.Port, config.Name, config.Username, config.Password, config.SSLMode)
 }
 
 // GetDB to get PostgreSQL DB using GORM

--- a/deploy/config/db.json
+++ b/deploy/config/db.json
@@ -5,6 +5,7 @@
     "name": "_DB_NAME",
     "username": "_DB_USERNAME",
     "password": "_DB_PASSWORD",
+    "sslmode": "disable",
     "maxIdleConns": 20,
     "maxOpenConns": 100,
     "connMaxLifetime": 30,

--- a/tls/main.go
+++ b/tls/main.go
@@ -363,6 +363,13 @@ func init() {
 			EnvVars:     []string{"DB_PASS"},
 			Destination: &dbConfigValues.Password,
 		},
+		&cli.StringFlag{
+			Name:        "db-sslmode",
+			Value:       "disable",
+			Usage:       "SSL native support to encrypt the connection to the backend",
+			EnvVars:     []string{"DB_SSLMODE"},
+			Destination: &dbConfigValues.SSLMode,
+		},
 		&cli.IntFlag{
 			Name:        "db-max-idle-conns",
 			Value:       20,


### PR DESCRIPTION
Using the native SSL support of Postgres to encrypt-decrypt communications to backend. More info at https://www.postgresql.org/docs/current/libpq-ssl.html

Implements #523 