### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_test_pr.yml
+++ b/.github/workflows/build_and_test_pr.yml
@@ -1,4 +1,6 @@
 name: Build and test PRs pushed to osctrl
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/jmpsec/osctrl/security/code-scanning/11](https://github.com/jmpsec/osctrl/security/code-scanning/11)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the provided workflow, the actions primarily involve checking out code and running builds, which typically only require `contents: read`. If additional permissions are needed for specific steps, they can be added later.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
