### PR TITLE
Cleanup code in cache for logs

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -340,27 +340,6 @@ func init() {
 			Destination: &redisConfigValues.DB,
 		},
 		&cli.IntFlag{
-			Name:        "redis-status-exp",
-			Value:       cache.StatusExpiration,
-			Usage:       "Redis expiration in hours for status logs",
-			EnvVars:     []string{"REDIS_STATUS_EXP"},
-			Destination: &redisConfigValues.StatusExpirationHours,
-		},
-		&cli.IntFlag{
-			Name:        "redis-result-exp",
-			Value:       cache.ResultExpiration,
-			Usage:       "Redis expiration in hours for result logs",
-			EnvVars:     []string{"REDIS_RESULT_EXP"},
-			Destination: &redisConfigValues.ResultExpirationHours,
-		},
-		&cli.IntFlag{
-			Name:        "redis-query-exp",
-			Value:       cache.QueryExpiration,
-			Usage:       "Redis expiration in hours for query logs",
-			EnvVars:     []string{"REDIS_QUERY_EXP"},
-			Destination: &redisConfigValues.QueryExpirationHours,
-		},
-		&cli.IntFlag{
 			Name:        "redis-conn-retry",
 			Value:       defaultRedisRetryTimeout,
 			Usage:       "Time in seconds to retry the connection to the cache, if set to 0 the service will stop if the connection fails",

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,9 +2,7 @@ package cache
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"time"
 
 	redis "github.com/go-redis/redis/v8"
 	"github.com/jmpsec/osctrl/types"
@@ -14,18 +12,6 @@ import (
 const (
 	// RedisKey to identify the configuration JSON key
 	RedisKey = "redis"
-	// StatusExpiration in hours to expire entries for status logs
-	StatusExpiration = 24
-	// ResultsExpiration in hours to expire entries for result logs
-	ResultExpiration = 24
-	// QueryExpiration in hours to expire entries for query logs
-	QueryExpiration = 24
-	// HashKeyResult to be used as hash-key to keep result logs
-	HashKeyResult = types.ResultLog
-	// HashKeyStatus to be used as hash-key to keep status logs
-	HashKeyStatus = types.StatusLog
-	// HashKeyQuery to be used as hash-key to keep query logs
-	HashKeyQuery = types.QueryLog
 )
 
 // RedisManager have access to cached data
@@ -36,15 +22,12 @@ type RedisManager struct {
 
 // JSONConfigurationRedis to hold all redis configuration values
 type JSONConfigurationRedis struct {
-	Host                  string `json:"host"`
-	Port                  string `json:"port"`
-	Password              string `json:"password"`
-	ConnectionString      string `json:"connectionstring"`
-	DB                    int    `json:"db"`
-	StatusExpirationHours int    `json:"status_exp_hours"`
-	ResultExpirationHours int    `json:"result_exp_hours"`
-	QueryExpirationHours  int    `json:"query_exp_hours"`
-	ConnRetry             int    `json:"conn_retry"`
+	Host             string `json:"host"`
+	Port             string `json:"port"`
+	Password         string `json:"password"`
+	ConnectionString string `json:"connectionstring"`
+	DB               int    `json:"db"`
+	ConnRetry        int    `json:"connRetry"`
 }
 
 // CachedQueryWriteData to store in cache query logs
@@ -53,14 +36,6 @@ type CachedQueryWriteData struct {
 	HostIdentifier string `json:"hostIdentifier"`
 	QueryData      types.QueryWriteData
 }
-
-// CachedStatusLogs to parse cached status logs
-type CachedStatusLogs map[string][]types.LogStatusData
-
-// CachedResultLogs to parse cached result logs
-type CachedResultLogs map[string][]types.LogResultData
-
-// CachedQueryLogs to parse cached query logs
 
 // LoadConfiguration to load the redis configuration file and assign to variables
 func LoadConfiguration(file, key string) (JSONConfigurationRedis, error) {
@@ -120,159 +95,4 @@ func CreateRedisManager(config JSONConfigurationRedis) (*RedisManager, error) {
 		return nil, err
 	}
 	return rm, nil
-}
-
-// GetStatusLogs to retrieve cached status logs
-func (r *RedisManager) GetStatusLogs(hostID, env string) (map[string][]byte, error) {
-	return r.GetLogs(types.StatusLog, hostID, env)
-}
-
-// StatusLogs to retrieve cached status logs
-func (r *RedisManager) StatusLogs(hostID, env string, secs int64) ([]types.LogStatusData, error) {
-	data, err := r.GetStatusLogs(hostID, env)
-	if err != nil {
-		return []types.LogStatusData{}, fmt.Errorf("error getting logs - %v", err)
-	}
-	var result []types.LogStatusData
-	for _, v := range data {
-		var logs []types.LogStatusData
-		if err := json.Unmarshal(v, &logs); err != nil {
-			return result, fmt.Errorf("error parsing logs - %v", err)
-		}
-		result = append(result, logs...)
-	}
-	return result, nil
-}
-
-// GetLogs to retrieve logs generically
-func (r *RedisManager) GetLogs(logType, hostID, envOrName string) (map[string][]byte, error) {
-	var keyMatch string
-	switch logType {
-	case types.StatusLog:
-		keyMatch = GenStatusMatch(hostID, envOrName)
-	case types.ResultLog:
-		keyMatch = GenResultMatch(hostID, envOrName)
-	case types.QueryLog:
-		keyMatch = GenQueryMatch(hostID, envOrName)
-		if hostID == "" {
-			keyMatch = GenQueryNameMatch(envOrName)
-		}
-	}
-	ctx := context.TODO()
-	iter := r.Client.Scan(ctx, 0, keyMatch, 0).Iterator()
-	mappedData := make(map[string][]byte)
-	for iter.Next(ctx) {
-		mapKey := iter.Val()
-		keyVal, err := r.Client.Get(ctx, mapKey).Result()
-		if err != nil {
-			return mappedData, fmt.Errorf("error retrieving key for %s - %v", logType, err)
-		}
-		mappedData[mapKey] = []byte(keyVal)
-	}
-	if err := iter.Err(); err != nil {
-		return mappedData, fmt.Errorf("error iterating %s - %v", logType, err)
-	}
-	return mappedData, nil
-}
-
-// GetResultLogs to retrieve cached result logs
-func (r *RedisManager) GetResultLogs(hostID, env string) (map[string][]byte, error) {
-	return r.GetLogs(types.ResultLog, hostID, env)
-}
-
-// HResultLogs to retrieve cached status logs
-func (r *RedisManager) ResultLogs(hostID, env string, secs int64) ([]types.LogResultData, error) {
-	data, err := r.GetResultLogs(hostID, env)
-	if err != nil {
-		return []types.LogResultData{}, fmt.Errorf("error getting logs - %v", err)
-	}
-	var result []types.LogResultData
-	for _, v := range data {
-		var logs []types.LogResultData
-		if err := json.Unmarshal(v, &logs); err != nil {
-			return result, fmt.Errorf("error parsing logs - %v", err)
-		}
-		result = append(result, logs...)
-	}
-	return result, nil
-}
-
-// GetQueryLogs to retrieve cached query logs
-func (r *RedisManager) GetQueryLogs(hostID, name string) (map[string][]byte, error) {
-	return r.GetLogs(types.QueryLog, hostID, name)
-}
-
-// GetQueryNameLogs to retrieve cached query logs only by query name
-func (r *RedisManager) GetQueryNameLogs(name string) (map[string][]byte, error) {
-	return r.GetLogs(types.QueryLog, "", name)
-}
-
-// HQueryLogs to retrieve cached query logs
-func (r *RedisManager) QueryLogs(name string) ([]CachedQueryWriteData, error) {
-	var result []CachedQueryWriteData
-	queryMap, err := r.GetQueryNameLogs(name)
-	if err != nil {
-		return result, fmt.Errorf("GetQueryNameLogs: %s", err)
-	}
-	for k, q := range queryMap {
-		// Split key into fields
-		name, hostId, unixtime := ParseQueryKey(k)
-		// Parse raw logs
-		var queryData types.QueryWriteData
-		if err := json.Unmarshal(q, &queryData); err != nil {
-			return result, fmt.Errorf("error parsing logs - %v", err)
-		}
-		// Verify query name matches
-		if queryData.Name != name {
-			return result, fmt.Errorf("query name does not match: %s != %s", queryData.Name, name)
-		}
-		rr := CachedQueryWriteData{
-			UnixTime:       unixtime,
-			HostIdentifier: hostId,
-			QueryData:      queryData,
-		}
-		result = append(result, rr)
-	}
-	return result, nil
-}
-
-// SetLogs to write logs to cache
-func (r *RedisManager) SetLogs(logType, hostID, envOrName string, data []byte) error {
-	var hKey string
-	var tExpire time.Duration
-	switch logType {
-	case types.StatusLog:
-		hKey = GenStatusKey(hostID, envOrName)
-		tExpire = time.Hour * time.Duration(r.Config.StatusExpirationHours)
-	case types.ResultLog:
-		hKey = GenResultKey(hostID, envOrName)
-		tExpire = time.Hour * time.Duration(r.Config.ResultExpirationHours)
-	case types.QueryLog:
-		hKey = GenQueryKey(hostID, envOrName)
-		tExpire = time.Hour * time.Duration(r.Config.QueryExpirationHours)
-	}
-	ctx := context.Background()
-	if err := r.Client.Set(ctx, hKey, data, tExpire).Err(); err != nil {
-		return fmt.Errorf("%s Set: %s", logType, err)
-	}
-	// Make sure we expire the key
-	if err := r.Client.Expire(ctx, hKey, tExpire).Err(); err != nil {
-		return fmt.Errorf("%s Expire: %s", logType, err)
-	}
-	return nil
-}
-
-// SetStatusLogs to write status to cache
-func (r *RedisManager) SetStatusLogs(hostID, env string, data []byte) error {
-	return r.SetLogs(types.StatusLog, hostID, env, data)
-}
-
-// SetResultLogs to write result logs to cache
-func (r *RedisManager) SetResultLogs(hostID, env string, data []byte) error {
-	return r.SetLogs(types.ResultLog, hostID, env, data)
-}
-
-// SetQueryLogs to write query logs to cache
-func (r *RedisManager) SetQueryLogs(hostID, name string, data []byte) error {
-	return r.SetLogs(types.QueryLog, hostID, name, data)
 }

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -2,62 +2,9 @@ package cache
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // PrepareAddr to generate redis connection string
 func PrepareAddr(config JSONConfigurationRedis) string {
 	return fmt.Sprintf("%s:%s", config.Host, config.Port)
-}
-
-// GenStatusKey to format the key to store status logs
-func GenStatusKey(hostID, env string) string {
-	return fmt.Sprintf("%s:%s:%s:%d", HashKeyStatus, hostID, env, time.Now().UnixMilli())
-}
-
-// GenStatusMatch to format the match expression to scan status logs
-func GenStatusMatch(hostID, env string) string {
-	return fmt.Sprintf("%s:%s:%s:*", HashKeyStatus, hostID, env)
-}
-
-// GenResultKey to format the key to store result logs
-func GenResultKey(hostID, env string) string {
-	return fmt.Sprintf("%s:%s:%s:%d", HashKeyResult, hostID, env, time.Now().UnixMilli())
-}
-
-// GenResultMatch to format the match expression to scan result logs
-func GenResultMatch(hostID, env string) string {
-	return fmt.Sprintf("%s:%s:%s:*", HashKeyResult, hostID, env)
-}
-
-// GenQueryKey to format the key to store query logs
-func GenQueryKey(hostID, name string) string {
-	return fmt.Sprintf("%s:%s:%s:%d", HashKeyQuery, name, hostID, time.Now().UnixMilli())
-}
-
-// GenQueryMatch to format the match expression to scan query logs
-func GenQueryMatch(hostID, name string) string {
-	return fmt.Sprintf("%s:%s:%s:*", HashKeyQuery, name, hostID)
-}
-
-// GenQueryNameMatch to format the match expression to scan for completed queries
-func GenQueryNameMatch(name string) string {
-	return fmt.Sprintf("%s:%s:*", HashKeyQuery, name)
-}
-
-// ParseQueryKey to parse the key used to cache queries
-func ParseQueryKey(key string) (string, string, int) {
-	parsed := strings.Split(key, ":")
-	// parsed[1] is query name
-	queryName := parsed[1]
-	// parsed[2] is hostIdentifier
-	hostIdentifier := parsed[2]
-	// parsed[3] is unixtime
-	i, err := strconv.Atoi(parsed[3])
-	if err != nil {
-		i = int(time.Now().Unix())
-	}
-	return queryName, hostIdentifier, i
 }

--- a/tls/main.go
+++ b/tls/main.go
@@ -309,27 +309,6 @@ func init() {
 			Destination: &redisConfigValues.DB,
 		},
 		&cli.IntFlag{
-			Name:        "redis-status-exp",
-			Value:       cache.StatusExpiration,
-			Usage:       "Redis expiration in hours for status logs",
-			EnvVars:     []string{"REDIS_STATUS_EXP"},
-			Destination: &redisConfigValues.StatusExpirationHours,
-		},
-		&cli.IntFlag{
-			Name:        "redis-result-exp",
-			Value:       cache.ResultExpiration,
-			Usage:       "Redis expiration in hours for result logs",
-			EnvVars:     []string{"REDIS_RESULT_EXP"},
-			Destination: &redisConfigValues.ResultExpirationHours,
-		},
-		&cli.IntFlag{
-			Name:        "redis-query-exp",
-			Value:       cache.QueryExpiration,
-			Usage:       "Redis expiration in hours for query logs",
-			EnvVars:     []string{"REDIS_QUERY_EXP"},
-			Destination: &redisConfigValues.QueryExpirationHours,
-		},
-		&cli.IntFlag{
 			Name:        "redis-conn-retry",
 			Value:       defaultRedisRetryTimeout,
 			Usage:       "Time in seconds to retry the connection to the cache, if set to 0 the service will stop if the connection fails",


### PR DESCRIPTION
Removing all references of logging status/result/query logs in cache/Redis, since it won't be enabled again as it was causing issues and it was just legacy code. Also removed the configuration parameters from JSON and `osctrl-admin` and `osctrl-tls` parameters for the same logging flags.