### PR TITLE
Refactor calls to debug messages in all services

### DIFF
--- a/cmd/admin/handlers/get.go
+++ b/cmd/admin/handlers/get.go
@@ -15,7 +15,9 @@ import (
 
 // FaviconHandler for the favicon
 func (h *HandlersAdmin) FaviconHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	w.Header().Set(utils.ContentType, "image/png")
 	http.ServeFile(w, r, "/static/favicon.png")
 }
@@ -35,20 +37,26 @@ func (h *HandlersAdmin) ErrorHandler(w http.ResponseWriter, r *http.Request) {
 // ForbiddenHandler for forbidden error requests
 func (h *HandlersAdmin) ForbiddenHandler(w http.ResponseWriter, r *http.Request) {
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusForbidden, errorContent)
 }
 
 // RootHandler - Handler for the root path
 func (h *HandlersAdmin) RootHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	http.Redirect(w, r, "/dashboard", http.StatusFound)
 }
 
 // PermissionsGETHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) PermissionsGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract username and verify
 	usernameVar := r.PathValue("username")
 	if usernameVar == "" || !h.Users.Exists(usernameVar) {
@@ -75,7 +83,9 @@ func (h *HandlersAdmin) PermissionsGETHandler(w http.ResponseWriter, r *http.Req
 
 // CarvesDownloadHandler for GET requests to download carves
 func (h *HandlersAdmin) CarvesDownloadHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Extract environment

--- a/cmd/admin/handlers/get.go
+++ b/cmd/admin/handlers/get.go
@@ -15,8 +15,8 @@ import (
 
 // FaviconHandler for the favicon
 func (h *HandlersAdmin) FaviconHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	w.Header().Set(utils.ContentType, "image/png")
 	http.ServeFile(w, r, "/static/favicon.png")
@@ -37,8 +37,8 @@ func (h *HandlersAdmin) ErrorHandler(w http.ResponseWriter, r *http.Request) {
 // ForbiddenHandler for forbidden error requests
 func (h *HandlersAdmin) ForbiddenHandler(w http.ResponseWriter, r *http.Request) {
 	// Debug HTTP for environment
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusForbidden, errorContent)
@@ -46,16 +46,16 @@ func (h *HandlersAdmin) ForbiddenHandler(w http.ResponseWriter, r *http.Request)
 
 // RootHandler - Handler for the root path
 func (h *HandlersAdmin) RootHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	http.Redirect(w, r, "/dashboard", http.StatusFound)
 }
 
 // PermissionsGETHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) PermissionsGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract username and verify
 	usernameVar := r.PathValue("username")
@@ -83,8 +83,8 @@ func (h *HandlersAdmin) PermissionsGETHandler(w http.ResponseWriter, r *http.Req
 
 // CarvesDownloadHandler for GET requests to download carves
 func (h *HandlersAdmin) CarvesDownloadHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/get.go
+++ b/cmd/admin/handlers/get.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -16,7 +15,7 @@ import (
 
 // FaviconHandler for the favicon
 func (h *HandlersAdmin) FaviconHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	w.Header().Set(utils.ContentType, "image/png")
 	http.ServeFile(w, r, "/static/favicon.png")
 }
@@ -36,20 +35,20 @@ func (h *HandlersAdmin) ErrorHandler(w http.ResponseWriter, r *http.Request) {
 // ForbiddenHandler for forbidden error requests
 func (h *HandlersAdmin) ForbiddenHandler(w http.ResponseWriter, r *http.Request) {
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusForbidden, errorContent)
 }
 
 // RootHandler - Handler for the root path
 func (h *HandlersAdmin) RootHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	http.Redirect(w, r, "/dashboard", http.StatusFound)
 }
 
 // PermissionsGETHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) PermissionsGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract username and verify
 	usernameVar := r.PathValue("username")
 	if usernameVar == "" || !h.Users.Exists(usernameVar) {
@@ -76,7 +75,7 @@ func (h *HandlersAdmin) PermissionsGETHandler(w http.ResponseWriter, r *http.Req
 
 // CarvesDownloadHandler for GET requests to download carves
 func (h *HandlersAdmin) CarvesDownloadHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Extract environment

--- a/cmd/admin/handlers/handlers.go
+++ b/cmd/admin/handlers/handlers.go
@@ -184,10 +184,24 @@ func WithDBLogger(dbfile string, config *backend.JSONConfigurationDB) HandlersOp
 	}
 }
 
-func WithDebugHTTP(logger *zerolog.Logger, cfg *config.DebugHTTPConfiguration) HandlersOption {
+func WithDebugHTTP(cfg *config.DebugHTTPConfiguration) HandlersOption {
 	return func(h *HandlersAdmin) {
-		h.DebugHTTP = logger
 		h.DebugHTTPConfig = cfg
+		h.DebugHTTP = nil
+		if cfg.Enabled {
+			l, err := logging.CreateDebugHTTP(cfg.File, logging.LumberjackConfig{
+				MaxSize:    25,
+				MaxBackups: 5,
+				MaxAge:     10,
+				Compress:   true,
+			})
+			if err != nil {
+				log.Err(err).Msg("error creating debug HTTP logger")
+				l = nil
+				h.DebugHTTPConfig.Enabled = false
+			}
+			h.DebugHTTP = l
+		}
 	}
 }
 

--- a/cmd/admin/handlers/handlers.go
+++ b/cmd/admin/handlers/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
@@ -42,6 +43,8 @@ type HandlersAdmin struct {
 	OsqueryTables   []types.OsqueryTable
 	AdminConfig     *config.JSONConfigurationService
 	DBLogger        *logging.LoggerDB
+	DebugHTTP       *zerolog.Logger
+	DebugHTTPConfig *config.DebugHTTPConfiguration
 }
 
 type HandlersOption func(*HandlersAdmin)
@@ -178,6 +181,13 @@ func WithDBLogger(dbfile string, config *backend.JSONConfigurationDB) HandlersOp
 			}
 		}
 		h.DBLogger = logger
+	}
+}
+
+func WithDebugHTTP(logger *zerolog.Logger, cfg *config.DebugHTTPConfiguration) HandlersOption {
+	return func(h *HandlersAdmin) {
+		h.DebugHTTP = logger
+		h.DebugHTTPConfig = cfg
 	}
 }
 

