### PR TITLE
Refactor distributed query

### DIFF
--- a/api/handlers/queries.go
+++ b/api/handlers/queries.go
@@ -218,6 +218,14 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 
 	// Remove duplicates from expected
 	expectedClear := removeStringDuplicates(expected)
+
+	// Create new record for query list
+	for _, id := range expectedClear {
+		if err := h.Queries.CreateNodeQuery(newQuery.ID, id); err != nil {
+			log.Err(err).Msgf("error creating node query for query %s and node %s", newQuery.Name, id)
+		}
+	}
+
 	// Update value for expected
 	if err := h.Queries.SetExpected(queryName, len(expectedClear), env.ID); err != nil {
 		apiErrorResponse(w, "error setting expected", http.StatusInternalServerError, err)

--- a/logging/process.go
+++ b/logging/process.go
@@ -84,6 +84,10 @@ func (l *LoggerTLS) ProcessLogQueryResult(queriesWrite types.QueryWriteRequest, 
 		if err := l.Queries.TrackExecution(q, node.UUID, queriesWrite.Statuses[q]); err != nil {
 			log.Err(err).Msg("error adding query execution")
 		}
+		// Instead of creating a new record in a separate table, we can just update the query status
+		if err := l.Queries.UpdateQueryStatus(q, node.ID, queriesWrite.Statuses[q]); err != nil {
+			log.Err(err).Msg("error updating query status")
+		}
 		// Check if query is completed
 		if err := l.Queries.VerifyComplete(q, envid); err != nil {
 			log.Err(err).Msg("error verifying and completing query")

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -79,6 +79,16 @@ type DistributedQuery struct {
 	Expiration    time.Time
 }
 
+// NodeQuery links a node to a query
+type NodeQuery struct {
+	NodeQueryID uint      `gorm:"primaryKey;autoIncrement"`
+	NodeID      uint      `gorm:"not null;index"`
+	QueryID     uint      `gorm:"not null;index"`
+	Status      string    `gorm:"type:varchar(50);default:'pending'"` // Indexed for fast lookups
+	AssignedAt  time.Time `gorm:"default:CURRENT_TIMESTAMP"`
+	CompletedAt time.Time
+}
+
 // DistributedQueryTarget to keep target logic for queries
 type DistributedQueryTarget struct {
 	gorm.Model
@@ -107,6 +117,7 @@ type Queries struct {
 func CreateQueries(backend *gorm.DB) *Queries {
 	var q *Queries
 	q = &Queries{DB: backend}
+
 	// table distributed_queries
 	if err := backend.AutoMigrate(&DistributedQuery{}); err != nil {
 		log.Fatal().Msgf("Failed to AutoMigrate table (distributed_queries): %v", err)


### PR DESCRIPTION
@javuto , This PR is not completed but shows the idea of how we move all the calculations from each node's distributed query request to the distributed query creation.


In this idea, we would create a new table that records which node should execute which query. In this case, we only iteration all nodes when we create the distributed query. When osquery sends the distributed query result, we only check this table and we don't need to go through the whole list of distributed queries.

I also preferred a small change:
- Use a single `status` column instead of several ones. It would be simplicity and readability. Also, it would be efficient when querying the status, we don't have to write a query for each column.  A classic example would be `"active = ? AND completed = ? AND deleted = ? AND expired = ? AND type = ? AND environment_id = ?",`

In this case, we can get rid of several tables, we only need one table to track the status of all distributed queries.

