### PR TITLE
Avoid spamming logs with unnecessary log entries for metadata mismatch

### DIFF
--- a/logging/utils.go
+++ b/logging/utils.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"github.com/jmpsec/osctrl/backend"
-	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -33,7 +32,6 @@ func sameConfigDB(loggerOne, loggerTwo backend.JSONConfigurationDB) bool {
 // Helper to be used preparing metadata for each decorator
 func metadataVerification(dst, src string) string {
 	if src != dst {
-		log.Warn().Msgf("mismatched metadata: %s != %s", dst, src)
 		if dst == "" {
 			return src
 		}


### PR DESCRIPTION
Removing unnecessary logs when metadata mismatches happens.