--- a/cmd/admin/handlers/json-carves.go
+++ b/cmd/admin/handlers/json-carves.go
@@ -51,7 +51,9 @@ type CarveTarget struct {
 
 // JSONCarvesHandler for JSON carves by target
 func (h *HandlersAdmin) JSONCarvesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-carves.go
+++ b/cmd/admin/handlers/json-carves.go
@@ -51,8 +51,8 @@ type CarveTarget struct {
 
 // JSONCarvesHandler for JSON carves by target
 func (h *HandlersAdmin) JSONCarvesHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/json-carves.go
+++ b/cmd/admin/handlers/json-carves.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
 	"github.com/jmpsec/osctrl/pkg/carves"
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/queries"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -53,7 +51,7 @@ type CarveTarget struct {
 
 // JSONCarvesHandler for JSON carves by target
 func (h *HandlersAdmin) JSONCarvesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-logs.go
+++ b/cmd/admin/handlers/json-logs.go
@@ -59,8 +59,8 @@ type QueryLogJSON struct {
 
 // JSONLogsHandler GET requests for JSON status/result logs by node and environment
 func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract type
 	logType := r.PathValue("type")
@@ -168,8 +168,8 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 
 // JSONQueryLogsHandler for JSON query logs by query name
 func (h *HandlersAdmin) JSONQueryLogsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/json-logs.go
+++ b/cmd/admin/handlers/json-logs.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
 	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -60,7 +59,7 @@ type QueryLogJSON struct {
 
 // JSONLogsHandler GET requests for JSON status/result logs by node and environment
 func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract type
 	logType := r.PathValue("type")
 	if logType == "" {
@@ -167,7 +166,7 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 
 // JSONQueryLogsHandler for JSON query logs by query name
 func (h *HandlersAdmin) JSONQueryLogsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-logs.go
+++ b/cmd/admin/handlers/json-logs.go
@@ -59,7 +59,9 @@ type QueryLogJSON struct {
 
 // JSONLogsHandler GET requests for JSON status/result logs by node and environment
 func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract type
 	logType := r.PathValue("type")
 	if logType == "" {
@@ -166,7 +168,9 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 
 // JSONQueryLogsHandler for JSON query logs by query name
 func (h *HandlersAdmin) JSONQueryLogsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-nodes.go
+++ b/cmd/admin/handlers/json-nodes.go
@@ -40,8 +40,8 @@ type NodeJSON struct {
 
 // JSONEnvironmentHandler - Handler for JSON endpoints by environment
 func (h *HandlersAdmin) JSONEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -114,8 +114,8 @@ func (h *HandlersAdmin) JSONEnvironmentHandler(w http.ResponseWriter, r *http.Re
 
 // JSONPlatformHandler - Handler for JSON endpoints by platform
 func (h *HandlersAdmin) JSONPlatformHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/json-nodes.go
+++ b/cmd/admin/handlers/json-nodes.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -41,7 +40,7 @@ type NodeJSON struct {
 
 // JSONEnvironmentHandler - Handler for JSON endpoints by environment
 func (h *HandlersAdmin) JSONEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -113,7 +112,7 @@ func (h *HandlersAdmin) JSONEnvironmentHandler(w http.ResponseWriter, r *http.Re
 
 // JSONPlatformHandler - Handler for JSON endpoints by platform
 func (h *HandlersAdmin) JSONPlatformHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-nodes.go
+++ b/cmd/admin/handlers/json-nodes.go
@@ -40,7 +40,9 @@ type NodeJSON struct {
 
 // JSONEnvironmentHandler - Handler for JSON endpoints by environment
 func (h *HandlersAdmin) JSONEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -112,7 +114,9 @@ func (h *HandlersAdmin) JSONEnvironmentHandler(w http.ResponseWriter, r *http.Re
 
 // JSONPlatformHandler - Handler for JSON endpoints by platform
 func (h *HandlersAdmin) JSONPlatformHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-queries.go
+++ b/cmd/admin/handlers/json-queries.go
@@ -123,8 +123,8 @@ func (h *HandlersAdmin) JSONSavedJSON(q queries.SavedQuery) SavedJSON {
 
 // JSONQueryHandler - Handler for JSON queries by target
 func (h *HandlersAdmin) JSONQueryHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/json-queries.go
+++ b/cmd/admin/handlers/json-queries.go
@@ -123,7 +123,9 @@ func (h *HandlersAdmin) JSONSavedJSON(q queries.SavedQuery) SavedJSON {
 
 // JSONQueryHandler - Handler for JSON queries by target
 func (h *HandlersAdmin) JSONQueryHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-queries.go
+++ b/cmd/admin/handlers/json-queries.go
@@ -4,9 +4,7 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/queries"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -125,7 +123,7 @@ func (h *HandlersAdmin) JSONSavedJSON(q queries.SavedQuery) SavedJSON {
 
 // JSONQueryHandler - Handler for JSON queries by target
 func (h *HandlersAdmin) JSONQueryHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-stats.go
+++ b/cmd/admin/handlers/json-stats.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
@@ -22,7 +21,7 @@ var (
 
 // JSONStatsHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) JSONStatsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Extract stats target

--- a/cmd/admin/handlers/json-stats.go
+++ b/cmd/admin/handlers/json-stats.go
@@ -21,7 +21,9 @@ var (
 
 // JSONStatsHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) JSONStatsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Extract stats target

--- a/cmd/admin/handlers/json-stats.go
+++ b/cmd/admin/handlers/json-stats.go
@@ -21,8 +21,8 @@ var (
 
 // JSONStatsHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) JSONStatsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/json-tags.go
+++ b/cmd/admin/handlers/json-tags.go
@@ -12,7 +12,9 @@ import (
 
 // JSONTagsHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) JSONTagsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-tags.go
+++ b/cmd/admin/handlers/json-tags.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
-	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -14,7 +12,7 @@ import (
 
 // JSONTagsHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) JSONTagsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/json-tags.go
+++ b/cmd/admin/handlers/json-tags.go
@@ -12,8 +12,8 @@ import (
 
 // JSONTagsHandler for platform/environment stats in JSON
 func (h *HandlersAdmin) JSONTagsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/post.go
+++ b/cmd/admin/handlers/post.go
@@ -22,8 +22,9 @@ import (
 
 // LoginPOSTHandler for login page for POST requests
 func (h *HandlersAdmin) LoginPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Never show the body in the login request
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
 	}
 	var l LoginRequest
 	// Parse request JSON body
@@ -54,8 +55,8 @@ func (h *HandlersAdmin) LoginPOSTHandler(w http.ResponseWriter, r *http.Request)
 
 // LogoutPOSTHandler for POST requests to logout
 func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var l LogoutRequest
 	// Get context data
@@ -87,8 +88,8 @@ func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request
 
 // QueryRunPOSTHandler for POST requests to run queries
 func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -247,8 +248,8 @@ func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // CarvesRunPOSTHandler for POST requests to run file carves
 func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -396,8 +397,8 @@ func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Requ
 
 // QueryActionsPOSTHandler for POST requests to queries
 func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -474,8 +475,8 @@ func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.R
 
 // CarvesActionsPOSTHandler - Handler for POST requests to carves
 func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var q DistributedCarvesActionRequest
 	// Get context data
@@ -521,8 +522,8 @@ func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.
 
 // ConfPOSTHandler for POST requests for saving configuration
 func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -723,8 +724,8 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // IntervalsPOSTHandler for POST requests for saving intervals
 func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment and verify
 	envVar := r.PathValue("env")
@@ -784,8 +785,8 @@ func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Requ
 
 // ExpirationPOSTHandler for POST requests for expiring enroll links
 func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -884,8 +885,8 @@ func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Req
 
 // NodeActionsPOSTHandler for POST requests for multi node action
 func (h *HandlersAdmin) NodeActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var m NodeMultiActionRequest
 	// Get context data
@@ -934,8 +935,8 @@ func (h *HandlersAdmin) NodeActionsPOSTHandler(w http.ResponseWriter, r *http.Re
 
 // EnvsPOSTHandler for POST request for /environments
 func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var c EnvironmentsRequest
 	// Get context data
@@ -1037,8 +1038,8 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // SettingsPOSTHandler for POST request for /settings
 func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract service
 	serviceVar := r.PathValue("service")
@@ -1126,8 +1127,8 @@ func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // UsersPOSTHandler for POST request for /users
 func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var u UsersRequest
 	// Get context data
@@ -1264,8 +1265,8 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 
 // TagsPOSTHandler for POST request for /tags
 func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var t TagsRequest
 	// Get context data
@@ -1351,8 +1352,8 @@ func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // TagNodesPOSTHandler for POST request for /tags/nodes
 func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var t TagNodesRequest
 	// Get context data
@@ -1414,8 +1415,8 @@ func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // PermissionsPOSTHandler for POST request for /users/permissions
 func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract username and verify
 	usernameVar := r.PathValue("username")
@@ -1477,8 +1478,8 @@ func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Re
 
 // EnrollPOSTHandler for POST requests enroll data
 func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -1582,8 +1583,8 @@ func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request
 
 // EditProfilePOSTHandler for POST requests to edit profile
 func (h *HandlersAdmin) EditProfilePOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var u UsersRequest
 	// Get context data
@@ -1653,8 +1654,8 @@ func (h *HandlersAdmin) EditProfilePOSTHandler(w http.ResponseWriter, r *http.Re
 
 // SavedQueriesPOSTHandler for POST requests to save queries
 func (h *HandlersAdmin) SavedQueriesPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	var s SavedQueryRequest
 	// Get context data

--- a/cmd/admin/handlers/post.go
+++ b/cmd/admin/handlers/post.go
@@ -22,7 +22,9 @@ import (
 
 // LoginPOSTHandler for login page for POST requests
 func (h *HandlersAdmin) LoginPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	var l LoginRequest
 	// Parse request JSON body
 	if h.Settings.DebugService(config.ServiceAdmin) {
@@ -52,7 +54,9 @@ func (h *HandlersAdmin) LoginPOSTHandler(w http.ResponseWriter, r *http.Request)
 
 // LogoutPOSTHandler for POST requests to logout
 func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	var l LogoutRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -83,7 +87,9 @@ func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request
 
 // QueryRunPOSTHandler for POST requests to run queries
 func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -241,7 +247,9 @@ func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // CarvesRunPOSTHandler for POST requests to run file carves
 func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -388,7 +396,9 @@ func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Requ
 
 // QueryActionsPOSTHandler for POST requests to queries
 func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -464,7 +474,9 @@ func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.R
 
 // CarvesActionsPOSTHandler - Handler for POST requests to carves
 func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	var q DistributedCarvesActionRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -509,7 +521,9 @@ func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.
 
 // ConfPOSTHandler for POST requests for saving configuration
 func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -709,7 +723,9 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // IntervalsPOSTHandler for POST requests for saving intervals
 func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract environment and verify
 	envVar := r.PathValue("env")
 	if envVar == "" || !h.Envs.Exists(envVar) {
@@ -768,7 +784,9 @@ func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Requ
 
 // ExpirationPOSTHandler for POST requests for expiring enroll links
 func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -866,7 +884,9 @@ func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Req
 
 // NodeActionsPOSTHandler for POST requests for multi node action
 func (h *HandlersAdmin) NodeActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	var m NodeMultiActionRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -914,7 +934,9 @@ func (h *HandlersAdmin) NodeActionsPOSTHandler(w http.ResponseWriter, r *http.Re
 
 // EnvsPOSTHandler for POST request for /environments
 func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	var c EnvironmentsRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1015,7 +1037,9 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // SettingsPOSTHandler for POST request for /settings
 func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract service
 	serviceVar := r.PathValue("service")
 	if serviceVar == "" {
@@ -1102,7 +1126,9 @@ func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // UsersPOSTHandler for POST request for /users
 func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	var u UsersRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1238,7 +1264,9 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 
 // TagsPOSTHandler for POST request for /tags
 func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	var t TagsRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1323,7 +1351,9 @@ func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // TagNodesPOSTHandler for POST request for /tags/nodes
 func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	var t TagNodesRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1384,7 +1414,9 @@ func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // PermissionsPOSTHandler for POST request for /users/permissions
 func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract username and verify
 	usernameVar := r.PathValue("username")
 	if usernameVar == "" || !h.Users.Exists(usernameVar) {
@@ -1445,7 +1477,9 @@ func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Re
 
 // EnrollPOSTHandler for POST requests enroll data
 func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -1548,7 +1582,9 @@ func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request
 
 // EditProfilePOSTHandler for POST requests to edit profile
 func (h *HandlersAdmin) EditProfilePOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	var u UsersRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1617,7 +1653,9 @@ func (h *HandlersAdmin) EditProfilePOSTHandler(w http.ResponseWriter, r *http.Re
 
 // SavedQueriesPOSTHandler for POST requests to save queries
 func (h *HandlersAdmin) SavedQueriesPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	var s SavedQueryRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/post.go
+++ b/cmd/admin/handlers/post.go
@@ -22,7 +22,7 @@ import (
 
 // LoginPOSTHandler for login page for POST requests
 func (h *HandlersAdmin) LoginPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	var l LoginRequest
 	// Parse request JSON body
 	if h.Settings.DebugService(config.ServiceAdmin) {
@@ -52,7 +52,7 @@ func (h *HandlersAdmin) LoginPOSTHandler(w http.ResponseWriter, r *http.Request)
 
 // LogoutPOSTHandler for POST requests to logout
 func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	var l LogoutRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -83,7 +83,7 @@ func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request
 
 // QueryRunPOSTHandler for POST requests to run queries
 func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -241,7 +241,7 @@ func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // CarvesRunPOSTHandler for POST requests to run file carves
 func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -388,7 +388,7 @@ func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Requ
 
 // QueryActionsPOSTHandler for POST requests to queries
 func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -464,7 +464,7 @@ func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.R
 
 // CarvesActionsPOSTHandler - Handler for POST requests to carves
 func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	var q DistributedCarvesActionRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -509,7 +509,7 @@ func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.
 
 // ConfPOSTHandler for POST requests for saving configuration
 func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -709,7 +709,7 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // IntervalsPOSTHandler for POST requests for saving intervals
 func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract environment and verify
 	envVar := r.PathValue("env")
 	if envVar == "" || !h.Envs.Exists(envVar) {
@@ -768,7 +768,7 @@ func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Requ
 
 // ExpirationPOSTHandler for POST requests for expiring enroll links
 func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -866,7 +866,7 @@ func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Req
 
 // NodeActionsPOSTHandler for POST requests for multi node action
 func (h *HandlersAdmin) NodeActionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	var m NodeMultiActionRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -914,7 +914,7 @@ func (h *HandlersAdmin) NodeActionsPOSTHandler(w http.ResponseWriter, r *http.Re
 
 // EnvsPOSTHandler for POST request for /environments
 func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	var c EnvironmentsRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1015,7 +1015,7 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // SettingsPOSTHandler for POST request for /settings
 func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract service
 	serviceVar := r.PathValue("service")
 	if serviceVar == "" {
@@ -1102,7 +1102,7 @@ func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // UsersPOSTHandler for POST request for /users
 func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	var u UsersRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1238,7 +1238,7 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 
 // TagsPOSTHandler for POST request for /tags
 func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	var t TagsRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1323,7 +1323,7 @@ func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 
 // TagNodesPOSTHandler for POST request for /tags/nodes
 func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	var t TagNodesRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1384,7 +1384,7 @@ func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Reque
 
 // PermissionsPOSTHandler for POST request for /users/permissions
 func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract username and verify
 	usernameVar := r.PathValue("username")
 	if usernameVar == "" || !h.Users.Exists(usernameVar) {
@@ -1445,7 +1445,7 @@ func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Re
 
 // EnrollPOSTHandler for POST requests enroll data
 func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -1548,7 +1548,7 @@ func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request
 
 // EditProfilePOSTHandler for POST requests to edit profile
 func (h *HandlersAdmin) EditProfilePOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	var u UsersRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1617,7 +1617,7 @@ func (h *HandlersAdmin) EditProfilePOSTHandler(w http.ResponseWriter, r *http.Re
 
 // SavedQueriesPOSTHandler for POST requests to save queries
 func (h *HandlersAdmin) SavedQueriesPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	var s SavedQueryRequest
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/templates.go
+++ b/cmd/admin/handlers/templates.go
@@ -69,7 +69,9 @@ func (h *HandlersAdmin) NewTemplateFiles(base string, layoutFilename string) *Te
 
 // LoginHandler for login page for GET requests
 func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Prepare template
 	t, err := template.ParseFiles(
 		h.TemplatesFolder+"/login.html",
@@ -95,7 +97,9 @@ func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvironmentHandler for environment view of the table
 func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -170,7 +174,9 @@ func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Reques
 
 // PlatformHandler for platform view of the table
 func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract platform
 	// FIXME verify platform
 	platform := r.PathValue("platform")
@@ -245,7 +251,9 @@ func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) 
 
 // QueryRunGETHandler for GET requests to run queries
 func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -326,7 +334,9 @@ func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Reques
 
 // QueryListGETHandler for GET requests to queries
 func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -385,7 +395,9 @@ func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Reque
 
 // SavedQueriesGETHandler for GET requests to queries
 func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -444,7 +456,9 @@ func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Re
 
 // CarvesRunGETHandler for GET requests to run file carves
 func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -519,7 +533,9 @@ func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Reque
 
 // CarvesListGETHandler for GET requests to carves
 func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -578,7 +594,9 @@ func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Requ
 
 // QueryLogsHandler for GET requests to see query results by name
 func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -668,7 +686,9 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 
 // CarvesDetailsHandler for GET requests to see carves details by name
 func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -774,7 +794,9 @@ func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Requ
 
 // ConfGETHandler for GET requests for /conf
 func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -832,7 +854,9 @@ func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnrollGETHandler for GET requests for /enroll
 func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -916,7 +940,9 @@ func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request)
 
 // EnrollGETHandler for GET requests for /enroll
 func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -991,7 +1017,9 @@ func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Req
 
 // NodeHandler for node view
 func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract uuid
 	uuid := r.PathValue("uuid")
 	if uuid == "" {
@@ -1104,7 +1132,9 @@ func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvsGETHandler for GET requests for /env
 func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1149,7 +1179,9 @@ func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // SettingsGETHandler for GET requests for /settings
 func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1219,7 +1251,9 @@ func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Reques
 
 // UsersGETHandler for GET requests for /users
 func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1276,7 +1310,9 @@ func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) 
 
 // TagsGETHandler for GET requests for /tags
 func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1335,7 +1371,9 @@ func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // EditProfileGETHandler for user profile edit
 func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1391,7 +1429,9 @@ func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Req
 
 // DashboardGETHandler for dashboard page
 func (h *HandlersAdmin) DashboardGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/templates.go
+++ b/cmd/admin/handlers/templates.go
@@ -69,8 +69,8 @@ func (h *HandlersAdmin) NewTemplateFiles(base string, layoutFilename string) *Te
 
 // LoginHandler for login page for GET requests
 func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Prepare template
 	t, err := template.ParseFiles(
@@ -97,8 +97,8 @@ func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvironmentHandler for environment view of the table
 func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -174,8 +174,8 @@ func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Reques
 
 // PlatformHandler for platform view of the table
 func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract platform
 	// FIXME verify platform
@@ -251,8 +251,8 @@ func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) 
 
 // QueryRunGETHandler for GET requests to run queries
 func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -334,8 +334,8 @@ func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Reques
 
 // QueryListGETHandler for GET requests to queries
 func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -395,8 +395,8 @@ func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Reque
 
 // SavedQueriesGETHandler for GET requests to queries
 func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -456,8 +456,8 @@ func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Re
 
 // CarvesRunGETHandler for GET requests to run file carves
 func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -533,8 +533,8 @@ func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Reque
 
 // CarvesListGETHandler for GET requests to carves
 func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -594,8 +594,8 @@ func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Requ
 
 // QueryLogsHandler for GET requests to see query results by name
 func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -686,8 +686,8 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 
 // CarvesDetailsHandler for GET requests to see carves details by name
 func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -794,8 +794,8 @@ func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Requ
 
 // ConfGETHandler for GET requests for /conf
 func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -854,8 +854,8 @@ func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnrollGETHandler for GET requests for /enroll
 func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -940,8 +940,8 @@ func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request)
 
 // EnrollGETHandler for GET requests for /enroll
 func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -1017,8 +1017,8 @@ func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Req
 
 // NodeHandler for node view
 func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract uuid
 	uuid := r.PathValue("uuid")
@@ -1132,8 +1132,8 @@ func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvsGETHandler for GET requests for /env
 func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1179,8 +1179,8 @@ func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // SettingsGETHandler for GET requests for /settings
 func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1251,8 +1251,8 @@ func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Reques
 
 // UsersGETHandler for GET requests for /users
 func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1310,8 +1310,8 @@ func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) 
 
 // TagsGETHandler for GET requests for /tags
 func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1371,8 +1371,8 @@ func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // EditProfileGETHandler for user profile edit
 func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -1429,8 +1429,8 @@ func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Req
 
 // DashboardGETHandler for dashboard page
 func (h *HandlersAdmin) DashboardGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/admin/handlers/templates.go
+++ b/cmd/admin/handlers/templates.go
@@ -69,7 +69,7 @@ func (h *HandlersAdmin) NewTemplateFiles(base string, layoutFilename string) *Te
 
 // LoginHandler for login page for GET requests
 func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Prepare template
 	t, err := template.ParseFiles(
 		h.TemplatesFolder+"/login.html",
@@ -95,7 +95,7 @@ func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvironmentHandler for environment view of the table
 func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -170,7 +170,7 @@ func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Reques
 
 // PlatformHandler for platform view of the table
 func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract platform
 	// FIXME verify platform
 	platform := r.PathValue("platform")
@@ -245,7 +245,7 @@ func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) 
 
 // QueryRunGETHandler for GET requests to run queries
 func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -326,7 +326,7 @@ func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Reques
 
 // QueryListGETHandler for GET requests to queries
 func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -385,7 +385,7 @@ func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Reque
 
 // SavedQueriesGETHandler for GET requests to queries
 func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -444,7 +444,7 @@ func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Re
 
 // CarvesRunGETHandler for GET requests to run file carves
 func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -519,7 +519,7 @@ func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Reque
 
 // CarvesListGETHandler for GET requests to carves
 func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -578,7 +578,7 @@ func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Requ
 
 // QueryLogsHandler for GET requests to see query results by name
 func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -668,7 +668,7 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 
 // CarvesDetailsHandler for GET requests to see carves details by name
 func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -774,7 +774,7 @@ func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Requ
 
 // ConfGETHandler for GET requests for /conf
 func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -832,7 +832,7 @@ func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnrollGETHandler for GET requests for /enroll
 func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -916,7 +916,7 @@ func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request)
 
 // EnrollGETHandler for GET requests for /enroll
 func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -991,7 +991,7 @@ func (h *HandlersAdmin) EnrollDownloadHandler(w http.ResponseWriter, r *http.Req
 
 // NodeHandler for node view
 func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract uuid
 	uuid := r.PathValue("uuid")
 	if uuid == "" {
@@ -1104,7 +1104,7 @@ func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvsGETHandler for GET requests for /env
 func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1149,7 +1149,7 @@ func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // SettingsGETHandler for GET requests for /settings
 func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1219,7 +1219,7 @@ func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Reques
 
 // UsersGETHandler for GET requests for /users
 func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1276,7 +1276,7 @@ func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) 
 
 // TagsGETHandler for GET requests for /tags
 func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1335,7 +1335,7 @@ func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
 
 // EditProfileGETHandler for user profile edit
 func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -1391,7 +1391,7 @@ func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Req
 
 // DashboardGETHandler for dashboard page
 func (h *HandlersAdmin) DashboardGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/tokens.go
+++ b/cmd/admin/handlers/tokens.go
@@ -21,7 +21,9 @@ type TokenJSON struct {
 
 // TokensGETHandler for GET requests for /tokens/{username}
 func (h *HandlersAdmin) TokensGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -55,7 +57,9 @@ func (h *HandlersAdmin) TokensGETHandler(w http.ResponseWriter, r *http.Request)
 
 // TokensPOSTHandler for POST request for /tokens/{username}/refresh
 func (h *HandlersAdmin) TokensPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/tokens.go
+++ b/cmd/admin/handlers/tokens.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
 	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -22,7 +21,7 @@ type TokenJSON struct {
 
 // TokensGETHandler for GET requests for /tokens/{username}
 func (h *HandlersAdmin) TokensGETHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions
@@ -56,7 +55,7 @@ func (h *HandlersAdmin) TokensGETHandler(w http.ResponseWriter, r *http.Request)
 
 // TokensPOSTHandler for POST request for /tokens/{username}/refresh
 func (h *HandlersAdmin) TokensPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Check permissions

--- a/cmd/admin/handlers/tokens.go
+++ b/cmd/admin/handlers/tokens.go
@@ -21,8 +21,8 @@ type TokenJSON struct {
 
 // TokensGETHandler for GET requests for /tokens/{username}
 func (h *HandlersAdmin) TokensGETHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
@@ -57,8 +57,8 @@ func (h *HandlersAdmin) TokensGETHandler(w http.ResponseWriter, r *http.Request)
 
 // TokensPOSTHandler for POST request for /tokens/{username}/refresh
 func (h *HandlersAdmin) TokensPOSTHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)

--- a/cmd/api/handlers/carves.go
+++ b/cmd/api/handlers/carves.go
@@ -18,7 +18,7 @@ import (
 
 // GET Handler to return a single carve in JSON
 func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract name
 	name := r.PathValue("name")
 	if name == "" {
@@ -62,7 +62,7 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 
 // GET Handler to return carve queries in JSON by target and environment
 func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -108,7 +108,7 @@ func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request
 
 // GET Handler to return carves in JSON by environment
 func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -143,7 +143,7 @@ func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
 
 // POST Handler to run a carve
 func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -218,7 +218,7 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 
 // CarvesActionHandler - POST Handler to delete/expire a carve
 func (h *HandlersApi) CarvesActionHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/carves.go
+++ b/cmd/api/handlers/carves.go
@@ -18,8 +18,9 @@ import (
 
 // GET Handler to return a single carve in JSON
 func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract name
 	name := r.PathValue("name")
@@ -64,8 +65,9 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 
 // GET Handler to return carve queries in JSON by target and environment
 func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -112,8 +114,9 @@ func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request
 
 // GET Handler to return carves in JSON by environment
 func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -149,8 +152,9 @@ func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
 
 // POST Handler to run a carve
 func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -226,8 +230,9 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 
 // CarvesActionHandler - POST Handler to delete/expire a carve
 func (h *HandlersApi) CarvesActionHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")

--- a/cmd/api/handlers/carves.go
+++ b/cmd/api/handlers/carves.go
@@ -18,7 +18,9 @@ import (
 
 // GET Handler to return a single carve in JSON
 func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract name
 	name := r.PathValue("name")
 	if name == "" {
@@ -62,7 +64,9 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 
 // GET Handler to return carve queries in JSON by target and environment
 func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -108,7 +112,9 @@ func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request
 
 // GET Handler to return carves in JSON by environment
 func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -143,7 +149,9 @@ func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
 
 // POST Handler to run a carve
 func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -218,7 +226,9 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 
 // CarvesActionHandler - POST Handler to delete/expire a carve
 func (h *HandlersApi) CarvesActionHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/environments.go
+++ b/cmd/api/handlers/environments.go
@@ -25,7 +25,7 @@ var (
 
 // EnvironmentHandler - GET Handler to return one environment by UUID as JSON
 func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -57,7 +57,7 @@ func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request)
 
 // EnvironmentMapHandler - GET Handler to return one environment as JSON
 func (h *HandlersApi) EnvironmentMapHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract target
 	targetVar := r.PathValue("target")
 	if targetVar == "" {
@@ -99,7 +99,7 @@ func (h *HandlersApi) EnvironmentMapHandler(w http.ResponseWriter, r *http.Reque
 
 // EnvironmentsHandler - GET Handler to return all environments as JSON
 func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
@@ -121,7 +121,7 @@ func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request
 
 // EnvEnrollHandler - GET Handler to return node enrollment values (secret, certificate, one-liner) for an environment as JSON
 func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -183,7 +183,7 @@ func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvRemoveHandler - GET Handler to return node removal values for an environment as JSON
 func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -239,7 +239,7 @@ func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvEnrollActionsHandler - POST Handler to perform actions (extend, expire) in enroll values
 func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -334,7 +334,7 @@ func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Req
 
 // EnvRemoveActionsHandler - POST Handler to perform actions (extend, expire) in remove values
 func (h *HandlersApi) EnvRemoveActionsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/environments.go
+++ b/cmd/api/handlers/environments.go
@@ -25,7 +25,9 @@ var (
 
 // EnvironmentHandler - GET Handler to return one environment by UUID as JSON
 func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -57,7 +59,9 @@ func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request)
 
 // EnvironmentMapHandler - GET Handler to return one environment as JSON
 func (h *HandlersApi) EnvironmentMapHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract target
 	targetVar := r.PathValue("target")
 	if targetVar == "" {
@@ -99,7 +103,9 @@ func (h *HandlersApi) EnvironmentMapHandler(w http.ResponseWriter, r *http.Reque
 
 // EnvironmentsHandler - GET Handler to return all environments as JSON
 func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
@@ -121,7 +127,9 @@ func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request
 
 // EnvEnrollHandler - GET Handler to return node enrollment values (secret, certificate, one-liner) for an environment as JSON
 func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -183,7 +191,9 @@ func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvRemoveHandler - GET Handler to return node removal values for an environment as JSON
 func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -239,7 +249,9 @@ func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvEnrollActionsHandler - POST Handler to perform actions (extend, expire) in enroll values
 func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -334,7 +346,9 @@ func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Req
 
 // EnvRemoveActionsHandler - POST Handler to perform actions (extend, expire) in remove values
 func (h *HandlersApi) EnvRemoveActionsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/environments.go
+++ b/cmd/api/handlers/environments.go
@@ -25,8 +25,9 @@ var (
 
 // EnvironmentHandler - GET Handler to return one environment by UUID as JSON
 func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -59,8 +60,9 @@ func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request)
 
 // EnvironmentMapHandler - GET Handler to return one environment as JSON
 func (h *HandlersApi) EnvironmentMapHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract target
 	targetVar := r.PathValue("target")
@@ -103,8 +105,9 @@ func (h *HandlersApi) EnvironmentMapHandler(w http.ResponseWriter, r *http.Reque
 
 // EnvironmentsHandler - GET Handler to return all environments as JSON
 func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
@@ -127,8 +130,9 @@ func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request
 
 // EnvEnrollHandler - GET Handler to return node enrollment values (secret, certificate, one-liner) for an environment as JSON
 func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -191,8 +195,9 @@ func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvRemoveHandler - GET Handler to return node removal values for an environment as JSON
 func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -249,8 +254,9 @@ func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
 
 // EnvEnrollActionsHandler - POST Handler to perform actions (extend, expire) in enroll values
 func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -346,8 +352,9 @@ func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Req
 
 // EnvRemoveActionsHandler - POST Handler to perform actions (extend, expire) in remove values
 func (h *HandlersApi) EnvRemoveActionsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")

--- a/cmd/api/handlers/get.go
+++ b/cmd/api/handlers/get.go
@@ -4,13 +4,13 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/pkg/utils"
-	"github.com/rs/zerolog/log"
 )
 
 // HealthHandler - Handle health requests
 func (h *HandlersApi) HealthHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusOK, []byte(okContent))
@@ -18,8 +18,9 @@ func (h *HandlersApi) HealthHandler(w http.ResponseWriter, r *http.Request) {
 
 // RootHandler - Handle root requests
 func (h *HandlersApi) RootHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusOK, []byte(okContent))
@@ -27,8 +28,9 @@ func (h *HandlersApi) RootHandler(w http.ResponseWriter, r *http.Request) {
 
 // ErrorHandler - Handle error requests
 func (h *HandlersApi) ErrorHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(errorContent))
@@ -36,8 +38,9 @@ func (h *HandlersApi) ErrorHandler(w http.ResponseWriter, r *http.Request) {
 
 // ForbiddenHandler - Handle forbidden error requests
 func (h *HandlersApi) ForbiddenHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusForbidden, []byte(errorContent))

--- a/cmd/api/handlers/get.go
+++ b/cmd/api/handlers/get.go
@@ -3,35 +3,33 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/utils"
 )
 
 // HealthHandler - Handle health requests
 func (h *HandlersApi) HealthHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusOK, []byte(okContent))
 }
 
 // RootHandler - Handle root requests
 func (h *HandlersApi) RootHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusOK, []byte(okContent))
 }
 
 // ErrorHandler - Handle error requests
 func (h *HandlersApi) ErrorHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(errorContent))
 }
 
 // ForbiddenHandler - Handle forbidden error requests
 func (h *HandlersApi) ForbiddenHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID), true)
+	utils.DebugHTTPDump(r, true)
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusForbidden, []byte(errorContent))
 }

--- a/cmd/api/handlers/get.go
+++ b/cmd/api/handlers/get.go
@@ -4,32 +4,41 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/pkg/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // HealthHandler - Handle health requests
 func (h *HandlersApi) HealthHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusOK, []byte(okContent))
 }
 
 // RootHandler - Handle root requests
 func (h *HandlersApi) RootHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusOK, []byte(okContent))
 }
 
 // ErrorHandler - Handle error requests
 func (h *HandlersApi) ErrorHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(errorContent))
 }
 
 // ForbiddenHandler - Handle forbidden error requests
 func (h *HandlersApi) ForbiddenHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusForbidden, []byte(errorContent))
 }

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/rs/zerolog"
 	"gorm.io/gorm"
 )
 
@@ -17,18 +18,20 @@ const errorContent = "❌"
 const okContent = "✅"
 
 type HandlersApi struct {
-	DB             *gorm.DB
-	Users          *users.UserManager
-	Tags           *tags.TagManager
-	Envs           *environments.Environment
-	Nodes          *nodes.NodeManager
-	Queries        *queries.Queries
-	Carves         *carves.Carves
-	Settings       *settings.Settings
-	RedisCache     *cache.RedisManager
-	ServiceVersion string
-	ServiceName    string
-	ApiConfig      *config.JSONConfigurationService
+	DB              *gorm.DB
+	Users           *users.UserManager
+	Tags            *tags.TagManager
+	Envs            *environments.Environment
+	Nodes           *nodes.NodeManager
+	Queries         *queries.Queries
+	Carves          *carves.Carves
+	Settings        *settings.Settings
+	RedisCache      *cache.RedisManager
+	ServiceVersion  string
+	ServiceName     string
+	ApiConfig       *config.JSONConfigurationService
+	DebugHTTP       *zerolog.Logger
+	DebugHTTPConfig *config.DebugHTTPConfiguration
 }
 
 type HandlersOption func(*HandlersApi)
@@ -96,6 +99,13 @@ func WithVersion(version string) HandlersOption {
 func WithName(name string) HandlersOption {
 	return func(h *HandlersApi) {
 		h.ServiceName = name
+	}
+}
+
+func WithDebugHTTP(logger *zerolog.Logger, cfg *config.DebugHTTPConfiguration) HandlersOption {
+	return func(h *HandlersApi) {
+		h.DebugHTTP = logger
+		h.DebugHTTPConfig = cfg
 	}
 }
 

--- a/cmd/api/handlers/login.go
+++ b/cmd/api/handlers/login.go
@@ -14,7 +14,9 @@ import (
 
 // LoginHandler - POST Handler for API login request
 func (h *HandlersApi) LoginHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/login.go
+++ b/cmd/api/handlers/login.go
@@ -14,8 +14,9 @@ import (
 
 // LoginHandler - POST Handler for API login request
 func (h *HandlersApi) LoginHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled, never log the body for login
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")

--- a/cmd/api/handlers/login.go
+++ b/cmd/api/handlers/login.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -15,7 +14,7 @@ import (
 
 // LoginHandler - POST Handler for API login request
 func (h *HandlersApi) LoginHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/nodes.go
+++ b/cmd/api/handlers/nodes.go
@@ -15,7 +15,9 @@ import (
 
 // NodeHandler - GET Handler for single JSON nodes
 func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -60,7 +62,9 @@ func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
 
 // ActiveNodesHandler - GET Handler for active JSON nodes
 func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -98,7 +102,9 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 
 // InactiveNodesHandler - GET Handler for inactive JSON nodes
 func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -136,7 +142,9 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 
 // AllNodesHandler - GET Handler for all JSON nodes
 func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -174,7 +182,9 @@ func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
 
 // DeleteNodeHandler - POST Handler to delete single node
 func (h *HandlersApi) DeleteNodeHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/nodes.go
+++ b/cmd/api/handlers/nodes.go
@@ -15,8 +15,9 @@ import (
 
 // NodeHandler - GET Handler for single JSON nodes
 func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -62,8 +63,9 @@ func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
 
 // ActiveNodesHandler - GET Handler for active JSON nodes
 func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -102,8 +104,9 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 
 // InactiveNodesHandler - GET Handler for inactive JSON nodes
 func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -142,8 +145,9 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 
 // AllNodesHandler - GET Handler for all JSON nodes
 func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -182,8 +186,9 @@ func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
 
 // DeleteNodeHandler - POST Handler to delete single node
 func (h *HandlersApi) DeleteNodeHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")

--- a/cmd/api/handlers/nodes.go
+++ b/cmd/api/handlers/nodes.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/nodes"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -16,7 +15,7 @@ import (
 
 // NodeHandler - GET Handler for single JSON nodes
 func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -61,7 +60,7 @@ func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
 
 // ActiveNodesHandler - GET Handler for active JSON nodes
 func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -99,7 +98,7 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 
 // InactiveNodesHandler - GET Handler for inactive JSON nodes
 func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -137,7 +136,7 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 
 // AllNodesHandler - GET Handler for all JSON nodes
 func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -175,7 +174,7 @@ func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
 
 // DeleteNodeHandler - POST Handler to delete single node
 func (h *HandlersApi) DeleteNodeHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/platforms.go
+++ b/cmd/api/handlers/platforms.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -13,7 +12,7 @@ import (
 
 // PlatformsHandler - GET Handler for multiple JSON platforms
 func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
@@ -35,7 +34,7 @@ func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
 
 // PlatformsEnvHandler - GET Handler to return platforms for one environment as JSON
 func (h *HandlersApi) PlatformsEnvHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/platforms.go
+++ b/cmd/api/handlers/platforms.go
@@ -12,8 +12,9 @@ import (
 
 // PlatformsHandler - GET Handler for multiple JSON platforms
 func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
@@ -36,8 +37,9 @@ func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
 
 // PlatformsEnvHandler - GET Handler to return platforms for one environment as JSON
 func (h *HandlersApi) PlatformsEnvHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")

--- a/cmd/api/handlers/platforms.go
+++ b/cmd/api/handlers/platforms.go
@@ -12,7 +12,9 @@ import (
 
 // PlatformsHandler - GET Handler for multiple JSON platforms
 func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
@@ -34,7 +36,9 @@ func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
 
 // PlatformsEnvHandler - GET Handler to return platforms for one environment as JSON
 func (h *HandlersApi) PlatformsEnvHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -30,8 +30,9 @@ var QueryTargets = map[string]bool{
 
 // QueryShowHandler - GET Handler to return a single query in JSON
 func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract name
 	name := r.PathValue("name")
@@ -76,8 +77,9 @@ func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
 
 // QueriesRunHandler - POST Handler to run a query
 func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -235,8 +237,9 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 
 // QueriesActionHandler - POST Handler to delete/expire a query
 func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -300,8 +303,9 @@ func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Reques
 
 // AllQueriesShowHandler - GET Handler to return all queries in JSON
 func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -337,8 +341,9 @@ func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Reque
 
 // QueryListHandler - GET Handler to return queries in JSON by target and environment
 func (h *HandlersApi) QueryListHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -385,8 +390,9 @@ func (h *HandlersApi) QueryListHandler(w http.ResponseWriter, r *http.Request) {
 
 // QueryResultsHandler - GET Handler to return a single query results in JSON
 func (h *HandlersApi) QueryResultsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract name
 	name := r.PathValue("name")

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -30,7 +30,9 @@ var QueryTargets = map[string]bool{
 
 // QueryShowHandler - GET Handler to return a single query in JSON
 func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract name
 	name := r.PathValue("name")
 	if name == "" {
@@ -74,7 +76,9 @@ func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
 
 // QueriesRunHandler - POST Handler to run a query
 func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -231,7 +235,9 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 
 // QueriesActionHandler - POST Handler to delete/expire a query
 func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -294,7 +300,9 @@ func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Reques
 
 // AllQueriesShowHandler - GET Handler to return all queries in JSON
 func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -329,7 +337,9 @@ func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Reque
 
 // QueryListHandler - GET Handler to return queries in JSON by target and environment
 func (h *HandlersApi) QueryListHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -375,7 +385,9 @@ func (h *HandlersApi) QueryListHandler(w http.ResponseWriter, r *http.Request) {
 
 // QueryResultsHandler - GET Handler to return a single query results in JSON
 func (h *HandlersApi) QueryResultsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract name
 	name := r.PathValue("name")
 	if name == "" {

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -30,7 +30,7 @@ var QueryTargets = map[string]bool{
 
 // QueryShowHandler - GET Handler to return a single query in JSON
 func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract name
 	name := r.PathValue("name")
 	if name == "" {
@@ -74,7 +74,7 @@ func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
 
 // QueriesRunHandler - POST Handler to run a query
 func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -231,7 +231,7 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 
 // QueriesActionHandler - POST Handler to delete/expire a query
 func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -294,7 +294,7 @@ func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Reques
 
 // AllQueriesShowHandler - GET Handler to return all queries in JSON
 func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -329,7 +329,7 @@ func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Reque
 
 // QueryListHandler - GET Handler to return queries in JSON by target and environment
 func (h *HandlersApi) QueryListHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -375,7 +375,7 @@ func (h *HandlersApi) QueryListHandler(w http.ResponseWriter, r *http.Request) {
 
 // QueryResultsHandler - GET Handler to return a single query results in JSON
 func (h *HandlersApi) QueryResultsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract name
 	name := r.PathValue("name")
 	if name == "" {

--- a/cmd/api/handlers/settings.go
+++ b/cmd/api/handlers/settings.go
@@ -13,7 +13,9 @@ import (
 
 // SettingsHandler - GET Handler for all settings including JSON
 func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
@@ -35,7 +37,9 @@ func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
 
 // SettingsServiceHandler - GET Handler for service specific settings excluding JSON
 func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract service
 	service := r.PathValue("service")
 	if service == "" {
@@ -68,7 +72,9 @@ func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Requ
 
 // SettingsServiceEnvHandler - GET Handler for service and environment specific settings excluding JSON
 func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract service
 	service := r.PathValue("service")
 	if service == "" {
@@ -117,7 +123,9 @@ func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.R
 
 // SettingsServiceJSONHandler - GET Handler for service specific settings including JSON
 func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	service := r.PathValue("service")
 	if service == "" {
@@ -150,7 +158,9 @@ func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.
 
 // GET Handler for service and environment specific settings including JSON
 func (h *HandlersApi) SettingsServiceEnvJSONHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	service := r.PathValue("service")
 	if service == "" {

--- a/cmd/api/handlers/settings.go
+++ b/cmd/api/handlers/settings.go
@@ -13,7 +13,7 @@ import (
 
 // SettingsHandler - GET Handler for all settings including JSON
 func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
@@ -35,7 +35,7 @@ func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
 
 // SettingsServiceHandler - GET Handler for service specific settings excluding JSON
 func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract service
 	service := r.PathValue("service")
 	if service == "" {
@@ -68,7 +68,7 @@ func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Requ
 
 // SettingsServiceEnvHandler - GET Handler for service and environment specific settings excluding JSON
 func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract service
 	service := r.PathValue("service")
 	if service == "" {
@@ -117,7 +117,7 @@ func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.R
 
 // SettingsServiceJSONHandler - GET Handler for service specific settings including JSON
 func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	service := r.PathValue("service")
 	if service == "" {
@@ -150,7 +150,7 @@ func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.
 
 // GET Handler for service and environment specific settings including JSON
 func (h *HandlersApi) SettingsServiceEnvJSONHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	service := r.PathValue("service")
 	if service == "" {

--- a/cmd/api/handlers/settings.go
+++ b/cmd/api/handlers/settings.go
@@ -13,8 +13,9 @@ import (
 
 // SettingsHandler - GET Handler for all settings including JSON
 func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
@@ -37,8 +38,9 @@ func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
 
 // SettingsServiceHandler - GET Handler for service specific settings excluding JSON
 func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract service
 	service := r.PathValue("service")
@@ -72,8 +74,9 @@ func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Requ
 
 // SettingsServiceEnvHandler - GET Handler for service and environment specific settings excluding JSON
 func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract service
 	service := r.PathValue("service")
@@ -123,8 +126,9 @@ func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.R
 
 // SettingsServiceJSONHandler - GET Handler for service specific settings including JSON
 func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	service := r.PathValue("service")
@@ -158,8 +162,9 @@ func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.
 
 // GET Handler for service and environment specific settings including JSON
 func (h *HandlersApi) SettingsServiceEnvJSONHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	service := r.PathValue("service")

--- a/cmd/api/handlers/tags.go
+++ b/cmd/api/handlers/tags.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
@@ -16,7 +15,7 @@ import (
 
 // AllTagsHandler - GET Handler for all JSON tags
 func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
@@ -38,7 +37,7 @@ func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagEnvHandler - GET Handler to return one tag for one environment as JSON
 func (h *HandlersApi) TagEnvHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -82,7 +81,7 @@ func (h *HandlersApi) TagEnvHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagsEnvHandler - GET Handler to return tags for one environment as JSON
 func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -120,7 +119,7 @@ func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagsActionHandler - POST Handler to create, update or delete tags
 func (h *HandlersApi) TagsActionHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/tags.go
+++ b/cmd/api/handlers/tags.go
@@ -15,7 +15,9 @@ import (
 
 // AllTagsHandler - GET Handler for all JSON tags
 func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
@@ -37,7 +39,9 @@ func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagEnvHandler - GET Handler to return one tag for one environment as JSON
 func (h *HandlersApi) TagEnvHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -81,7 +85,9 @@ func (h *HandlersApi) TagEnvHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagsEnvHandler - GET Handler to return tags for one environment as JSON
 func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -119,7 +125,9 @@ func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagsActionHandler - POST Handler to create, update or delete tags
 func (h *HandlersApi) TagsActionHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {

--- a/cmd/api/handlers/tags.go
+++ b/cmd/api/handlers/tags.go
@@ -15,8 +15,9 @@ import (
 
 // AllTagsHandler - GET Handler for all JSON tags
 func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
@@ -39,8 +40,9 @@ func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagEnvHandler - GET Handler to return one tag for one environment as JSON
 func (h *HandlersApi) TagEnvHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -85,8 +87,9 @@ func (h *HandlersApi) TagEnvHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagsEnvHandler - GET Handler to return tags for one environment as JSON
 func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")
@@ -125,8 +128,9 @@ func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
 
 // TagsActionHandler - POST Handler to create, update or delete tags
 func (h *HandlersApi) TagsActionHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract environment
 	envVar := r.PathValue("env")

--- a/cmd/api/handlers/users.go
+++ b/cmd/api/handlers/users.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -13,7 +12,7 @@ import (
 
 // UserHandler - GET Handler for single JSON nodes
 func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Extract username
 	usernameVar := r.PathValue("username")
 	if usernameVar == "" {
@@ -41,7 +40,7 @@ func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
 
 // UsersHandler - GET Handler for multiple JSON nodes
 func (h *HandlersApi) UsersHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID), false)
+	utils.DebugHTTPDump(r, false)
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {

--- a/cmd/api/handlers/users.go
+++ b/cmd/api/handlers/users.go
@@ -12,8 +12,9 @@ import (
 
 // UserHandler - GET Handler for single JSON nodes
 func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract username
 	usernameVar := r.PathValue("username")
@@ -42,8 +43,9 @@ func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
 
 // UsersHandler - GET Handler for multiple JSON nodes
 func (h *HandlersApi) UsersHandler(w http.ResponseWriter, r *http.Request) {
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, false)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)

--- a/cmd/api/handlers/users.go
+++ b/cmd/api/handlers/users.go
@@ -12,7 +12,9 @@ import (
 
 // UserHandler - GET Handler for single JSON nodes
 func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Extract username
 	usernameVar := r.PathValue("username")
 	if usernameVar == "" {
@@ -40,7 +42,9 @@ func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
 
 // UsersHandler - GET Handler for multiple JSON nodes
 func (h *HandlersApi) UsersHandler(w http.ResponseWriter, r *http.Request) {
-	utils.DebugHTTPDump(r, false)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, false)
+	}
 	// Get context data and check access
 	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
 	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/carves"
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
@@ -13,6 +14,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/version"
+	"github.com/rs/zerolog"
 )
 
 const (
@@ -45,16 +47,18 @@ var validPlatform = map[string]bool{
 
 // HandlersTLS to keep all handlers for TLS
 type HandlersTLS struct {
-	Envs         *environments.Environment
-	EnvsMap      *environments.MapEnvironments
-	Nodes        *nodes.NodeManager
-	Tags         *tags.TagManager
-	Queries      *queries.Queries
-	Carves       *carves.Carves
-	Settings     *settings.Settings
-	SettingsMap  *settings.MapSettings
-	Logs         *logging.LoggerTLS
-	WriteHandler *batchWriter
+	Envs            *environments.Environment
+	EnvsMap         *environments.MapEnvironments
+	Nodes           *nodes.NodeManager
+	Tags            *tags.TagManager
+	Queries         *queries.Queries
+	Carves          *carves.Carves
+	Settings        *settings.Settings
+	SettingsMap     *settings.MapSettings
+	Logs            *logging.LoggerTLS
+	WriteHandler    *batchWriter
+	DebugHTTP       *zerolog.Logger
+	DebugHTTPConfig *config.DebugHTTPConfiguration
 }
 
 // TLSResponse to be returned to requests
@@ -132,6 +136,13 @@ func WithLogs(logs *logging.LoggerTLS) Option {
 func WithWriteHandler(writeHandler *batchWriter) Option {
 	return func(h *HandlersTLS) {
 		h.WriteHandler = writeHandler
+	}
+}
+
+func WithDebugHTTP(logger *zerolog.Logger, cfg *config.DebugHTTPConfiguration) Option {
+	return func(h *HandlersTLS) {
+		h.DebugHTTP = logger
+		h.DebugHTTPConfig = cfg
 	}
 }
 

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -142,12 +142,10 @@ func CreateHandlersTLS(opts ...Option) *HandlersTLS {
 		opt(h)
 	}
 	// All these opt function need be refactored to reduce unnecessary complexity
-
 	return h
 }
 
 func (h *HandlersTLS) PrometheusMiddleware(next http.Handler) http.Handler {
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		rw := NewResponseWriter(w)

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -46,7 +46,9 @@ func (h *HandlersTLS) EnrollHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.EnrollRequest
 	body, err := io.ReadAll(r.Body)
@@ -124,7 +126,9 @@ func (h *HandlersTLS) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.ConfigRequest
 	body, err := io.ReadAll(r.Body)
@@ -203,7 +207,9 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 	// Debug HTTP here so the body will be uncompressed
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Extract POST body and decode JSON
 	var t types.LogRequest
 	body, err := io.ReadAll(r.Body)
@@ -273,7 +279,9 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.QueryReadRequest
 	body, err := io.ReadAll(r.Body)
@@ -349,7 +357,9 @@ func (h *HandlersTLS) QueryWriteHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.QueryWriteRequest
 	body, err := io.ReadAll(r.Body)
@@ -430,7 +440,9 @@ func (h *HandlersTLS) QuickEnrollHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Retrieve type of script
 	script := r.PathValue("script")
 	if script == "" {
@@ -501,7 +513,9 @@ func (h *HandlersTLS) QuickRemoveHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Retrieve type of script
 	script := r.PathValue("script")
 	if script == "" {
@@ -574,7 +588,9 @@ func (h *HandlersTLS) CarveInitHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.CarveInitRequest
 	body, err := io.ReadAll(r.Body)
@@ -641,7 +657,9 @@ func (h *HandlersTLS) CarveBlockHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.CarveBlockRequest
 	body, err := io.ReadAll(r.Body)
@@ -699,7 +717,9 @@ func (h *HandlersTLS) FlagsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.FlagsRequest
 	body, err := io.ReadAll(r.Body)
@@ -756,7 +776,9 @@ func (h *HandlersTLS) CertHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.CertRequest
 	body, err := io.ReadAll(r.Body)
@@ -807,7 +829,9 @@ func (h *HandlersTLS) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.VerifyRequest
 	body, err := io.ReadAll(r.Body)
@@ -895,7 +919,9 @@ func (h *HandlersTLS) ScriptHandler(w http.ResponseWriter, r *http.Request) {
 		actionVar += environments.PowershellTarget
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Decode read POST body
 	var t types.ScriptRequest
 	body, err := io.ReadAll(r.Body)
@@ -951,7 +977,9 @@ func (h *HandlersTLS) EnrollPackageHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, true)
+	if log.Debug().Enabled() {
+		utils.DebugHTTPDump(r, true)
+	}
 	// Retrieve package
 	packageVar := r.PathValue("package")
 	if packageVar == "" {

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -46,7 +46,7 @@ func (h *HandlersTLS) EnrollHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.EnrollRequest
 	body, err := io.ReadAll(r.Body)
@@ -124,7 +124,7 @@ func (h *HandlersTLS) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.ConfigRequest
 	body, err := io.ReadAll(r.Body)
@@ -203,7 +203,7 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 	// Debug HTTP here so the body will be uncompressed
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Extract POST body and decode JSON
 	var t types.LogRequest
 	body, err := io.ReadAll(r.Body)
@@ -273,7 +273,7 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.QueryReadRequest
 	body, err := io.ReadAll(r.Body)
@@ -349,7 +349,7 @@ func (h *HandlersTLS) QueryWriteHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.QueryWriteRequest
 	body, err := io.ReadAll(r.Body)
@@ -430,7 +430,7 @@ func (h *HandlersTLS) QuickEnrollHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Retrieve type of script
 	script := r.PathValue("script")
 	if script == "" {
@@ -501,7 +501,7 @@ func (h *HandlersTLS) QuickRemoveHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Retrieve type of script
 	script := r.PathValue("script")
 	if script == "" {
@@ -574,7 +574,7 @@ func (h *HandlersTLS) CarveInitHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.CarveInitRequest
 	body, err := io.ReadAll(r.Body)
@@ -641,7 +641,7 @@ func (h *HandlersTLS) CarveBlockHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.CarveBlockRequest
 	body, err := io.ReadAll(r.Body)
@@ -699,7 +699,7 @@ func (h *HandlersTLS) FlagsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.FlagsRequest
 	body, err := io.ReadAll(r.Body)
@@ -756,7 +756,7 @@ func (h *HandlersTLS) CertHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.CertRequest
 	body, err := io.ReadAll(r.Body)
@@ -807,7 +807,7 @@ func (h *HandlersTLS) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.VerifyRequest
 	body, err := io.ReadAll(r.Body)
@@ -895,7 +895,7 @@ func (h *HandlersTLS) ScriptHandler(w http.ResponseWriter, r *http.Request) {
 		actionVar += environments.PowershellTarget
 	}
 	// Debug HTTP for environment
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Decode read POST body
 	var t types.ScriptRequest
 	body, err := io.ReadAll(r.Body)
@@ -951,7 +951,7 @@ func (h *HandlersTLS) EnrollPackageHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Debug HTTP
-	utils.DebugHTTPDump(r, (*h.EnvsMap)[env.Name].DebugHTTP, true)
+	utils.DebugHTTPDump(r, true)
 	// Retrieve package
 	packageVar := r.PathValue("package")
 	if packageVar == "" {

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -46,8 +46,8 @@ func (h *HandlersTLS) EnrollHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.EnrollRequest
@@ -126,8 +126,8 @@ func (h *HandlersTLS) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP for environment
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.ConfigRequest
@@ -207,8 +207,8 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 	// Debug HTTP here so the body will be uncompressed
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Extract POST body and decode JSON
 	var t types.LogRequest
@@ -279,8 +279,8 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.QueryReadRequest
@@ -357,8 +357,8 @@ func (h *HandlersTLS) QueryWriteHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Debug HTTP
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.QueryWriteRequest
@@ -440,8 +440,8 @@ func (h *HandlersTLS) QuickEnrollHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Debug HTTP
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Retrieve type of script
 	script := r.PathValue("script")
@@ -513,8 +513,8 @@ func (h *HandlersTLS) QuickRemoveHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Debug HTTP
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Retrieve type of script
 	script := r.PathValue("script")
@@ -588,8 +588,8 @@ func (h *HandlersTLS) CarveInitHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.CarveInitRequest
@@ -657,8 +657,8 @@ func (h *HandlersTLS) CarveBlockHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Debug HTTP
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.CarveBlockRequest
@@ -716,9 +716,9 @@ func (h *HandlersTLS) FlagsHandler(w http.ResponseWriter, r *http.Request) {
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
 		return
 	}
-	// Debug HTTP for environment
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.FlagsRequest
@@ -775,9 +775,9 @@ func (h *HandlersTLS) CertHandler(w http.ResponseWriter, r *http.Request) {
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
 		return
 	}
-	// Debug HTTP for environment
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.CertRequest
@@ -828,9 +828,9 @@ func (h *HandlersTLS) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
 		return
 	}
-	// Debug HTTP for environment
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.VerifyRequest
@@ -918,9 +918,9 @@ func (h *HandlersTLS) ScriptHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		actionVar += environments.PowershellTarget
 	}
-	// Debug HTTP for environment
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Decode read POST body
 	var t types.ScriptRequest
@@ -976,9 +976,9 @@ func (h *HandlersTLS) EnrollPackageHandler(w http.ResponseWriter, r *http.Reques
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
 		return
 	}
-	// Debug HTTP
-	if log.Debug().Enabled() {
-		utils.DebugHTTPDump(r, true)
+	// Debug HTTP if enabled
+	if h.DebugHTTPConfig.Enabled {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
 	// Retrieve package
 	packageVar := r.PathValue("package")

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -142,6 +142,7 @@ func osctrlService() {
 	log.Info().Msg("Initializing backend...")
 	// Attempt to connect to backend waiting until is ready
 	for {
+		log.Debug().Msgf("Creating DB manager with %v", flagParams.DBConfigValues)
 		db, err = backend.CreateDBManager(flagParams.DBConfigValues)
 		if db != nil {
 			log.Info().Msg("Connection to backend successful!")
@@ -160,6 +161,7 @@ func osctrlService() {
 	log.Info().Msg("Initializing cache...")
 	// Attempt to connect to cache waiting until is ready
 	for {
+		log.Debug().Msgf("Creating Redis manager with %v", flagParams.RedisConfigValues)
 		redis, err = cache.CreateRedisManager(flagParams.RedisConfigValues)
 		if redis != nil {
 			log.Info().Msg("Connection to cache successful!")
@@ -244,11 +246,9 @@ func osctrlService() {
 		log.Info().Msg("Metrics are enabled")
 		// Register Prometheus metrics
 		handlers.RegisterMetrics(prometheus.DefaultRegisterer)
-
 		// Creating a new prometheus service
 		prometheusServer := http.NewServeMux()
 		prometheusServer.Handle("/metrics", promhttp.Handler())
-
 		go func() {
 			log.Info().Msgf("Starting prometheus server at %s:%s", flagParams.ConfigValues.MetricsListener, flagParams.ConfigValues.MetricsPort)
 			err := http.ListenAndServe(flagParams.ConfigValues.MetricsListener+":"+flagParams.ConfigValues.MetricsPort, prometheusServer)

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -96,6 +96,9 @@ type ServiceFlagParams struct {
 	// Carved files folder
 	CarvedDir string
 
+	// Debug HTTP configuration values
+	DebugHTTPValues DebugHTTPConfiguration
+
 	// Service configuration values
 	ConfigValues JSONConfigurationService
 	// DB writer configuration values
@@ -129,6 +132,7 @@ func InitTLSFlags(params *ServiceFlagParams) []cli.Flag {
 	allFlags = append(allFlags, initCarverFlags(params, ServiceTLS)...)
 	allFlags = append(allFlags, initS3LoggingFlags(params)...)
 	allFlags = append(allFlags, initKafkaFlags(params)...)
+	allFlags = append(allFlags, initDebugFlags(params, ServiceTLS)...)
 	return allFlags
 }
 
@@ -147,6 +151,7 @@ func InitAdminFlags(params *ServiceFlagParams) []cli.Flag {
 	allFlags = append(allFlags, initJWTFlags(params)...)
 	allFlags = append(allFlags, initOsqueryFlags(params)...)
 	allFlags = append(allFlags, initAdminFlags(params)...)
+	allFlags = append(allFlags, initDebugFlags(params, ServiceAdmin)...)
 	return allFlags
 }
 
@@ -161,6 +166,7 @@ func InitAPIFlags(params *ServiceFlagParams) []cli.Flag {
 	allFlags = append(allFlags, initDBFlags(params)...)
 	allFlags = append(allFlags, initTLSSecurityFlags(params)...)
 	allFlags = append(allFlags, initJWTFlags(params)...)
+	allFlags = append(allFlags, initDebugFlags(params, ServiceAPI)...)
 	return allFlags
 }
 
@@ -752,6 +758,33 @@ func initAdminFlags(params *ServiceFlagParams) []cli.Flag {
 			Usage:       "Directory for all the received carved files from osquery",
 			EnvVars:     []string{"CARVED_FILES"},
 			Destination: &params.CarvedDir,
+		},
+	}
+}
+
+// initDebugFlags initializes all the debug logging specific flags
+func initDebugFlags(params *ServiceFlagParams, service string) []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "enable-http-debug",
+			Value:       false,
+			Usage:       "Enable HTTP Debug mode to dump full HTTP incoming request",
+			EnvVars:     []string{"HTTP_DEBUG"},
+			Destination: &params.DebugHTTPValues.Enabled,
+		},
+		&cli.StringFlag{
+			Name:        "http-debug-file",
+			Value:       "debug-http-" + service + ".log",
+			Usage:       "File to dump the HTTP requests when HTTP Debug mode is enabled",
+			EnvVars:     []string{"HTTP_DEBUG_FILE"},
+			Destination: &params.DebugHTTPValues.File,
+		},
+		&cli.BoolFlag{
+			Name:        "http-debug-show-body",
+			Value:       false,
+			Usage:       "Show body of the HTTP requests when HTTP Debug mode is enabled",
+			EnvVars:     []string{"HTTP_DEBUG_SHOW_BODY"},
+			Destination: &params.DebugHTTPValues.ShowBody,
 		},
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -104,3 +104,10 @@ type KafkaConfiguration struct {
 	SASL              KafkaSASLConfigurations `json:"sasl"`
 	Topic             string                  `json:"topic"`
 }
+
+// DebugHTTPConfiguration to hold all debug configuration values
+type DebugHTTPConfiguration struct {
+	Enabled  bool   `json:"enabled"`
+	File     string `json:"file"`
+	ShowBody bool   `json:"showBody"`
+}

--- a/pkg/logging/debughttp.go
+++ b/pkg/logging/debughttp.go
@@ -1,0 +1,25 @@
+package logging
+
+import (
+	"github.com/rs/zerolog"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
+)
+
+const (
+	// Default time format for loggers
+	LoggerTimeFormat string = "2006-01-02T15:04:05.999Z07:00"
+)
+
+// CreateDebugHTTP to initialize the debug HTTP logger
+func CreateDebugHTTP(filename string, cfg LumberjackConfig) (*zerolog.Logger, error) {
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	z := zerolog.New(&lumberjack.Logger{
+		Filename:   filename,
+		MaxSize:    cfg.MaxSize,
+		MaxBackups: cfg.MaxBackups,
+		MaxAge:     cfg.MaxAge,
+		Compress:   cfg.Compress,
+	})
+	logger := z.With().Caller().Timestamp().Logger()
+	return &logger, nil
+}

--- a/pkg/logging/debughttp.go
+++ b/pkg/logging/debughttp.go
@@ -12,7 +12,6 @@ const (
 
 // CreateDebugHTTP to initialize the debug HTTP logger
 func CreateDebugHTTP(filename string, cfg LumberjackConfig) (*zerolog.Logger, error) {
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	z := zerolog.New(&lumberjack.Logger{
 		Filename:   filename,
 		MaxSize:    cfg.MaxSize,
@@ -20,6 +19,6 @@ func CreateDebugHTTP(filename string, cfg LumberjackConfig) (*zerolog.Logger, er
 		MaxAge:     cfg.MaxAge,
 		Compress:   cfg.Compress,
 	})
-	logger := z.With().Caller().Timestamp().Logger()
+	logger := z.Output(zerolog.ConsoleWriter{TimeFormat: LoggerTimeFormat}).With().Caller().Logger()
 	return &logger, nil
 }

--- a/pkg/logging/debughttp.go
+++ b/pkg/logging/debughttp.go
@@ -12,6 +12,7 @@ const (
 
 // CreateDebugHTTP to initialize the debug HTTP logger
 func CreateDebugHTTP(filename string, cfg LumberjackConfig) (*zerolog.Logger, error) {
+	zerolog.TimeFieldFormat = LoggerTimeFormat
 	z := zerolog.New(&lumberjack.Logger{
 		Filename:   filename,
 		MaxSize:    cfg.MaxSize,
@@ -19,6 +20,6 @@ func CreateDebugHTTP(filename string, cfg LumberjackConfig) (*zerolog.Logger, er
 		MaxAge:     cfg.MaxAge,
 		Compress:   cfg.Compress,
 	})
-	logger := z.Output(zerolog.ConsoleWriter{TimeFormat: LoggerTimeFormat}).With().Caller().Logger()
+	logger := z.With().Caller().Timestamp().Logger()
 	return &logger, nil
 }

--- a/pkg/utils/http-utils.go
+++ b/pkg/utils/http-utils.go
@@ -143,7 +143,7 @@ func DebugHTTP(r *http.Request, showBody bool) string {
 
 // DebugHTTPDump - Helper for debugging purposes and dump a full HTTP request
 func DebugHTTPDump(l *zerolog.Logger, r *http.Request, showBody bool) {
-	l.Debug().Msg(DebugHTTP(r, showBody))
+	l.Log().Msg(DebugHTTP(r, showBody))
 }
 
 // GetIP - Helper to get the IP address from a HTTP request

--- a/pkg/utils/http-utils.go
+++ b/pkg/utils/http-utils.go
@@ -125,28 +125,24 @@ func SendRequest(reqType, reqURL string, params io.Reader, headers map[string]st
 }
 
 // DebugHTTP - Helper for debugging purposes and dump a full HTTP request
-func DebugHTTP(r *http.Request, debugCheck bool, showBody bool) string {
+func DebugHTTP(r *http.Request, showBody bool) string {
 	var debug string
-	if debugCheck {
-		debug = fmt.Sprintf("%s\n", "---------------- request")
-		requestDump, err := httputil.DumpRequest(r, showBody)
-		if err != nil {
-			log.Err(err).Msg("error while dumprequest")
-		}
-		debug += fmt.Sprintf("%s\n", string(requestDump))
-		if !showBody {
-			debug += fmt.Sprintf("%s\n", "---------------- No Body")
-		}
-		debug += fmt.Sprintf("%s\n", "---------------- end")
+	debug = fmt.Sprintf("%s\n", "---------------- request")
+	requestDump, err := httputil.DumpRequest(r, showBody)
+	if err != nil {
+		log.Err(err).Msg("error while dumprequest")
 	}
+	debug += fmt.Sprintf("%s\n", string(requestDump))
+	if !showBody {
+		debug += fmt.Sprintf("%s\n", "---------------- No Body")
+	}
+	debug += fmt.Sprintf("%s\n", "---------------- end")
 	return debug
 }
 
 // DebugHTTPDump - Helper for debugging purposes and dump a full HTTP request
-func DebugHTTPDump(r *http.Request, debugCheck bool, showBody bool) {
-	if debugCheck {
-		log.Debug().Msg(DebugHTTP(r, debugCheck, showBody))
-	}
+func DebugHTTPDump(r *http.Request, showBody bool) {
+	log.Debug().Msg(DebugHTTP(r, showBody))
 }
 
 // GetIP - Helper to get the IP address from a HTTP request

--- a/pkg/utils/http-utils.go
+++ b/pkg/utils/http-utils.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -141,8 +142,8 @@ func DebugHTTP(r *http.Request, showBody bool) string {
 }
 
 // DebugHTTPDump - Helper for debugging purposes and dump a full HTTP request
-func DebugHTTPDump(r *http.Request, showBody bool) {
-	log.Debug().Msg(DebugHTTP(r, showBody))
+func DebugHTTPDump(l *zerolog.Logger, r *http.Request, showBody bool) {
+	l.Debug().Msg(DebugHTTP(r, showBody))
 }
 
 // GetIP - Helper to get the IP address from a HTTP request

--- a/pkg/utils/http-utils_test.go
+++ b/pkg/utils/http-utils_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -93,68 +92,6 @@ func TestSendRequest(t *testing.T) {
 		headers["test"] = "aaa"
 		_, _, err := SendRequest(http.MethodPost, server.URL+"/server/testing", nil, headers)
 		assert.NoError(t, err)
-	})
-}
-
-func TestDebugHTTP(t *testing.T) {
-	t.Run("no debug", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodGet, "https://whatever/server/path", nil)
-		output := DebugHTTP(req, false, false)
-		assert.Equal(t, ``, output)
-	})
-	t.Run("debug no body", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodGet, "https://whatever/server/path", nil)
-		output := DebugHTTP(req, true, false)
-		expected := fmt.Sprintf("%s\n", "---------------- request")
-		expected += fmt.Sprintf("%s\r\n", "GET /server/path HTTP/1.1")
-		expected += fmt.Sprintf("%s\r\n\r\n\n", "Host: whatever")
-		expected += fmt.Sprintf("%s\n", "---------------- No Body")
-		expected += fmt.Sprintf("%s\n", "---------------- end")
-		assert.Equal(t, expected, output)
-	})
-	t.Run("debug with body", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodGet, "https://whatever/server/path", nil)
-		output := DebugHTTP(req, true, false)
-		expected := fmt.Sprintf("%s\n", "---------------- request")
-		expected += fmt.Sprintf("%s\r\n", "GET /server/path HTTP/1.1")
-		expected += fmt.Sprintf("%s\r\n\r\n\n", "Host: whatever")
-		expected += fmt.Sprintf("%s\n", "---------------- No Body")
-		expected += fmt.Sprintf("%s\n", "---------------- end")
-		assert.Equal(t, expected, output)
-	})
-}
-
-func TestDebugHTTPDump(t *testing.T) {
-	t.Run("no debug", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodGet, "https://whatever/server/path", nil)
-		output := captureOutput(func() {
-			DebugHTTPDump(req, false, false)
-		})
-		assert.Equal(t, ``, output)
-	})
-	t.Run("debug no body", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodGet, "https://whatever/server/path", nil)
-		output := captureOutput(func() {
-			DebugHTTPDump(req, true, false)
-		})
-		expected := fmt.Sprintf("%s\n", "---------------- request")
-		expected += fmt.Sprintf("%s\r\n", "GET /server/path HTTP/1.1")
-		expected += fmt.Sprintf("%s\r\n\r\n\n", "Host: whatever")
-		expected += fmt.Sprintf("%s\n", "---------------- No Body")
-		expected += fmt.Sprintf("%s\n", "---------------- end")
-		assert.Contains(t, output, expected)
-	})
-	t.Run("debug with body", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodGet, "https://whatever/server/path", nil)
-		output := captureOutput(func() {
-			DebugHTTPDump(req, true, false)
-		})
-		expected := fmt.Sprintf("%s\n", "---------------- request")
-		expected += fmt.Sprintf("%s\r\n", "GET /server/path HTTP/1.1")
-		expected += fmt.Sprintf("%s\r\n\r\n\n", "Host: whatever")
-		expected += fmt.Sprintf("%s\n", "---------------- No Body")
-		expected += fmt.Sprintf("%s\n", "---------------- end")
-		assert.Contains(t, output, expected)
 	})
 }
 


### PR DESCRIPTION
- Refactor in `osctrl-tls`, `osctrl-admin` and `osctrl-api` to all calls of debug messages to avoid getting the setting value from the backend.
- Added three new flags to all services to set debug HTTP settings.
* `--enable-http-debug`
* `--http-debug-file`
* `--http-debug-show-body`
- When enabled, the debug HTTP logs will go into a separate file.