### PR TITLE
Prevent nil pointer when loading any JSON configuration

### DIFF
--- a/admin/handlers/handlers.go
+++ b/admin/handlers/handlers.go
@@ -182,8 +182,10 @@ func WithDBLogger(dbfile string, config *backend.JSONConfigurationDB) HandlersOp
 			logger, err := logging.CreateLoggerDBConfig(*config)
 			if err != nil {
 				log.Err(err).Msg("error creating DB logger (config)")
-				logger.Enabled = false
-				logger.Database = nil
+				logger = &logging.LoggerDB{
+					Enabled:  false,
+					Database: nil,
+				}
 			}
 			h.DBLogger = logger
 			return
@@ -191,8 +193,10 @@ func WithDBLogger(dbfile string, config *backend.JSONConfigurationDB) HandlersOp
 		logger, err := logging.CreateLoggerDBFile(dbfile)
 		if err != nil {
 			log.Err(err).Msg("error creating DB logger (file)")
-			logger.Enabled = false
-			logger.Database = nil
+			logger = &logging.LoggerDB{
+				Enabled:  false,
+				Database: nil,
+			}
 		}
 		h.DBLogger = logger
 	}

--- a/admin/handlers/handlers.go
+++ b/admin/handlers/handlers.go
@@ -181,7 +181,7 @@ func WithDBLogger(dbfile string, config *backend.JSONConfigurationDB) HandlersOp
 			}
 			logger, err := logging.CreateLoggerDBConfig(*config)
 			if err != nil {
-				log.Err(err).Msg("error creating DB logger")
+				log.Err(err).Msg("error creating DB logger (config)")
 				logger.Enabled = false
 				logger.Database = nil
 			}
@@ -190,7 +190,7 @@ func WithDBLogger(dbfile string, config *backend.JSONConfigurationDB) HandlersOp
 		}
 		logger, err := logging.CreateLoggerDBFile(dbfile)
 		if err != nil {
-			log.Err(err).Msg("error creating DB logger")
+			log.Err(err).Msg("error creating DB logger (file)")
 			logger.Enabled = false
 			logger.Database = nil
 		}

--- a/admin/jwt.go
+++ b/admin/jwt.go
@@ -3,12 +3,13 @@ package main
 import (
 	"crypto/rsa"
 	"crypto/tls"
+	"fmt"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
-	"github.com/spf13/viper"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 // Function to load the configuration file
@@ -22,6 +23,9 @@ func loadJWTConfiguration(file string) (types.JSONConfigurationJWT, error) {
 	}
 	// JWT values
 	jwtRaw := viper.Sub(settings.AuthJWT)
+	if jwtRaw == nil {
+		return cfg, fmt.Errorf("JSON key %s not found in file %s", settings.AuthJWT, file)
+	}
 	if err := jwtRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}

--- a/admin/main.go
+++ b/admin/main.go
@@ -206,7 +206,7 @@ func loadConfiguration(file, service string) (types.JSONConfigurationAdmin, erro
 	// Admin values
 	adminRaw := viper.Sub(service)
 	if adminRaw == nil {
-		return cfg, fmt.Errorf("JSON key %s not found in %s", service, file)
+		return cfg, fmt.Errorf("JSON key %s not found in file %s", service, file)
 	}
 	if err := adminRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err

--- a/admin/oauth.go
+++ b/admin/oauth.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -26,6 +28,9 @@ func loadOAuth(file string) (JSONConfigurationOAuth, error) {
 	}
 	// OAuth values
 	oauthRaw := viper.Sub(settings.AuthOAuth)
+	if oauthRaw == nil {
+		return cfg, fmt.Errorf("JSON key %s not found in %s", settings.AuthOAuth, file)
+	}
 	if err := oauthRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}

--- a/admin/oidc.go
+++ b/admin/oidc.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"fmt"
 
 	"github.com/jmpsec/osctrl/settings"
