### PR TITLE
SQL query shown in query list

### DIFF
--- a/admin/templates/queries.html
+++ b/admin/templates/queries.html
@@ -122,7 +122,7 @@
               data: 'query',
               render: function (data, type, row, meta) {
                 if (type === 'display') {
-                  return queryResultLink(data.link, data.name, "/query/{{ .EnvUUID }}/logs/" + data.name);
+                  return queryResultLink(data.link, data.query, "/query/{{ .EnvUUID }}/logs/" + data.name);
                 } else {
                   return data;
                 }


### PR DESCRIPTION
Showing the SQL query in the query list from `osctrl-admin`, instead of the name that is not very descriptive.