### PR TITLE
Multiple changes to osctrl-api: Crash fix, show carve queries and better targets to list queries

### DIFF
--- a/admin/handlers/json-queries.go
+++ b/admin/handlers/json-queries.go
@@ -11,8 +11,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const ()
-
 // Define targets to be used
 var (
 	QueryTargets = map[string]bool{

--- a/api/handlers/carves.go
+++ b/api/handlers/carves.go
@@ -66,6 +66,103 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAPICarvesOK)
 }
 
+// GET Handler to return carve queries in JSON by target and environment
+func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request) {
+	h.Inc(metricAPICarvesReq)
+	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAPI, settings.NoEnvironmentID), false)
+	// Extract environment
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Get environment
+	env, err := h.Envs.GetByUUID(envVar)
+	if err != nil {
+		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Get context data and check access
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.CarveLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Extract target
+	targetVar := r.PathValue("target")
+	if targetVar == "" {
+		apiErrorResponse(w, "error with target", http.StatusBadRequest, nil)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Verify target
+	if !QueryTargets[targetVar] {
+		apiErrorResponse(w, "invalid target", http.StatusBadRequest, nil)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Get carves
+	carves, err := h.Queries.GetCarves(targetVar, env.ID)
+	if err != nil {
+		apiErrorResponse(w, "error getting carves", http.StatusInternalServerError, err)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	if len(carves) == 0 {
+		apiErrorResponse(w, "no carves", http.StatusNotFound, nil)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Serialize and serve JSON
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, carves)
+	h.Inc(metricAPICarvesOK)
+}
+
+// GET Handler to return carves in JSON by environment
+func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
+	h.Inc(metricAPICarvesReq)
+	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(settings.ServiceAPI, settings.NoEnvironmentID), false)
+	// Extract environment
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Get environment
+	env, err := h.Envs.GetByUUID(envVar)
+	if err != nil {
+		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, nil)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Get context data and check access
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.CarveLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Get carves
+	carves, err := h.Carves.GetByEnv(env.ID)
+	if err != nil {
+		apiErrorResponse(w, "error getting carves", http.StatusInternalServerError, err)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	if len(carves) == 0 {
+		apiErrorResponse(w, "no carves", http.StatusNotFound, nil)
+		h.Inc(metricAPICarvesErr)
+		return
+	}
+	// Serialize and serve JSON
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, carves)
+	h.Inc(metricAPICarvesOK)
+}
+
 // POST Handler to run a carve
 func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 	h.Inc(metricAPICarvesReq)
@@ -212,6 +309,13 @@ func (h *HandlersApi) CarvesActionHandler(w http.ResponseWriter, r *http.Request
 			return
 		}
 		msgReturn = fmt.Sprintf("carve %s expired successfully", nameVar)
+	case settings.CarveComplete:
+		if err := h.Queries.Complete(nameVar, env.ID); err != nil {
+			apiErrorResponse(w, "error completing carve", http.StatusInternalServerError, err)
+			h.Inc(metricAPICarvesErr)
+			return
+		}
+		msgReturn = fmt.Sprintf("carve %s completed successfully", nameVar)
 	}
 	// Return message as serialized response
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: msgReturn})

--- a/api/handlers/carves.go
+++ b/api/handlers/carves.go
@@ -107,12 +107,12 @@ func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request
 	// Get carves
 	carves, err := h.Queries.GetCarves(targetVar, env.ID)
 	if err != nil {
-		apiErrorResponse(w, "error getting carves", http.StatusInternalServerError, err)
+		apiErrorResponse(w, "error getting carve queries", http.StatusInternalServerError, err)
 		h.Inc(metricAPICarvesErr)
 		return
 	}
 	if len(carves) == 0 {
-		apiErrorResponse(w, "no carves", http.StatusNotFound, nil)
+		apiErrorResponse(w, "no carve queries", http.StatusNotFound, nil)
 		h.Inc(metricAPICarvesErr)
 		return
 	}