-	"github.com/spf13/viper"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 // JSONConfigurationOIDC to keep all OIDC details for auth
@@ -30,6 +31,9 @@ func loadOIDC(file string) (JSONConfigurationOIDC, error) {
 	}
 	// OAuth values
 	oauthRaw := viper.Sub(settings.AuthOIDC)
+	if oauthRaw == nil {
+		return cfg, fmt.Errorf("JSON key %s not found in %s", settings.AuthOIDC, file)
+	}
 	if err := oauthRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}

--- a/admin/saml.go
+++ b/admin/saml.go
@@ -45,6 +45,9 @@ func loadSAML(file string) (JSONConfigurationSAML, error) {
 	}
 	// SAML values
 	samlRaw := viper.Sub(settings.AuthSAML)
+	if samlRaw == nil {
+		return cfg, fmt.Errorf("JSON key %s not found in %s", settings.AuthSAML, file)
+	}
 	if err := samlRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}

--- a/api/jwt.go
+++ b/api/jwt.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/jmpsec/osctrl/settings"
 	"github.com/jmpsec/osctrl/types"
 	"github.com/rs/zerolog/log"
@@ -17,8 +19,11 @@ func loadJWTConfiguration(file string) (types.JSONConfigurationJWT, error) {
 		return cfg, err
 	}
 	// JWT values
