### PR TITLE
Improvements to elastic logger for osctrl-tls

### DIFF
--- a/logging/elastic.go
+++ b/logging/elastic.go
@@ -20,7 +20,8 @@ type ElasticConfiguration struct {
 	Host           string `json:"host"`
 	Port           string `json:"port"`
 	IndexPrefix    string `json:"indexPrefix"`
-	IndexSeparator string `json:"indexSeparator"` // Expected is . for prefix.YYYY.MM.DD
+	DateSeparator  string `json:"dateSeparator"`  // Expected is . for YYYY.MM.DD
+	IndexSeparator string `json:"indexSeparator"` // Expected is - for prefix-YYYY.MM.DD
 }
 
 // LoggerElastic will be used to log data using Elastic
@@ -82,7 +83,7 @@ func LoadElastic(file string) (ElasticConfiguration, error) {
 // IndexName - Function to return the index name
 func (logE *LoggerElastic) IndexName() string {
 	now := time.Now().UTC()
-	fNow := strings.ReplaceAll(now.Format("2006-01-02"), "-", logE.Configuration.IndexSeparator)
+	fNow := strings.ReplaceAll(now.Format("2006-01-02"), "-", logE.Configuration.DateSeparator)
 	return fmt.Sprintf("%s%s%s", logE.Configuration.IndexPrefix, logE.Configuration.IndexSeparator, fNow)
 }
 

--- a/logging/elastic.go
+++ b/logging/elastic.go
@@ -1,9 +1,9 @@
 package logging
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/elastic/go-elasticsearch/esapi"
@@ -98,7 +98,7 @@ func (logE *LoggerElastic) Send(logType string, data []byte, environment, uuid s
 	}
 	req := esapi.IndexRequest{
 		Index:   logE.IndexName(),
-		Body:    strings.NewReader(string(data)),
+		Body:    bytes.NewReader(data),
 		Refresh: "true",
 	}
 	res, err := req.Do(context.Background(), logE.Client)

--- a/logging/elastic.go
+++ b/logging/elastic.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -95,6 +96,10 @@ func (logE *LoggerElastic) Send(logType string, data []byte, environment, uuid s
 	}
 	if debug {
 		log.Debug().Msgf("DebugService: Sending %d bytes to Elastic for %s - %s", len(data), environment, uuid)
+	}
+	var logs []interface{}
+	if err := json.Unmarshal(data, &logs); err != nil {
+		log.Err(err).Msg("Error unmarshalling data")
 	}
 	req := esapi.IndexRequest{
 		Index:   logE.IndexName(),

--- a/logging/elastic.go
+++ b/logging/elastic.go
@@ -17,10 +17,10 @@ import (
 
 // ElasticConfiguration to hold all elastic configuration values
 type ElasticConfiguration struct {
-	Host        string `json:"host"`
-	Port        string `json:"port"`
-	IndexPrefix string `json:"indexPrefix"`
-	IndexString string `json:"indexString"` // Expected is %s-%s for prefix-YYYY-MM-DD
+	Host           string `json:"host"`
+	Port           string `json:"port"`
+	IndexPrefix    string `json:"indexPrefix"`
+	IndexSeparator string `json:"indexSeparator"` // Expected is . for prefix.YYYY.MM.DD
 }
 
 // LoggerElastic will be used to log data using Elastic
@@ -82,7 +82,8 @@ func LoadElastic(file string) (ElasticConfiguration, error) {
 // IndexName - Function to return the index name
 func (logE *LoggerElastic) IndexName() string {
 	now := time.Now().UTC()
-	return fmt.Sprintf(logE.Configuration.IndexString, logE.Configuration.IndexPrefix, now.Format("2006-01-02"))
+	fNow := strings.ReplaceAll(now.Format("2006-01-02"), "-", logE.Configuration.IndexSeparator)
+	return fmt.Sprintf("%s%s%s", logE.Configuration.IndexPrefix, logE.Configuration.IndexSeparator, fNow)
 }
 
 // Settings - Function to prepare settings for the logger


### PR DESCRIPTION
Defining separator for index prefix and date and parsing events. This may end up being rewritten using the bulk API for elasticsearch but for now it stays like this.