### PR TITLE
Delete and expire carves and queries via osctrl-api

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -574,10 +574,12 @@ func osctrlAPIService() {
 	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryShowHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/results/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryResultsHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiAllQueriesPath+"/{env}"), handlerAuthCheck(http.HandlerFunc(handlersApi.AllQueriesShowHandler)))
+	muxAPI.Handle("POST "+_apiPath(apiQueriesPath)+"/{env}/{action}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesActionHandler)))
 	// API: carves by environment
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesRunHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
+	muxAPI.Handle("POST "+_apiPath(apiCarvesPath)+"/{env}/{action}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesActionHandler)))
 	// API: users
 	muxAPI.Handle("GET "+_apiPath(apiUsersPath)+"/{username}", handlerAuthCheck(http.HandlerFunc(handlersApi.UserHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiUsersPath), handlerAuthCheck(http.HandlerFunc(handlersApi.UsersHandler)))

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -461,6 +461,12 @@ paths:
       description: Returns the requested on-demand query results by name and environment
       operationId: QueryResultsHandler
       parameters:
+        - name: env
+          in: path
+          description: Name or UUID of the requested osctrl environment
+          required: true
+          schema:
+            type: string
         - name: name
           in: path
           description: Name of the requested on-demand query
@@ -495,6 +501,66 @@ paths:
       security:
         - Authorization:
             - query
+  /queries/{env}/{action}/{name}:
+    post:
+      tags:
+        - queries
+      summary: Execute action on on-demand query
+      description: Executes an action (delete/expire) in the on-demand query by name and environment
+      operationId: QueriesActionHandler
+      parameters:
+        - name: env
+          in: path
+          description: Name or UUID of the requested osctrl environment
+          required: true
+          schema:
+            type: string
+        - name: action
+          in: path
+          description: Action to execute (delete, expire)
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: path
+          description: Name of the requested on-demand query
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiGenericResponse"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        403:
+          description: no access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        404:
+          description: no queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        500:
+          description: error getting queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+      security:
+        - Authorization:
+            - admin
   /all-queries/{env}:
     get:
       tags:
@@ -542,7 +608,7 @@ paths:
   /carves/{env}:
     get:
       tags:
-        - queries
+        - carves
       summary: Get file carves
       description: Returns all file carves by environment
       operationId: CarvesShowHandler
@@ -625,7 +691,7 @@ paths:
   /carves/{env}/{name}:
     get:
       tags:
-        - queries
+        - carves
       summary: Get a file carve
       description: Returns a file carve by environment and name
       operationId: CarveShowHandler
@@ -672,6 +738,66 @@ paths:
       security:
         - Authorization:
             - carve
+  /carves/{env}/{action}/{name}:
+    post:
+      tags:
+        - carves
+      summary: Execute action on file carve
+      description: Executes an action (delete/expire) in the file carve by name and environment
+      operationId: CarvesActionHandler
+      parameters:
+        - name: env
+          in: path
+          description: Name or UUID of the requested osctrl environment
+          required: true
+          schema:
+            type: string
+        - name: action
+          in: path
+          description: Action to execute (delete, expire)
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: path
+          description: Name of the requested file carve
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiGenericResponse"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        403:
+          description: no access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        404:
+          description: no queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        500:
+          description: error getting queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+      security:
+        - Authorization:
+            - admin
   /users:
     get:
       tags:

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -247,6 +247,13 @@ func (q *Queries) Gets(target, qtype string, envid uint) ([]DistributedQuery, er
 	return queries, nil
 }
 
+// Checks if a query exists in an environment, regardless of the status
+func (q *Queries) Exists(name string, envid uint) bool {
+	var count int64
+	q.DB.Model(&DistributedQuery{}).Where("name = ? AND environment_id = ?", name, envid).Count(&count)
+	return (count > 0)
+}
+
 // GetActive all active queries and carves by target
 func (q *Queries) GetActive(envid uint) ([]DistributedQuery, error) {
 	var queries []DistributedQuery

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -73,6 +73,14 @@ const (
 	SetRpmPackage   string = "set_rpm"
 )
 
+// Types of query/carve actions
+const (
+	QueryDelete string = "delete"
+	QueryExpire string = "expire"
+	CarveDelete string = QueryDelete
+	CarveExpire string = QueryExpire
+)
+
 // Types of package
 const (
 	PackageDeb string = "deb"


### PR DESCRIPTION
Executing `expire` and `delete` actions for on-demand queries and file carves, via `osctrl-api`. Also updated the YAML for OpenAPI with the new code.