-	headersRaw := viper.Sub(settings.AuthJWT)
-	if err := headersRaw.Unmarshal(&cfg); err != nil {
+	jwtRaw := viper.Sub(settings.AuthJWT)
+	if jwtRaw == nil {
+		return cfg, fmt.Errorf("JSON key %s not found in %s", settings.AuthJWT, file)
+	}
+	if err := jwtRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
 	// No errors!

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -48,6 +48,9 @@ func LoadConfiguration(file, key string) (JSONConfigurationDB, error) {
 	}
 	// Backend values
 	dbRaw := viper.Sub(key)
+	if dbRaw == nil {
+		return config, fmt.Errorf("JSON key %s not found in %s", key, file)
+	}
 	if err := dbRaw.Unmarshal(&config); err != nil {
 		return config, err
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -46,8 +46,11 @@ func LoadConfiguration(file, key string) (JSONConfigurationRedis, error) {
 		return config, err
 	}
 	// Backend values
-	dbRaw := viper.Sub(key)
-	if err := dbRaw.Unmarshal(&config); err != nil {
+	redisRaw := viper.Sub(key)
+	if redisRaw == nil {
+		return config, fmt.Errorf("JSON key %s not found in %s", key, file)
+	}
+	if err := redisRaw.Unmarshal(&config); err != nil {
 		return config, err
 	}
 	// No errors!

--- a/carves/s3.go
+++ b/carves/s3.go
@@ -85,6 +85,9 @@ func LoadS3(file string) (types.S3Configuration, error) {
 		return _s3Cfg, err
 	}
 	cfgRaw := viper.Sub(settings.LoggingS3)
+	if cfgRaw == nil {
+		return _s3Cfg, fmt.Errorf("JSON key %s not found in %s", settings.LoggingS3, file)
+	}
 	if err := cfgRaw.Unmarshal(&_s3Cfg); err != nil {
 		return _s3Cfg, err
 	}

--- a/cli/api.go
+++ b/cli/api.go
@@ -68,7 +68,7 @@ func loadAPIConfiguration(file string) (JSONConfigurationAPI, error) {
 	// API values
 	apiRaw := viper.Sub(projectName)
 	if apiRaw == nil {
-		return config, fmt.Errorf("could not find key %s", projectName)
+		return config, fmt.Errorf("JSON key %s not found in %s", projectName, file)
 	}
 	if err := apiRaw.Unmarshal(&config); err != nil {
 		return config, err

--- a/logging/elastic.go
+++ b/logging/elastic.go
@@ -73,6 +73,9 @@ func LoadElastic(file string) (ElasticConfiguration, error) {
 		return _elasticCfg, err
 	}
 	cfgRaw := viper.Sub(settings.LoggingElastic)
+	if cfgRaw == nil {
+		return _elasticCfg, fmt.Errorf("JSON key %s not found in %s", settings.LoggingElastic, file)
+	}
 	if err := cfgRaw.Unmarshal(&_elasticCfg); err != nil {
 		return _elasticCfg, err
 	}

--- a/logging/graylog.go
+++ b/logging/graylog.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -32,8 +33,10 @@ func LoadGraylog(file string) (GraylogConfiguration, error) {
 		return _graylogCfg, err
 	}
 	cfgRaw := viper.Sub(settings.LoggingGraylog)
-	err = cfgRaw.Unmarshal(&_graylogCfg)
-	if err != nil {
+	if cfgRaw == nil {
+		return _graylogCfg, fmt.Errorf("JSON key %s not found in %s", settings.LoggingGraylog, file)
+	}
+	if err := cfgRaw.Unmarshal(&_graylogCfg); err != nil {
 		return _graylogCfg, err
 	}
 	// No errors!

--- a/logging/kinesis.go
+++ b/logging/kinesis.go
@@ -65,6 +65,9 @@ func LoadKinesis(file string) (KinesisConfiguration, error) {
 		return _kinesisCfg, err
 	}
 	cfgRaw := viper.Sub(settings.LoggingSplunk)
+	if cfgRaw == nil {
+		return _kinesisCfg, fmt.Errorf("JSON key %s not found in %s", settings.LoggingSplunk, file)
+	}
 	if err := cfgRaw.Unmarshal(&_kinesisCfg); err != nil {
 		return _kinesisCfg, err
 	}

--- a/logging/logstash.go
+++ b/logging/logstash.go
@@ -61,6 +61,9 @@ func LoadLogstash(file string) (LogstashConfiguration, error) {
 		return _logstashCfg, err
 	}
 	cfgRaw := viper.Sub(settings.LoggingLogstash)
+	if cfgRaw == nil {
+		return _logstashCfg, fmt.Errorf("JSON key %s not found in %s", settings.LoggingLogstash, file)
+	}
 	if err := cfgRaw.Unmarshal(&_logstashCfg); err != nil {
 		return _logstashCfg, err
 	}

--- a/logging/s3.go
+++ b/logging/s3.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -72,6 +73,9 @@ func LoadS3(file string) (types.S3Configuration, error) {
 		return _s3Cfg, err
 	}
 	cfgRaw := viper.Sub(settings.LoggingS3)
+	if cfgRaw == nil {
+		return _s3Cfg, fmt.Errorf("JSON key %s not found in %s", settings.LoggingS3, file)
+	}
 	if err := cfgRaw.Unmarshal(&_s3Cfg); err != nil {
 		return _s3Cfg, err
 	}

--- a/logging/splunk.go
+++ b/logging/splunk.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -54,6 +55,9 @@ func LoadSplunk(file string) (SlunkConfiguration, error) {
 		return _splunkCfg, err
 	}
 	cfgRaw := viper.Sub(settings.LoggingSplunk)
+	if cfgRaw == nil {
+		return _splunkCfg, fmt.Errorf("JSON key %s not found in %s", settings.LoggingSplunk, file)
+	}
 	if err := cfgRaw.Unmarshal(&_splunkCfg); err != nil {
 		return _splunkCfg, err
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -35,6 +35,9 @@ func LoadConfiguration() (Configuration, error) {
 		return _metricsCfg, err
 	}
 	cfgRaw := viper.Sub(metricsName)
+	if cfgRaw == nil {
+		return _metricsCfg, fmt.Errorf("JSON key %s not found in %s", metricsName, metricsConfigFile)
+	}
 	if err := cfgRaw.Unmarshal(&_metricsCfg); err != nil {
 		return _metricsCfg, err
 	}


### PR DESCRIPTION
When loading any JSON configuration file, if the key was missing, it would leave a nil pointer that could crash the service. This PR prevents that from happening.