### PR TITLE
Update action/download-artifacts to latest version

### DIFF
--- a/.github/actions/build/docker/action.yml
+++ b/.github/actions/build/docker/action.yml
@@ -39,7 +39,7 @@ runs:
 
     ########################### Download osctrl binary ###########################
     - name: Download osctrl binary
-      uses: actions/download-artifact@v4.1.2
+      uses: actions/download-artifact@v4.3.0
       with:
         name: osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 

--- a/.github/actions/build/dpkg/action.yml
+++ b/.github/actions/build/dpkg/action.yml
@@ -31,7 +31,7 @@ runs:
 
     ########################### Download osctrl binary ###########################
     - name: Download a osctrl binaries
-      uses: actions/download-artifact@v4.1.2
+      uses: actions/download-artifact@v4.3.0
       with:
         name: osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 

--- a/.github/actions/tagged_release/github/action.yml
+++ b/.github/actions/tagged_release/github/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     ########################### Download osctrl binary ###########################
     - name: Download osctrl binaries
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4.3.0
       with:
         name: osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 
@@ -53,7 +53,7 @@ runs:
     ########################### Download osctrl DEB package ###########################
     - name: Download osctrl binaries
       if: ${{ inputs.go_os }} == 'linux'
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4.3.0
       with:
         name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}-${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
 

--- a/.github/actions/test/binaries/action.yml
+++ b/.github/actions/test/binaries/action.yml
@@ -49,7 +49,7 @@ runs:
 
     ########################### Download artifacts ###########################
     - name: Download a osctrl binaries
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4.3.0
       with:
         name: osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_branch }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.bin
 

--- a/.github/workflows/build_and_test_main_merge.yml
+++ b/.github/workflows/build_and_test_main_merge.yml
@@ -145,7 +145,7 @@ jobs:
     steps:
       ########################### Get digests from build ###########################
       - name: Download digests
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.3.0
         with:
           pattern: digests-osctrl-${{ matrix.components }}-*
           merge-multiple: true

--- a/.github/workflows/create_tagged_releases.yml
+++ b/.github/workflows/create_tagged_releases.yml
@@ -157,7 +157,7 @@ jobs:
 
       ########################### Get digests from build ###########################
       - name: Download digests
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.3.0
         with:
           pattern: digests-osctrl-${{ matrix.components }}-*
           merge-multiple: true


### PR DESCRIPTION
Bumping the `action/download-artifacts` to latest version to avoid known issues. 