### PR TITLE
Add log level and format configuration options for services

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -260,14 +260,14 @@ func init() {
 		},
 		&cli.StringFlag{
 			Name:        "log-level",
-			Value:       "info",
+			Value:       types.LogLevelInfo,
 			Usage:       "Log level for the service",
 			EnvVars:     []string{"SERVICE_LOG_LEVEL"},
 			Destination: &adminConfigValues.LogLevel,
 		},
 		&cli.StringFlag{
 			Name:        "log-format",
-			Value:       "json",
+			Value:       types.LogFormatJSON,
 			Usage:       "Log format for the service",
 			EnvVars:     []string{"SERVICE_LOG_FORMAT"},
 			Destination: &adminConfigValues.LogFormat,
@@ -1039,22 +1039,22 @@ func cliAction(c *cli.Context) error {
 func initializeLogger(logLevel, logFormat string) {
 
 	switch strings.ToLower(logLevel) {
-	case "debug":
+	case types.LogLevelDebug:
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	case "info":
+	case types.LogLevelInfo:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	case "warn":
+	case types.LogLevelWarn:
 		zerolog.SetGlobalLevel(zerolog.WarnLevel)
-	case "error":
+	case types.LogLevelError:
 		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
 	default:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 
 	switch strings.ToLower(logFormat) {
-	case "json":
+	case types.LogFormatJSON:
 		log.Logger = log.With().Caller().Logger()
-	case "console":
+	case types.LogFormatConsole:
 		zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
 			return filepath.Base(file) + ":" + strconv.Itoa(line)
 		}

--- a/api/main.go
+++ b/api/main.go
@@ -207,14 +207,14 @@ func init() {
 		},
 		&cli.StringFlag{
 			Name:        "log-level",
-			Value:       "info",
+			Value:       types.LogLevelInfo,
 			Usage:       "Log level for the service",
 			EnvVars:     []string{"SERVICE_LOG_LEVEL"},
 			Destination: &apiConfigValues.LogLevel,
 		},
 		&cli.StringFlag{
 			Name:        "log-format",
-			Value:       "json",
+			Value:       types.LogFormatJSON,
 			Usage:       "Log format for the service",
 			EnvVars:     []string{"SERVICE_LOG_FORMAT"},
 			Destination: &apiConfigValues.LogFormat,
@@ -687,22 +687,22 @@ func cliAction(c *cli.Context) error {
 func initializeLogger(logLevel, logFormat string) {
 
 	switch strings.ToLower(logLevel) {
-	case "debug":
+	case types.LogLevelDebug:
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	case "info":
+	case types.LogLevelInfo:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	case "warn":
+	case types.LogLevelWarn:
 		zerolog.SetGlobalLevel(zerolog.WarnLevel)
-	case "error":
+	case types.LogLevelError:
 		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
 	default:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 
 	switch strings.ToLower(logFormat) {
-	case "json":
+	case types.LogFormatJSON:
 		log.Logger = log.With().Caller().Logger()
-	case "console":
+	case types.LogFormatConsole:
 		zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
 			return filepath.Base(file) + ":" + strconv.Itoa(line)
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -2,6 +2,18 @@ package types
 
 import "time"
 
+const (
+	// log levels
+	LogLevelDebug string = "debug"
+	LogLevelInfo  string = "info"
+	LogLevelWarn  string = "warn"
+	LogLevelError string = "error"
+
+	// log formats
+	LogFormatConsole string = "console"
+	LogFormatJSON    string = "json"
+)
+
 // JSONConfigurationTLS to hold TLS service configuration values
 type JSONConfigurationTLS struct {
 	Listener        string `json:"listener"`

--- a/types/types.go
+++ b/types/types.go
@@ -6,6 +6,8 @@ import "time"
 type JSONConfigurationTLS struct {
 	Listener        string `json:"listener"`
 	Port            string `json:"port"`
+	LogLevel        string `json:"logLevel"`
+	LogFormat       string `json:"logFormat"`
 	MetricsListener string `json:"metricsListener"`
 	MetricsPort     string `json:"metricsPort"`
 	MetricsEnabled  bool   `json:"metricsEnabled"`
@@ -19,6 +21,8 @@ type JSONConfigurationTLS struct {
 type JSONConfigurationAdmin struct {
 	Listener   string `json:"listener"`
 	Port       string `json:"port"`
+	LogLevel   string `json:"logLevel"`
+	LogFormat  string `json:"logFormat"`
 	Host       string `json:"host"`
 	Auth       string `json:"auth"`
 	Logger     string `json:"logger"`
@@ -28,11 +32,13 @@ type JSONConfigurationAdmin struct {
 
 // JSONConfigurationAPI to hold API service configuration values
 type JSONConfigurationAPI struct {
-	Listener string `json:"listener"`
-	Port     string `json:"port"`
-	Host     string `json:"host"`
-	Auth     string `json:"auth"`
-	Carver   string `json:"carver"`
+	Listener  string `json:"listener"`
+	Port      string `json:"port"`
+	LogLevel  string `json:"logLevel"`
+	LogFormat string `json:"logFormat"`
+	Host      string `json:"host"`
+	Auth      string `json:"auth"`
+	Carver    string `json:"carver"`
 }
 
 // JSONConfigurationHeaders to keep all headers details for auth


### PR DESCRIPTION
Introduce configuration options for log level and format in services, allowing customization of logging behavior. This change enhances the flexibility of logging by enabling different log levels and formats through command-line flags and environment variables.

The change was made for admin and api. For tls, I would like to discuss a better naming convention:
- We need a configuration for server's logs
- We need another logger configuration for exports logs and results from osquery

Also, the code are highly duplicated and I would like to remove the duplication.

For documentation, do you know where should update these configuration options?