### PR TITLE
Avoid replacing metadata values with the string mismatched

### DIFF
--- a/admin/templates/components/page-modals.html
+++ b/admin/templates/components/page-modals.html
@@ -193,22 +193,20 @@
               </div>
               <div class="modal-body">
                 <div class="form-group row">
-                  <label class="col-md-3 col-form-label" for="query_name">Qury name: </label>
-                  <div class="col-md-9">
+                  <label class="col-md-2 col-form-label" for="query_name">Query name: </label>
+                  <div class="col-md-4">
                     <input class="form-control" name="query_name" id="query_name" type="text" autocomplete="off"
                       autofocus>
+                  </div>
+                  <label class="col-md-3 col-form-label" for="query_interval">Interval in seconds: </label>
+                  <div class="col-md-3">
+                    <input class="form-control" name="query_interval" id="query_interval" type="text" autocomplete="off">
                   </div>
                 </div>
                 <div class="form-group row">
                   <label class="col-md-3 col-form-label" for="query_sql">SQL Query: </label>
                   <div class="col-md-9">
                     <input class="form-control" name="query_sql" id="query_sql" type="text" autocomplete="off">
-                  </div>
-                </div>
-                <div class="form-group row">
-                  <label class="col-md-3 col-form-label" for="query_interval">Interval in seconds: </label>
-                  <div class="col-md-9">
-                    <input class="form-control" name="query_interval" id="query_interval" type="text" autocomplete="off">
                   </div>
                 </div>
               </div>

--- a/logging/utils.go
+++ b/logging/utils.go
@@ -37,7 +37,6 @@ func metadataVerification(dst, src string) string {
 			return src
 		}
 		log.Warn().Msgf("mismatched metadata: %s != %s", dst, src)
-		return Mismatched
 	}
 	return src
 }


### PR DESCRIPTION
When there was some mismatched metadata, the value `mismatched` could end up being written as a node's metadata. This prevents it.