### PR TITLE
Run queries and carves with expiration using osctrl-cli

### DIFF
--- a/cli/api-carve.go
+++ b/cli/api-carve.go
@@ -49,10 +49,11 @@ func (api *OsctrlAPI) CompleteCarve(env, identifier string) error {
 }
 
 // RunCarve to initiate a carve in osctrl
-func (api *OsctrlAPI) RunCarve(env, uuid, path string) (types.ApiQueriesResponse, error) {
+func (api *OsctrlAPI) RunCarve(env, uuid, path string, exp int) (types.ApiQueriesResponse, error) {
 	c := types.ApiDistributedCarveRequest{
 		UUID: uuid,
 		Path: path,
+		ExpHours: exp,
 	}
 	var r types.ApiQueriesResponse
 	reqURL := fmt.Sprintf("%s%s%s/%s", api.Configuration.URL, APIPath, APICarves, env)

--- a/cli/api-query.go
+++ b/cli/api-query.go
@@ -38,21 +38,30 @@ func (api *OsctrlAPI) GetQuery(env, name string) (queries.DistributedQuery, erro
 }
 
 // DeleteQuery to delete query from osctrl
+// TODO: Implement this function
 func (api *OsctrlAPI) DeleteQuery(env, identifier string) error {
 	return nil
 }
 
+// ExpireQuery to expire query from osctrl
+// TODO: Implement this function
+func (api *OsctrlAPI) ExpireQuery(env, identifier string) error {
+	return nil
+}
+
 // CompleteQuery to complete a query from osctrl
+// TODO: Implement this function
 func (api *OsctrlAPI) CompleteQuery(env, identifier string) error {
 	return nil
 }
 
 // RunQuery to initiate a query in osctrl
-func (api *OsctrlAPI) RunQuery(env, uuid, query string, hidden bool) (types.ApiQueriesResponse, error) {
+func (api *OsctrlAPI) RunQuery(env, uuid, query string, hidden bool, exp int) (types.ApiQueriesResponse, error) {
 	q := types.ApiDistributedQueryRequest{
-		UUIDs:  []string{uuid},
-		Query:  query,
-		Hidden: hidden,
+		UUIDs:    []string{uuid},
+		Query:    query,
+		Hidden:   hidden,
+		ExpHours: exp,
 	}
 	var r types.ApiQueriesResponse
 	reqURL := fmt.Sprintf("%s%s%s/%s", api.Configuration.URL, APIPath, APIQueries, env)

--- a/cli/main.go
+++ b/cli/main.go
@@ -1255,6 +1255,24 @@ func init() {
 					Action: cliWrapper(deleteQuery),
 				},
 				{
+					Name:    "expire",
+					Aliases: []string{"e"},
+					Usage:   "Mark an on-demand query as expired",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    "name",
+							Aliases: []string{"n"},
+							Usage:   "Query name to be expired",
+						},
+						&cli.StringFlag{
+							Name:    "env",
+							Aliases: []string{"e"},
+							Usage:   "Environment to be used",
+						},
+					},
+					Action: cliWrapper(expireQuery),
+				},
+				{
 					Name:    "run",
 					Aliases: []string{"r"},
 					Usage:   "Start a new on-demand query",
@@ -1279,6 +1297,12 @@ func init() {
 							Aliases: []string{"x"},
 							Hidden:  false,
 							Usage:   "Mark query as hidden",
+						},
+						&cli.IntFlag{
+							Name:    "expiration",
+							Aliases: []string{"E"},
+							Value:   6,
+							Usage:   "Expiration in hours (0 for no expiration)",
 						},
 					},
 					Action: cliWrapper(runQuery),
@@ -1369,6 +1393,24 @@ func init() {
 					Action: cliWrapper(deleteCarve),
 				},
 				{
+					Name:    "expire",
+					Aliases: []string{"e"},
+					Usage:   "Mark a file carve as expired",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    "name",
+							Aliases: []string{"n"},
+							Usage:   "Carve name to be expired",
+						},
+						&cli.StringFlag{
+							Name:    "env",
+							Aliases: []string{"e"},
+							Usage:   "Environment to be used",
+						},
+					},
+					Action: cliWrapper(expireCarve),
+				},
+				{
 					Name:    "run",
 					Aliases: []string{"r"},
 					Usage:   "Start a new carve for a file or a directory",
@@ -1387,6 +1429,12 @@ func init() {
 							Name:    "uuid",
 							Aliases: []string{"u"},
 							Usage:   "Node UUID to be used",
+						},
+						&cli.IntFlag{
+							Name:    "expiration",
+							Aliases: []string{"E"},
+							Value:   6,
+							Usage:   "Expiration in hours (0 for no expiration)",
 						},
 					},
 					Action: cliWrapper(runCarve),


### PR DESCRIPTION
Provide the expiration in hours when using `osctrl-cli` to run queries or carves.