### PR TITLE
Fix error when creating node queries for large datasets

### DIFF
--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -408,7 +408,7 @@ func (q *Queries) CreateNodeQueries(nodeIDs []uint, queryID uint) error {
 			QueryID: queryID,
 		})
 	}
-	if err := q.DB.Create(&nodeQueries).Error; err != nil {
+	if err := q.DB.CreateInBatches(&nodeQueries, 1000).Error; err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Implement batch creation of node queries to handle more than 10,000 nodes efficiently.

It's a quick fix and I think it's a good idea to applied the batchsize as a global configuration for DB cofig.

It can be done by:
```go
db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
    CreateBatchSize: 1000, 
})
```