### PR TITLE
Removing references to Debug Service or HTTP from all services

### DIFF
--- a/cmd/admin/handlers/get.go
+++ b/cmd/admin/handlers/get.go
@@ -60,9 +60,7 @@ func (h *HandlersAdmin) PermissionsGETHandler(w http.ResponseWriter, r *http.Req
 	// Extract username and verify
 	usernameVar := r.PathValue("username")
 	if usernameVar == "" || !h.Users.Exists(usernameVar) {
-		if h.Settings.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: error getting username")
-		}
+		log.Info().Msgf("error getting username: [%s]", usernameVar)
 		return
 	}
 	// Get context data
@@ -136,9 +134,7 @@ func (h *HandlersAdmin) CarvesDownloadHandler(w http.ResponseWriter, r *http.Req
 		Size: int64(carve.CarveSize),
 		File: carve.ArchivePath,
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Carve download")
-	}
+	log.Debug().Msg("Initiating carve download")
 	if h.Carves.Carver == config.CarverS3 {
 		downloadURL, err := h.Carves.S3.GetDownloadLink(carve)
 		if err != nil {

--- a/cmd/admin/handlers/post.go
+++ b/cmd/admin/handlers/post.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/settings"
@@ -28,9 +27,7 @@ func (h *HandlersAdmin) LoginPOSTHandler(w http.ResponseWriter, r *http.Request)
 	}
 	var l LoginRequest
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&l); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -47,9 +44,7 @@ func (h *HandlersAdmin) LoginPOSTHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Login response sent")
-	}
+	log.Debug().Msg("Login response sent")
 	adminOKResponse(w, "/dashboard")
 }
 
@@ -62,9 +57,7 @@ func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&l); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -80,9 +73,7 @@ func (h *HandlersAdmin) LogoutPOSTHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Logout response sent")
-	}
+	log.Debug().Msg("Logout response sent")
 	adminOKResponse(w, "OK")
 }
 
@@ -111,9 +102,7 @@ func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	var q DistributedQueryRequest
 	if err := json.NewDecoder(r.Body).Decode(&q); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
@@ -147,10 +136,8 @@ func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Reque
 		adminErrorResponse(w, "error creating query", http.StatusInternalServerError, err)
 		return
 	}
-
 	// List all the nodes that match the query
 	var expected []uint
-
 	targetNodesID := []uint{}
 	// TODO: Refactor this to use osctrl-api instead of direct DB queries
 	// Create environment target
@@ -240,9 +227,7 @@ func (h *HandlersAdmin) QueryRunPOSTHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Query run response sent")
-	}
+	log.Debug().Msg("Query run response sent")
 	adminOKResponse(w, "OK")
 }
 
@@ -271,9 +256,7 @@ func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	var c DistributedCarveRequest
 	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
@@ -389,9 +372,7 @@ func (h *HandlersAdmin) CarvesRunPOSTHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Carve run response sent")
-	}
+	log.Debug().Msg("Carve run response sent")
 	adminOKResponse(w, "OK")
 }
 
@@ -420,9 +401,7 @@ func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	var q DistributedQueryActionRequest
 	if err := json.NewDecoder(r.Body).Decode(&q); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
@@ -468,9 +447,7 @@ func (h *HandlersAdmin) QueryActionsPOSTHandler(w http.ResponseWriter, r *http.R
 		adminOKResponse(w, "queries delete successfully")
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Query run response sent")
-	}
+	log.Debug().Msg("Query run response sent")
 }
 
 // CarvesActionsPOSTHandler - Handler for POST requests to carves
@@ -487,9 +464,7 @@ func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&q); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -509,15 +484,11 @@ func (h *HandlersAdmin) CarvesActionsPOSTHandler(w http.ResponseWriter, r *http.
 		}
 		adminOKResponse(w, "carves delete successfully")
 	case "test":
-		if h.Settings.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: testing action")
-		}
+		log.Debug().Msg("testing action")
 		adminOKResponse(w, "test successful")
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Carves action response sent")
-	}
+	log.Debug().Msg("Carves action response sent")
 }
 
 // ConfPOSTHandler for POST requests for saving configuration
@@ -546,9 +517,7 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -583,9 +552,7 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		// Send response
-		if h.Settings.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: Configuration response sent")
-		}
+		log.Debug().Msg("Configuration response sent")
 		adminOKResponse(w, "configuration saved successfully")
 		return
 	}
@@ -608,9 +575,7 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		// Send response
-		if h.Settings.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: Options response sent")
-		}
+		log.Debug().Msg("Options response sent")
 		adminOKResponse(w, "options saved successfully")
 		return
 	}
@@ -633,9 +598,7 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		// Send response
-		if h.Settings.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: Schedule response sent")
-		}
+		log.Debug().Msg("Schedule response sent")
 		adminOKResponse(w, "schedule saved successfully")
 		return
 	}
@@ -658,9 +621,7 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		// Send response
-		if h.Settings.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: Packs response sent")
-		}
+		log.Debug().Msg("Packs response sent")
 		adminOKResponse(w, "packs saved successfully")
 		return
 	}
@@ -683,9 +644,7 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		// Send response
-		if h.Settings.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: Decorators response sent")
-		}
+		log.Debug().Msg("Decorators response sent")
 		adminOKResponse(w, "decorators saved successfully")
 		return
 	}
@@ -708,18 +667,14 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		// Send response
-		if h.Settings.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: ATC response sent")
-		}
+		log.Debug().Msg("ATC response sent")
 		adminOKResponse(w, "ATC saved successfully")
 		return
 	}
 	// If we are here, means that the request received was empty
 	responseMessage := "empty configuration"
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusInternalServerError, AdminResponse{Message: responseMessage})
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msgf("DebugService: %s", responseMessage)
-	}
+	log.Debug().Msgf("%s", responseMessage)
 }
 
 // IntervalsPOSTHandler for POST requests for saving intervals
@@ -749,9 +704,7 @@ func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -777,9 +730,7 @@ func (h *HandlersAdmin) IntervalsPOSTHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Intervals response sent")
-	}
+	log.Debug().Msg("Intervals response sent")
 	adminOKResponse(w, "intervals saved successfully")
 }
 
@@ -809,9 +760,7 @@ func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -878,9 +827,7 @@ func (h *HandlersAdmin) ExpirationPOSTHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Expiration response sent")
-	}
+	log.Debug().Msg("Expiration response sent")
 }
 
 // NodeActionsPOSTHandler for POST requests for multi node action
@@ -897,9 +844,7 @@ func (h *HandlersAdmin) NodeActionsPOSTHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -928,9 +873,7 @@ func (h *HandlersAdmin) NodeActionsPOSTHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Multi-node action response sent")
-	}
+	log.Debug().Msg("Multi-node action response sent")
 }
 
 // EnvsPOSTHandler for POST request for /environments
