### PR TITLE
Flag to enable the `osctrld` endpoints

### DIFF
--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -294,7 +294,7 @@ func osctrlService() {
 	muxTLS.HandleFunc("GET /{env}/{secretpath}/package/{package}", handlersTLS.EnrollPackageHandler)
 
 	// Enable osctrld endpoints
-	if flagParams.Osctrld {
+	if flagParams.OsctrldConfigValues.Enabled {
 		log.Info().Msg("Enabling osctrld endpoints")
 		// TLS: osctrld retrieve flags
 		muxTLS.HandleFunc("POST /{env}/"+environments.DefaultFlagsPath, handlersTLS.FlagsHandler)

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -65,9 +65,6 @@ type ServiceFlagParams struct {
 	// TLS private key file
 	TLSKeyFile string
 
-	// Enable osctrld service
-	Osctrld bool
-
 	// Logger configuration file
 	LoggerFile string
 	// Logger DB configuration will be the same as the main DB
@@ -101,6 +98,9 @@ type ServiceFlagParams struct {
 
 	// Debug HTTP configuration values
 	DebugHTTPValues DebugHTTPConfiguration
+
+	// osctrld configuration values
+	OsctrldConfigValues OsctrldConfiguration
 
 	// Service configuration values
 	ConfigValues JSONConfigurationService
@@ -801,7 +801,7 @@ func initOsctrldFlags(params *ServiceFlagParams) []cli.Flag {
 			Value:       false,
 			Usage:       "Enable osctrld endpoints.",
 			EnvVars:     []string{"OSCTRLD"},
-			Destination: &params.Osctrld,
+			Destination: &params.OsctrldConfigValues.Enabled,
 		},
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -111,3 +111,8 @@ type DebugHTTPConfiguration struct {
 	File     string `json:"file"`
 	ShowBody bool   `json:"showBody"`
 }
+
+// OsctrldConfiguration to hold osctrld configuration values
+type OsctrldConfiguration struct {
+	Enabled bool `json:"enabled"`
+}


### PR DESCRIPTION
Adding the flag `--enable-osctrld` to enable the `osctrld` endpoints in `osctrl-tls`. By default, they are disabled.