### PR TITLE
Add metrics for log processing and batch flush durations

### DIFF
--- a/cmd/tls/handlers/metrics.go
+++ b/cmd/tls/handlers/metrics.go
@@ -8,6 +8,7 @@ const (
 	StatusCode    = "status_code"
 	Environment   = "osctrl_env"
 	RequestType   = "type"
+	LogType       = "log_type"
 )
 
 var (
@@ -21,9 +22,27 @@ var (
 		Help:    "The size of requests",
 		Buckets: []float64{100, 1000, 10000, 100000, 1000000},
 	}, []string{Environment, RequestType})
+	logProcessDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "osctrl_tls_log_process_duration_seconds",
+		Help:    "The duration of log/scheduled query processing",
+		Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10},
+	}, []string{Environment, LogType})
+	distributedQueryProcessingDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "osctrl_tls_distributed_query_process_duration_seconds",
+		Help:    "The duration of distributed query result processing",
+		Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10},
+	}, []string{Environment})
+	batchFlushDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "osctrl_tls_batch_flush_duration_seconds",
+		Help:    "The duration of batch data flushing to backend",
+		Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5},
+	}, []string{"operation"})
 )
 
 func RegisterMetrics(reg prometheus.Registerer) {
 	reg.MustRegister(requestDuration)
 	reg.MustRegister(requestSize)
+	reg.MustRegister(logProcessDuration)
+	reg.MustRegister(distributedQueryProcessingDuration)
+	reg.MustRegister(batchFlushDuration)
 }

--- a/cmd/tls/handlers/writers.go
+++ b/cmd/tls/handlers/writers.go
@@ -77,21 +77,43 @@ func (bw *batchWriter) run() {
 
 // flush performs the bulk update for a batch of events.
 func (bw *batchWriter) flush(batch map[uint]lastSeenUpdate) {
+	start := time.Now()
+	batchSize := len(batch)
 
-	nodeIDs := make([]uint, 0, len(batch))
+	nodeIDs := make([]uint, 0, batchSize)
 	for _, ev := range batch {
 		nodeIDs = append(nodeIDs, ev.NodeID)
 
 		// Update the node's IP address.
 		// Since the IP address changes infrequently, no need to update in bulk.
 		if ev.IP != "" {
+			ipStart := time.Now()
 			if err := bw.nodesRepo.UpdateIP(ev.NodeID, ev.IP); err != nil {
 				log.Err(err).Uint("node_id", ev.NodeID).Str("ip", ev.IP).Msg("updating IP failed")
 			}
+			ipDuration := time.Since(ipStart).Seconds()
+			// Record IP update duration
+			batchFlushDuration.WithLabelValues("ip_update").Observe(ipDuration)
 		}
 	}
-	log.Info().Int("count", len(batch)).Msg("flushed batch")
+
+	log.Info().Int("count", batchSize).Msg("flushing batch")
+
+	// Measure last_seen batch update duration
+	lastSeenStart := time.Now()
 	if err := bw.nodesRepo.RefreshLastSeenBatch(nodeIDs); err != nil {
 		log.Err(err).Msg("refreshing last seen batch failed")
 	}
+	lastSeenDuration := time.Since(lastSeenStart).Seconds()
+
+	// Record total flush duration and batch last_seen update duration
+	totalDuration := time.Since(start).Seconds()
+	batchFlushDuration.WithLabelValues("total").Observe(totalDuration)
+	batchFlushDuration.WithLabelValues("last_seen_update").Observe(lastSeenDuration)
+
+	log.Info().
+		Int("count", batchSize).
+		Float64("duration_seconds", totalDuration).
+		Float64("last_seen_update_seconds", lastSeenDuration).
+		Msg("batch flush completed")
 }


### PR DESCRIPTION
Introduce metrics to track the duration of log processing, distributed query processing, and batch flushing operations. 

It helps us to measure the time spent on the background tasks.