### PR TITLE
Using osctrl-api by osctrl-cli for expire/delete queries and carves

### DIFF
--- a/cli/api-carve.go
+++ b/cli/api-carve.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jmpsec/osctrl/carves"
+	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
 	"github.com/rs/zerolog/log"
 )
@@ -39,20 +40,52 @@ func (api *OsctrlAPI) GetCarve(env, name string) (carves.CarvedFile, error) {
 }
 
 // DeleteCarve to delete carve from osctrl
-func (api *OsctrlAPI) DeleteCarve(env, identifier string) error {
-	return nil
+func (api *OsctrlAPI) DeleteCarve(env, name string) (types.ApiGenericResponse, error) {
+	var r types.ApiGenericResponse
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/%s", api.Configuration.URL, APIPath, APICarves, env, settings.CarveDelete, name)
+	rawQ, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return r, fmt.Errorf("error api request - %v - %s", err, string(rawQ))
+	}
+	if err := json.Unmarshal(rawQ, &r); err != nil {
+		return r, fmt.Errorf("can not parse body - %v", err)
+	}
+	return r, nil
+}
+
+// ExpireCarve to expire carve from osctrl
+func (api *OsctrlAPI) ExpireCarve(env, name string) (types.ApiGenericResponse, error) {
+	var r types.ApiGenericResponse
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/%s", api.Configuration.URL, APIPath, APICarves, env, settings.QueryExpire, name)
+	rawQ, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return r, fmt.Errorf("error api request - %v - %s", err, string(rawQ))
+	}
+	if err := json.Unmarshal(rawQ, &r); err != nil {
+		return r, fmt.Errorf("can not parse body - %v", err)
+	}
+	return r, nil
 }
 
 // CompleteCarve to complete a carve from osctrl
-func (api *OsctrlAPI) CompleteCarve(env, identifier string) error {
-	return nil
+func (api *OsctrlAPI) CompleteCarve(env, name string) (types.ApiGenericResponse, error) {
+	var r types.ApiGenericResponse
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/%s", api.Configuration.URL, APIPath, APICarves, env, settings.CarveComplete, name)
+	rawQ, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return r, fmt.Errorf("error api request - %v - %s", err, string(rawQ))
+	}
+	if err := json.Unmarshal(rawQ, &r); err != nil {
+		return r, fmt.Errorf("can not parse body - %v", err)
+	}
+	return r, nil
 }
 
 // RunCarve to initiate a carve in osctrl
 func (api *OsctrlAPI) RunCarve(env, uuid, path string, exp int) (types.ApiQueriesResponse, error) {
 	c := types.ApiDistributedCarveRequest{
-		UUID: uuid,
-		Path: path,
+		UUID:     uuid,
+		Path:     path,
 		ExpHours: exp,
 	}
 	var r types.ApiQueriesResponse

--- a/cli/api-query.go
+++ b/cli/api-query.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jmpsec/osctrl/queries"
+	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
 )
 
@@ -38,21 +39,45 @@ func (api *OsctrlAPI) GetQuery(env, name string) (queries.DistributedQuery, erro
 }
 
 // DeleteQuery to delete query from osctrl
-// TODO: Implement this function
-func (api *OsctrlAPI) DeleteQuery(env, identifier string) error {
-	return nil
+func (api *OsctrlAPI) DeleteQuery(env, name string) (types.ApiGenericResponse, error) {
+	var r types.ApiGenericResponse
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/%s", api.Configuration.URL, APIPath, APIQueries, env, settings.QueryDelete, name)
+	rawQ, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return r, fmt.Errorf("error api request - %v - %s", err, string(rawQ))
+	}
+	if err := json.Unmarshal(rawQ, &r); err != nil {
+		return r, fmt.Errorf("can not parse body - %v", err)
+	}
+	return r, nil
 }
 
 // ExpireQuery to expire query from osctrl
-// TODO: Implement this function
-func (api *OsctrlAPI) ExpireQuery(env, identifier string) error {
-	return nil
+func (api *OsctrlAPI) ExpireQuery(env, name string) (types.ApiGenericResponse, error) {
+	var r types.ApiGenericResponse
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/%s", api.Configuration.URL, APIPath, APIQueries, env, settings.QueryExpire, name)
+	rawQ, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return r, fmt.Errorf("error api request - %v - %s", err, string(rawQ))
+	}
+	if err := json.Unmarshal(rawQ, &r); err != nil {
+		return r, fmt.Errorf("can not parse body - %v", err)
+	}
+	return r, nil
 }
 
 // CompleteQuery to complete a query from osctrl
-// TODO: Implement this function
-func (api *OsctrlAPI) CompleteQuery(env, identifier string) error {
-	return nil
+func (api *OsctrlAPI) CompleteQuery(env, name string) (types.ApiGenericResponse, error) {
+	var r types.ApiGenericResponse
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/%s", api.Configuration.URL, APIPath, APIQueries, env, settings.QueryComplete, name)
+	rawQ, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return r, fmt.Errorf("error api request - %v - %s", err, string(rawQ))
+	}
+	if err := json.Unmarshal(rawQ, &r); err != nil {
+		return r, fmt.Errorf("can not parse body - %v", err)
+	}
+	return r, nil
 }
 
 // RunQuery to initiate a query in osctrl

