### PR TITLE
Decorating tags with environment name via `osctrl-api`

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -595,6 +595,7 @@ func osctrlAPIService() {
 	muxAPI.Handle("GET "+_apiPath(apiPlatformsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.PlatformsHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiPlatformsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.PlatformsEnvHandler)))
 	// API: environments
+	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/map/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentMapHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentHandler)))
 	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvEnrollHandler)))
 	muxAPI.Handle("POST "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{action}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvEnrollActionsHandler)))

--- a/cli/api-environment.go
+++ b/cli/api-environment.go
@@ -38,6 +38,20 @@ func (api *OsctrlAPI) GetEnvironment(identifier string) (environments.TLSEnviron
 	return e, nil
 }
 
+// GetEnvMap to retrieve a map of environments by ID
+func (api *OsctrlAPI) GetEnvMap() (environments.MapEnvByID, error) {
+	var envMap environments.MapEnvByID
+	reqURL := fmt.Sprintf("%s%s%s/map/id", api.Configuration.URL, APIPath, APIEnvironments)
+	rawE, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return envMap, fmt.Errorf("error api request - %v - %s", err, string(rawE))
+	}
+	if err := json.Unmarshal(rawE, &envMap); err != nil {
+		return envMap, fmt.Errorf("can not parse body - %v", err)
+	}
+	return envMap, nil
+}
+
 // ExtendEnrollment to extend in time the enrollment URL of an environment
 func (api *OsctrlAPI) ExtendEnrollment(identifier string) (string, error) {
 	return api.ActionEnrollmentRemove(identifier, settings.ActionExtend, "enroll", nil)

--- a/environments/environments.go
+++ b/environments/environments.go
@@ -96,6 +96,19 @@ type TLSEnvironment struct {
 // MapEnvironments to hold the TLS environments by name and UUID
 type MapEnvironments map[string]TLSEnvironment
 
+// NameUUID to just hold the environment name and UUID
+type NameUUID struct {
+	Name string
+	UUID string
+	ID   uint
+}
+
+// MapEnvByID to hold the environments name and UUID by ID
+type MapEnvByID map[uint]NameUUID
+
+// MapEnvByString to hold the environments name and UUID by string
+type MapEnvByString map[string]NameUUID
+
 // Environment keeps all TLS Environments
 type Environment struct {
 	DB *gorm.DB
@@ -252,6 +265,43 @@ func (environment *Environment) GetMap() (MapEnvironments, error) {
 	for _, e := range all {
 		_map[e.Name] = e
 		_map[e.UUID] = e
+	}
+	return _map, nil
+}
+
+// GetMapByID returns a smaller map of environments by ID
+func (environment *Environment) GetMapByID() (MapEnvByID, error) {
+	all, err := environment.All()
+	if err != nil {
+		return nil, fmt.Errorf("error getting environments %v", err)
+	}
+	_map := make(MapEnvByID)
+	for _, e := range all {
+		_n := NameUUID{
+			Name: e.Name,
+			UUID: e.UUID,
+			ID:   e.ID,
+		}
+		_map[e.ID] = _n
+	}
+	return _map, nil
+}
+
+// GetMapByString returns a smaller map of environments by string (name and UUID)
+func (environment *Environment) GetMapByString() (MapEnvByString, error) {
+	all, err := environment.All()
+	if err != nil {
+		return nil, fmt.Errorf("error getting environments %v", err)
+	}
+	_map := make(MapEnvByString)
+	for _, e := range all {
+		_n := NameUUID{
+			Name: e.Name,
+			UUID: e.UUID,
+			ID:   e.ID,
+		}
+		_map[e.Name] = _n
+		_map[e.UUID] = _n
 	}
 	return _map, nil
 }


### PR DESCRIPTION
* Adding new path for `osctrl-api` to return a map with all environments by ID, with the name and the UUID
* Utilize the new path with `osctrl-cli` to decorate tags with environment name