### PR TITLE
Refactor `strings.NewReader` into bytes to avoid allocations

### DIFF
--- a/pkg/logging/db.go
+++ b/pkg/logging/db.go
@@ -61,7 +61,7 @@ func CreateLoggerDBFile(dbfile string) (*LoggerDB, error) {
 	// Initialize backend
 	backend, err := backend.CreateDBManagerFile(dbfile)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create backend - %w", err)
+		return nil, fmt.Errorf("failed to create backend - %w", err)
 	}
 	return CreateLoggerDB(backend)
 }
@@ -71,7 +71,7 @@ func CreateLoggerDBConfig(dbConfig backend.JSONConfigurationDB) (*LoggerDB, erro
 	// Initialize backend
 	backend, err := backend.CreateDBManager(dbConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create backend - %w", err)
+		return nil, fmt.Errorf("failed to create backend - %w", err)
 	}
 	return CreateLoggerDB(backend)
 }

--- a/pkg/logging/elastic.go
+++ b/pkg/logging/elastic.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -126,7 +127,7 @@ func (logE *LoggerElastic) Send(logType string, data []byte, environment, uuid s
 		}
 		req := esapi.IndexRequest{
 			Index:   logE.IndexName(),
-			Body:    strings.NewReader(string(jsonEvent)),
+			Body:    bytes.NewReader(jsonEvent),
 			Refresh: "true",
 		}
 		res, err := req.Do(context.Background(), logE.Client)

--- a/pkg/logging/graylog.go
+++ b/pkg/logging/graylog.go
@@ -1,9 +1,9 @@
 package logging
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/config"
@@ -136,7 +136,7 @@ func (logGL *LoggerGraylog) Send(logType string, data []byte, environment, uuid 
 		if err != nil {
 			log.Err(err).Msg("error marshaling data")
 		}
-		jsonParam := strings.NewReader(string(jsonMessage))
+		jsonParam := bytes.NewReader(jsonMessage)
 		if debug {
 			log.Debug().Msgf("Sending %d bytes to Graylog for %s - %s", len(data), environment, uuid)
 		}

--- a/pkg/logging/logstash.go
+++ b/pkg/logging/logstash.go
@@ -1,9 +1,9 @@
 package logging
 
 import (
+	"bytes"
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/settings"
@@ -100,7 +100,7 @@ func (logLS *LoggerLogstash) SendHTTP(logType string, data []byte, environment, 
 	if debug {
 		log.Debug().Msgf("Send %s via Logstash HTTP", logType)
 	}
-	jsonData := strings.NewReader(string(data))
+	jsonData := bytes.NewReader(data)
 	if debug {
 		log.Debug().Msgf("Sending %d bytes to Logstash HTTP for %s - %s", len(data), environment, uuid)
 	}

--- a/pkg/logging/splunk.go
+++ b/pkg/logging/splunk.go
@@ -1,9 +1,9 @@
 package logging
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/config"
@@ -134,7 +134,7 @@ func (logSP *LoggerSplunk) Send(logType string, data []byte, environment, uuid s
 	if err != nil {
 		log.Err(err).Msgf("Error parsing data")
 	}
-	jsonParam := strings.NewReader(string(jsonEvents))
+	jsonParam := bytes.NewReader(jsonEvents)
 	if debug {
 		log.Debug().Msgf("Sending %d bytes to Splunk for %s - %s", len(data), environment, uuid)
 	}


### PR DESCRIPTION
Avoid using `strings.NewReader` when `bytes.NewReader` can be used and avoid unnecessary allocation.