@@ -947,9 +890,7 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1012,15 +953,6 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 		adminOKResponse(w, "environment deleted successfully")
-	case "debug":
-		// FIXME verify fields
-		if h.Envs.Exists(c.Name) {
-			if err := h.Envs.ChangeDebugHTTP(c.Name, c.DebugHTTP); err != nil {
-				adminErrorResponse(w, "error changing DebugHTTP", http.StatusInternalServerError, err)
-				return
-			}
-		}
-		adminOKResponse(w, "debug changed successfully")
 	case "edit":
 		if h.Envs.Exists(c.UUID) {
 			if err := h.Envs.UpdateHostname(c.UUID, c.Hostname); err != nil {
@@ -1031,9 +963,7 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 		adminOKResponse(w, "debug changed successfully")
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Environments response sent")
-	}
+	log.Debug().Msg("Environments response sent")
 }
 
 // SettingsPOSTHandler for POST request for /settings
@@ -1061,9 +991,7 @@ func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&s); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1120,9 +1048,7 @@ func (h *HandlersAdmin) SettingsPOSTHandler(w http.ResponseWriter, r *http.Reque
 		adminOKResponse(w, "setting deleted successfully")
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Settings response sent")
-	}
+	log.Debug().Msg("Settings response sent")
 }
 
 // UsersPOSTHandler for POST request for /users
@@ -1139,9 +1065,7 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1258,9 +1182,7 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 		}
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Users response sent")
-	}
+	log.Debug().Msg("Users response sent")
 }
 
 // TagsPOSTHandler for POST request for /tags
@@ -1277,9 +1199,7 @@ func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1345,9 +1265,7 @@ func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 		adminOKResponse(w, "tag removed successfully")
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Tags response sent")
-	}
+	log.Debug().Msg("Tags response sent")
 }
 
 // TagNodesPOSTHandler for POST request for /tags/nodes
@@ -1364,9 +1282,7 @@ func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1407,9 +1323,7 @@ func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Tags response sent")
-	}
+	log.Debug().Msg("Tags response sent")
 	adminOKResponse(w, "tags processed successfully")
 }
 
@@ -1433,9 +1347,7 @@ func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1470,9 +1382,7 @@ func (h *HandlersAdmin) PermissionsPOSTHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Users response sent")
-	}
+	log.Debug().Msg("Users response sent")
 	adminOKResponse(w, "permissions updated successfully")
 }
 
@@ -1502,9 +1412,7 @@ func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1575,9 +1483,7 @@ func (h *HandlersAdmin) EnrollPOSTHandler(w http.ResponseWriter, r *http.Request
 		}
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Configuration response sent")
-	}
+	log.Debug().Msg("Configuration response sent")
 	adminOKResponse(w, "enroll data saved")
 }
 
@@ -1590,9 +1496,7 @@ func (h *HandlersAdmin) EditProfilePOSTHandler(w http.ResponseWriter, r *http.Re
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1647,9 +1551,7 @@ func (h *HandlersAdmin) EditProfilePOSTHandler(w http.ResponseWriter, r *http.Re
 		adminOKResponse(w, "profiled updated successfully")
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Edit profile response sent")
-	}
+	log.Debug().Msg("Edit profile response sent")
 }
 
 // SavedQueriesPOSTHandler for POST requests to save queries
@@ -1661,9 +1563,7 @@ func (h *HandlersAdmin) SavedQueriesPOSTHandler(w http.ResponseWriter, r *http.R
 	// Get context data
 	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	if err := json.NewDecoder(r.Body).Decode(&s); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
 		return
@@ -1680,7 +1580,5 @@ func (h *HandlersAdmin) SavedQueriesPOSTHandler(w http.ResponseWriter, r *http.R
 		adminOKResponse(w, "query saved successfully")
 	}
 	// Serialize and send response
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Saved query response sent")
-	}
+	log.Debug().Msg("Saved query response sent")
 }

--- a/cmd/admin/handlers/templates.go
+++ b/cmd/admin/handlers/templates.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
 	"github.com/jmpsec/osctrl/pkg/carves"
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/settings"
@@ -39,16 +38,11 @@ var validTarget = map[string]bool{
 // TODO until a better implementation, all users are admin
 func (h *HandlersAdmin) TemplateMetadata(ctx sessions.ContextValue, version string) TemplateMetadata {
 	return TemplateMetadata{
-		Username:       ctx[sessions.CtxUser],
-		Level:          "admin",
-		CSRFToken:      ctx[sessions.CtxCSRF],
-		Service:        "osctrl-admin",
-		Version:        version,
-		TLSDebug:       h.Settings.DebugService(config.ServiceTLS),
-		AdminDebug:     h.Settings.DebugService(config.ServiceAdmin),
-		APIDebug:       h.Settings.DebugService(config.ServiceAPI),
-		AdminDebugHTTP: h.Settings.DebugHTTP(config.ServiceAdmin, settings.NoEnvironmentID),
-		APIDebugHTTP:   h.Settings.DebugHTTP(config.ServiceAPI, settings.NoEnvironmentID),
+		Username:  ctx[sessions.CtxUser],
+		Level:     "admin",
+		CSRFToken: ctx[sessions.CtxCSRF],
+		Service:   "osctrl-admin",
+		Version:   version,
 	}
 }
 
@@ -90,9 +84,7 @@ func (h *HandlersAdmin) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Login template served")
-	}
+	log.Debug().Msg("Login template served")
 }
 
 // EnvironmentHandler for environment view of the table
@@ -167,9 +159,7 @@ func (h *HandlersAdmin) EnvironmentHandler(w http.ResponseWriter, r *http.Reques
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Environment table template served")
-	}
+	log.Debug().Msg("Environment table template served")
 }
 
 // PlatformHandler for platform view of the table
@@ -244,9 +234,7 @@ func (h *HandlersAdmin) PlatformHandler(w http.ResponseWriter, r *http.Request) 
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Platform table template served")
-	}
+	log.Debug().Msg("Platform table template served")
 }
 
 // QueryRunGETHandler for GET requests to run queries
@@ -327,9 +315,7 @@ func (h *HandlersAdmin) QueryRunGETHandler(w http.ResponseWriter, r *http.Reques
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Query run template served")
-	}
+	log.Debug().Msg("Query run template served")
 }
 
 // QueryListGETHandler for GET requests to queries
@@ -388,9 +374,7 @@ func (h *HandlersAdmin) QueryListGETHandler(w http.ResponseWriter, r *http.Reque
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Query list template served")
-	}
+	log.Debug().Msg("Query list template served")
 }
 
 // SavedQueriesGETHandler for GET requests to queries
@@ -449,9 +433,7 @@ func (h *HandlersAdmin) SavedQueriesGETHandler(w http.ResponseWriter, r *http.Re
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Query list template served")
-	}
+	log.Debug().Msg("Query list template served")
 }
 
 // CarvesRunGETHandler for GET requests to run file carves
