### PR TITLE
Fix to `IsActive` utility function in nodes package

### DIFF
--- a/pkg/nodes/utils.go
+++ b/pkg/nodes/utils.go
@@ -5,36 +5,36 @@ import (
 	"time"
 )
 
-// Helper to get what is the last seen time for a node
+// Helper to get what is the last seen time for a node, inactive should be negative to check for past activity
 func IsActive(n OsqueryNode, inactive int64) bool {
 	now := time.Now()
 	// Check status if not empty/zero
 	if !n.LastStatus.IsZero() {
-		if n.LastStatus.Sub(now).Hours() < math.Abs(float64(inactive)) {
+		if math.Abs(n.LastStatus.Sub(now).Hours()) < math.Abs(float64(inactive)) {
 			return true
 		}
 	}
 	// Check result if not empty/zero
 	if !n.LastResult.IsZero() {
-		if n.LastResult.Sub(now).Hours() < math.Abs(float64(inactive)) {
+		if math.Abs(n.LastResult.Sub(now).Hours()) < math.Abs(float64(inactive)) {
 			return true
 		}
 	}
 	// Check config if not empty/zero
 	if !n.LastConfig.IsZero() {
-		if n.LastConfig.Sub(now).Hours() < math.Abs(float64(inactive)) {
+		if math.Abs(n.LastConfig.Sub(now).Hours()) < math.Abs(float64(inactive)) {
 			return true
 		}
 	}
 	// Check query read if not empty/zero
 	if !n.LastQueryRead.IsZero() {
-		if n.LastQueryRead.Sub(now).Hours() < math.Abs(float64(inactive)) {
+		if math.Abs(n.LastQueryRead.Sub(now).Hours()) < math.Abs(float64(inactive)) {
 			return true
 		}
 	}
 	// Check query write if not empty/zero
 	if !n.LastQueryWrite.IsZero() {
-		if n.LastQueryWrite.Sub(now).Hours() < math.Abs(float64(inactive)) {
+		if math.Abs(n.LastQueryWrite.Sub(now).Hours()) < math.Abs(float64(inactive)) {
 			return true
 		}
 	}

--- a/pkg/nodes/utils_test.go
+++ b/pkg/nodes/utils_test.go
@@ -1,0 +1,32 @@
+package nodes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsActive(t *testing.T) {
+	now := time.Now()
+	node := OsqueryNode{
+		LastStatus:     now.Add(-time.Minute * 50),
+		LastResult:     now.Add(-time.Minute * 50),
+		LastConfig:     now.Add(-time.Minute * 50),
+		LastQueryRead:  now.Add(-time.Minute * 50),
+		LastQueryWrite: now.Add(-time.Minute * 50),
+	}
+	assert.True(t, IsActive(node, -1))
+}
+
+func TestIsActiveNegative(t *testing.T) {
+	now := time.Now()
+	node := OsqueryNode{
+		LastStatus:     now.Add(-time.Hour * 6),
+		LastResult:     now.Add(-time.Hour * 12),
+		LastConfig:     now.Add(-time.Hour * 8),
+		LastQueryRead:  now.Add(-time.Hour * 6),
+		LastQueryWrite: now.Add(-time.Hour * 7),
+	}
+	assert.False(t, IsActive(node, -5))
+}


### PR DESCRIPTION
Adding tests to the utility function `IsActive` for nodes and small fix to compare times in absolute values.