### PR TITLE
Using new flags from config pkg in `osctrl-api`

### DIFF
--- a/cmd/api/auth.go
+++ b/cmd/api/auth.go
@@ -27,9 +27,9 @@ func extractHeaderToken(r *http.Request) string {
 }
 
 // Handler to check access to a resource based on the authentication enabled
-func handlerAuthCheck(h http.Handler) http.Handler {
+func handlerAuthCheck(h http.Handler, auth, jwtSecret string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch apiConfig.Auth {
+		switch auth {
 		case config.AuthNone:
 			// Set middleware values
 			s := make(handlers.ContextValue)
@@ -44,7 +44,7 @@ func handlerAuthCheck(h http.Handler) http.Handler {
 				http.Redirect(w, r, forbiddenPath, http.StatusForbidden)
 				return
 			}
-			claims, valid := apiUsers.CheckToken(jwtConfig.JWTSecret, token)
+			claims, valid := apiUsers.CheckToken(jwtSecret, token)
 			if !valid {
 				http.Redirect(w, r, forbiddenPath, http.StatusForbidden)
 				return

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -28,7 +28,7 @@ type HandlersApi struct {
 	RedisCache     *cache.RedisManager
 	ServiceVersion string
 	ServiceName    string
-	ApiConfig      *config.JSONConfigurationAPI
+	ApiConfig      *config.JSONConfigurationService
 }
 
 type HandlersOption func(*HandlersApi)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -40,24 +40,8 @@ const (
 	serviceDescription = "API service for osctrl"
 	// Application description
 	appDescription = serviceDescription + ", a fast and efficient osquery management"
-	// Default service configuration file
-	defConfigurationFile = "config/" + config.ServiceAPI + ".json"
-	// Default DB configuration file
-	defDBConfigurationFile = "config/db.json"
-	// Default redis configuration file
-	defRedisConfigurationFile = "config/redis.json"
-	// Default TLS certificate file
-	defTLSCertificateFile = "config/tls.crt"
-	// Default TLS private key file
-	defTLSKeyFile = "config/tls.key"
-	// Default JWT configuration file
-	defJWTConfigurationFile = "config/jwt.json"
 	// Default refreshing interval in seconds
 	defaultRefresh int = 300
-	// Default timeout to attempt backend reconnect
-	defaultBackendRetryTimeout int = 7
-	// Default timeout to attempt redis reconnect
-	defaultRedisRetryTimeout int = 7
 )
 
 // Paths
@@ -95,43 +79,20 @@ const (
 
 // Global variables
 var (
-	err               error
-	apiConfigValues   config.JSONConfigurationAPI
-	apiConfig         config.JSONConfigurationAPI
-	dbConfigValues    backend.JSONConfigurationDB
-	dbConfig          backend.JSONConfigurationDB
-	redisConfigValues cache.JSONConfigurationRedis
-	redisConfig       cache.JSONConfigurationRedis
-	jwtConfigValues   config.JSONConfigurationJWT
-	jwtConfig         config.JSONConfigurationJWT
-	db                *backend.DBManager
-	redis             *cache.RedisManager
-	apiUsers          *users.UserManager
-	tagsmgr           *tags.TagManager
-	settingsmgr       *settings.Settings
-	envs              *environments.Environment
-	nodesmgr          *nodes.NodeManager
-	queriesmgr        *queries.Queries
-	filecarves        *carves.Carves
-	handlersApi       *handlers.HandlersApi
-	app               *cli.App
-	flags             []cli.Flag
-)
-
-// Variables for flags
-var (
-	configFlag        bool
-	serviceConfigFile string
-	redisConfigFile   string
-	dbFlag            bool
-	redisFlag         bool
-	dbConfigFile      string
-	loggerValue       string
-	jwtFlag           bool
-	jwtConfigFile     string
-	tlsServer         bool
-	tlsCertFile       string
-	tlsKeyFile        string
+	err         error
+	db          *backend.DBManager
+	redis       *cache.RedisManager
+	apiUsers    *users.UserManager
+	tagsmgr     *tags.TagManager
+	settingsmgr *settings.Settings
+	envs        *environments.Environment
+	nodesmgr    *nodes.NodeManager
+	queriesmgr  *queries.Queries
+	filecarves  *carves.Carves
+	handlersApi *handlers.HandlersApi
+	app         *cli.App
+	flags       []cli.Flag
+	flagParams  config.ServiceFlagParams
 )
 
 // Valid values for auth and logging in configuration
@@ -141,8 +102,8 @@ var validAuth = map[string]bool{
 }
 
 // Function to load the configuration file and assign to variables
-func loadConfiguration(file, service string) (config.JSONConfigurationAPI, error) {
-	var cfg config.JSONConfigurationAPI
+func loadConfiguration(file, service string) (config.JSONConfigurationService, error) {
+	var cfg config.JSONConfigurationService
 	log.Info().Msgf("Loading %s", file)
 	// Load file and read config
 	viper.SetConfigFile(file)
@@ -167,276 +128,8 @@ func loadConfiguration(file, service string) (config.JSONConfigurationAPI, error
 
 // Initialization code
 func init() {
-	// Initialize CLI flags
-	flags = []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "config",
-			Aliases:     []string{"c"},
-			Value:       false,
-			Usage:       "Provide service configuration via JSON file",
-			EnvVars:     []string{"SERVICE_CONFIG"},
-			Destination: &configFlag,
-		},
-		&cli.StringFlag{
-			Name:        "config-file",
-			Aliases:     []string{"C"},
-			Value:       defConfigurationFile,
-			Usage:       "Load service configuration from `FILE`",
-			EnvVars:     []string{"SERVICE_CONFIG_FILE"},
-			Destination: &serviceConfigFile,
-		},
-		&cli.StringFlag{
-			Name:        "listener",
-			Aliases:     []string{"l"},
-			Value:       "0.0.0.0",
-			Usage:       "Listener for the service",
-			EnvVars:     []string{"SERVICE_LISTENER"},
-			Destination: &apiConfigValues.Listener,
-		},
-		&cli.StringFlag{
-			Name:        "port",
-			Aliases:     []string{"p"},
-			Value:       "9002",
-			Usage:       "TCP port for the service",
-			EnvVars:     []string{"SERVICE_PORT"},
-			Destination: &apiConfigValues.Port,
-		},
-		&cli.StringFlag{
-			Name:        "log-level",
-			Value:       config.LogLevelInfo,
-			Usage:       "Log level for the service",
-			EnvVars:     []string{"SERVICE_LOG_LEVEL"},
-			Destination: &apiConfigValues.LogLevel,
-		},
-		&cli.StringFlag{
-			Name:        "log-format",
-			Value:       config.LogFormatJSON,
-			Usage:       "Log format for the service",
-			EnvVars:     []string{"SERVICE_LOG_FORMAT"},
-			Destination: &apiConfigValues.LogFormat,
-		},
-		&cli.StringFlag{
-			Name:        "auth",
-			Aliases:     []string{"A"},
-			Value:       config.AuthNone,
-			Usage:       "Authentication mechanism for the service",
-			EnvVars:     []string{"SERVICE_AUTH"},
-			Destination: &apiConfigValues.Auth,
-		},
-		&cli.StringFlag{
-			Name:        "host",
-			Aliases:     []string{"H"},
-			Value:       "0.0.0.0",
-			Usage:       "Exposed hostname the service uses",
-			EnvVars:     []string{"SERVICE_HOST"},
-			Destination: &apiConfigValues.Host,
-		},
-		&cli.StringFlag{
-			Name:        "logging",
-			Aliases:     []string{"L"},
-			Value:       config.LoggingNone,
-			Usage:       "Logging mechanism to handle logs from nodes",
-			EnvVars:     []string{"SERVICE_LOGGER"},
-			Destination: &loggerValue,
-		},
-		&cli.BoolFlag{
-			Name:        "redis",
-			Aliases:     []string{"r"},
-			Value:       false,
-			Usage:       "Provide redis configuration via JSON file",
-			EnvVars:     []string{"REDIS_CONFIG"},
-			Destination: &redisFlag,
-		},
-		&cli.StringFlag{
-			Name:        "redis-file",
-			Aliases:     []string{"R"},
-			Value:       defRedisConfigurationFile,
-			Usage:       "Load redis configuration from `FILE`",
-			EnvVars:     []string{"REDIS_CONFIG_FILE"},
-			Destination: &redisConfigFile,
-		},
-		&cli.StringFlag{
-			Name:        "redis-connection-string",
-			Value:       "",
-			Usage:       "Redis connection string, must include schema (<redis|rediss|unix>://<user>:<pass>@<host>:<port>/<db>?<options>",
-			EnvVars:     []string{"REDIS_CONNECTION_STRING"},
-			Destination: &redisConfigValues.ConnectionString,
-		},
-		&cli.StringFlag{
-			Name:        "redis-host",
-			Value:       "127.0.0.1",
-			Usage:       "Redis host to be connected to",
-			EnvVars:     []string{"REDIS_HOST"},
-			Destination: &redisConfigValues.Host,
-		},
-		&cli.StringFlag{
-			Name:        "redis-port",
-			Value:       "6379",
-			Usage:       "Redis port to be connected to",
-			EnvVars:     []string{"REDIS_PORT"},
-			Destination: &redisConfigValues.Port,
-		},
-		&cli.StringFlag{
-			Name:        "redis-pass",
-			Value:       "",
-			Usage:       "Password to be used for redis",
-			EnvVars:     []string{"REDIS_PASS"},
-			Destination: &redisConfigValues.Password,
-		},
-		&cli.IntFlag{
-			Name:        "redis-db",
-			Value:       0,
-			Usage:       "Redis database to be selected after connecting",
-			EnvVars:     []string{"REDIS_DB"},
-			Destination: &redisConfigValues.DB,
-		},
-		&cli.IntFlag{
-			Name:        "redis-conn-retry",
-			Value:       defaultRedisRetryTimeout,
-			Usage:       "Time in seconds to retry the connection to the cache, if set to 0 the service will stop if the connection fails",
-			EnvVars:     []string{"REDIS_CONN_RETRY"},
-			Destination: &redisConfigValues.ConnRetry,
-		},
-		&cli.BoolFlag{
-			Name:        "db",
-			Aliases:     []string{"d"},
-			Value:       false,
-			Usage:       "Provide DB configuration via JSON file",
-			EnvVars:     []string{"DB_CONFIG"},
-			Destination: &dbFlag,
-		},
-		&cli.StringFlag{
-			Name:        "db-file",
-			Aliases:     []string{"D"},
-			Value:       defDBConfigurationFile,
-			Usage:       "Load DB configuration from `FILE`",
-			EnvVars:     []string{"DB_CONFIG_FILE"},
-			Destination: &dbConfigFile,
-		},
-		&cli.StringFlag{
-			Name:        "db-host",
-			Value:       "127.0.0.1",
-			Usage:       "Backend host to be connected to",
-			EnvVars:     []string{"DB_HOST"},
-			Destination: &dbConfigValues.Host,
-		},
-		&cli.StringFlag{
-			Name:        "db-port",
-			Value:       "5432",
-			Usage:       "Backend port to be connected to",
-			EnvVars:     []string{"DB_PORT"},
-			Destination: &dbConfigValues.Port,
-		},
-		&cli.StringFlag{
-			Name:        "db-name",
-			Value:       "osctrl",
-			Usage:       "Database name to be used in the backend",
-			EnvVars:     []string{"DB_NAME"},
-			Destination: &dbConfigValues.Name,
-		},
-		&cli.StringFlag{
-			Name:        "db-user",
-			Value:       "postgres",
-			Usage:       "Username to be used for the backend",
-			EnvVars:     []string{"DB_USER"},
-			Destination: &dbConfigValues.Username,
-		},
-		&cli.StringFlag{
-			Name:        "db-pass",
-			Value:       "postgres",
-			Usage:       "Password to be used for the backend",
-			EnvVars:     []string{"DB_PASS"},
-			Destination: &dbConfigValues.Password,
-		},
-		&cli.StringFlag{
-			Name:        "db-sslmode",
-			Value:       "disable",
-			Usage:       "SSL native support to encrypt the connection to the backend",
-			EnvVars:     []string{"DB_SSLMODE"},
-			Destination: &dbConfigValues.SSLMode,
-		},
-		&cli.IntFlag{
-			Name:        "db-max-idle-conns",
-			Value:       20,
-			Usage:       "Maximum number of connections in the idle connection pool",
-			EnvVars:     []string{"DB_MAX_IDLE_CONNS"},
-			Destination: &dbConfigValues.MaxIdleConns,
-		},
-		&cli.IntFlag{
-			Name:        "db-max-open-conns",
-			Value:       100,
-			Usage:       "Maximum number of open connections to the database",
-			EnvVars:     []string{"DB_MAX_OPEN_CONNS"},
-			Destination: &dbConfigValues.MaxOpenConns,
-		},
-		&cli.IntFlag{
-			Name:        "db-conn-max-lifetime",
-			Value:       30,
-			Usage:       "Maximum amount of time a connection may be reused",
-			EnvVars:     []string{"DB_CONN_MAX_LIFETIME"},
-			Destination: &dbConfigValues.ConnMaxLifetime,
-		},
-		&cli.IntFlag{
-			Name:        "db-conn-retry",
-			Value:       defaultBackendRetryTimeout,
-			Usage:       "Time in seconds to retry the connection to the database, if set to 0 the service will stop if the connection fails",
-			EnvVars:     []string{"DB_CONN_RETRY"},
-			Destination: &dbConfigValues.ConnRetry,
-		},
-		&cli.BoolFlag{
-			Name:        "tls",
-			Aliases:     []string{"t"},
-			Value:       false,
-			Usage:       "Enable TLS termination. It requires certificate and key",
-			EnvVars:     []string{"TLS_SERVER"},
-			Destination: &tlsServer,
-		},
-		&cli.StringFlag{
-			Name:        "cert",
-			Aliases:     []string{"T"},
-			Value:       defTLSCertificateFile,
-			Usage:       "TLS termination certificate from `FILE`",
-			EnvVars:     []string{"TLS_CERTIFICATE"},
-			Destination: &tlsCertFile,
-		},
-		&cli.StringFlag{
-			Name:        "key",
-			Aliases:     []string{"K"},
-			Value:       defTLSKeyFile,
-			Usage:       "TLS termination private key from `FILE`",
-			EnvVars:     []string{"TLS_KEY"},
-			Destination: &tlsKeyFile,
-		},
-		&cli.BoolFlag{
-			Name:        "jwt",
-			Aliases:     []string{"j"},
-			Value:       false,
-			Usage:       "Provide JWT configuration via JSON file",
-			EnvVars:     []string{"JWT_CONFIG"},
-			Destination: &jwtFlag,
-		},
-		&cli.StringFlag{
-			Name:        "jwt-file",
-			Value:       defJWTConfigurationFile,
-			Usage:       "Load JWT configuration from `FILE`",
-			EnvVars:     []string{"JWT_CONFIG_FILE"},
-			Destination: &jwtConfigFile,
-		},
-		&cli.StringFlag{
-			Name:        "jwt-secret",
-			Usage:       "Password to be used for the backend",
-			EnvVars:     []string{"JWT_SECRET"},
-			Destination: &jwtConfigValues.JWTSecret,
-		},
-		&cli.IntFlag{
-			Name:        "jwt-expire",
-			Value:       3,
-			Usage:       "Maximum amount of hours for the tokens to expire",
-			EnvVars:     []string{"JWT_EXPIRE"},
-			Destination: &jwtConfigValues.HoursToExpire,
-		},
-	}
-
+	// Initialize CLI flags using the config package
+	flags = config.InitAdminFlags(&flagParams)
 }
 
 // Go go!
@@ -444,39 +137,39 @@ func osctrlAPIService() {
 	// ////////////////////////////// Backend
 	log.Info().Msg("Initializing backend...")
 	for {
-		db, err = backend.CreateDBManager(dbConfig)
+		db, err = backend.CreateDBManager(flagParams.DBConfigValues)
 		if db != nil {
 			log.Info().Msg("Connection to backend successful!")
 			break
 		}
 		if err != nil {
 			log.Err(err).Msg("Failed to connect to backend")
-			if dbConfig.ConnRetry == 0 {
+			if flagParams.DBConfigValues.ConnRetry == 0 {
 				log.Fatal().Msg("Connection to backend failed and no retry was set")
 			}
 		}
-		log.Info().Msgf("Backend NOT ready! Retrying in %d seconds...\n", dbConfig.ConnRetry)
-		time.Sleep(time.Duration(dbConfig.ConnRetry) * time.Second)
+		log.Info().Msgf("Backend NOT ready! Retrying in %d seconds...\n", flagParams.DBConfigValues.ConnRetry)
+		time.Sleep(time.Duration(flagParams.DBConfigValues.ConnRetry) * time.Second)
 	}
 	// ////////////////////////////// Cache
 	log.Info().Msg("Initializing cache...")
 	for {
-		redis, err = cache.CreateRedisManager(redisConfig)
+		redis, err = cache.CreateRedisManager(flagParams.RedisConfigValues)
 		if redis != nil {
 			log.Info().Msg("Connection to cache successful!")
 			break
 		}
 		if err != nil {
 			log.Err(err).Msg("Failed to connect to cache")
-			if redisConfig.ConnRetry == 0 {
+			if flagParams.RedisConfigValues.ConnRetry == 0 {
 				log.Fatal().Msg("Connection to cache failed and no retry was set")
 			}
 		}
-		log.Info().Msgf("Cache NOT ready! Retrying in %d seconds...\n", redisConfig.ConnRetry)
-		time.Sleep(time.Duration(redisConfig.ConnRetry) * time.Second)
+		log.Info().Msgf("Cache NOT ready! Retrying in %d seconds...\n", flagParams.RedisConfigValues.ConnRetry)
+		time.Sleep(time.Duration(flagParams.RedisConfigValues.ConnRetry) * time.Second)
 	}
 	log.Info().Msg("Initialize users")
-	apiUsers = users.CreateUserManager(db.Conn, &jwtConfig)
+	apiUsers = users.CreateUserManager(db.Conn, &flagParams.JWTConfigValues)
 	log.Info().Msg("Initialize tags")
 	tagsmgr = tags.CreateTagManager(db.Conn)
 	log.Info().Msg("Initialize environment")
@@ -489,9 +182,9 @@ func osctrlAPIService() {
 	log.Info().Msg("Initialize queries")
 	queriesmgr = queries.CreateQueries(db.Conn)
 	log.Info().Msg("Initialize carves")
-	filecarves = carves.CreateFileCarves(db.Conn, apiConfig.Carver, nil)
+	filecarves = carves.CreateFileCarves(db.Conn, flagParams.ConfigValues.Carver, nil)
 	log.Info().Msg("Loading service settings")
-	if err := loadingSettings(settingsmgr); err != nil {
+	if err := loadingSettings(settingsmgr, flagParams.ConfigValues); err != nil {
 		log.Fatal().Msgf("Error loading settings - %v", err)
 	}
 	// Initialize Admin handlers before router
@@ -524,58 +217,136 @@ func osctrlAPIService() {
 	muxAPI.HandleFunc("GET "+forbiddenPath, handlersApi.ForbiddenHandler)
 
 	// ///////////////////////// UNAUTHENTICATED
-	muxAPI.Handle("POST "+_apiPath(apiLoginPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.LoginHandler)))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiLoginPath)+"/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.LoginHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// ///////////////////////// AUTHENTICATED
 	// API: nodes by environment
-	muxAPI.Handle("GET "+_apiPath(apiNodesPath)+"/{env}/all", handlerAuthCheck(http.HandlerFunc(handlersApi.AllNodesHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiNodesPath)+"/{env}/active", handlerAuthCheck(http.HandlerFunc(handlersApi.ActiveNodesHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiNodesPath)+"/{env}/inactive", handlerAuthCheck(http.HandlerFunc(handlersApi.InactiveNodesHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiNodesPath)+"/{env}/node/{node}", handlerAuthCheck(http.HandlerFunc(handlersApi.NodeHandler)))
-	muxAPI.Handle("POST "+_apiPath(apiNodesPath)+"/{env}/delete", handlerAuthCheck(http.HandlerFunc(handlersApi.DeleteNodeHandler)))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiNodesPath)+"/{env}/all",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.AllNodesHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiNodesPath)+"/{env}/active",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.ActiveNodesHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiNodesPath)+"/{env}/inactive",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.InactiveNodesHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiNodesPath)+"/{env}/node/{node}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.NodeHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiNodesPath)+"/{env}/delete",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.DeleteNodeHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// API: queries by environment
-	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.AllQueriesShowHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/list/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryListHandler)))
-	muxAPI.Handle("POST "+_apiPath(apiQueriesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesRunHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryShowHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/{env}/results/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueryResultsHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiAllQueriesPath+"/{env}"), handlerAuthCheck(http.HandlerFunc(handlersApi.AllQueriesShowHandler)))
-	muxAPI.Handle("POST "+_apiPath(apiQueriesPath)+"/{env}/{action}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesActionHandler)))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiQueriesPath)+"/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.AllQueriesShowHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiQueriesPath)+"/{env}/list/{target}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.QueryListHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiQueriesPath)+"/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesRunHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiQueriesPath)+"/{env}/{name}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.QueryShowHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiQueriesPath)+"/{env}/results/{name}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.QueryResultsHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiAllQueriesPath+"/{env}"),
+		handlerAuthCheck(http.HandlerFunc(handlersApi.AllQueriesShowHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiQueriesPath)+"/{env}/{action}/{name}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesActionHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// API: carves by environment
-	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/queries/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveQueriesHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/list", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveListHandler)))
-	muxAPI.Handle("POST "+_apiPath(apiCarvesPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesRunHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler)))
-	muxAPI.Handle("POST "+_apiPath(apiCarvesPath)+"/{env}/{action}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesActionHandler)))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiCarvesPath)+"/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiCarvesPath)+"/{env}/queries/{target}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.CarveQueriesHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiCarvesPath)+"/{env}/list",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.CarveListHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiCarvesPath)+"/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesRunHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiCarvesPath)+"/{env}/{name}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.CarveShowHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiCarvesPath)+"/{env}/{action}/{name}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.CarvesActionHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// API: users
-	muxAPI.Handle("GET "+_apiPath(apiUsersPath)+"/{username}", handlerAuthCheck(http.HandlerFunc(handlersApi.UserHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiUsersPath), handlerAuthCheck(http.HandlerFunc(handlersApi.UsersHandler)))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiUsersPath)+"/{username}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.UserHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiUsersPath),
+		handlerAuthCheck(http.HandlerFunc(handlersApi.UsersHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// API: platforms
-	muxAPI.Handle("GET "+_apiPath(apiPlatformsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.PlatformsHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiPlatformsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.PlatformsEnvHandler)))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiPlatformsPath),
+		handlerAuthCheck(http.HandlerFunc(handlersApi.PlatformsHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiPlatformsPath)+"/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.PlatformsEnvHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// API: environments
-	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentsHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/map/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentMapHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvEnrollHandler)))
-	muxAPI.Handle("POST "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{action}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvEnrollActionsHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiEnvironmentsPath)+"/{env}/remove/{target}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentHandler)))
-	muxAPI.Handle("POST "+_apiPath(apiEnvironmentsPath)+"/{env}/remove/{action}", handlerAuthCheck(http.HandlerFunc(handlersApi.EnvRemoveActionsHandler)))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiEnvironmentsPath),
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentsHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiEnvironmentsPath)+"/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiEnvironmentsPath)+"/map/{target}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentMapHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{target}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvEnrollHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiEnvironmentsPath)+"/{env}/enroll/{action}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvEnrollActionsHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiEnvironmentsPath)+"/{env}/remove/{target}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiEnvironmentsPath)+"/{env}/remove/{action}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvRemoveActionsHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// API: tags by environment
-	muxAPI.Handle("GET "+_apiPath(apiTagsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.AllTagsHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiTagsPath)+"/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.TagsEnvHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiTagsPath)+"/{env}/{name}", handlerAuthCheck(http.HandlerFunc(handlersApi.TagEnvHandler)))
-	muxAPI.Handle("POST "+_apiPath(apiTagsPath)+"/{env}/{action}", handlerAuthCheck(http.HandlerFunc(handlersApi.TagsActionHandler)))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiTagsPath),
+		handlerAuthCheck(http.HandlerFunc(handlersApi.AllTagsHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiTagsPath)+"/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.TagsEnvHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiTagsPath)+"/{env}/{name}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.TagEnvHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiTagsPath)+"/{env}/{action}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.TagsActionHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// API: settings by environment
-	muxAPI.Handle("GET "+_apiPath(apiSettingsPath), handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiSettingsPath)+"/{service}", handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsServiceHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiSettingsPath)+"/{service}/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsServiceEnvHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiSettingsPath)+"/{service}/json", handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsServiceJSONHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiSettingsPath)+"/{service}/json/{env}", handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsServiceEnvJSONHandler)))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiSettingsPath),
+		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiSettingsPath)+"/{service}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsServiceHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiSettingsPath)+"/{service}/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsServiceEnvHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiSettingsPath)+"/{service}/json",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsServiceJSONHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiSettingsPath)+"/{service}/json/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingsServiceEnvJSONHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 
 	// Launch listeners for API server