--- a/cli/carve.go
+++ b/cli/carve.go
@@ -136,11 +136,19 @@ func completeCarve(c *cli.Context) error {
 	if dbFlag {
 		e, err := envs.Get(env)
 		if err != nil {
-			return err
+			return fmt.Errorf("❌ error env get - %s", err)
 		}
-		return queriesmgr.Complete(name, e.ID)
+		if err := queriesmgr.Complete(name, e.ID); err != nil {
+			return fmt.Errorf("❌ error completing carve - %s", err)
+		}
 	} else if apiFlag {
-		return osctrlAPI.CompleteQuery(env, name)
+		_, err := osctrlAPI.CompleteQuery(env, name)
+		if err != nil {
+			return fmt.Errorf("❌ error completing carve - %s", err)
+		}
+	}
+	if !silentFlag {
+		fmt.Printf("✅ carve %s completed successfully\n", name)
 	}
 	return nil
 }
@@ -160,11 +168,19 @@ func deleteCarve(c *cli.Context) error {
 	if dbFlag {
 		e, err := envs.Get(env)
 		if err != nil {
-			return err
+			return fmt.Errorf("❌ error env get - %s", err)
 		}
-		return queriesmgr.Delete(name, e.ID)
+		if err := queriesmgr.Delete(name, e.ID); err != nil {
+			return fmt.Errorf("❌ error deleting carve - %s", err)
+		}
 	} else if apiFlag {
-		return osctrlAPI.DeleteQuery(env, name)
+		_, err := osctrlAPI.DeleteQuery(env, name)
+		if err != nil {
+			return fmt.Errorf("❌ error deleting carve - %s", err)
+		}
+	}
+	if !silentFlag {
+		fmt.Printf("✅ carve %s deleted successfully\n", name)
 	}
 	return nil
 }
@@ -184,11 +200,19 @@ func expireCarve(c *cli.Context) error {
 	if dbFlag {
 		e, err := envs.Get(env)
 		if err != nil {
-			return err
+			return fmt.Errorf("❌ error env get - %s", err)
 		}
-		return queriesmgr.Expire(name, e.ID)
+		if err := queriesmgr.Expire(name, e.ID); err != nil {
+			return fmt.Errorf("❌ error expiring carve - %s", err)
+		}
 	} else if apiFlag {
-		return osctrlAPI.ExpireQuery(env, name)
+		_, err := osctrlAPI.ExpireQuery(env, name)
+		if err != nil {
+			return fmt.Errorf("❌ error expiring carve - %s", err)
+		}
+	}
+	if !silentFlag {
+		fmt.Printf("✅ carve %s expired successfully\n", name)
 	}
 	return nil
 }
@@ -214,7 +238,7 @@ func runCarve(c *cli.Context) error {
 	if dbFlag {
 		e, err := envs.Get(env)
 		if err != nil {
-			return err
+			return fmt.Errorf("❌ %s", err)
 		}
 		carveName := carves.GenCarveName()
 		newQuery := queries.DistributedQuery{
@@ -233,21 +257,21 @@ func runCarve(c *cli.Context) error {
 			EnvironmentID: e.ID,
 		}
 		if err := queriesmgr.Create(newQuery); err != nil {
-			return err
+			return fmt.Errorf("❌ %s", err)
 		}
 		if (uuid != "") && nodesmgr.CheckByUUID(uuid) {
 			if err := queriesmgr.CreateTarget(carveName, queries.QueryTargetUUID, uuid); err != nil {
-				return err
+				return fmt.Errorf("❌ error creating target - %s", err)
 			}
 		}
 		if err := queriesmgr.SetExpected(carveName, 1, e.ID); err != nil {
-			return err
+			return fmt.Errorf("❌ error setting expected - %s", err)
 		}
 		return nil
 	} else if apiFlag {
 		c, err := osctrlAPI.RunCarve(env, uuid, path, expHours)
 		if err != nil {
-			return err
+			return fmt.Errorf("❌ error running carve - %s", err)
 		}
 		if !silentFlag {
 			fmt.Printf("✅ carve %s created successfully\n", c.Name)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -75,10 +75,12 @@ const (
 
 // Types of query/carve actions
 const (
-	QueryDelete string = "delete"
-	QueryExpire string = "expire"
-	CarveDelete string = QueryDelete
-	CarveExpire string = QueryExpire
+	QueryDelete   string = "delete"
+	QueryExpire   string = "expire"
+	QueryComplete string = "complete"
+	CarveDelete   string = QueryDelete
+	CarveExpire   string = QueryExpire
+	CarveComplete string = QueryComplete
 )
 
 // Types of package


### PR DESCRIPTION
Utilizing `osctrl-api` with `osctrl-cli` to perform actions (delete/expire) in distributed queries and file carves.