### PR TITLE
Potential fix for code scanning alert no. 25: Use of a known vulnerable action

### DIFF
--- a/.github/actions/test/binaries/action.yml
+++ b/.github/actions/test/binaries/action.yml
@@ -49,7 +49,7 @@ runs:
 
     ########################### Download artifacts ###########################
     - name: Download a osctrl binaries
-      uses: actions/download-artifact@v4.1.2
+      uses: actions/download-artifact@v4.1.3
       with:
         name: osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_branch }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 


### PR DESCRIPTION
Potential fix for [https://github.com/jmpsec/osctrl/security/code-scanning/25](https://github.com/jmpsec/osctrl/security/code-scanning/25)

To fix the problem, the vulnerable version of the `actions/download-artifact` action (`v4.1.2`) should be updated to the secure version (`v4.1.3`). This change ensures that the workflow uses the latest patched version of the action, addressing the identified vulnerability. The update is straightforward and involves modifying the `uses` field in the relevant step of the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
