### PR TITLE
Fix for metadata updates done wrong on mismatch

### DIFF
--- a/logging/utils.go
+++ b/logging/utils.go
@@ -33,10 +33,13 @@ func sameConfigDB(loggerOne, loggerTwo backend.JSONConfigurationDB) bool {
 // Helper to be used preparing metadata for each decorator
 func metadataVerification(dst, src string) string {
 	if src != dst {
+		log.Warn().Msgf("mismatched metadata: %s != %s", dst, src)
 		if dst == "" {
 			return src
 		}
-		log.Warn().Msgf("mismatched metadata: %s != %s", dst, src)
+		if src == "" {
+			return dst
+		}
 	}
 	return src
 }


### PR DESCRIPTION
If the recorded metadata was different than the incoming metadata, incorrect updates could happen.