### PR TITLE
Fix for osctrl-api context type mismatch

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -5,16 +5,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/jmpsec/osctrl/api/handlers"
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/utils"
 	"github.com/rs/zerolog/log"
 )
-
-// contextValue to hold session data in the context
-type contextValue map[string]string
-
-// contextKey to help with the context key, to pass session data
-type contextKey string
 
 const (
 	// Key to identify request context
@@ -51,9 +46,9 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 		switch apiConfig.Auth {
 		case settings.AuthNone:
 			// Set middleware values
-			s := make(contextValue)
+			s := make(handlers.ContextValue)
 			s["user"] = "admin"
-			ctx := context.WithValue(r.Context(), contextKey(contextAPI), s)
+			ctx := context.WithValue(r.Context(), handlers.ContextKey(contextAPI), s)
 			// Access granted
 			h.ServeHTTP(w, r.WithContext(ctx))
 		case settings.AuthJWT:
@@ -73,9 +68,9 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 				log.Err(err).Msgf("error updating token for user %s", claims.Username)
 			}
 			// Set middleware values
-			s := make(contextValue)
+			s := make(handlers.ContextValue)
 			s["user"] = claims.Username
-			ctx := context.WithValue(r.Context(), contextKey(contextAPI), s)
+			ctx := context.WithValue(r.Context(), handlers.ContextKey(contextAPI), s)
 			// Access granted
 			h.ServeHTTP(w, r.WithContext(ctx))
 		}

--- a/api/handlers/carves.go
+++ b/api/handlers/carves.go
@@ -41,7 +41,7 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.CarveLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPICarvesErr)
@@ -85,7 +85,7 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.CarveLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPICarvesErr)
@@ -170,7 +170,7 @@ func (h *HandlersApi) CarvesActionHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPICarvesErr)
@@ -237,7 +237,7 @@ func (h *HandlersApi) apiCarvesShowHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.CarveLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPICarvesErr)

--- a/api/handlers/environments.go
+++ b/api/handlers/environments.go
@@ -36,7 +36,7 @@ func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.UserLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIEnvsErr)
@@ -55,7 +55,7 @@ func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request
 	h.Inc(metricAPIEnvsReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAPI, settings.NoEnvironmentID), false)
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIEnvsErr)
@@ -99,7 +99,7 @@ func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.UserLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIEnvsErr)
@@ -170,7 +170,7 @@ func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.UserLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIEnvsErr)
@@ -235,7 +235,7 @@ func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIEnvsErr)
@@ -346,7 +346,7 @@ func (h *HandlersApi) EnvRemoveActionsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIQueriesErr)

--- a/api/handlers/nodes.go
+++ b/api/handlers/nodes.go
@@ -32,7 +32,7 @@ func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.UserLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPINodesErr)
@@ -84,7 +84,7 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPINodesErr)
@@ -129,7 +129,7 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPINodesErr)
@@ -174,7 +174,7 @@ func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPINodesErr)
@@ -219,7 +219,7 @@ func (h *HandlersApi) DeleteNodeHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPINodesErr)

--- a/api/handlers/platforms.go
+++ b/api/handlers/platforms.go
@@ -15,7 +15,7 @@ func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAPIPlatformsReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAPI, settings.NoEnvironmentID), false)
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIPlatformsErr)
@@ -59,7 +59,7 @@ func (h *HandlersApi) PlatformsEnvHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIPlatformsErr)

--- a/api/handlers/queries.go
+++ b/api/handlers/queries.go
@@ -40,7 +40,7 @@ func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.QueryLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIQueriesErr)
@@ -84,7 +84,7 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.QueryLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIQueriesErr)
@@ -235,7 +235,7 @@ func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIQueriesErr)
@@ -302,7 +302,7 @@ func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.QueryLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIQueriesErr)
@@ -344,7 +344,7 @@ func (h *HandlersApi) HiddenQueriesShowHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.QueryLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIQueriesErr)
@@ -393,7 +393,7 @@ func (h *HandlersApi) QueryResultsHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.QueryLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIQueriesErr)

--- a/api/handlers/settings.go
+++ b/api/handlers/settings.go
@@ -15,7 +15,7 @@ func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAPISettingsReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAPI, settings.NoEnvironmentID), false)
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPISettingsErr)
@@ -54,7 +54,7 @@ func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPISettingsErr)
@@ -111,7 +111,7 @@ func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPISettingsErr)
@@ -150,7 +150,7 @@ func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPISettingsErr)
@@ -207,7 +207,7 @@ func (h *HandlersApi) SettingsServiceEnvJSONHandler(w http.ResponseWriter, r *ht
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPISettingsErr)

--- a/api/handlers/tags.go
+++ b/api/handlers/tags.go
@@ -15,7 +15,7 @@ func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAPITagsReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAPI, settings.NoEnvironmentID), false)
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPITagsErr)
@@ -59,7 +59,7 @@ func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPITagsErr)

--- a/api/handlers/users.go
+++ b/api/handlers/users.go
@@ -29,7 +29,7 @@ func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIUsersErr)
@@ -48,7 +48,7 @@ func (h *HandlersApi) UsersHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAPINodesReq)
 	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAPI, settings.NoEnvironmentID), false)
 	// Get context data and check access
-	ctx := r.Context().Value(contextKey(contextAPI)).(contextValue)
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		h.Inc(metricAPIUsersErr)

--- a/api/handlers/utils.go
+++ b/api/handlers/utils.go
@@ -10,11 +10,11 @@ import (
 	"gorm.io/gorm"
 )
 
-// contextValue to hold session data in the context
-type contextValue map[string]string
+// ContextValue to hold session data in the context
+type ContextValue map[string]string
 
-// contextKey to help with the context key, to pass session data
-type contextKey string
+// ContextKey to help with the context key, to pass session data
+type ContextKey string
 
 // APIQueryData to hold query result data
 type APIQueryData map[string]string


### PR DESCRIPTION
This pull request fixes a context type mismatch issue https://github.com/jmpsec/osctrl/issues/549 in the osctrl-api code. The `contextValue` and `contextKey` types have been renamed to `ContextValue` and `ContextKey` respectively to be used by `auth.go`.