-	serviceListener := apiConfig.Listener + ":" + apiConfig.Port
-	if tlsServer {
+	serviceListener := flagParams.ConfigValues.Listener + ":" + flagParams.ConfigValues.Port
+	if flagParams.TLSServer {
 		cfg := &tls.Config{
 			MinVersion:               tls.VersionTLS12,
 			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
@@ -594,7 +365,7 @@ func osctrlAPIService() {
 			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
 		}
 		log.Info().Msgf("%s v%s - HTTPS listening %s", serviceName, serviceVersion, serviceListener)
-		if err := srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile); err != nil {
+		if err := srv.ListenAndServeTLS(flagParams.TLSCertFile, flagParams.TLSKeyFile); err != nil {
 			log.Fatal().Msgf("ListenAndServeTLS: %v", err)
 		}
 	} else {
@@ -608,40 +379,32 @@ func osctrlAPIService() {
 // Action to run when no flags are provided to run checks and prepare data
 func cliAction(c *cli.Context) error {
 	// Load configuration if external JSON config file is used
-	if configFlag {
-		apiConfig, err = loadConfiguration(serviceConfigFile, config.ServiceAPI)
+	if flagParams.ConfigFlag {
+		flagParams.ConfigValues, err = loadConfiguration(flagParams.ServiceConfigFile, config.ServiceAPI)
 		if err != nil {
-			return fmt.Errorf("failed to load service configuration %s - %s", serviceConfigFile, err.Error())
+			return fmt.Errorf("failed to load service configuration %s - %s", flagParams.ServiceConfigFile, err.Error())
 		}
-	} else {
-		apiConfig = apiConfigValues
 	}
 	// Load DB configuration if external JSON config file is used
-	if dbFlag {
-		dbConfig, err = backend.LoadConfiguration(dbConfigFile, backend.DBKey)
+	if flagParams.DBFlag {
+		flagParams.DBConfigValues, err = backend.LoadConfiguration(flagParams.DBConfigFile, backend.DBKey)
 		if err != nil {
 			return fmt.Errorf("failed to load DB configuration - %s", err.Error())
 		}
-	} else {
-		dbConfig = dbConfigValues
 	}
 	// Load redis configuration if external JSON config file is used
-	if redisFlag {
-		redisConfig, err = cache.LoadConfiguration(redisConfigFile, cache.RedisKey)
+	if flagParams.RedisFlag {
+		flagParams.RedisConfigValues, err = cache.LoadConfiguration(flagParams.RedisConfigFile, cache.RedisKey)
 		if err != nil {
 			return fmt.Errorf("failed to load redis configuration - %s", err.Error())
 		}
-	} else {
-		redisConfig = redisConfigValues
 	}
 	// Load JWT configuration if external JWT JSON config file is used
-	if jwtFlag {
-		jwtConfig, err = loadJWTConfiguration(jwtConfigFile)
+	if flagParams.JWTFlag {
+		flagParams.JWTConfigValues, err = loadJWTConfiguration(flagParams.JWTConfigFile)
 		if err != nil {
 			return fmt.Errorf("failed to load JWT configuration - %s", err.Error())
 		}
-	} else {
-		jwtConfig = jwtConfigValues
 	}
 	return nil
 }
@@ -700,7 +463,7 @@ func main() {
 	}
 
 	// Initialize service logger
-	initializeLogger(apiConfig.LogLevel, apiConfig.LogFormat)
+	initializeLogger(flagParams.ConfigValues.LogLevel, flagParams.ConfigValues.LogFormat)
 
 	// Run the service
 	osctrlAPIService()

--- a/cmd/api/settings.go
+++ b/cmd/api/settings.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Function to load all settings for the service
-func loadingSettings(mgr *settings.Settings) error {
+func loadingSettings(mgr *settings.Settings, cfg config.JSONConfigurationService) error {
 	// Check if service settings for debug service is ready
 	if mgr.DebugService(config.ServiceAPI) {
 		log.Debug().Msg("DebugService: Initializing settings")
@@ -45,7 +45,7 @@ func loadingSettings(mgr *settings.Settings) error {
 		}
 	}
 	// Write JSON config to settings
-	if err := mgr.SetAPIJSON(apiConfig, settings.NoEnvironmentID); err != nil {
+	if err := mgr.SetAPIJSON(cfg, settings.NoEnvironmentID); err != nil {
 		return fmt.Errorf("Failed to add JSON values to configuration: %w", err)
 	}
 	return nil

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -150,6 +150,20 @@ func InitAdminFlags(params *ServiceFlagParams) []cli.Flag {
 	return allFlags
 }
 
+// InitAPIFlags initializes all the flags needed for the API service
+func InitAPIFlags(params *ServiceFlagParams) []cli.Flag {
+	var allFlags []cli.Flag
+	// Add flags by category
+	allFlags = append(allFlags, initConfigFlags(params, ServiceAPI)...)
+	allFlags = append(allFlags, initServiceFlags(params)...)
+	allFlags = append(allFlags, initLoggingFlags(params, ServiceAPI)...)
+	allFlags = append(allFlags, initRedisFlags(params)...)
+	allFlags = append(allFlags, initDBFlags(params)...)
+	allFlags = append(allFlags, initTLSSecurityFlags(params)...)
+	allFlags = append(allFlags, initJWTFlags(params)...)
+	return allFlags
+}
+
 // initConfigFlags initializes configuration-related flags
 func initConfigFlags(params *ServiceFlagParams, service string) []cli.Flag {
 	return []cli.Flag{

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -77,17 +77,6 @@ type JSONConfigurationWriter struct {
 	WriterBufferSize int           `json:"writerBufferSize"`
 }
 
-// JSONConfigurationAPI to hold API service configuration values
-type JSONConfigurationAPI struct {
-	Listener  string `json:"listener"`
-	Port      string `json:"port"`
-	LogLevel  string `json:"logLevel"`
-	LogFormat string `json:"logFormat"`
-	Host      string `json:"host"`
-	Auth      string `json:"auth"`
-	Carver    string `json:"carver"`
-}
-
 // JSONConfigurationJWT to hold all JWT configuration values
 type JSONConfigurationJWT struct {
 	JWTSecret     string `json:"jwtSecret"`

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -351,7 +351,7 @@ func (conf *Settings) SetAdminJSON(cfg config.JSONConfigurationService, envID ui
 }
 
 // SetAPIJSON sets all the JSON configuration values for API service
-func (conf *Settings) SetAPIJSON(cfg config.JSONConfigurationAPI, envID uint) error {
+func (conf *Settings) SetAPIJSON(cfg config.JSONConfigurationService, envID uint) error {
 	if err := conf.SetJSON(config.ServiceAPI, JSONListener, cfg.Listener, envID); err != nil {
 		return err
 	}


### PR DESCRIPTION
Complete the refactor in `osctrl-api` to utilize the flags from the new config pkg. It follows up the work in #622 #625 and #627 