### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create_tagged_releases.yml
+++ b/.github/workflows/create_tagged_releases.yml
@@ -6,6 +6,9 @@ on:
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
+permissions:
+  contents: read
+
 env:
   GOLANG_VERSION: 1.24.2
   OSQUERY_VERSION: 5.16.0
@@ -223,6 +226,8 @@ jobs:
   create_release:
     needs: [build_and_test, create_deb_packages, push_docker_images]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     strategy:
       matrix:
         components: ["tls", "admin", "api", "cli"]


### PR DESCRIPTION
Potential fix for [https://github.com/jmpsec/osctrl/security/code-scanning/20](https://github.com/jmpsec/osctrl/security/code-scanning/20)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for all jobs. Additionally, we will add job-specific `permissions` blocks for jobs that require elevated permissions, such as `create_release`, which needs `contents: write` to create a release. This approach ensures that each job has only the permissions it needs, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
