### PR TITLE
Show AJAX error in the browser console

### DIFF
--- a/admin/static/js/functions.js
+++ b/admin/static/js/functions.js
@@ -16,13 +16,22 @@ function sendGetRequest(req_url, _modal, _callback) {
       }
     },
     error: function (jqXhr, textStatus, errorThrown) {
-      var _clientmsg = 'Client: ' + errorThrown;
+      console.log(jqXhr);
+      if (jqXhr.status === 302) {
+        window.location.replace(jqXhr.responseText);
+      }
+      var _clientmsg = "Client: " + errorThrown;
       var _serverJSON = $.parseJSON(jqXhr.responseText);
       var _servermsg = 'Server: ' + _serverJSON.message;
       $("#errorModalMessageClient").text(_clientmsg);
       console.log(_clientmsg);
       $("#errorModalMessageServer").text(_servermsg);
       $("#errorModal").modal();
+    },
+    statusCode: {
+      302: function() {
+        console.log('302');
+      }
     }
   });
 }
@@ -30,13 +39,13 @@ function sendGetRequest(req_url, _modal, _callback) {
 function sendPostRequest(req_data, req_url, _redir, _modal, _callback) {
   $.ajax({
     url: req_url,
-    dataType: 'json',
-    type: 'POST',
-    contentType: 'application/json',
+    dataType: "json",
+    type: "POST",
+    contentType: "application/json",
     data: JSON.stringify(req_data),
     processData: false,
     success: function (data, textStatus, jQxhr) {
-      console.log('OK');
+      console.log("OK");
       console.log(data);
       if (_modal) {
         $("#successModalMessage").text(data.message);
@@ -50,13 +59,22 @@ function sendPostRequest(req_data, req_url, _redir, _modal, _callback) {
       }
     },
     error: function (jqXhr, textStatus, errorThrown) {
-      var _clientmsg = 'Client: ' + errorThrown;
+      console.log(jqXhr);
+      if (jqXhr.status === 302) {
+        window.location.replace(jqXhr.responseText);
+      }
+      var _clientmsg = "Client: " + errorThrown;
       var _serverJSON = $.parseJSON(jqXhr.responseText);
-      var _servermsg = 'Server: ' + _serverJSON.message;
+      var _servermsg = "Server: " + _serverJSON.message;
       $("#errorModalMessageClient").text(_clientmsg);
       console.log(_clientmsg);
       $("#errorModalMessageServer").text(_servermsg);
       $("#errorModal").modal();
+    },
+    statusCode: {
+      302: function () {
+        console.log("302");
+      },
     }
   });
 }

--- a/admin/static/js/functions.js
+++ b/admin/static/js/functions.js
@@ -16,9 +16,6 @@ function sendGetRequest(req_url, _modal, _callback) {
       }
     },
     error: function (jqXhr, textStatus, errorThrown) {
-      if (jqXhr.status === 302) {
-        window.location.replace(jqXhr.responseText);
-      }
       var _clientmsg = "Client: " + errorThrown;
       var _serverJSON = $.parseJSON(jqXhr.responseText);
       var _servermsg = 'Server: ' + _serverJSON.message;
@@ -26,11 +23,6 @@ function sendGetRequest(req_url, _modal, _callback) {
       console.log(_clientmsg);
       $("#errorModalMessageServer").text(_servermsg);
       $("#errorModal").modal();
-    },
-    statusCode: {
-      302: function() {
-        console.log('302');
-      }
     }
   });
 }
@@ -58,9 +50,6 @@ function sendPostRequest(req_data, req_url, _redir, _modal, _callback) {
       }
     },
     error: function (jqXhr, textStatus, errorThrown) {
-      if (jqXhr.status === 302) {
-        window.location.replace(jqXhr.responseText);
-      }
       var _clientmsg = "Client: " + errorThrown;
       var _serverJSON = $.parseJSON(jqXhr.responseText);
       var _servermsg = "Server: " + _serverJSON.message;
@@ -68,11 +57,6 @@ function sendPostRequest(req_data, req_url, _redir, _modal, _callback) {
       console.log(_clientmsg);
       $("#errorModalMessageServer").text(_servermsg);
       $("#errorModal").modal();
-    },
-    statusCode: {
-      302: function () {
-        console.log("302");
-      },
     }
   });
 }

