### PR TITLE
Handle GET/POST if for SAML routes

### DIFF
--- a/admin/auth.go
+++ b/admin/auth.go
@@ -47,23 +47,19 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 		case settings.AuthSAML:
 			samlSession, err := samlMiddleware.Session.GetSession(r)
 			if err != nil {
-				log.Err(err).Msg("GetSession")
 				http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
 				return
 			}
 			if samlSession == nil {
-				log.Error().Msg("No SAML session")
 				http.Redirect(w, r, samlConfig.LogoutURL, http.StatusFound)
 				return
 			}
 			jwtSessionClaims, ok := samlSession.(samlsp.JWTSessionClaims)
 			if !ok {
-				log.Error().Msg("JWTSessionClaims")
 				return
 			}
 			samlUser := jwtSessionClaims.Subject
 			if samlUser == "" {
-				log.Error().Msg("SAML user is empty")
 				return
 			}
 			// Check if user is already authenticated

--- a/admin/main.go
+++ b/admin/main.go
@@ -917,7 +917,10 @@ func osctrlAdminService() {
 	adminMux.Handle("POST "+logoutPath, handlerAuthCheck(http.HandlerFunc(handlersAdmin.LogoutPOSTHandler)))
 	// SAML ACS
 	if adminConfig.Auth == settings.AuthSAML {
-		adminMux.Handle("/saml/", samlMiddleware)
+		adminMux.Handle("GET /saml/metadata", samlMiddleware)
+		adminMux.Handle("POST /saml/metadata", samlMiddleware)
+		adminMux.Handle("GET /saml/acs", samlMiddleware)
+		adminMux.Handle("POST /saml/acs", samlMiddleware)
 		adminMux.HandleFunc("GET "+loginPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
 		})

--- a/admin/main.go
+++ b/admin/main.go
@@ -917,8 +917,7 @@ func osctrlAdminService() {
 	adminMux.Handle("POST "+logoutPath, handlerAuthCheck(http.HandlerFunc(handlersAdmin.LogoutPOSTHandler)))
 	// SAML ACS
 	if adminConfig.Auth == settings.AuthSAML {
-		adminMux.Handle("GET /saml/", samlMiddleware)
-		adminMux.Handle("POST /saml/", samlMiddleware)
+		adminMux.Handle("/saml/", samlMiddleware)
 		adminMux.HandleFunc("GET "+loginPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
 		})

--- a/admin/main.go
+++ b/admin/main.go
@@ -917,10 +917,10 @@ func osctrlAdminService() {
 	adminMux.Handle("POST "+logoutPath, handlerAuthCheck(http.HandlerFunc(handlersAdmin.LogoutPOSTHandler)))
 	// SAML ACS
 	if adminConfig.Auth == settings.AuthSAML {
-		adminMux.Handle("GET /saml/metadata", samlMiddleware)
-		adminMux.Handle("POST /saml/metadata", samlMiddleware)
 		adminMux.Handle("GET /saml/acs", samlMiddleware)
 		adminMux.Handle("POST /saml/acs", samlMiddleware)
+		adminMux.Handle("GET /saml/metadata", samlMiddleware)
+		adminMux.Handle("POST /saml/metadata", samlMiddleware)
 		adminMux.HandleFunc("GET "+loginPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
 		})

--- a/admin/main.go
+++ b/admin/main.go
@@ -918,6 +918,7 @@ func osctrlAdminService() {
 	// SAML ACS
 	if adminConfig.Auth == settings.AuthSAML {
 		adminMux.Handle("GET /saml/", samlMiddleware)
+		adminMux.Handle("POST /saml/", samlMiddleware)
 		adminMux.HandleFunc("GET "+loginPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, samlConfig.LoginURL, http.StatusFound)
 		})

--- a/admin/saml.go
+++ b/admin/saml.go
@@ -51,8 +51,35 @@ func loadSAML(file string) (JSONConfigurationSAML, error) {
 	if err := samlRaw.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
+	// Verify SAML configuration
+	if err := verifySAML(cfg); err != nil {
+		return cfg, err
+	}
 	// No errors!
 	return cfg, nil
+}
+
+// Function to verify SAML configuration
+func verifySAML(cfg JSONConfigurationSAML) error {
+	if cfg.CertPath == "" {
+		return fmt.Errorf("Missing CertPath")
+	}
+	if cfg.KeyPath == "" {
+		return fmt.Errorf("Missing KeyPath")
+	}
+	if cfg.MetaDataURL == "" {
+		return fmt.Errorf("Missing MetaDataURL")
+	}
+	if cfg.RootURL == "" {
+		return fmt.Errorf("Missing RootURL")
+	}
+	if cfg.LoginURL == "" {
+		return fmt.Errorf("Missing LoginURL")
+	}
+	if cfg.LogoutURL == "" {
+		return fmt.Errorf("Missing LogoutURL")
+	}
+	return nil
 }
 
 // Function to initialize variables when using SAML for authentication


### PR DESCRIPTION
After the migration to the native `http.ServeMux`, the routes for the `/saml/` paths were only catching `GET` requests. It was making SAML to not work correctly. This fixes the issue and also added a verifier for the SAML JSON configuration so there won't be any nil pointers and #338 can be closed.