--- a/api/main.go
+++ b/api/main.go
@@ -570,7 +570,7 @@ func osctrlAPIService() {
 	muxAPI.Handle("POST "+_apiPath(apiNodesPath)+"/{env}/delete", handlerAuthCheck(http.HandlerFunc(handlersApi.DeleteNodeHandler)))
 	// API: queries by environment
 	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.AllQueriesShowHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/{target}/list", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryListHandler)))
+	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/list/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryListHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiQueriesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesRunHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryShowHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/results/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryResultsHandler)))
@@ -578,7 +578,7 @@ func osctrlAPIService() {
 	muxAPI.Handle("POST "+_apiPath(apiQueriesPath)+"/{env}/{action}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesActionHandler)))
 	// API: carves by environment
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/{target}/queries", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveQueriesHandler)))
+	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/queries/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveQueriesHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/list", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveListHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesRunHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))

--- a/api/main.go
+++ b/api/main.go
@@ -570,6 +570,7 @@ func osctrlAPIService() {
 	muxAPI.Handle("POST "+_apiPath(apiNodesPath)+"/{env}/delete", handlerAuthCheck(http.HandlerFunc(handlersApi.DeleteNodeHandler)))
 	// API: queries by environment
 	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.AllQueriesShowHandler)))
+	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/{target}/list", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryListHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiQueriesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesRunHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryShowHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/results/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryResultsHandler)))
@@ -577,6 +578,8 @@ func osctrlAPIService() {
 	muxAPI.Handle("POST "+_apiPath(apiQueriesPath)+"/{env}/{action}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesActionHandler)))
 	// API: carves by environment
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
+	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/{target}/queries", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveQueriesHandler)))
+	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/list", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveListHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesRunHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiCarvesPath)+"/{env}/{action}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesActionHandler)))

--- a/cli/api-carve.go
+++ b/cli/api-carve.go
@@ -6,23 +6,24 @@ import (
 	"strings"
 
 	"github.com/jmpsec/osctrl/carves"
+	"github.com/jmpsec/osctrl/queries"
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
 	"github.com/rs/zerolog/log"
 )
 
 // GetCarveQueries to retrieve carves from osctrl