--- a/admin/static/js/functions.js
+++ b/admin/static/js/functions.js
@@ -16,7 +16,6 @@ function sendGetRequest(req_url, _modal, _callback) {
       }
     },
     error: function (jqXhr, textStatus, errorThrown) {
-      console.log(jqXhr);
       if (jqXhr.status === 302) {
         window.location.replace(jqXhr.responseText);
       }
@@ -59,7 +58,6 @@ function sendPostRequest(req_data, req_url, _redir, _modal, _callback) {
       }
     },
     error: function (jqXhr, textStatus, errorThrown) {
-      console.log(jqXhr);
       if (jqXhr.status === 302) {
         window.location.replace(jqXhr.responseText);
       }

--- a/admin/templates/carves.html
+++ b/admin/templates/carves.html
@@ -94,6 +94,11 @@
             dataSrc: function(json) {
               $('.card-header').removeClass("bg-danger");
               return json.data;
+            },
+            error: function(xhr, error, code) {
+              console.log("Error: " + error);
+              console.log("Error code: " + code);
+              console.log("Error response: " + xhr.responseText);
             }
           },
           columns : [

--- a/admin/templates/carves.html
+++ b/admin/templates/carves.html
@@ -96,6 +96,7 @@
               return json.data;
             },
             error: function(xhr, error, code) {
+              $('.card-header').addClass("bg-danger");
               console.log("Error: " + error);
               console.log("Error code: " + code);
               console.log("Error response: " + xhr.responseText);

--- a/admin/templates/node.html
+++ b/admin/templates/node.html
@@ -560,6 +560,11 @@
             dataSrc: function(json) {
               $('#status-card-header').removeClass("bg-danger");
               return json.data;
+            },
+            error: function(xhr, error, code) {
+              console.log("Error: " + error);
+              console.log("Error code: " + code);
+              console.log("Error response: " + xhr.responseText);
             }
           },
           columns : [
@@ -614,6 +619,11 @@
             dataSrc: function(json) {
               $('#result-card-header').removeClass("bg-danger");
               return json.data;
+            },
+            error: function(xhr, error, code) {
+              console.log("Error: " + error);
+              console.log("Error code: " + code);
+              console.log("Error response: " + xhr.responseText);
             }
           },
           columns : [

--- a/admin/templates/node.html
+++ b/admin/templates/node.html
@@ -562,6 +562,7 @@
               return json.data;
             },
             error: function(xhr, error, code) {
+              $('#status-card-header').addClass("bg-danger");
               console.log("Error: " + error);
               console.log("Error code: " + code);
               console.log("Error response: " + xhr.responseText);
@@ -621,6 +622,7 @@
               return json.data;
             },
             error: function(xhr, error, code) {
+              $('#result-card-header').addClass("bg-danger");
               console.log("Error: " + error);
               console.log("Error code: " + code);
               console.log("Error response: " + xhr.responseText);

--- a/admin/templates/queries-logs.html
+++ b/admin/templates/queries-logs.html
@@ -135,6 +135,7 @@
               return json.data;
             },
             error: function(xhr, error, code) {
+              $('.card-header').addClass("bg-danger");
               console.log("Error: " + error);
               console.log("Error code: " + code);
               console.log("Error response: " + xhr.responseText);

--- a/admin/templates/queries-logs.html
+++ b/admin/templates/queries-logs.html
@@ -133,6 +133,11 @@
             dataSrc: function(json) {
               $('#status-card-header').removeClass("bg-danger");
               return json.data;
+            },
+            error: function(xhr, error, code) {
+              console.log("Error: " + error);
+              console.log("Error code: " + code);
+              console.log("Error response: " + xhr.responseText);
             }
           },
           columns : [

--- a/admin/templates/queries.html
+++ b/admin/templates/queries.html
@@ -95,6 +95,7 @@
               return json.data;
             },
             error: function(xhr, error, code) {
+              $('.card-header').addClass("bg-danger");
               console.log("Error: " + error);
               console.log("Error code: " + code);
               console.log("Error response: " + xhr.responseText);

--- a/admin/templates/queries.html
+++ b/admin/templates/queries.html
@@ -93,6 +93,11 @@
             dataSrc: function(json) {
               $('.card-header').removeClass("bg-danger");
               return json.data;
+            },
+            error: function(xhr, error, code) {
+              console.log("Error: " + error);
+              console.log("Error code: " + code);
+              console.log("Error response: " + xhr.responseText);
             }
           },
           columns : [

--- a/admin/templates/saved.html
+++ b/admin/templates/saved.html
@@ -92,6 +92,7 @@
               return json.data;
             },
             error: function(xhr, error, code) {
+              $('.card-header').addClass("bg-danger");
               console.log("Error: " + error);
               console.log("Error code: " + code);
               console.log("Error response: " + xhr.responseText);

--- a/admin/templates/saved.html
+++ b/admin/templates/saved.html
@@ -90,6 +90,11 @@
             dataSrc: function(json) {
               $('.card-header').removeClass("bg-danger");
               return json.data;
+            },
+            error: function(xhr, error, code) {
+              console.log("Error: " + error);
+              console.log("Error code: " + code);
+              console.log("Error response: " + xhr.responseText);
             }
           },
           columns : [

--- a/admin/templates/table.html
+++ b/admin/templates/table.html
@@ -128,11 +128,25 @@
                "<'row'<'col-sm-12 col-md-4'B><'col-sm-12 col-md-4 text-center'i><'col-sm-12 col-md-4'p>>",
           processing : true,
           order : [[ 8, "desc" ]],
-          ajax : {
-            url: "/json/{{ .Selector }}/{{ .SelectorName }}/{{ .Target }}",
-            dataSrc: function(json) {
+          ajax : async (data, callback, settings) => {
+            try {
+              const response = await fetch("/json/{{ .Selector }}/{{ .SelectorName }}/{{ .Target }}", {
+                method: 'GET',
+                redirect: 'manual' // Disable automatic redirects
+              });
+              if (response.type === 'opaqueredirect' || response.status === 302) {
+                const redirectUrl = response.headers.get('Location');
+                if (redirectUrl) {
+                  window.location.href = redirectUrl;
+                  return;
+                }
+              }
+              const jsonData = await response.json();
               $('.card-header').removeClass("bg-danger");
-              return json.data;
+              callback(jsonData);
+            } catch (error) {
+              console.error(error);
+              $('.card-header').addClass("bg-danger");
             }
           },
           columns : [

--- a/admin/templates/table.html
+++ b/admin/templates/table.html
@@ -130,18 +130,14 @@
           order : [[ 8, "desc" ]],
           ajax : {
             url: "/json/{{ .Selector }}/{{ .SelectorName }}/{{ .Target }}",
-            dataSrc: function (json, status, xhr) {
+            dataSrc: function(json) {
               $('.card-header').removeClass("bg-danger");
               return json.data;
             },
-            error: function (xhr) {
-              if (xhr.status === 302) {
-                var redirectUrl = xhr.getResponseHeader('Location');
-                if (redirectUrl) {
-                    window.location.href = redirectUrl;
-                }
-              }
-              $('.card-header').addClass("bg-danger");
+            error: function(xhr, error, code) {
+              console.log("Error: " + error);
+              console.log("Error code: " + code);
+              console.log("Error response: " + xhr.responseText);
             }
           },
           columns : [

--- a/admin/templates/table.html
+++ b/admin/templates/table.html
@@ -135,6 +135,7 @@
               return json.data;
             },
             error: function(xhr, error, code) {
+              $('.card-header').addClass("bg-danger");
               console.log("Error: " + error);
               console.log("Error code: " + code);
               console.log("Error response: " + xhr.responseText);

--- a/admin/templates/table.html
+++ b/admin/templates/table.html
@@ -128,25 +128,15 @@
                "<'row'<'col-sm-12 col-md-4'B><'col-sm-12 col-md-4 text-center'i><'col-sm-12 col-md-4'p>>",
           processing : true,
           order : [[ 8, "desc" ]],
-          ajax : async (data, callback, settings) => {
-            try {
-              const response = await fetch("/json/{{ .Selector }}/{{ .SelectorName }}/{{ .Target }}", {
-                method: 'GET',
-                redirect: 'manual' // Disable automatic redirects
-              });
-              if (response.type === 'opaqueredirect' || response.status === 302) {
-                const redirectUrl = response.headers.get('Location');
-                if (redirectUrl) {
-                  window.location.href = redirectUrl;
-                  return;
-                }
+          ajax : {
+            url: "/json/{{ .Selector }}/{{ .SelectorName }}/{{ .Target }}",
+            dataSrc: function (json, status, xhr) {
+              if (xhr.status === 302) {
+                window.location.href = xhr.getResponseHeader("Location");
+                return [];
               }
-              const jsonData = await response.json();
               $('.card-header').removeClass("bg-danger");
-              callback(jsonData);
-            } catch (error) {
-              console.error(error);
-              $('.card-header').addClass("bg-danger");
+              return json.data;
             }
           },
           columns : [

--- a/admin/templates/table.html
+++ b/admin/templates/table.html
@@ -131,12 +131,17 @@
           ajax : {
             url: "/json/{{ .Selector }}/{{ .SelectorName }}/{{ .Target }}",
             dataSrc: function (json, status, xhr) {
-              if (xhr.status === 302) {
-                window.location.href = xhr.getResponseHeader("Location");
-                return [];
-              }
               $('.card-header').removeClass("bg-danger");
               return json.data;
+            },
+            error: function (xhr) {
+              if (xhr.status === 302) {
+                var redirectUrl = xhr.getResponseHeader('Location');
+                if (redirectUrl) {
+                    window.location.href = redirectUrl;
+                }
+              }
+              $('.card-header').addClass("bg-danger");
             }
           },
           columns : [


### PR DESCRIPTION
Since AJAX requests must follow 302s transparently, is not possible to catch when a request to a data JSON endpoint redirects to something else (login page), so it needs changes to the server response. Also tried to use the `fetch` method in JavaScript but it was not working correctly and code was too messy. So I just output the error in the console and #138 can be closed as not possible.