@@ -526,9 +508,7 @@ func (h *HandlersAdmin) CarvesRunGETHandler(w http.ResponseWriter, r *http.Reque
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Query run template served")
-	}
+	log.Debug().Msg("Query run template served")
 }
 
 // CarvesListGETHandler for GET requests to carves
@@ -587,9 +567,7 @@ func (h *HandlersAdmin) CarvesListGETHandler(w http.ResponseWriter, r *http.Requ
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Carve list template served")
-	}
+	log.Debug().Msg("Carve list template served")
 }
 
 // QueryLogsHandler for GET requests to see query results by name
@@ -679,9 +657,7 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Query logs template served")
-	}
+	log.Debug().Msg("Query logs template served")
 }
 
 // CarvesDetailsHandler for GET requests to see carves details by name
@@ -787,9 +763,7 @@ func (h *HandlersAdmin) CarvesDetailsHandler(w http.ResponseWriter, r *http.Requ
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Carve details template served")
-	}
+	log.Debug().Msg("Carve details template served")
 }
 
 // ConfGETHandler for GET requests for /conf
@@ -847,9 +821,7 @@ func (h *HandlersAdmin) ConfGETHandler(w http.ResponseWriter, r *http.Request) {
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Conf template served")
-	}
+	log.Debug().Msg("Conf template served")
 }
 
 // EnrollGETHandler for GET requests for /enroll
@@ -933,9 +905,7 @@ func (h *HandlersAdmin) EnrollGETHandler(w http.ResponseWriter, r *http.Request)
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Enroll template served")
-	}
+	log.Debug().Msg("Enroll template served")
 }
 
 // EnrollGETHandler for GET requests for /enroll
@@ -1125,9 +1095,7 @@ func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Node template served")
-	}
+	log.Debug().Msg("Node template served")
 }
 
 // EnvsGETHandler for GET requests for /env
@@ -1172,9 +1140,7 @@ func (h *HandlersAdmin) EnvsGETHandler(w http.ResponseWriter, r *http.Request) {
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Environments template served")
-	}
+	log.Debug().Msg("Environments template served")
 }
 
 // SettingsGETHandler for GET requests for /settings
@@ -1244,9 +1210,7 @@ func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Reques
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Settings template served")
-	}
+	log.Debug().Msg("Settings template served")
 }
 
 // UsersGETHandler for GET requests for /users
@@ -1303,9 +1267,7 @@ func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) 
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Users template served")
-	}
+	log.Debug().Msg("Users template served")
 }
 
 // TagsGETHandler for GET requests for /tags
@@ -1364,9 +1326,7 @@ func (h *HandlersAdmin) TagsGETHandler(w http.ResponseWriter, r *http.Request) {
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Tags template served")
-	}
+	log.Debug().Msg("Tags template served")
 }
 
 // EditProfileGETHandler for user profile edit
@@ -1422,9 +1382,7 @@ func (h *HandlersAdmin) EditProfileGETHandler(w http.ResponseWriter, r *http.Req
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Profile template served")
-	}
+	log.Debug().Msg("Profile template served")
 }
 
 // DashboardGETHandler for dashboard page
@@ -1480,7 +1438,5 @@ func (h *HandlersAdmin) DashboardGETHandler(w http.ResponseWriter, r *http.Reque
 		log.Err(err).Msg("template error")
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Dashboard template served")
-	}
+	log.Debug().Msg("Dashboard template served")
 }

--- a/cmd/admin/handlers/tokens.go
+++ b/cmd/admin/handlers/tokens.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -74,9 +73,7 @@ func (h *HandlersAdmin) TokensPOSTHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Parse request JSON body
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Decoding POST body")
-	}
+	log.Debug().Msg("Decoding POST body")
 	var t TokenRequest
 	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
 		adminErrorResponse(w, "error parsing POST body", http.StatusInternalServerError, err)
@@ -92,17 +89,13 @@ func (h *HandlersAdmin) TokensPOSTHandler(w http.ResponseWriter, r *http.Request
 		adminErrorResponse(w, "error getting user", http.StatusInternalServerError, err)
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Creating token")
-	}
+	log.Debug().Msg("Creating token")
 	token, exp, err := h.Users.CreateToken(user.Username, h.AdminConfig.Host, t.ExpHours)
 	if err != nil {
 		adminErrorResponse(w, "error creating token", http.StatusInternalServerError, err)
 		return
 	}