-func (api *OsctrlAPI) GetCarveQueries(target, env string) ([]carves.CarvedFile, error) {
-	var cs []carves.CarvedFile
+func (api *OsctrlAPI) GetCarveQueries(target, env string) ([]queries.DistributedQuery, error) {
+	var qs []queries.DistributedQuery
 	reqURL := fmt.Sprintf("%s%s%s/%s/queries/%s", api.Configuration.URL, APIPath, APICarves, env, target)
 	rawCs, err := api.GetGeneric(reqURL, nil)
 	if err != nil {
-		return cs, fmt.Errorf("error api request - %v - %s", err, string(rawCs))
+		return qs, fmt.Errorf("error api request - %v - %s", err, string(rawCs))
 	}
-	if err := json.Unmarshal(rawCs, &cs); err != nil {
-		return cs, fmt.Errorf("can not parse body - %v", err)
+	if err := json.Unmarshal(rawCs, &qs); err != nil {
+		return qs, fmt.Errorf("can not parse body - %v", err)
 	}
-	return cs, nil
+	return qs, nil
 }
 
 // GetCarves to retrieve carves from osctrl

--- a/cli/api-carve.go
+++ b/cli/api-carve.go
@@ -14,7 +14,7 @@ import (
 // GetCarveQueries to retrieve carves from osctrl
 func (api *OsctrlAPI) GetCarveQueries(target, env string) ([]carves.CarvedFile, error) {
 	var cs []carves.CarvedFile
-	reqURL := fmt.Sprintf("%s%s%s/%s/%s/list", api.Configuration.URL, APIPath, APICarves, env, target)
+	reqURL := fmt.Sprintf("%s%s%s/%s/queries/%s", api.Configuration.URL, APIPath, APICarves, env, target)
 	rawCs, err := api.GetGeneric(reqURL, nil)
 	if err != nil {
 		return cs, fmt.Errorf("error api request - %v - %s", err, string(rawCs))

--- a/cli/api-carve.go
+++ b/cli/api-carve.go
@@ -11,10 +11,24 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// GetCarveQueries to retrieve carves from osctrl
+func (api *OsctrlAPI) GetCarveQueries(target, env string) ([]carves.CarvedFile, error) {
+	var cs []carves.CarvedFile
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/list", api.Configuration.URL, APIPath, APICarves, env, target)
+	rawCs, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return cs, fmt.Errorf("error api request - %v - %s", err, string(rawCs))
+	}
+	if err := json.Unmarshal(rawCs, &cs); err != nil {
+		return cs, fmt.Errorf("can not parse body - %v", err)
+	}
+	return cs, nil
+}
+
 // GetCarves to retrieve carves from osctrl
 func (api *OsctrlAPI) GetCarves(env string) ([]carves.CarvedFile, error) {
 	var cs []carves.CarvedFile
-	reqURL := fmt.Sprintf("%s%s%s/%s", api.Configuration.URL, APIPath, APICarves, env)
+	reqURL := fmt.Sprintf("%s%s%s/%s/list", api.Configuration.URL, APIPath, APICarves, env)
 	rawCs, err := api.GetGeneric(reqURL, nil)
 	if err != nil {
 		return cs, fmt.Errorf("error api request - %v - %s", err, string(rawCs))

--- a/cli/api-query.go
+++ b/cli/api-query.go
@@ -11,9 +11,9 @@ import (
 )
 
 // GetQueries to retrieve queries from osctrl
-func (api *OsctrlAPI) GetQueries(env string) ([]queries.DistributedQuery, error) {
+func (api *OsctrlAPI) GetQueries(target, env string) ([]queries.DistributedQuery, error) {
 	var qs []queries.DistributedQuery
-	reqURL := fmt.Sprintf("%s%s%s/%s", api.Configuration.URL, APIPath, APIQueries, env)
+	reqURL := fmt.Sprintf("%s%s%s/%s/%s/list", api.Configuration.URL, APIPath, APIQueries, env, target)
 	rawQs, err := api.GetGeneric(reqURL, nil)
 	if err != nil {
 		return qs, fmt.Errorf("error api request - %v - %s", err, string(rawQs))

--- a/cli/api-query.go
+++ b/cli/api-query.go
@@ -13,7 +13,7 @@ import (
 // GetQueries to retrieve queries from osctrl
 func (api *OsctrlAPI) GetQueries(target, env string) ([]queries.DistributedQuery, error) {
 	var qs []queries.DistributedQuery
-	reqURL := fmt.Sprintf("%s%s%s/%s/%s/list", api.Configuration.URL, APIPath, APIQueries, env, target)
+	reqURL := fmt.Sprintf("%s%s%s/%s/list/%s", api.Configuration.URL, APIPath, APIQueries, env, target)
 	rawQs, err := api.GetGeneric(reqURL, nil)
 	if err != nil {
 		return qs, fmt.Errorf("error api request - %v - %s", err, string(rawQs))

--- a/cli/carve.go
+++ b/cli/carve.go
@@ -141,14 +141,14 @@ func listCarveQueries(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("❌ error env get - %s", err)
 		}
-		qs, err = queriesmgr.GetQueries(target, e.ID)
+		qs, err = queriesmgr.GetCarves(target, e.ID)
 		if err != nil {
-			return fmt.Errorf("❌ error get queries - %s", err)
+			return fmt.Errorf("❌ error get carve queries - %s", err)
 		}
 	} else if apiFlag {
 		qs, err = osctrlAPI.GetQueries(target, env)
 		if err != nil {
-			return fmt.Errorf("❌ error get queries - %s", err)
+			return fmt.Errorf("❌ error get carve queries - %s", err)
 		}
 	}
 	header := []string{
@@ -182,11 +182,11 @@ func listCarveQueries(c *cli.Context) error {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader(header)
 		if len(qs) > 0 {
-			fmt.Printf("Existing %s queries (%d):\n", target, len(qs))
+			fmt.Printf("Existing %s carve queries (%d):\n", target, len(qs))
 			data := queriesToData(qs, nil)
 			table.AppendBulk(data)
 		} else {
-			fmt.Printf("No %s nodes\n", target)
+			fmt.Printf("No %s carve queries\n", target)
 		}
 		table.Render()
 	}

--- a/cli/carve.go
+++ b/cli/carve.go
@@ -146,7 +146,7 @@ func listCarveQueries(c *cli.Context) error {
 			return fmt.Errorf("❌ error get carve queries - %s", err)
 		}
 	} else if apiFlag {
-		qs, err = osctrlAPI.GetQueries(target, env)
+		qs, err = osctrlAPI.GetCarveQueries(target, env)
 		if err != nil {
 			return fmt.Errorf("❌ error get carve queries - %s", err)
 		}

--- a/cli/main.go
+++ b/cli/main.go
@@ -1342,6 +1342,12 @@ func init() {
 							Hidden:  false,
 							Usage:   "Show hidden queries",
 						},
+						&cli.BoolFlag{
+							Name:    "expired",
+							Aliases: []string{"E"},
+							Hidden:  false,
+							Usage:   "Show expired queries",
+						},
 						&cli.StringFlag{
 							Name:    "env",
 							Aliases: []string{"e"},
@@ -1359,7 +1365,7 @@ func init() {
 				{
 					Name:    "complete",
 					Aliases: []string{"c"},
-					Usage:   "Mark an file carve as completed",
+					Usage:   "Mark an file carve query as completed",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:    "name",
@@ -1377,7 +1383,7 @@ func init() {
 				{
 					Name:    "delete",
 					Aliases: []string{"d"},
-					Usage:   "Mark a file carve as deleted",
+					Usage:   "Mark a file carve query as deleted",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:    "name",
@@ -1395,7 +1401,7 @@ func init() {
 				{
 					Name:    "expire",
 					Aliases: []string{"e"},
-					Usage:   "Mark a file carve as expired",
+					Usage:   "Mark a file carve query as expired",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:    "name",
@@ -1444,30 +1450,6 @@ func init() {
 					Aliases: []string{"l"},
 					Usage:   "List file carves",
 					Flags: []cli.Flag{
-						&cli.BoolFlag{
-							Name:    "all",
-							Aliases: []string{"v"},
-							Hidden:  true,
-							Usage:   "Show all carves",
-						},
-						&cli.BoolFlag{
-							Name:    "active",
-							Aliases: []string{"a"},
-							Hidden:  false,
-							Usage:   "Show active carves",
-						},
-						&cli.BoolFlag{
-							Name:    "completed, c",
-							Aliases: []string{"c"},
-							Hidden:  false,
-							Usage:   "Show completed carves",
-						},
-						&cli.BoolFlag{
-							Name:    "deleted",
-							Aliases: []string{"d"},
-							Hidden:  false,
-							Usage:   "Show deleted carves",
-						},
 						&cli.StringFlag{
 							Name:    "env",
 							Aliases: []string{"e"},
@@ -1475,6 +1457,49 @@ func init() {
 						},
 					},
 					Action: cliWrapper(listCarves),
+				},
+				{
+					Name:    "list-queries",
+					Aliases: []string{"l"},
+					Usage:   "List file carves queries",
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:    "all",
+							Aliases: []string{"v"},
+							Hidden:  true,
+							Usage:   "Show all file carves queries",
+						},
+						&cli.BoolFlag{
+							Name:    "active",
+							Aliases: []string{"a"},
+							Hidden:  false,
+							Usage:   "Show active file carves queries",
+						},
+						&cli.BoolFlag{
+							Name:    "completed",
+							Aliases: []string{"c"},
+							Hidden:  false,
+							Usage:   "Show completed file carves queries",
+						},
+						&cli.BoolFlag{
+							Name:    "expired",
+							Aliases: []string{"E"},
+							Hidden:  false,
+							Usage:   "Show expired file carves queries",
+						},
+						&cli.BoolFlag{
+							Name:    "deleted",
+							Aliases: []string{"d"},
+							Hidden:  false,
+							Usage:   "Show deleted file carves queries",
+						},
+						&cli.StringFlag{
+							Name:    "env",
+							Aliases: []string{"e"},
+							Usage:   "Environment to be used",
+						},
+					},
+					Action: cliWrapper(listCarveQueries),
 				},
 			},
 		},

--- a/cli/main.go
+++ b/cli/main.go
@@ -1314,8 +1314,8 @@ func init() {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
 							Name:    "all",
-							Aliases: []string{"v"},
-							Hidden:  true,
+							Aliases: []string{"A"},
+							Hidden:  false,
 							Usage:   "Show all queries",
 						},
 						&cli.BoolFlag{
@@ -1465,8 +1465,8 @@ func init() {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
 							Name:    "all",
-							Aliases: []string{"v"},
-							Hidden:  true,
+							Aliases: []string{"A"},
+							Hidden:  false,
 							Usage:   "Show all file carves queries",
 						},
 						&cli.BoolFlag{

--- a/cli/query.go
+++ b/cli/query.go
@@ -40,6 +40,8 @@ func queryToData(q queries.DistributedQuery, header []string) [][]string {
 		stringifyBool(q.Hidden),
 		stringifyBool(q.Completed),
 		stringifyBool(q.Deleted),
+		stringifyBool(q.Expired),
+		q.Expiration.String(),
 	}
 	data = append(data, _q)
 	return data
@@ -63,6 +65,9 @@ func listQueries(c *cli.Context) error {
 	if c.Bool("hidden") {
 		target = "hidden"
 	}
+	if c.Bool("expired") {
+		target = "expired"
+	}
 	env := c.String("env")
 	if env == "" {
 		fmt.Println("❌ environment is required")
@@ -80,7 +85,7 @@ func listQueries(c *cli.Context) error {
 			return fmt.Errorf("❌ error get queries - %s", err)
 		}
 	} else if apiFlag {
-		qs, err = osctrlAPI.GetQueries(env)
+		qs, err = osctrlAPI.GetQueries(target, env)
 		if err != nil {
 			return fmt.Errorf("❌ error get queries - %s", err)
 		}
@@ -96,6 +101,8 @@ func listQueries(c *cli.Context) error {
 		"Hidden",
 		"Completed",
 		"Deleted",
+		"Expired",
+		"Expiration",
 	}
 	// Prepare output
 	if formatFlag == jsonFormat {

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -399,6 +399,62 @@ paths:
       security:
         - Authorization:
             - query
+  /queries/{env}/{target}/list:
+    get:
+      tags:
+        - queries
+      summary: Get on-demand queries
+      description: Returns all on-demand queries by target and environment
+      operationId: QueryListHandler
+      parameters:
+        - name: env
+          in: path
+          description: Name or UUID of the requested osctrl environment
+          required: true
+          schema:
+            type: string
+        - name: target
+          in: path
+          description: Query target to retrieve (all, all-full, active, hidden-active, completed, expired, saved, hidden-completed, deleted, hidden)
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DistributedQuery"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        403:
+          description: no access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        404:
+          description: no queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        500:
+          description: error getting queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+      security:
+        - Authorization:
+            - query
   /queries/{env}/{name}:
     get:
       tags:
@@ -654,7 +710,7 @@ paths:
         - queries
       summary: Run new file carve
       description: Creates a new file carve to run
-      operationId: CarvesRunHandler
+      operationId: CarveListHandler
       requestBody:
         content:
           application/json:
@@ -667,6 +723,62 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiQueriesResponse"
+        403:
+          description: no access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        404:
+          description: no queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        500:
+          description: error getting queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+      security:
+        - Authorization:
+            - carve
+  /carves/{env}/{target}/list:
+    get:
+      tags:
+        - carves
+      summary: Get file carves
+      description: Returns all file carves by target and environment
+      operationId: CarveListHandler
+      parameters:
+        - name: env
+          in: path
+          description: Name or UUID of the requested osctrl environment
+          required: true
+          schema:
+            type: string
+        - name: target
+          in: path
+          description: Carve target to retrieve (all, all-full, active, hidden-active, completed, expired, saved, hidden-completed, deleted, hidden)
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DistributedQuery"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         403:
           description: no access
           content:

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -399,7 +399,7 @@ paths:
       security:
         - Authorization:
             - query
-  /queries/{env}/{target}/list:
+  /queries/{env}/list/{target}:
     get:
       tags:
         - queries
@@ -744,13 +744,63 @@ paths:
       security:
         - Authorization:
             - carve
-  /carves/{env}/{target}/list:
+  /carves/{env}/list:
     get:
       tags:
         - carves
       summary: Get file carves
       description: Returns all file carves by target and environment
       operationId: CarveListHandler
+      parameters:
+        - name: env
+          in: path
+          description: Name or UUID of the requested osctrl environment
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CarvedFile"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        403:
+          description: no access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        404:
+          description: no queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        500:
+          description: error getting queries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+      security:
+        - Authorization:
+            - carve
+  /carves/{env}/queries/{target}:
+    get:
+      tags:
+        - carves
+      summary: Get file carves queries
+      description: Returns all file carves queries by target and environment
+      operationId: CarveQueriesHandler
       parameters:
         - name: env
           in: path

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -174,7 +174,7 @@ func (q *Queries) Gets(target, qtype string, envid uint) ([]DistributedQuery, er
 		}
 	case TargetCompleted:
 		if err := q.DB.Where(
-			"active = ? AND completed = ? AND deleted = ? AND type = ? AND expired = ? AND environment_id = ?",
+			"active = ? AND completed = ? AND deleted = ? AND expired = ? AND type = ? AND environment_id = ?",
 			false,
 			true,
 			false,


### PR DESCRIPTION
Multiple things implemented in `osctrl-api`, including fix for https://github.com/jmpsec/osctrl/issues/549
* Crash fix when attempting to run a query using `osctrl-api`
* List of targets when listing queries and carve queries
* Ability to list carve queries as well as carves
* Full support in `osctrl-cli` for all `osctrl-api` changes
* Updated OpenAPI YAML file