### PR TITLE
Run queries and carves via osctrl-api with expiration

### DIFF
--- a/admin/handlers/post.go
+++ b/admin/handlers/post.go
@@ -140,7 +140,7 @@ func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Reque
 	}
 	// FIXME check if query is carve and user has permissions to carve
 	// Prepare and create new query
-	expTime := h.queryExpiration(q.ExpHours)
+	expTime := queries.QueryExpiration(q.ExpHours)
 	if q.ExpHours == 0 {
 		expTime = time.Time{}
 	}
@@ -297,6 +297,11 @@ func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Requ
 	query := generateCarveQuery(c.Path, false)
 	// Prepare and create new carve
 	carveName := generateCarveName()
+	// Set query expiration
+	expTime := queries.QueryExpiration(c.ExpHours)
+	if c.ExpHours == 0 {
+		expTime = time.Time{}
+	}
 	newQuery := queries.DistributedQuery{
 		Query:         query,
 		Name:          carveName,
@@ -307,7 +312,7 @@ func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Requ
 		Completed:     false,
 		Deleted:       false,
 		Expired:       false,
-		Expiration:    h.queryExpiration(c.ExpHours),
+		Expiration:    expTime,
 		Type:          queries.CarveQueryType,
 		Path:          c.Path,
 		EnvironmentID: env.ID,

--- a/admin/handlers/utils.go
+++ b/admin/handlers/utils.go
@@ -208,8 +208,3 @@ func (h *HandlersAdmin) generateFlags(flagsRaw, secretFile, certFile string) str
 	replaced := strings.Replace(flagsRaw, "__SECRET_FILE__", secretFile, 1)
 	return strings.Replace(replaced, "__CERT_FILE__", certFile, 1)
 }
-
-// Helper to generate the time.Time for the expiration of a query or carve based on hours
-func (h *HandlersAdmin) queryExpiration(exp int) time.Time {
-	return time.Now().Add(time.Duration(exp) * time.Hour)
-}

--- a/api/handlers/carves.go
+++ b/api/handlers/carves.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/jmpsec/osctrl/carves"
 	"github.com/jmpsec/osctrl/queries"
@@ -103,9 +104,14 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 		h.Inc(metricAPICarvesErr)
 		return
 	}
+	expTime := queries.QueryExpiration(c.ExpHours)
+	if c.ExpHours == 0 {
+		expTime = time.Time{}
+	}
 	query := carves.GenCarveQuery(c.Path, false)
 	// Prepare and create new carve
 	carveName := carves.GenCarveName()
+
 	newQuery := queries.DistributedQuery{
 		Query:         query,
 		Name:          carveName,
@@ -113,6 +119,8 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 		Expected:      0,
 		Executions:    0,
 		Active:        true,
+		Expired:       false,
+		Expiration:    expTime,
 		Completed:     false,
 		Deleted:       false,
 		Type:          queries.CarveQueryType,

--- a/api/handlers/queries.go
+++ b/api/handlers/queries.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/jmpsec/osctrl/queries"
 	"github.com/jmpsec/osctrl/settings"
@@ -103,6 +104,10 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 		h.Inc(metricAPIQueriesErr)
 		return
 	}
+	expTime := queries.QueryExpiration(q.ExpHours)
+	if q.ExpHours == 0 {
+		expTime = time.Time{}
+	}
 	// Prepare and create new query
 	queryName := queries.GenQueryName()
 	newQuery := queries.DistributedQuery{
@@ -112,6 +117,8 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 		Expected:      0,
 		Executions:    0,
 		Active:        true,
+		Expired:       false,
+		Expiration:    expTime,
 		Completed:     false,
 		Deleted:       false,
 		Hidden:        q.Hidden,

--- a/queries/utils.go
+++ b/queries/utils.go
@@ -1,8 +1,17 @@
 package queries
 
-import "github.com/jmpsec/osctrl/utils"
+import (
+	"time"
+
+	"github.com/jmpsec/osctrl/utils"
+)
 
 // Helper to generate a random query name
 func GenQueryName() string {
 	return "query_" + utils.RandomForNames()
+}
+
+// Helper to generate the time.Time for the expiration of a query or carve based on hours
+func QueryExpiration(exp int) time.Time {
+	return time.Now().Add(time.Duration(exp) * time.Hour)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -122,12 +122,14 @@ type ApiDistributedQueryRequest struct {
 	Hosts        []string `json:"host_list"`
 	Query        string   `json:"query"`
 	Hidden       bool     `json:"hidden"`
+	ExpHours     int      `json:"exp_hours"`
 }
 
 // ApiDistributedCarveRequest to receive query requests
 type ApiDistributedCarveRequest struct {
-	UUID string `json:"uuid"`
-	Path string `json:"path"`
+	UUID     string `json:"uuid"`
+	Path     string `json:"path"`
+	ExpHours int    `json:"exp_hours"`
 }
 
 // ApiNodeGenericRequest to receive generic node requests


### PR DESCRIPTION
Providing the expiration in hours, or no expiration if value is zero, using `osctrl-api`, for queries and carves.