-	if h.Settings.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Updating token")
-	}
+	log.Debug().Msg("Updating token")
 	if err := h.Users.UpdateToken(user.Username, token, exp); err != nil {
 		adminErrorResponse(w, "error updating token", http.StatusInternalServerError, err)
 		return

--- a/cmd/admin/handlers/types-templates.go
+++ b/cmd/admin/handlers/types-templates.go
@@ -24,11 +24,6 @@ type TemplateMetadata struct {
 	Level          string
 	Service        string
 	Version        string
-	TLSDebug       bool
-	AdminDebug     bool
-	APIDebug       bool
-	AdminDebugHTTP bool
-	APIDebugHTTP   bool
 	CSRFToken      string
 }
 

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -210,9 +210,7 @@ func osctrlAdminService() {
 
 	// Start SAML Middleware if we are using SAML
 	if flagParams.ConfigValues.Auth == config.AuthSAML {
-		if settingsmgr.DebugService(config.ServiceAdmin) {
-			log.Debug().Msg("DebugService: SAML keypair")
-		}
+		log.Debug().Msg("SAML enabled for authentication")
 		// Initialize SAML keypair to sign SAML Request.
 		var err error
 		samlData, err = keypairSAML(samlConfig)
@@ -240,9 +238,7 @@ func osctrlAdminService() {
 			_t = int64(defaultRefresh)
 		}
 		for {
-			if settingsmgr.DebugService(config.ServiceAdmin) {
-				log.Debug().Msg("DebugService: Cleaning up sessions")
-			}
+			log.Debug().Msg("Cleaning up sessions")
 			sessionsmgr.Cleanup()
 			time.Sleep(time.Duration(_t) * time.Second)
 		}
@@ -256,9 +252,7 @@ func osctrlAdminService() {
 			_t = int64(defaultExpiration)
 		}
 		for {
-			if settingsmgr.DebugService(config.ServiceAdmin) {
-				log.Debug().Msg("DebugService: Cleaning up expired queries/carves")
-			}
+			log.Debug().Msg("Cleaning up expired queries/carves")
 			allEnvs, err := envs.All()
 			if err != nil {
 				log.Err(err).Msg("Error getting all environments")

--- a/cmd/admin/settings.go
+++ b/cmd/admin/settings.go
@@ -11,21 +11,7 @@ import (
 // Function to load all settings for the service
 func loadingSettings(mgr *settings.Settings, cfg config.JSONConfigurationService) error {
 	// Check if service settings for debug service is ready
-	if mgr.DebugService(config.ServiceAdmin) {
-		log.Debug().Msg("DebugService: Initializing settings")
-	}
-	// Check if service settings for debug service is ready
-	if !mgr.IsValue(config.ServiceAdmin, settings.DebugService, settings.NoEnvironmentID) {
-		if err := mgr.NewBooleanValue(config.ServiceAdmin, settings.DebugService, false, settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to settings: %w", settings.DebugService, err)
-		}
-	}
-	// Check if service settings for debug HTTP is ready
-	if !mgr.IsValue(config.ServiceAdmin, settings.DebugHTTP, settings.NoEnvironmentID) {
-		if err := mgr.NewBooleanValue(config.ServiceAdmin, settings.DebugHTTP, false, settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to settings: %w", settings.DebugHTTP, err)
-		}
-	}
+	log.Debug().Msg("Initializing settings")
 	// Check if service settings for sessions cleanup is ready
 	if !mgr.IsValue(config.ServiceAdmin, settings.CleanupSessions, settings.NoEnvironmentID) {
 		if err := mgr.NewIntegerValue(config.ServiceAdmin, settings.CleanupSessions, int64(defaultRefresh), settings.NoEnvironmentID); err != nil {

--- a/cmd/admin/static/js/settings.js
+++ b/cmd/admin/static/js/settings.js
@@ -62,19 +62,3 @@ function changeBooleanSetting(_name) {
   };
   sendPostRequest(data, _url, '', false);
 }
-
-function changeDebug(_name, service) {
-  var _csrftoken = $("#csrftoken").val();
-  var _value = $("#" + _name + '_' + service).is(':checked');
-
-  var _url = '/settings/' + service;
-
-  var data = {
-    csrftoken: _csrftoken,
-    action: 'change',
-    name: _name,
-    type: 'boolean',
-    boolean: _value,
-  };
-  sendPostRequest(data, _url, '', false);
-}

--- a/cmd/admin/templates/components/page-aside-right.html
+++ b/cmd/admin/templates/components/page-aside-right.html
@@ -7,30 +7,6 @@
         <div class="tab-pane p-3" role="tablist" style="height: 100%;">
           <h6>Admin Server Settings</h6>
           <div class="aside-options" role="tab">
-            <div class="clearfix mt-3">
-              <small>
-                <b>Admin service debug</b>
-              </small>
-              <label class="switch switch-label switch-pill switch-success switch-sm float-right">
-                <input id="debug_service_admin" class="switch-input" type="checkbox" onclick="changeDebug('debug_service', 'admin');" {{ if .AdminDebug }} checked {{ end }}>
-                <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
-              </label>
-            </div>
-            <div>
-              <small class="text-muted">Verbose service logging for Admin</small>
-            </div>
-            <div class="clearfix mt-3">
-              <small>
-                <b>Admin UI HTTP debug</b>
-              </small>
-              <label class="switch switch-label switch-pill switch-success switch-sm float-right">
-                <input id="debug_http_admin" class="switch-input" type="checkbox" onclick="changeDebug('debug_http', 'admin');" {{ if .AdminDebugHTTP }} checked {{ end }}>
-                <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
-              </label>
-            </div>
-            <div>
-              <small class="text-muted">Verbose HTTP logging for Admin</small>
-            </div>
             <div class="clearfix mt-4">
               <small>
                 <button class="btn btn-block btn-sm btn-info" type="button" onclick="window.location = '/settings/admin';">
@@ -66,18 +42,6 @@
 
           <h6>TLS Server Settings</h6>
           <div class="aside-options">
-            <div class="clearfix mt-3">
-              <small>
-                <b>TLS service debug</b>
-              </small>
-              <label class="switch switch-label switch-pill switch-success switch-sm float-right">
-                <input id="debug_service_tls" class="switch-input" type="checkbox" onclick="changeDebug('debug_service', 'tls');" {{ if .TLSDebug }} checked {{ end }}>
-                <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
-              </label>
-            </div>
-            <div>
-              <small class="text-muted">Verbose service logging for TLS</small>
-            </div>
             <div class="clearfix mt-4">
               <small>
                 <button class="btn btn-block btn-sm btn-secondary" type="button" onclick="window.location = '/environments';">
@@ -103,30 +67,6 @@
 
           <h6>API Server Settings</h6>
           <div class="aside-options">
-            <div class="clearfix mt-3">
-              <small>
-                <b>API service debug</b>
-              </small>
-              <label class="switch switch-label switch-pill switch-success switch-sm float-right">
-                <input id="debug_service_api" class="switch-input" type="checkbox" onclick="changeDebug('debug_service', 'api');" {{ if .APIDebug }} checked {{ end }}>
-                <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
-              </label>
-            </div>
-            <div>
-              <small class="text-muted">Verbose service logging for API</small>
-            </div>
-            <div class="clearfix mt-3">
-              <small>
-                <b>API HTTP debug</b>
-              </small>
-              <label class="switch switch-label switch-pill switch-success switch-sm float-right">
-                <input id="debug_http_api" class="switch-input" type="checkbox" onclick="changeDebug('debug_http', 'api');" {{ if .APIDebugHTTP }} checked {{ end }}>
-                <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
-              </label>
-            </div>
-            <div>
-              <small class="text-muted">Verbose HTTP logging for API</small>
-            </div>
             <div class="clearfix mt-4">
               <small>
                 <button class="btn btn-block btn-sm btn-info" type="button" onclick="window.location = '/settings/api';">

--- a/cmd/api/handlers/carves.go
+++ b/cmd/api/handlers/carves.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/carves"
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/types"
@@ -57,9 +56,7 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned carve %s", name)
-	}
+	log.Debug().Msgf("Returned carve %s", name)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, carve)
 }
 
@@ -109,6 +106,7 @@ func (h *HandlersApi) CarveQueriesHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Serialize and serve JSON
+	log.Debug().Msgf("Returned %d carves", len(carves))
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, carves)
 }
 
@@ -147,6 +145,7 @@ func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
+	log.Debug().Msgf("Returned %d carves", len(carves))
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, carves)
 }
 
@@ -225,6 +224,7 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Return query name as serialized response
+	log.Debug().Msgf("Created query %s", newQuery.Name)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiQueriesResponse{Name: newQuery.Name})
 }
 
@@ -291,5 +291,6 @@ func (h *HandlersApi) CarvesActionHandler(w http.ResponseWriter, r *http.Request
 		msgReturn = fmt.Sprintf("carve %s completed successfully", nameVar)
 	}
 	// Return message as serialized response
+	log.Debug().Msgf("%s", msgReturn)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: msgReturn})
 }

