### PR TITLE
Assign the cache client when initializing the nodes manager

### DIFF
--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -91,13 +91,17 @@ type StatsData struct {
 
 // NodeManager to handle all nodes of the system
 type NodeManager struct {
-	DB *gorm.DB
+	DB    *gorm.DB
+	Cache *redis.Client
 }
 
 // CreateNodes to initialize the nodes struct and its tables
 func CreateNodes(backend *gorm.DB, cache *redis.Client) *NodeManager {
 	var n *NodeManager
-	n = &NodeManager{DB: backend}
+	n = &NodeManager{
+		DB:    backend,
+		Cache: cache,
+	}
 	// table osquery_nodes
 	if err := backend.AutoMigrate(&OsqueryNode{}); err != nil {
 		log.Fatal().Msgf("Failed to AutoMigrate table (osquery_nodes): %v", err)


### PR DESCRIPTION
Follow up change for https://github.com/jmpsec/osctrl/pull/609 to assign the cache client when initializing the nodes manager.