### PR TITLE
Potential fix for code scanning alert no. 24: Use of a known vulnerable action

### DIFF
--- a/.github/actions/tagged_release/github/action.yml
+++ b/.github/actions/tagged_release/github/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     ########################### Download osctrl binary ###########################
     - name: Download osctrl binaries
-      uses: actions/download-artifact@v4.1.2
+      uses: actions/download-artifact@v4.1.3
       with:
         name: osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 
@@ -53,7 +53,7 @@ runs:
     ########################### Download osctrl DEB package ###########################
     - name: Download osctrl binaries
       if: ${{ inputs.go_os }} == 'linux'
-      uses: actions/download-artifact@v4.1.2
+      uses: actions/download-artifact@v4.1.3
       with:
         name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}-${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
 


### PR DESCRIPTION
Potential fix for [https://github.com/jmpsec/osctrl/security/code-scanning/24](https://github.com/jmpsec/osctrl/security/code-scanning/24)

To fix the issue, we need to update the version of the `actions/download-artifact` action from `v4.1.2` to `v4.1.3` in all instances where it is used in the workflow file. This ensures that the workflow uses a secure version of the action, addressing the known vulnerability. The changes will be made in the `.github/actions/tagged_release/github/action.yml` file, specifically on lines 25 and 56.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