--- a/cmd/api/handlers/environments.go
+++ b/cmd/api/handlers/environments.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/types"
@@ -52,9 +51,7 @@ func (h *HandlersApi) EnvironmentHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned environment %s", env.Name)
-	}
+	log.Debug().Msgf("Returned environment %s", env.Name)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, env)
 }
 
@@ -97,9 +94,7 @@ func (h *HandlersApi) EnvironmentMapHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned environments map")
-	}
+	log.Debug().Msg("Returned environments map")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, envMap)
 }
 
@@ -122,9 +117,7 @@ func (h *HandlersApi) EnvironmentsHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned environments")
-	}
+	log.Debug().Msg("Returned environments")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, envAll)
 }
 
@@ -187,9 +180,7 @@ func (h *HandlersApi) EnvEnrollHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned environment %s", returnData)
-	}
+	log.Debug().Msgf("Returned data for environment%s : %s", env.Name, returnData)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiDataResponse{Data: returnData})
 }
 
@@ -246,10 +237,8 @@ func (h *HandlersApi) EnvRemoveHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned environment %s", types.ApiDataResponse{Data: returnData})
-	}
-	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, env)
+	log.Debug().Msgf("Returned data for environment%s : %s", env.Name, returnData)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiDataResponse{Data: returnData})
 }
 
 // EnvEnrollActionsHandler - POST Handler to perform actions (extend, expire) in enroll values
@@ -347,6 +336,7 @@ func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// Return query name as serialized response
+	log.Debug().Msgf("Returned data for environment %s : %s", env.Name, msgReturn)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: msgReturn})
 }
 
@@ -420,5 +410,6 @@ func (h *HandlersApi) EnvRemoveActionsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// Return query name as serialized response
+	log.Debug().Msgf("Returned data for environment %s : %s", env.Name, msgReturn)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: msgReturn})
 }

--- a/cmd/api/handlers/login.go
+++ b/cmd/api/handlers/login.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -61,8 +60,6 @@ func (h *HandlersApi) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		user.APIToken = token
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returning token for %s", user.Username)
-	}
+	log.Debug().Msgf("Returning token for %s", user.Username)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiLoginResponse{Token: user.APIToken})
 }

--- a/cmd/api/handlers/nodes.go
+++ b/cmd/api/handlers/nodes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
@@ -55,9 +54,7 @@ func (h *HandlersApi) NodeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned node %s", nodeVar)
-	}
+	log.Debug().Msgf("Returned node %s", nodeVar)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, node)
 }
 
@@ -96,9 +93,7 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned nodes")
-	}
+	log.Debug().Msg("Returned nodes")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, nodes)
 }
 
@@ -137,9 +132,7 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned nodes")
-	}
+	log.Debug().Msg("Returned nodes")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, nodes)
 }
 
@@ -178,9 +171,7 @@ func (h *HandlersApi) AllNodesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned nodes")
-	}
+	log.Debug().Msg("Returned nodes")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, nodes)
 }
 
@@ -223,8 +214,6 @@ func (h *HandlersApi) DeleteNodeHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned node %s", n.UUID)
-	}
+	log.Debug().Msgf("Returned node %s", n.UUID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: "node deleted"})
 }

--- a/cmd/api/handlers/platforms.go
+++ b/cmd/api/handlers/platforms.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -29,9 +28,7 @@ func (h *HandlersApi) PlatformsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned platforms")
-	}
+	log.Debug().Msg("Returned platforms")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, platforms)
 }
 
@@ -70,8 +67,6 @@ func (h *HandlersApi) PlatformsEnvHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned platforms")
-	}
+	log.Debug().Msg("Returned platforms")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, platforms)
 }

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/types"
@@ -69,9 +68,7 @@ func (h *HandlersApi) QueryShowHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned query %s", name)
-	}
+	log.Debug().Msgf("Returned query %s", name)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, query)
 }
 
@@ -232,6 +229,7 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Return query name as serialized response
+	log.Debug().Msgf("Created query %s", newQuery.Name)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiQueriesResponse{Name: newQuery.Name})
 }
 
@@ -298,6 +296,7 @@ func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Reques
 		msgReturn = fmt.Sprintf("query %s completed successfully", nameVar)
 	}
 	// Return message as serialized response
+	log.Debug().Msgf("Returned message %s", msgReturn)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: msgReturn})
 }
 
@@ -336,6 +335,7 @@ func (h *HandlersApi) AllQueriesShowHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Serialize and serve JSON
+	log.Debug().Msgf("Returned %d queries", len(queries))
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, queries)
 }
 
@@ -385,6 +385,7 @@ func (h *HandlersApi) QueryListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
+	log.Debug().Msgf("Returned %d queries", len(queries))
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, queries)
 }
 
@@ -431,5 +432,6 @@ func (h *HandlersApi) QueryResultsHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// Serialize and serve JSON
+	log.Debug().Msgf("Returned query results for %s", name)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, queryLogs)
 }

--- a/cmd/api/handlers/settings.go
+++ b/cmd/api/handlers/settings.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -30,9 +29,7 @@ func (h *HandlersApi) SettingsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned settings")
-	}
+	log.Debug().Msg("Returned settings")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 }
 
@@ -66,9 +63,7 @@ func (h *HandlersApi) SettingsServiceHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned settings")
-	}
+	log.Debug().Msg("Returned settings")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 }
 
@@ -118,9 +113,7 @@ func (h *HandlersApi) SettingsServiceEnvHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned settings")
-	}
+	log.Debug().Msg("Returned settings")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 }
 
@@ -154,9 +147,7 @@ func (h *HandlersApi) SettingsServiceJSONHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned settings")
-	}
+	log.Debug().Msg("Returned settings")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 }
 
@@ -206,8 +197,6 @@ func (h *HandlersApi) SettingsServiceEnvJSONHandler(w http.ResponseWriter, r *ht
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned settings")
-	}
+	log.Debug().Msg("Returned settings")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, serviceSettings)
 }

--- a/cmd/api/handlers/tags.go
+++ b/cmd/api/handlers/tags.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
@@ -32,9 +31,7 @@ func (h *HandlersApi) AllTagsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned tags")
-	}
+	log.Debug().Msgf("Returned %d tags", len(tags))
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, tags)
 }
 
@@ -79,9 +76,7 @@ func (h *HandlersApi) TagEnvHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned tag")
-	}
+	log.Debug().Msg("Returned tag")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, tag)
 }
 
@@ -120,9 +115,7 @@ func (h *HandlersApi) TagsEnvHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned tags")
-	}
+	log.Debug().Msgf("Returned %d tags", len(tags))
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, tags)
 }
 
@@ -217,8 +210,6 @@ func (h *HandlersApi) TagsActionHandler(w http.ResponseWriter, r *http.Request) 
 		returnData = "tag removed successfully"
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned %s", returnData)
-	}
+	log.Debug().Msgf("Returned [%s]", returnData)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiDataResponse{Data: returnData})
 }

