### PR TITLE
Fix to prevent queries not completing

### DIFF
--- a/queries/queries.go
+++ b/queries/queries.go
@@ -91,7 +91,7 @@ type NodeQuery struct {
 	gorm.Model
 	NodeID  uint   `gorm:"not null;index"`
 	QueryID uint   `gorm:"not null;index"`
-	Status  string `gorm:"type:varchar(8);default:'pending'"`
+	Status  string `gorm:"type:varchar(10);default:'pending'"`
 }
 
 // DistributedQueryTarget to keep target logic for queries


### PR DESCRIPTION
Fix for #577 

Schema for the table `node_queries` must be altered manually to expand its size. Use this query:

```
ALTER TABLE node_queries ALTER COLUMN status TYPE varchar (10);
```

This should resolve the issue.