### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,9 @@ on:
       - '.golangci.yml'
       - '.github/workflows/golangci-lint.yml'
 
+permissions:
+  contents: read
+
 env:
   GOLANG_VERSION: 1.24.2
 


### PR DESCRIPTION
Potential fix for [https://github.com/jmpsec/osctrl/security/code-scanning/14](https://github.com/jmpsec/osctrl/security/code-scanning/14)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs linting tasks, it requires minimal permissions. The `contents: read` permission is sufficient for this workflow, as it allows the workflow to read repository contents without granting unnecessary write access.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs, as there is only one job (`golangci`) in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
