### PR TITLE
Use the `last_seen` field in the `node.html` template

### DIFF
--- a/cmd/admin/templates/node.html
+++ b/cmd/admin/templates/node.html
@@ -256,42 +256,10 @@
                             </div>
                             <div class="row">
                               <label class="col-md-3 col-form-label">
-                                <small><b>Last Status</b></small>
+                                <small><b>Last Seen</b></small>
                               </label>
                               <div class="col-md-9 col-form-label">
-                                <p class="form-control-static">{{ pastFutureTimes .LastStatus }}</p>
-                              </div>
-                            </div>
-                            <div class="row">
-                              <label class="col-md-3 col-form-label">
-                                <small><b>Last Result</b></small>
-                              </label>
-                              <div class="col-md-9 col-form-label">
-                                <p class="form-control-static">{{ pastFutureTimes .LastResult }}</p>
-                              </div>
-                            </div>
-                            <div class="row">
-                              <label class="col-md-3 col-form-label">
-                                <small><b>Last Config</b></small>
-                              </label>
-                              <div class="col-md-9 col-form-label">
-                                <p class="form-control-static">{{ pastFutureTimes .LastConfig }}</p>
-                              </div>
-                            </div>
-                            <div class="row">
-                              <label class="col-md-3 col-form-label">
-                                <small><b>Query Read</b></small>
-                              </label>
-                              <div class="col-md-9 col-form-label">
-                                <p class="form-control-static">{{ pastFutureTimes .LastQueryRead }}</p>
-                              </div>
-                            </div>
-                            <div class="row">
-                              <label class="col-md-3 col-form-label">
-                                <small><b>Query Write</b></small>
-                              </label>
-                              <div class="col-md-9 col-form-label">
-                                <p class="form-control-static">{{ pastFutureTimes .LastQueryWrite }}</p>
+                                <p class="form-control-static">{{ pastFutureTimes .LastSeen }}</p>
                               </div>
                             </div>
                             <div class="row">

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -2019,19 +2019,7 @@ components:
           format: int32
         RawEnrollment:
           type: string
-        LastStatus:
-          type: string
-          format: date-time
-        LastResult:
-          type: string
-          format: date-time
-        LastConfig:
-          type: string
-          format: date-time
-        LastQueryRead:
-          type: string
-          format: date-time
-        LastQueryWrite:
+        LastSeen:
           type: string
           format: date-time
         UserID:


### PR DESCRIPTION
With the changes landed in #607 some of the node columns were removed and a new one was added to keep when the node was last seen. This PR fixes the HTML template for `osctrl-admin` to prevent accessing the removed fields.
Also updated the OpenAPI yaml.