--- a/cmd/api/handlers/users.go
+++ b/cmd/api/handlers/users.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -35,9 +34,7 @@ func (h *HandlersApi) UserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msgf("DebugService: Returned user %s", usernameVar)
-	}
+	log.Debug().Msgf("Returned user %s", usernameVar)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, user)
 }
 
@@ -64,8 +61,6 @@ func (h *HandlersApi) UsersHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serialize and serve JSON
-	if h.Settings.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Returned users")
-	}
+	log.Debug().Msgf("Returned %d users", len(users))
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, users)
 }

--- a/cmd/api/settings.go
+++ b/cmd/api/settings.go
@@ -10,22 +10,7 @@ import (
 
 // Function to load all settings for the service
 func loadingSettings(mgr *settings.Settings, cfg config.JSONConfigurationService) error {
-	// Check if service settings for debug service is ready
-	if mgr.DebugService(config.ServiceAPI) {
-		log.Debug().Msg("DebugService: Initializing settings")
-	}
-	// Check if service settings for debug service is ready
-	if !mgr.IsValue(config.ServiceAPI, settings.DebugService, settings.NoEnvironmentID) {
-		if err := mgr.NewBooleanValue(config.ServiceAPI, settings.DebugService, false, settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to settings: %w", settings.DebugService, err)
-		}
-	}
-	// Check if service settings for debug HTTP is ready
-	if !mgr.IsValue(config.ServiceAPI, settings.DebugHTTP, settings.NoEnvironmentID) {
-		if err := mgr.NewBooleanValue(config.ServiceAPI, settings.DebugHTTP, false, settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to settings: %w", settings.DebugHTTP, err)
-		}
-	}
+	log.Debug().Msg("Initializing settings")
 	// Check if service settings for metrics is ready, initialize if so
 	if !mgr.IsValue(config.ServiceAPI, settings.ServiceMetrics, settings.NoEnvironmentID) {
 		if err := mgr.NewBooleanValue(config.ServiceAPI, settings.ServiceMetrics, false, settings.NoEnvironmentID); err != nil {

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -218,9 +218,7 @@ func osctrlService() {
 			_t = int64(defaultRefresh)
 		}
 		for {
-			if settingsmgr.DebugService(config.ServiceTLS) {
-				log.Info().Msg("DebugService: Refreshing environments")
-			}
+			log.Debug().Msg("Refreshing environments")
 			envsmap = refreshEnvironments()
 			time.Sleep(time.Duration(_t) * time.Second)
 		}
@@ -235,9 +233,7 @@ func osctrlService() {
 			_t = int64(defaultRefresh)
 		}
 		for {
-			if settingsmgr.DebugService(config.ServiceTLS) {
-				log.Info().Msg("DebugService: Refreshing settings")
-			}
+			log.Debug().Msg("Refreshing settings")
 			settingsmap = refreshSettings()
 			time.Sleep(time.Duration(_t) * time.Second)
 		}

--- a/cmd/tls/settings.go
+++ b/cmd/tls/settings.go
@@ -9,12 +9,6 @@ import (
 
 // Function to load all settings for the service
 func loadingSettings(mgr *settings.Settings, cfg config.JSONConfigurationService) error {
-	// Check if service settings for debug service is ready
-	if !mgr.IsValue(config.ServiceTLS, settings.DebugService, settings.NoEnvironmentID) {
-		if err := mgr.NewBooleanValue(config.ServiceTLS, settings.DebugService, false, settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to configuration: %w", settings.DebugService, err)
-		}
-	}
 	// Check if service settings for accelerated seconds is ready
 	if !mgr.IsValue(config.ServiceTLS, settings.AcceleratedSeconds, settings.NoEnvironmentID) {
 		if err := mgr.NewIntegerValue(config.ServiceTLS, settings.AcceleratedSeconds, int64(defaultAccelerate), settings.NoEnvironmentID); err != nil {

--- a/pkg/carves/s3.go
+++ b/pkg/carves/s3.go
@@ -104,7 +104,7 @@ func (carveS3 *CarverS3) Settings(mgr *settings.Settings) {
 func (carveS3 *CarverS3) Upload(block CarvedBlock, uuid, data string) error {
 	ctx := context.Background()
 	if carveS3.Debug {
-		log.Debug().Msgf("DebugService: Sending %d bytes to S3 for %s - %s", block.Size, block.Environment, uuid)
+		log.Debug().Msgf("Sending %d bytes to S3 for %s - %s", block.Size, block.Environment, uuid)
 	}
 	// Decode before upload
 	toUpload, err := base64.StdEncoding.DecodeString(data)
@@ -123,7 +123,7 @@ func (carveS3 *CarverS3) Upload(block CarvedBlock, uuid, data string) error {
 		return fmt.Errorf("error sending data to s3 - %w", err)
 	}
 	if carveS3.Debug {
-		log.Debug().Msgf("DebugService: S3 Upload %+v", uploadOutput)
+		log.Debug().Msgf("S3 Upload %+v", uploadOutput)
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func (carveS3 *CarverS3) Archive(carve CarvedFile, blocks []CarvedBlock) (*Carve
 		return nil, fmt.Errorf("CompleteMultipartUpload - %w", err)
 	}
 	if carveS3.Debug {
-		log.Debug().Msgf("DebugService: S3 Archived %s [%d bytes] - %s", res.File, res.Size, *multiOutput.Key)
+		log.Debug().Msgf("S3 Archived %s [%d bytes] - %s", res.File, res.Size, *multiOutput.Key)
 	}
 	return res, nil
 }
@@ -204,7 +204,7 @@ func (carveS3 *CarverS3) Archive(carve CarvedFile, blocks []CarvedBlock) (*Carve
 func (carveS3 *CarverS3) Download(carve CarvedFile) (io.WriterAt, error) {
 	ctx := context.Background()
 	if carveS3.Debug {
-		log.Debug().Msgf("DebugService: Downloading %s from S3", carve.ArchivePath)
+		log.Debug().Msgf("Downloading %s from S3", carve.ArchivePath)
 	}
 	downloader := manager.NewDownloader(carveS3.Client)
 	var fileReader io.WriterAt
@@ -218,7 +218,7 @@ func (carveS3 *CarverS3) Download(carve CarvedFile) (io.WriterAt, error) {
 		return nil, fmt.Errorf("Download - %w", err)
 	}
 	if carveS3.Debug {
-		log.Debug().Msgf("DebugService: S3 Downloaded %s [%d bytes]", carve.ArchivePath, downloadedBytes)
+		log.Debug().Msgf("S3 Downloaded %s [%d bytes]", carve.ArchivePath, downloadedBytes)
 	}
 	return fileReader, nil
 }
@@ -227,7 +227,7 @@ func (carveS3 *CarverS3) Download(carve CarvedFile) (io.WriterAt, error) {
 func (carveS3 *CarverS3) GetDownloadLink(carve CarvedFile) (string, error) {
 	ctx := context.Background()
 	if carveS3.Debug {
-		log.Debug().Msgf("DebugService: Downloading link %s from S3", carve.ArchivePath)
+		log.Debug().Msgf("Downloading link %s from S3", carve.ArchivePath)
 	}
 	preClient := s3.NewPresignClient(carveS3.Client)
 	lnk, err := preClient.PresignGetObject(ctx, &s3.GetObjectInput{

--- a/pkg/environments/environments.go
+++ b/pkg/environments/environments.go
@@ -557,20 +557,3 @@ func (environment *Environment) NotExpireRemove(idEnv string) error {
 	}
 	return nil
 }
-
-// DebugHTTP to check if the environment has enabled debugging for HTTP
-func (environment *Environment) DebugHTTP(name string) bool {
-	env, err := environment.Get(name)
-	if err != nil {
-		return false
-	}
-	return env.DebugHTTP
-}
-
-// ChangeDebugHTTP to change the value of DebugHTTP for an environment
-func (environment *Environment) ChangeDebugHTTP(idEnv string, value bool) error {
-	if err := environment.DB.Model(&TLSEnvironment{}).Where("name = ? OR uuid = ?", idEnv, idEnv).Updates(map[string]interface{}{"debug_http": value}).Error; err != nil {
-		return fmt.Errorf("UpdatesChangeDebugHTTP %w", err)
-	}
-	return nil
-}

--- a/pkg/logging/elastic.go
+++ b/pkg/logging/elastic.go
@@ -99,10 +99,10 @@ func (logE *LoggerElastic) Settings(mgr *settings.Settings) {
 // Send - Function that sends JSON logs to Elastic
 func (logE *LoggerElastic) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
-		log.Debug().Msgf("DebugService: Send %s to Elastic", logType)
+		log.Debug().Msgf("Send %s to Elastic", logType)
 	}
 	if debug {
-		log.Debug().Msgf("DebugService: Sending %d bytes to Elastic for %s - %s", len(data), environment, uuid)
+		log.Debug().Msgf("Sending %d bytes to Elastic for %s - %s", len(data), environment, uuid)
 	}
 	var logs []interface{}
 	if logType == types.QueryLog {
@@ -139,6 +139,6 @@ func (logE *LoggerElastic) Send(logType string, data []byte, environment, uuid s
 		}
 	}
 	if debug {
-		log.Debug().Msgf("DebugService: Sent %d bytes of %s to Elastic from %s:%s", len(data), logType, uuid, environment)
+		log.Debug().Msgf("Sent %d bytes of %s to Elastic from %s:%s", len(data), logType, uuid, environment)
 	}
 }

--- a/pkg/logging/graylog.go
+++ b/pkg/logging/graylog.go
@@ -96,7 +96,7 @@ func (logGL *LoggerGraylog) Settings(mgr *settings.Settings) {
 // Send - Function that sends JSON logs to Graylog
 func (logGL *LoggerGraylog) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
-		log.Debug().Msgf("DebugService: Send %s via graylog", logType)
+		log.Debug().Msgf("Send %s via graylog", logType)
 	}
 	// Convert the array in an array of multiple message
 	var logs []interface{}
@@ -138,7 +138,7 @@ func (logGL *LoggerGraylog) Send(logType string, data []byte, environment, uuid 
 		}
 		jsonParam := strings.NewReader(string(jsonMessage))
 		if debug {
-			log.Debug().Msgf("DebugService: Sending %d bytes to Graylog for %s - %s", len(data), environment, uuid)
+			log.Debug().Msgf("Sending %d bytes to Graylog for %s - %s", len(data), environment, uuid)
 		}
 		// Send log with a POST to the Graylog URL
 		resp, body, err := utils.SendRequest(GraylogMethod, logGL.Configuration.URL, jsonParam, logGL.Headers)
@@ -147,7 +147,7 @@ func (logGL *LoggerGraylog) Send(logType string, data []byte, environment, uuid 
 			return
 		}
 		if debug {
-			log.Debug().Msgf("DebugService: HTTP %d %s", resp, body)
+			log.Debug().Msgf("HTTP %d %s", resp, body)
 		}
 	}
 }

--- a/pkg/logging/kafka.go
+++ b/pkg/logging/kafka.go
@@ -88,7 +88,7 @@ func (l *LoggerKafka) Settings(mgr *settings.Settings) {
 func (l *LoggerKafka) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
 		log.Info().Msgf(
-			"DebugService: Sending %d bytes to Kafka topic %s for %s - %s",
+			"Sending %d bytes to Kafka topic %s for %s - %s",
 			len(data), l.config.Topic, environment, uuid)
 	}
 

--- a/pkg/logging/kinesis.go
+++ b/pkg/logging/kinesis.go
@@ -87,7 +87,7 @@ func (logSK *LoggerKinesis) Settings(mgr *settings.Settings) {
 // Send - Function that sends JSON logs to Splunk HTTP Event Collector
 func (logSK *LoggerKinesis) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
-		log.Debug().Msgf("DebugService: Sending %d bytes to Kinesis for %s - %s", len(data), environment, uuid)
+		log.Debug().Msgf("Sending %d bytes to Kinesis for %s - %s", len(data), environment, uuid)
 	}
 	streamName := aws.String(logSK.Configuration.Stream)
 	putOutput, err := logSK.KinesisClient.PutRecord(&kinesis.PutRecordInput{
@@ -99,6 +99,6 @@ func (logSK *LoggerKinesis) Send(logType string, data []byte, environment, uuid 
 		log.Err(err).Msg("Error sending kinesis stream")
 	}
 	if debug {
-		log.Debug().Msgf("DebugService: PutRecordOutput %s", putOutput.String())
+		log.Debug().Msgf("PutRecordOutput %s", putOutput.String())
 	}
 }

--- a/pkg/logging/logstash.go
+++ b/pkg/logging/logstash.go
@@ -98,11 +98,11 @@ func (logLS *LoggerLogstash) Settings(mgr *settings.Settings) {
 // SendHTTP - Function that sends JSON logs to Logstash via HTTP
 func (logLS *LoggerLogstash) SendHTTP(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
-		log.Debug().Msgf("DebugService: Send %s via Logstash HTTP", logType)
+		log.Debug().Msgf("Send %s via Logstash HTTP", logType)
 	}
 	jsonData := strings.NewReader(string(data))
 	if debug {
-		log.Debug().Msgf("DebugService: Sending %d bytes to Logstash HTTP for %s - %s", len(data), environment, uuid)
+		log.Debug().Msgf("Sending %d bytes to Logstash HTTP for %s - %s", len(data), environment, uuid)
 	}
 	httpURL := fmt.Sprintf("http://%s:%s", logLS.Configuration.Host, logLS.Configuration.Port)
 	// Send log with a POST to the Splunk URL
@@ -111,17 +111,17 @@ func (logLS *LoggerLogstash) SendHTTP(logType string, data []byte, environment, 
 		log.Err(err).Msg("Error sending request")
 	}
 	if debug {
-		log.Debug().Msgf("DebugService: HTTP %d %s", resp, body)
+		log.Debug().Msgf("HTTP %d %s", resp, body)
 	}
 }
 
 // SendUDP - Function that sends data to Logstash via UDP
 func (logLS *LoggerLogstash) SendUDP(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
-		log.Debug().Msgf("DebugService: Send %s via Logstash TCP", logType)
+		log.Debug().Msgf("Send %s via Logstash TCP", logType)
 	}
 	if debug {
-		log.Debug().Msgf("DebugService: Sending %d bytes to Logstash TCP for %s - %s", len(data), environment, uuid)
+		log.Debug().Msgf("Sending %d bytes to Logstash TCP for %s - %s", len(data), environment, uuid)
 	}
 	connAddr := fmt.Sprintf(LogstashConnStr, logLS.Configuration.Host, logLS.Configuration.Port)
 	conn, err := net.Dial("udp", connAddr)
@@ -134,17 +134,17 @@ func (logLS *LoggerLogstash) SendUDP(logType string, data []byte, environment, u
 		log.Err(err).Msg("Error writing to Logstash")
 	}
 	if debug {
-		log.Debug().Msg("DebugService: Sent data to Logstash TCP")
+		log.Debug().Msg("Sent data to Logstash TCP")
 	}
 }
 
 // SendTCP - Function that sends data to Logstash via TCP
 func (logLS *LoggerLogstash) SendTCP(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
-		log.Debug().Msgf("DebugService: Send %s via Logstash UDP", logType)
+		log.Debug().Msgf("Send %s via Logstash UDP", logType)
 	}
 	if debug {
-		log.Debug().Msgf("DebugService: Sending %d bytes to Logstash UDP for %s - %s", len(data), environment, uuid)
+		log.Debug().Msgf("Sending %d bytes to Logstash UDP for %s - %s", len(data), environment, uuid)
 	}
 	connAddr := fmt.Sprintf(LogstashConnStr, logLS.Configuration.Host, logLS.Configuration.Port)
 	conn, err := net.Dial("tcp", connAddr)
@@ -157,6 +157,6 @@ func (logLS *LoggerLogstash) SendTCP(logType string, data []byte, environment, u
 		log.Err(err).Msg("Error writing to Logstash")
 	}
 	if debug {
-		log.Debug().Msg("DebugService: Sent data to Logstash UDP")
+		log.Debug().Msg("Sent data to Logstash UDP")
 	}
 }

--- a/pkg/logging/s3.go
+++ b/pkg/logging/s3.go
@@ -92,7 +92,7 @@ func (logS3 *LoggerS3) Settings(mgr *settings.Settings) {
 func (logS3 *LoggerS3) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	ctx := context.Background()
 	if debug {
-		log.Debug().Msgf("DebugService: Sending %d bytes to S3 for %s - %s", len(data), environment, uuid)
+		log.Debug().Msgf("Sending %d bytes to S3 for %s - %s", len(data), environment, uuid)
 	}
 	ptrContentLength := int64(len(data))
 	result, err := logS3.Uploader.Upload(ctx, &s3.PutObjectInput{
@@ -106,6 +106,6 @@ func (logS3 *LoggerS3) Send(logType string, data []byte, environment, uuid strin
 		log.Err(err).Msg("Error sending data to s3")
 	}
 	if debug {
-		log.Debug().Msgf("DebugService: S3 Upload %+v", result)
+		log.Debug().Msgf("S3 Upload %+v", result)
 	}
 }

--- a/pkg/logging/splunk.go
+++ b/pkg/logging/splunk.go
@@ -91,7 +91,7 @@ func (logSP *LoggerSplunk) Settings(mgr *settings.Settings) {
 // Send - Function that sends JSON logs to Splunk HTTP Event Collector
 func (logSP *LoggerSplunk) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
-		log.Debug().Msgf("DebugService: Send %s via splunk", logType)
+		log.Debug().Msgf("Send %s via splunk", logType)
 	}
 	// Check if this is result/status or query
 	var sourceType string
@@ -136,7 +136,7 @@ func (logSP *LoggerSplunk) Send(logType string, data []byte, environment, uuid s
 	}
 	jsonParam := strings.NewReader(string(jsonEvents))
 	if debug {
-		log.Debug().Msgf("DebugService: Sending %d bytes to Splunk for %s - %s", len(data), environment, uuid)
+		log.Debug().Msgf("Sending %d bytes to Splunk for %s - %s", len(data), environment, uuid)
 	}
 	// Send log with a POST to the Splunk URL
 	resp, body, err := utils.SendRequest(SplunkMethod, logSP.Configuration.URL, jsonParam, logSP.Headers)
@@ -144,6 +144,6 @@ func (logSP *LoggerSplunk) Send(logType string, data []byte, environment, uuid s
 		log.Err(err).Msgf("Error sending request")
 	}
 	if debug {
-		log.Debug().Msgf("DebugService: HTTP %d %s", resp, body)
+		log.Debug().Msgf("HTTP %d %s", resp, body)
 	}
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -72,8 +72,6 @@ const (
 
 // Names for all possible settings values for services
 const (
-	DebugHTTP          string = "debug_http"
-	DebugService       string = "debug_service"
 	RefreshEnvs        string = "refresh_envs"
 	RefreshSettings    string = "refresh_settings"
 	CleanupSessions    string = "cleanup_sessions"
@@ -527,24 +525,6 @@ func (conf *Settings) IsValue(service, name string, envID uint) bool {
 func (conf *Settings) IsJSON(service, name string, envID uint) bool {
 	_, err := conf.RetrieveJSON(service, name, envID)
 	return err == nil
-}
-
-// DebugHTTP checks if http debugging is enabled by service
-func (conf *Settings) DebugHTTP(service string, envID uint) bool {
-	value, err := conf.RetrieveValue(service, DebugHTTP, envID)
-	if err != nil {
-		return false
-	}
-	return value.Boolean
-}
-
-// DebugService checks if debugging is enabled by service
-func (conf *Settings) DebugService(service string) bool {
-	value, err := conf.RetrieveValue(service, DebugService, NoEnvironmentID)
-	if err != nil {
-		return false
-	}
-	return value.Boolean
 }
 
 // RefreshEnvs gets the interval in seconds to refresh environments by service


### PR DESCRIPTION
Removing all references for `debug_service` and `debug_http` settings and better debug messages.