### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_test_main_merge.yml
+++ b/.github/workflows/build_and_test_main_merge.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   GOLANG_VERSION: 1.24.2
   OSQUERY_VERSION: 5.16.0
@@ -139,6 +142,9 @@ jobs:
   push_docker_images:
     needs: [create_docker_images]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         components: ["tls", "admin", "api", "cli"]


### PR DESCRIPTION
Potential fix for [https://github.com/jmpsec/osctrl/security/code-scanning/19](https://github.com/jmpsec/osctrl/security/code-scanning/19)

To fix the issue, we will add a `permissions` block to the workflow. At the root level, we will set the default permissions to `contents: read`, which is sufficient for most CI workflows. For jobs that require additional permissions, such as `push_docker_images`, we will define job-specific permissions to grant only the necessary access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
