### PR TITLE
Adding service users

### DIFF
--- a/cmd/admin/auth.go
+++ b/cmd/admin/auth.go
@@ -66,7 +66,7 @@ func handlerAuthCheck(h http.Handler, auth string) http.Handler {
 						http.Redirect(w, r, forbiddenPath, http.StatusFound)
 						return
 					}
-					u, err = adminUsers.New(samlUser, "", samlUser, "", false)
+					u, err = adminUsers.New(samlUser, "", samlUser, "", false, false)
 					if err != nil {
 						log.Err(err).Msgf("error creating user %s", samlUser)
 						http.Redirect(w, r, forbiddenPath, http.StatusFound)

--- a/cmd/admin/handlers/post.go
+++ b/cmd/admin/handlers/post.go
@@ -1083,7 +1083,7 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		// Prepare user to create
-		newUser, err := h.Users.New(u.Username, u.NewPassword, u.Email, u.Fullname, u.Admin)
+		newUser, err := h.Users.New(u.Username, u.NewPassword, u.Email, u.Fullname, u.Admin, u.Service)
 		if err != nil {
 			adminErrorResponse(w, "error with new user", http.StatusInternalServerError, err)
 			return
@@ -1179,6 +1179,18 @@ func (h *HandlersAdmin) UsersPOSTHandler(w http.ResponseWriter, r *http.Request)
 				}
 			}
 			adminOKResponse(w, "admin changed successfully")
+		}
+	case "service":
+		if u.Username == ctx[sessions.CtxUser] {
+			adminErrorResponse(w, "not a good idea", http.StatusInternalServerError, fmt.Errorf("attempt to service current user %s", u.Username))
+			return
+		}
+		if h.Users.Exists(u.Username) {
+			if err := h.Users.ChangeService(u.Username, u.Service); err != nil {
+				adminErrorResponse(w, "error changing service", http.StatusInternalServerError, err)
+				return
+			}
+			adminOKResponse(w, "service changed successfully")
 		}
 	}
 	// Serialize and send response

--- a/cmd/admin/handlers/templates.go
+++ b/cmd/admin/handlers/templates.go
@@ -1249,10 +1249,16 @@ func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) 
 		log.Err(err).Msg("error getting platforms")
 		return
 	}
-	// Get current users
-	users, err := h.Users.All()
+	// Get current regular users
+	systemUsers, err := h.Users.AllNonService()
 	if err != nil {
 		log.Err(err).Msg("error getting users")
+		return
+	}
+	// Get current service users
+	serviceUsers, err := h.Users.AllService()
+	if err != nil {
+		log.Err(err).Msg("error getting service users")
 		return
 	}
 	// Prepare template data
@@ -1261,7 +1267,8 @@ func (h *HandlersAdmin) UsersGETHandler(w http.ResponseWriter, r *http.Request) 
 		Metadata:     h.TemplateMetadata(ctx, h.ServiceVersion),
 		Environments: h.allowedEnvironments(ctx[sessions.CtxUser], envAll),
 		Platforms:    platforms,
-		CurrentUsers: users,
+		SystemUsers:  systemUsers,
+		ServiceUsers: serviceUsers,
 	}
 	if err := t.Execute(w, templateData); err != nil {
 		log.Err(err).Msg("template error")

--- a/cmd/admin/handlers/types-requests.go
+++ b/cmd/admin/handlers/types-requests.go
@@ -123,6 +123,7 @@ type UsersRequest struct {
 	NewPassword  string   `json:"new_password"`
 	Token        bool     `json:"token"`
 	Admin        bool     `json:"admin"`
+	Service      bool     `json:"service"`
 	Environments []string `json:"environments"`
 }
 

--- a/cmd/admin/handlers/types-templates.go
+++ b/cmd/admin/handlers/types-templates.go
@@ -20,11 +20,11 @@ type LoginTemplateData struct {
 
 // TemplateMetadata to pass some metadata to templates
 type TemplateMetadata struct {
-	Username       string
-	Level          string
-	Service        string
-	Version        string
-	CSRFToken      string
+	Username  string
+	Level     string
+	Service   string
+	Version   string
+	CSRFToken string
 }
 
 // AsideLeftMetadata to pass metadata to the aside left menu
@@ -185,7 +185,8 @@ type UsersTemplateData struct {
 	Title        string
 	Environments []environments.TLSEnvironment
 	Platforms    []string
-	CurrentUsers []users.AdminUser
+	SystemUsers  []users.AdminUser
+	ServiceUsers []users.AdminUser
 	Metadata     TemplateMetadata
 	LeftMetadata AsideLeftMetadata
 }

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -135,10 +135,10 @@ func loadConfiguration(file, service string) (config.JSONConfigurationService, e
 	}
 	// Check if values are valid
 	if !validAuth[cfg.Auth] {
-		return cfg, fmt.Errorf("Invalid auth method")
+		return cfg, fmt.Errorf("invalid auth method")
 	}
 	if !validCarver[cfg.Carver] {
-		return cfg, fmt.Errorf("Invalid carver method")
+		return cfg, fmt.Errorf("invalid carver method")
 	}
 	// No errors!
 	return cfg, nil
@@ -566,41 +566,41 @@ func cliAction(c *cli.Context) error {
 	if flagParams.ConfigFlag {
 		flagParams.ConfigValues, err = loadConfiguration(flagParams.ServiceConfigFile, config.ServiceAdmin)
 		if err != nil {
-			return fmt.Errorf("Failed to load service configuration %s - %w", flagParams.ServiceConfigFile, err)
+			return fmt.Errorf("failed to load service configuration %s - %w", flagParams.ServiceConfigFile, err)
 		}
 	}
 	// Load redis configuration if external JSON config file is used
 	if flagParams.RedisFlag {
 		flagParams.RedisConfigValues, err = cache.LoadConfiguration(flagParams.RedisConfigFile, cache.RedisKey)
 		if err != nil {
-			return fmt.Errorf("Failed to load redis configuration - %w", err)
+			return fmt.Errorf("failed to load redis configuration - %w", err)
 		}
 	}
 	// Load DB configuration if external JSON config file is used
 	if flagParams.DBFlag {
 		flagParams.DBConfigValues, err = backend.LoadConfiguration(flagParams.DBConfigFile, backend.DBKey)
 		if err != nil {
-			return fmt.Errorf("Failed to load DB configuration - %w", err)
+			return fmt.Errorf("failed to load DB configuration - %w", err)
 		}
 	}
 	// Load SAML configuration if this authentication is used in the service config
 	if flagParams.ConfigValues.Auth == config.AuthSAML {
 		samlConfig, err = loadSAML(flagParams.SAMLConfigFile)
 		if err != nil {
-			return fmt.Errorf("Failed to load SAML configuration - %w", err)
+			return fmt.Errorf("failed to load SAML configuration - %w", err)
 		}
 	}
 	// Load JWT configuration if external JWT JSON config file is used
 	if flagParams.JWTFlag {
 		flagParams.JWTConfigValues, err = loadJWTConfiguration(flagParams.JWTConfigFile)
 		if err != nil {
-			return fmt.Errorf("Failed to load JWT configuration - %w", err)
+			return fmt.Errorf("failed to load JWT configuration - %w", err)
 		}
 	}
 	// Load osquery tables JSON file
 	osqueryTables, err = loadOsqueryTables(flagParams.OsqueryTablesFile)
 	if err != nil {
-		return fmt.Errorf("Failed to load osquery tables - %w", err)
+		return fmt.Errorf("failed to load osquery tables - %w", err)
 	}
 	// Load carver configuration if external JSON config file is used
 	if flagParams.ConfigValues.Carver == config.CarverS3 {
@@ -610,7 +610,7 @@ func cliAction(c *cli.Context) error {
 			carvers3, err = carves.CreateCarverS3File(flagParams.CarverConfigFile)
 		}
 		if err != nil {
-			return fmt.Errorf("Failed to initiate s3 carver - %w", err)
+			return fmt.Errorf("failed to initiate s3 carver - %w", err)
 		}
 	}
 	return nil

--- a/cmd/admin/saml.go
+++ b/cmd/admin/saml.go
@@ -62,22 +62,22 @@ func loadSAML(file string) (JSONConfigurationSAML, error) {
 // Function to verify SAML configuration
 func verifySAML(cfg JSONConfigurationSAML) error {
 	if cfg.CertPath == "" {
-		return fmt.Errorf("Missing CertPath")
+		return fmt.Errorf("missing CertPath")
 	}
 	if cfg.KeyPath == "" {
-		return fmt.Errorf("Missing KeyPath")
+		return fmt.Errorf("missing KeyPath")
 	}
 	if cfg.MetaDataURL == "" {
-		return fmt.Errorf("Missing MetaDataURL")
+		return fmt.Errorf("missing MetaDataURL")
 	}
 	if cfg.RootURL == "" {
-		return fmt.Errorf("Missing RootURL")
+		return fmt.Errorf("missing RootURL")
 	}
 	if cfg.LoginURL == "" {
-		return fmt.Errorf("Missing LoginURL")
+		return fmt.Errorf("missing LoginURL")
 	}
 	if cfg.LogoutURL == "" {
-		return fmt.Errorf("Missing LogoutURL")
+		return fmt.Errorf("missing LogoutURL")
 	}
 	return nil
 }
@@ -88,23 +88,23 @@ func keypairSAML(config JSONConfigurationSAML) (samlThings, error) {
 	var err error
 	data.KeyPair, err = tls.LoadX509KeyPair(config.CertPath, config.KeyPath)
 	if err != nil {
-		return data, fmt.Errorf("LoadX509KeyPair %w", err)
+		return data, fmt.Errorf("loadX509KeyPair %w", err)
 	}
 	data.KeyPair.Leaf, err = x509.ParseCertificate(data.KeyPair.Certificate[0])
 	if err != nil {
-		return data, fmt.Errorf("ParseCertificate %w", err)
+		return data, fmt.Errorf("parseCertificate %w", err)
 	}
 	data.IdpMetadataURL, err = url.Parse(config.MetaDataURL)
 	if err != nil {
-		return data, fmt.Errorf("Parse MetadataURL %w", err)
+		return data, fmt.Errorf("parse MetadataURL %w", err)
 	}
 	data.IdpMetadata, err = samlsp.FetchMetadata(context.Background(), http.DefaultClient, *data.IdpMetadataURL)
 	if err != nil {
-		return data, fmt.Errorf("Fetch Metadata %w", err)
+		return data, fmt.Errorf("fetch Metadata %w", err)
 	}
 	data.RootURL, err = url.Parse(config.RootURL)
 	if err != nil {
-		return data, fmt.Errorf("Parse RootURL %w", err)
+		return data, fmt.Errorf("parse RootURL %w", err)
 	}
 	return data, nil
 }

--- a/cmd/admin/settings.go
+++ b/cmd/admin/settings.go
@@ -15,30 +15,30 @@ func loadingSettings(mgr *settings.Settings, cfg config.JSONConfigurationService
 	// Check if service settings for sessions cleanup is ready
 	if !mgr.IsValue(config.ServiceAdmin, settings.CleanupSessions, settings.NoEnvironmentID) {
 		if err := mgr.NewIntegerValue(config.ServiceAdmin, settings.CleanupSessions, int64(defaultRefresh), settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to configuration: %w", settings.CleanupSessions, err)
+			return fmt.Errorf("failed to add %s to configuration: %w", settings.CleanupSessions, err)
 		}
 	}
 	// Check if service settings for queries/carves cleanup is ready
 	if !mgr.IsValue(config.ServiceAdmin, settings.CleanupExpired, settings.NoEnvironmentID) {
 		if err := mgr.NewIntegerValue(config.ServiceAdmin, settings.CleanupExpired, int64(defaultExpiration), settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to configuration: %w", settings.CleanupExpired, err)
+			return fmt.Errorf("failed to add %s to configuration: %w", settings.CleanupExpired, err)
 		}
 	}
 	// Check if service settings for node inactive hours is ready
 	if !mgr.IsValue(config.ServiceAdmin, settings.InactiveHours, settings.NoEnvironmentID) {
 		if err := mgr.NewIntegerValue(config.ServiceAdmin, settings.InactiveHours, int64(defaultInactive), settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to configuration: %w", settings.InactiveHours, err)
+			return fmt.Errorf("failed to add %s to configuration: %w", settings.InactiveHours, err)
 		}
 	}
 	// Check if service settings for display dashboard is ready
 	if !mgr.IsValue(config.ServiceAdmin, settings.NodeDashboard, settings.NoEnvironmentID) {
 		if err := mgr.NewBooleanValue(config.ServiceAdmin, settings.NodeDashboard, false, settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to settings: %w", settings.NodeDashboard, err)
+			return fmt.Errorf("failed to add %s to settings: %w", settings.NodeDashboard, err)
 		}
 	}
 	// Write JSON config to settings
 	if err := mgr.SetAdminJSON(cfg, settings.NoEnvironmentID); err != nil {
-		return fmt.Errorf("Failed to add JSON values to configuration: %w", err)
+		return fmt.Errorf("failed to add JSON values to configuration: %w", err)
 	}
 	return nil
 }

--- a/cmd/admin/static/js/users.js
+++ b/cmd/admin/static/js/users.js
@@ -16,6 +16,7 @@ function confirmAddUser() {
   var _fullname = $("#user_fullname").val();
   var _password = $("#user_password").val();
   var _admin = $("#user_admin").is(":checked");
+  var _service = $("#user_service").is(":checked");
   var _token = $("#user_token").is(":checked");
 
   var data = {
@@ -26,6 +27,7 @@ function confirmAddUser() {
     fullname: _fullname,
     new_password: _password,
     admin: _admin,
+    service: _service,
     token: _token,
   };
   sendPostRequest(data, _url, _url, false);
@@ -43,7 +45,7 @@ function confirmDeleteUser(_user) {
 
 function changeAdminUser(_user) {
   var _csrftoken = $("#csrftoken").val();
-  var _value = $("#" + _user).is(":checked");
+  var _value = $("#admin_" + _user).is(":checked");
 
   if (_value) {
     $("#permissions-button-" + _user).hide();
@@ -59,7 +61,22 @@ function changeAdminUser(_user) {
     username: _user,
     admin: _value,
   };
-  sendPostRequest(data, _url, "", false);
+  sendPostRequest(data, _url, _url, false);
+}
+
+function changeServiceUser(_user) {
+  var _csrftoken = $("#csrftoken").val();
+  var _value = $("#service_" + _user).is(":checked");
+
+  var _url = window.location.pathname;
+
+  var data = {
+    csrftoken: _csrftoken,
+    action: "service",
+    username: _user,
+    service: _value,
+  };
+  sendPostRequest(data, _url, _url, false);
 }
 
 function deleteUser(_user) {

--- a/cmd/admin/templates/users.html
+++ b/cmd/admin/templates/users.html
@@ -46,14 +46,15 @@
                       <th width="15%">Email</th>
                       <th width="10%">Fullname</th>
                       <th width="10%">Last IP</th>
-                      <th width="25%">Last UserAgent</th>
+                      <th width="20%">Last UserAgent</th>
                       <th width="5%">Admin</th>
+                      <th width="5%">Service</th>
                       <th width="15%">Last Session</th>
                       <th width="10%"></th>
                     </tr>
                   </thead>
                   <tbody>
-                  {{range  $i, $e := $.CurrentUsers}}
+                  {{range  $i, $e := $.SystemUsers}}
                     <tr>
                       <td>{{ $e.Username }}</td>
                       <td>
@@ -80,7 +81,110 @@
                       </td>
                       <td>
                         <label class="switch switch-label switch-pill switch-success switch-sm" data-tooltip="true" data-placement="top" title="Change">
-                          <input id="{{ $e.Username }}" class="switch-input" type="checkbox" onclick="changeAdminUser('{{ $e.Username }}');" {{ if $e.Admin }} checked {{ end }}>
+                          <input id="admin_{{ $e.Username }}" class="switch-input" type="checkbox" onclick="changeAdminUser('{{ $e.Username }}');" {{ if $e.Admin }} checked {{ end }}>
+                          <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
+                        </label>
+                      </td>
+                      <td>
+                        <label class="switch switch-label switch-pill switch-success switch-sm" data-tooltip="true" data-placement="top" title="Change">
+                          <input id="service_{{ $e.Username }}" class="switch-input" type="checkbox" onclick="changeServiceUser('{{ $e.Username }}');" {{ if $e.Service }} checked {{ end }}>
+                          <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
+                        </label>
+                      </td>
+                      <td>{{ pastFutureTimes $e.LastAccess }}</td>
+                      <td>
+                        <button type="button" class="btn btn-sm btn-ghost-info" data-tooltip="true" data-placement="top" title="API Token"
+                        onclick="showAPIToken('{{ $e.APIToken }}', '{{ pastFutureTimes $e.TokenExpire }}', '{{ $e.Username }}');">
+                          <i class="fas fa-key"></i>
+                        </button>
+                        <button id="permissions-button-{{ $e.Username }}" type="button" class="btn btn-sm btn-ghost-primary" data-tooltip="true" data-placement="top" title="Permissions"
+                          onclick="showPermissions('{{ $e.Username }}');">
+                          <i class="fas fa-lock"></i>
+                        </button>
+                        <button type="button" class="btn btn-sm btn-ghost-danger" data-tooltip="true" data-placement="top" title="Delete User"
+                        onclick="confirmDeleteUser('{{ $e.Username }}');">
+                          <i class="far fa-trash-alt"></i>
+                        </button>
+                        <button type="button" class="btn btn-sm btn-ghost-warning" data-tooltip="true" data-placement="top" title="Change Password"
+                        onclick="changePassword('{{ $e.Username }}');">
+                          <i class="fas fa-user-lock"></i>
+                        </button>
+                      </td>
+                    </tr>
+                  {{ end }}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div class="card mt-2">
+              <div class="card-header">
+                <i class="fas fa-robot"></i> Service Users
+
+                <div class="card-header-actions">
+                  <div class="row">
+                    <div class="card-header-action mr-3">
+                      <button id="users_add" class="btn btn-sm btn-block btn-dark"
+                        data-tooltip="true" data-placement="bottom" title="Add User" onclick="addUser();">
+                        <i class="fas fa-plus"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+
+              <div class="card-body">
+
+                <table class="table table-responsive-sm table-bordered table-striped text-center">
+                  <thead>
+                    <tr>
+                      <th width="10%">Username</th>
+                      <th width="15%">Email</th>
+                      <th width="10%">Fullname</th>
+                      <th width="10%">Last IP</th>
+                      <th width="20%">Last UserAgent</th>
+                      <th width="5%">Admin</th>
+                      <th width="5%">Service</th>
+                      <th width="15%">Last Session</th>
+                      <th width="10%"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                  {{range  $i, $e := $.ServiceUsers}}
+                    <tr>
+                      <td>{{ $e.Username }}</td>
+                      <td>
+                        <p id="email" data-tooltip="true" data-user="{{ $e.Username }}" class="editable-field" role="button" tabindex="0" title="Click to edit...">{{ $e.Email }}</p>
+                      </td>
+                      <td>
+                        <p id="fullname" data-tooltip="true" data-user="{{ $e.Username }}" class="editable-field" role="button" tabindex="0" title="Click to edit...">{{ $e.Fullname }}</p>
+                      </td>
+                      <td>
+                        {{ if eq $e.LastIPAddress "" }}
+                          None
+                        {{ else }}
+                          {{ $e.LastIPAddress }}
+                        {{ end }}
+                      </td>
+                      <td>
+                        <code>
+                        {{ if eq $e.LastUserAgent "" }}
+                          None
+                        {{ else }}
+                          {{ $e.LastUserAgent }}
+                        {{ end }}
+                        </code>
+                      </td>
+                      <td>
+                        <label class="switch switch-label switch-pill switch-success switch-sm" data-tooltip="true" data-placement="top" title="Change">
+                          <input id="admin_{{ $e.Username }}" class="switch-input" type="checkbox" onclick="changeAdminUser('{{ $e.Username }}');" {{ if $e.Admin }} checked {{ end }}>
+                          <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
+                        </label>
+                      </td>
+                      <td>
+                        <label class="switch switch-label switch-pill switch-success switch-sm" data-tooltip="true" data-placement="top" title="Change">
+                          <input id="service_{{ $e.Username }}" class="switch-input" type="checkbox" onclick="changeServiceUser('{{ $e.Username }}');" {{ if $e.Service }} checked {{ end }}>
                           <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
                         </label>
                       </td>
@@ -145,6 +249,13 @@
                       <div class="col-md-2">
                         <label class="switch switch-label switch-pill switch-success switch-sm" data-tooltip="true" data-placement="top" title="Change">
                           <input id="user_admin" class="switch-input" type="checkbox">
+                          <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
+                        </label>
+                      </div>
+                      <label class="col-md-1 col-form-label" for="user_service">Service: </label>
+                      <div class="col-md-2">
+                        <label class="switch switch-label switch-pill switch-success switch-sm" data-tooltip="true" data-placement="top" title="Change">
+                          <input id="user_service" class="switch-input" type="checkbox">
                           <span class="switch-slider" data-checked="On" data-unchecked="Off"></span>
                         </label>
                       </div>

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -230,6 +230,12 @@ func init() {
 							Hidden:  false,
 							Usage:   "Make this user an admin",
 						},
+						&cli.BoolFlag{
+							Name:    "service",
+							Aliases: []string{"s"},
+							Hidden:  false,
+							Usage:   "Make this user a service accoiunt",
+						},
 						&cli.StringFlag{
 							Name:    "environment",
 							Aliases: []string{"e"},
@@ -285,6 +291,18 @@ func init() {
 							Aliases: []string{"d"},
 							Hidden:  false,
 							Usage:   "Make this user an non-admin",
+						},
+						&cli.BoolFlag{
+							Name:    "service",
+							Aliases: []string{"s"},
+							Hidden:  false,
+							Usage:   "Make this user a service account",
+						},
+						&cli.BoolFlag{
+							Name:    "non-service",
+							Aliases: []string{"S"},
+							Hidden:  false,
+							Usage:   "Make this user a non-service account",
 						},
 						&cli.StringFlag{
 							Name:    "environment",

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -234,7 +234,7 @@ func init() {
 							Name:    "service",
 							Aliases: []string{"s"},
 							Hidden:  false,
-							Usage:   "Make this user a service accoiunt",
+							Usage:   "Make this user a service account",
 						},
 						&cli.StringFlag{
 							Name:    "environment",

--- a/cmd/cli/user.go
+++ b/cmd/cli/user.go
@@ -50,7 +50,8 @@ func addUser(c *cli.Context) error {
 	email := c.String("email")
 	fullname := c.String("fullname")
 	admin := c.Bool("admin")
-	user, err := adminUsers.New(username, password, email, fullname, admin)
+	service := c.Bool("service")
+	user, err := adminUsers.New(username, password, email, fullname, admin, service)
 	if err != nil {
 		return fmt.Errorf("error with new user - %w", err)
 	}
@@ -99,6 +100,18 @@ func editUser(c *cli.Context) error {
 	if notAdmin {
 		if err := adminUsers.ChangeAdmin(username, false); err != nil {
 			return fmt.Errorf("error changing non-admin - %w", err)
+		}
+	}
+	service := c.Bool("service")
+	if service {
+		if err := adminUsers.ChangeService(username, true); err != nil {
+			return fmt.Errorf("error changing service - %w", err)
+		}
+	}
+	nonService := c.Bool("non-service")
+	if nonService {
+		if err := adminUsers.ChangeService(username, false); err != nil {
+			return fmt.Errorf("error changing service - %w", err)
 		}
 	}
 	if !silentFlag {

--- a/pkg/users/permissions_test.go
+++ b/pkg/users/permissions_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPermissions(t *testing.T) {
+func setupTestManagerForPermissions(t *testing.T) (*UserManager, sqlmock.Sqlmock) {
 	conf := config.JSONConfigurationJWT{
 		JWTSecret:     "test",
 		HoursToExpire: 1,
@@ -23,7 +23,6 @@ func TestPermissions(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to open mock sql db, got error: %v", err)
 	}
-	defer mockDB.Close()
 	if mockDB == nil {
 		t.Error("mock db is null")
 	}
@@ -34,436 +33,586 @@ func TestPermissions(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create new postgres database: %v", err)
 	}
-	var manager *UserManager
-	t.Run("CreateUserManagerForPermissions", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1 AND table_type = $2`)).WithArgs("admin_users", "BASE TABLE").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}), sqlmock.NewRows([]string{"RowsAffected"}).AddRow(1).AddRow(1))
-		mock.ExpectExec(`CREATE TABLE "admin_users" .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1 AND table_type = $2`)).WithArgs("user_permissions", "BASE TABLE").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}), sqlmock.NewRows([]string{"RowsAffected"}).AddRow(1).AddRow(1))
-		mock.ExpectExec(`CREATE TABLE "user_permissions" .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-
-		manager = CreateUserManager(_postgres, &conf)
-
-		assert.NotEqual(t, nil, manager)
-	})
-	t.Run("CreatePermission", func(t *testing.T) {
-		tt := time.Now()
-		perm := UserPermission{
-			Username:      "testUser",
-			AccessType:    0,
-			AccessValue:   true,
-			EnvironmentID: 111,
-			Environment:   "testEnv",
-			GrantedBy:     "test",
-		}
-		perm.CreatedAt = tt
-		perm.UpdatedAt = tt
-
-		mock.ExpectBegin()
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`INSERT INTO "user_permissions" ("created_at","updated_at","deleted_at","username","access_type","access_value","environment","environment_id","granted_by") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING "id"`)).WithArgs(tt, tt, nil, perm.Username, perm.AccessType, perm.AccessValue, perm.Environment, perm.EnvironmentID, perm.GrantedBy).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
-		mock.ExpectCommit()
-		err := manager.CreatePermission(perm)
-
-		assert.NoError(t, err)
-
-		assert.Equal(t, "testUser", perm.Username)
-		assert.Equal(t, "test", perm.GrantedBy)
-		assert.Equal(t, 111, int(perm.EnvironmentID))
-		assert.Equal(t, "testEnv", perm.Environment)
-	})
-	t.Run("CreatePermissions", func(t *testing.T) {
-		tt := time.Now()
-		perm1 := UserPermission{
-			Username:      "testUser1",
-			AccessType:    0,
-			AccessValue:   true,
-			EnvironmentID: 111,
-			Environment:   "testEnv",
-			GrantedBy:     "test",
-		}
-		perm1.CreatedAt = tt
-		perm1.UpdatedAt = tt
-		perm2 := UserPermission{
-			Username:      "testUser2",
-			AccessType:    0,
-			AccessValue:   true,
-			EnvironmentID: 222,
-			Environment:   "testEnv",
-			GrantedBy:     "test",
-		}
-		perm2.CreatedAt = tt
-		perm2.UpdatedAt = tt
-
-		mock.ExpectBegin()
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`INSERT INTO "user_permissions" ("created_at","updated_at","deleted_at","username","access_type","access_value","environment","environment_id","granted_by") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING "id"`)).WithArgs(tt, tt, nil, perm1.Username, perm1.AccessType, perm1.AccessValue, perm1.Environment, perm1.EnvironmentID, perm1.GrantedBy).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
-		mock.ExpectCommit()
-		mock.ExpectBegin()
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`INSERT INTO "user_permissions" ("created_at","updated_at","deleted_at","username","access_type","access_value","environment","environment_id","granted_by") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING "id"`)).WithArgs(tt, tt, nil, perm2.Username, perm2.AccessType, perm2.AccessValue, perm2.Environment, perm2.EnvironmentID, perm2.GrantedBy).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
-		mock.ExpectCommit()
-		err := manager.CreatePermissions([]UserPermission{perm1, perm2})
-
-		assert.NoError(t, err)
-
-		assert.Equal(t, "testUser1", perm1.Username)
-		assert.Equal(t, "test", perm1.GrantedBy)
-		assert.Equal(t, 111, int(perm1.EnvironmentID))
-		assert.Equal(t, "testEnv", perm1.Environment)
-		assert.Equal(t, "testUser2", perm2.Username)
-		assert.Equal(t, "test", perm2.GrantedBy)
-		assert.Equal(t, 222, int(perm2.EnvironmentID))
-		assert.Equal(t, "testEnv", perm2.Environment)
-	})
-	t.Run("GenEnvUserAccess", func(t *testing.T) {
-		envs := []string{"env1", "env2"}
-		access := manager.GenEnvUserAccess(envs, true, false, true, false)
-
-		assert.Equal(t, true, access["env1"].User)
-		assert.Equal(t, false, access["env1"].Query)
-		assert.Equal(t, true, access["env1"].Carve)
-		assert.Equal(t, false, access["env1"].Admin)
-		assert.Equal(t, true, access["env2"].User)
-		assert.Equal(t, false, access["env2"].Query)
-		assert.Equal(t, true, access["env2"].Carve)
-		assert.Equal(t, false, access["env2"].Admin)
-	})
-	t.Run("GenUserAccess", func(t *testing.T) {
-		env := environments.TLSEnvironment{
-			UUID: "testUUID",
-		}
-		envAccess := EnvAccess{
-			User:  true,
-			Query: false,
-			Carve: true,
-			Admin: false,
-		}
-		access := manager.GenUserAccess(env, envAccess)
-
-		assert.Equal(t, true, access["testUUID"].User)
-		assert.Equal(t, false, access["testUUID"].Query)
-		assert.Equal(t, true, access["testUUID"].Carve)
-		assert.Equal(t, false, access["testUUID"].Admin)
-	})
-	t.Run("GenUserPermission", func(t *testing.T) {
-		perm := manager.GenUserPermission("testUser", "test", "testEnv", 111, false)
-
-		assert.Equal(t, "testUser", perm.Username)
-		assert.Equal(t, "testEnv", perm.Environment)
-		assert.Equal(t, 111, perm.AccessType)
-		assert.Equal(t, false, perm.AccessValue)
-	})
-	t.Run("GenPermissions", func(t *testing.T) {
-		uAccess := make(UserAccess)
-		envAccess := EnvAccess{
-			User:  true,
-			Query: false,
-			Carve: true,
-			Admin: false,
-		}
-		uAccess["testUUID"] = envAccess
-		perms := manager.GenPermissions("testUser", "test", uAccess)
-
-		assert.Equal(t, 4, len(perms))
-	})
-	t.Run("CheckPermissions", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2) AND "user_permissions"."deleted_at" IS NULL`)).WithArgs("testUser", "testEnv").WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value"}).AddRow("testUser", AdminLevel, true))
-
-		access := manager.CheckPermissions("testUser", AdminLevel, "testEnv")
-
-		assert.NoError(t, err)
-
-		assert.Equal(t, true, access)
-	})
-	t.Run("CheckPermissionsNoEnv", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE (username = $1 AND admin = $2) AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser", true).WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		access := manager.CheckPermissions("testUser", AdminLevel, NoEnvironment)
-
-		assert.NoError(t, err)
-
-		assert.Equal(t, true, access)
-	})
-	t.Run("ChangePermissionMismatch", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		perm := UserPermission{
-			Username:    "testUser",
-			Environment: "testEnv",
-			GrantedBy:   "test",
-			AccessType:  int(AdminLevel),
-			AccessValue: true,
-		}
-		err := manager.ChangePermission("testUser", "testEnv2", perm)
-
-		assert.Error(t, err)
-	})
-	t.Run("ChangePermission", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "user_permissions" SET "access_type"=$1,"access_value"=$2,"granted_by"=$3,"updated_at"=$4 WHERE "user_permissions"."deleted_at" IS NULL AND "id" = $5`)).WithArgs(AdminLevel, false, "test", sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
-
-		perm := UserPermission{
-			Username:    "testUser",
-			Environment: "testEnv",
-			GrantedBy:   "test",
-			AccessType:  int(AdminLevel),
-			AccessValue: false,
-		}
-		perm.ID = 1
-		err := manager.ChangePermission("testUser", "testEnv", perm)
-
-		assert.NoError(t, err)
-	})
-	t.Run("ChangePermissions", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "user_permissions" SET "access_type"=$1,"access_value"=$2,"granted_by"=$3,"updated_at"=$4 WHERE "user_permissions"."deleted_at" IS NULL AND "id" = $5`)).WithArgs(AdminLevel, false, "test", sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
-
-		perm := UserPermission{
-			Username:    "testUser",
-			Environment: "testEnv",
-			GrantedBy:   "test",
-			AccessType:  int(AdminLevel),
-			AccessValue: false,
-		}
-		perm.ID = 1
-		err := manager.ChangePermissions("testUser", "testEnv", []UserPermission{perm})
-
-		assert.NoError(t, err)
-	})
-	t.Run("ChangePermissions", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "user_permissions" SET "access_type"=$1,"access_value"=$2,"granted_by"=$3,"updated_at"=$4 WHERE "user_permissions"."deleted_at" IS NULL AND "id" = $5`)).WithArgs(AdminLevel, false, "test", sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
-
-		perm := UserPermission{
-			Username:    "testUser",
-			Environment: "testEnv",
-			GrantedBy:   "test",
-			AccessType:  int(AdminLevel),
-			AccessValue: false,
-		}
-		perm.ID = 1
-		err := manager.ChangePermissions("testUser", "testEnv", []UserPermission{perm})
-
-		assert.NoError(t, err)
-	})
-	t.Run("GetPermission", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", AdminLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", AdminLevel, true, "test"))
-
-		uPerm, err := manager.GetPermission("testUser", "testEnv", AdminLevel)
-
-		assert.NoError(t, err)
-
-		assert.Equal(t, "testUser", uPerm.Username)
-		assert.Equal(t, "test", uPerm.GrantedBy)
-		assert.Equal(t, int(AdminLevel), int(uPerm.AccessType))
-		assert.Equal(t, true, uPerm.AccessValue)
-	})
-	t.Run("GetEnvPermissions", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2) AND "user_permissions"."deleted_at" IS NULL`)).WithArgs("testUser", "testEnv").WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", AdminLevel, true, "test").AddRow("testUser", QueryLevel, true, "test"))
-
-		uPerms, err := manager.GetEnvPermissions("testUser", "testEnv")
-
-		assert.NoError(t, err)
-
-		assert.Equal(t, 2, len(uPerms))
-	})
-	t.Run("GetAllPermissions", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE username = $1 AND "user_permissions"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", AdminLevel, true, "test").AddRow("testUser", QueryLevel, true, "test"))
-
-		uPerms, err := manager.GetAllPermissions("testUser")
-
-		assert.NoError(t, err)
-
-		assert.Equal(t, 2, len(uPerms))
-	})
-	t.Run("SetEnvLevel", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", AdminLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", AdminLevel, false, "test"))
-
-		err := manager.SetEnvLevel("testUser", "testEnv", AdminLevel, true)
-
-		assert.NoError(t, err)
-	})
-	t.Run("SetEnvAdmin", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", AdminLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", AdminLevel, false, "test"))
-
-		err := manager.SetEnvAdmin("testUser", "testEnv", true)
-
-		assert.NoError(t, err)
-	})
-	t.Run("SetEnvCarve", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", CarveLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", CarveLevel, false, "test"))
-
-		err := manager.SetEnvCarve("testUser", "testEnv", true)
-
-		assert.NoError(t, err)
-	})
-	t.Run("SetEnvQuery", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", QueryLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", QueryLevel, false, "test"))
-
-		err := manager.SetEnvQuery("testUser", "testEnv", true)
-
-		assert.NoError(t, err)
-	})
-	t.Run("SetEnvUser", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", UserLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", UserLevel, false, "test"))
-
-		err := manager.SetEnvUser("testUser", "testEnv", true)
-
-		assert.NoError(t, err)
-	})
-	t.Run("ChangeAccess", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", UserLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", UserLevel, true, "test"))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", QueryLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", QueryLevel, false, "test"))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", CarveLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", CarveLevel, false, "test"))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT 1`)).WithArgs("testUser", "testEnv", AdminLevel).WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).AddRow("testUser", AdminLevel, false, "test"))
-
-		envAccess := EnvAccess{
-			User:  true,
-			Query: true,
-			Carve: true,
-			Admin: true,
-		}
-		err := manager.ChangeAccess("testUser", "testEnv", envAccess)
-
-		assert.NoError(t, err)
-	})
-	t.Run("GetAccess", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE username = $1 AND "user_permissions"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by", "environment"}).AddRow("testUser", AdminLevel, true, "test", "testEnv").AddRow("testUser", UserLevel, true, "test", "testEnv").AddRow("testUser", CarveLevel, false, "test", "testEnv").AddRow("testUser", QueryLevel, false, "test", "testEnv"))
-
-		uAccess, err := manager.GetAccess("testUser")
-
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(uAccess))
-		for k, v := range uAccess {
-			assert.Equal(t, "testEnv", k)
-			assert.Equal(t, true, v.Admin)
-			assert.Equal(t, true, v.User)
-			assert.Equal(t, false, v.Query)
-			assert.Equal(t, false, v.Carve)
-		}
-	})
-	t.Run("GetEnvAccess", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2) AND "user_permissions"."deleted_at" IS NULL`)).WithArgs("testUser", "testEnv").WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by", "environment"}).AddRow("testUser", AdminLevel, true, "test", "testEnv").AddRow("testUser", UserLevel, true, "test", "testEnv").AddRow("testUser", CarveLevel, false, "test", "testEnv").AddRow("testUser", QueryLevel, false, "test", "testEnv"))
-
-		eAccess, err := manager.GetEnvAccess("testUser", "testEnv")
-
-		assert.NoError(t, err)
-		assert.Equal(t, true, eAccess.Admin)
-		assert.Equal(t, true, eAccess.User)
-		assert.Equal(t, false, eAccess.Query)
-		assert.Equal(t, false, eAccess.Carve)
-	})
-	t.Run("DeleteEnvPermissions", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2) AND "user_permissions"."deleted_at" IS NULL`)).WithArgs("testUser", "testEnv").WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by", "id"}).AddRow("testUser", AdminLevel, true, "test", 1).AddRow("testUser", QueryLevel, true, "test", 2))
-
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`DELETE FROM "user_permissions" WHERE "user_permissions"."id" = $1`)).WithArgs(1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
-
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`DELETE FROM "user_permissions" WHERE "user_permissions"."id" = $1`)).WithArgs(2).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
-
-		err := manager.DeleteEnvPermissions("testUser", "testEnv")
-
-		assert.NoError(t, err)
-	})
+
+	// Set up mock expectations for AutoMigrate before creating the manager
+	// admin_users table
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1 AND table_type = $2`)).
+		WithArgs("admin_users", "BASE TABLE").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
+	mock.ExpectExec(`CREATE TABLE "admin_users" .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// user_permissions table
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1 AND table_type = $2`)).
+		WithArgs("user_permissions", "BASE TABLE").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
+	mock.ExpectExec(`CREATE TABLE "user_permissions" .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	manager := CreateUserManager(_postgres, &conf)
+	return manager, mock
+}
+
+func TestCreateUserManagerForPermissions(t *testing.T) {
+	manager, _ := setupTestManagerForPermissions(t)
+	assert.NotEqual(t, nil, manager)
+}
+
+func TestCreatePermission(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	tt := time.Now()
+	perm := UserPermission{
+		Username:      "testUser",
+		AccessType:    0,
+		AccessValue:   true,
+		EnvironmentID: 111,
+		Environment:   "testEnv",
+		GrantedBy:     "test",
+	}
+	perm.CreatedAt = tt
+	perm.UpdatedAt = tt
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`INSERT INTO "user_permissions" ("created_at","updated_at","deleted_at","username","access_type","access_value","environment","environment_id","granted_by") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING "id"`)).
+		WithArgs(tt, tt, nil, perm.Username, perm.AccessType, perm.AccessValue, perm.Environment, perm.EnvironmentID, perm.GrantedBy).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
+	mock.ExpectCommit()
+	err := manager.CreatePermission(perm)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testUser", perm.Username)
+	assert.Equal(t, "test", perm.GrantedBy)
+	assert.Equal(t, 111, int(perm.EnvironmentID))
+	assert.Equal(t, "testEnv", perm.Environment)
+}
+
+func TestCreatePermissions(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	tt := time.Now()
+	perm1 := UserPermission{
+		Username:      "testUser1",
+		AccessType:    0,
+		AccessValue:   true,
+		EnvironmentID: 111,
+		Environment:   "testEnv",
+		GrantedBy:     "test",
+	}
+	perm1.CreatedAt = tt
+	perm1.UpdatedAt = tt
+	perm2 := UserPermission{
+		Username:      "testUser2",
+		AccessType:    0,
+		AccessValue:   true,
+		EnvironmentID: 222,
+		Environment:   "testEnv",
+		GrantedBy:     "test",
+	}
+	perm2.CreatedAt = tt
+	perm2.UpdatedAt = tt
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`INSERT INTO "user_permissions" ("created_at","updated_at","deleted_at","username","access_type","access_value","environment","environment_id","granted_by") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING "id"`)).
+		WithArgs(tt, tt, nil, perm1.Username, perm1.AccessType, perm1.AccessValue, perm1.Environment, perm1.EnvironmentID, perm1.GrantedBy).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
+	mock.ExpectCommit()
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`INSERT INTO "user_permissions" ("created_at","updated_at","deleted_at","username","access_type","access_value","environment","environment_id","granted_by") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING "id"`)).
+		WithArgs(tt, tt, nil, perm2.Username, perm2.AccessType, perm2.AccessValue, perm2.Environment, perm2.EnvironmentID, perm2.GrantedBy).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
+	mock.ExpectCommit()
+	err := manager.CreatePermissions([]UserPermission{perm1, perm2})
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testUser1", perm1.Username)
+	assert.Equal(t, "test", perm1.GrantedBy)
+	assert.Equal(t, 111, int(perm1.EnvironmentID))
+	assert.Equal(t, "testEnv", perm1.Environment)
+	assert.Equal(t, "testUser2", perm2.Username)
+	assert.Equal(t, "test", perm2.GrantedBy)
+	assert.Equal(t, 222, int(perm2.EnvironmentID))
+	assert.Equal(t, "testEnv", perm2.Environment)
+}
+
+func TestGenEnvUserAccess(t *testing.T) {
+	manager, _ := setupTestManagerForPermissions(t)
+	envs := []string{"env1", "env2"}
+	access := manager.GenEnvUserAccess(envs, true, false, true, false)
+
+	assert.Equal(t, true, access["env1"].User)
+	assert.Equal(t, false, access["env1"].Query)
+	assert.Equal(t, true, access["env1"].Carve)
+	assert.Equal(t, false, access["env1"].Admin)
+	assert.Equal(t, true, access["env2"].User)
+	assert.Equal(t, false, access["env2"].Query)
+	assert.Equal(t, true, access["env2"].Carve)
+	assert.Equal(t, false, access["env2"].Admin)
+}
+
+func TestGenUserAccess(t *testing.T) {
+	manager, _ := setupTestManagerForPermissions(t)
+	env := environments.TLSEnvironment{
+		UUID: "testUUID",
+	}
+	envAccess := EnvAccess{
+		User:  true,
+		Query: false,
+		Carve: true,
+		Admin: false,
+	}
+	access := manager.GenUserAccess(env, envAccess)
+
+	assert.Equal(t, true, access["testUUID"].User)
+	assert.Equal(t, false, access["testUUID"].Query)
+	assert.Equal(t, true, access["testUUID"].Carve)
+	assert.Equal(t, false, access["testUUID"].Admin)
+}
+
+func TestGenUserPermission(t *testing.T) {
+	manager, _ := setupTestManagerForPermissions(t)
+	perm := manager.GenUserPermission("testUser", "test", "testEnv", 111, false)
+
+	assert.Equal(t, "testUser", perm.Username)
+	assert.Equal(t, "testEnv", perm.Environment)
+	assert.Equal(t, 111, perm.AccessType)
+	assert.Equal(t, false, perm.AccessValue)
+}
+
+func TestGenPermissions(t *testing.T) {
+	manager, _ := setupTestManagerForPermissions(t)
+	uAccess := make(UserAccess)
+	envAccess := EnvAccess{
+		User:  true,
+		Query: false,
+		Carve: true,
+		Admin: false,
+	}
+	uAccess["testUUID"] = envAccess
+	perms := manager.GenPermissions("testUser", "test", uAccess)
+
+	assert.Equal(t, 4, len(perms))
+}
+
+func TestCheckPermissions(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "username", "admin", "environment_id"}).
+			AddRow("aa@bb.com", "testUser", false, 123))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2) AND "user_permissions"."deleted_at" IS NULL`)).
+		WithArgs("testUser", "testEnv").
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value"}).
+			AddRow("testUser", AdminLevel, true))
+
+	access := manager.CheckPermissions("testUser", AdminLevel, "testEnv")
+
+	assert.Equal(t, true, access)
+}
+
+func TestCheckPermissionsNoEnv(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "username", "admin", "environment_id"}).
+			AddRow("aa@bb.com", "testUser", true, 123))
+
+	access := manager.CheckPermissions("testUser", AdminLevel, NoEnvironment)
+
+	assert.Equal(t, true, access)
+}
+
+func TestChangePermissionMismatch(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	perm := UserPermission{
+		Username:    "testUser",
+		Environment: "testEnv",
+		GrantedBy:   "test",
+		AccessType:  int(AdminLevel),
+		AccessValue: true,
+	}
+	err := manager.ChangePermission("testUser", "testEnv2", perm)
+
+	assert.Error(t, err)
+}
+
+func TestChangePermission(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "user_permissions" SET "access_type"=$1,"access_value"=$2,"granted_by"=$3,"updated_at"=$4 WHERE "user_permissions"."deleted_at" IS NULL AND "id" = $5`)).
+		WithArgs(AdminLevel, false, "test", sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	perm := UserPermission{
+		Username:    "testUser",
+		Environment: "testEnv",
+		GrantedBy:   "test",
+		AccessType:  int(AdminLevel),
+		AccessValue: false,
+	}
+	perm.ID = 1
+	err := manager.ChangePermission("testUser", "testEnv", perm)
+
+	assert.NoError(t, err)
+}
+
+func TestChangePermissions(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "user_permissions" SET "access_type"=$1,"access_value"=$2,"granted_by"=$3,"updated_at"=$4 WHERE "user_permissions"."deleted_at" IS NULL AND "id" = $5`)).
+		WithArgs(AdminLevel, false, "test", sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	perm := UserPermission{
+		Username:    "testUser",
+		Environment: "testEnv",
+		GrantedBy:   "test",
+		AccessType:  int(AdminLevel),
+		AccessValue: false,
+	}
+	perm.ID = 1
+	err := manager.ChangePermissions("testUser", "testEnv", []UserPermission{perm})
+
+	assert.NoError(t, err)
+}
+
+func TestGetPermission(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", AdminLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", AdminLevel, true, "test"))
+
+	uPerm, err := manager.GetPermission("testUser", "testEnv", AdminLevel)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testUser", uPerm.Username)
+	assert.Equal(t, "test", uPerm.GrantedBy)
+	assert.Equal(t, int(AdminLevel), int(uPerm.AccessType))
+	assert.Equal(t, true, uPerm.AccessValue)
+}
+
+func TestGetEnvPermissions(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2) AND "user_permissions"."deleted_at" IS NULL`)).
+		WithArgs("testUser", "testEnv").
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", AdminLevel, true, "test").
+			AddRow("testUser", QueryLevel, true, "test"))
+
+	uPerms, err := manager.GetEnvPermissions("testUser", "testEnv")
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(uPerms))
+}
+
+func TestGetAllPermissions(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE username = $1 AND "user_permissions"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", AdminLevel, true, "test").
+			AddRow("testUser", QueryLevel, true, "test"))
+
+	uPerms, err := manager.GetAllPermissions("testUser")
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(uPerms))
+}
+
+func TestSetEnvLevel(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", AdminLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", AdminLevel, false, "test"))
+
+	err := manager.SetEnvLevel("testUser", "testEnv", AdminLevel, true)
+
+	assert.NoError(t, err)
+}
+
+func TestSetEnvAdmin(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", AdminLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", AdminLevel, false, "test"))
+
+	err := manager.SetEnvAdmin("testUser", "testEnv", true)
+
+	assert.NoError(t, err)
+}
+
+func TestSetEnvCarve(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", CarveLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", CarveLevel, false, "test"))
+
+	err := manager.SetEnvCarve("testUser", "testEnv", true)
+
+	assert.NoError(t, err)
+}
+
+func TestSetEnvQuery(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", QueryLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", QueryLevel, false, "test"))
+
+	err := manager.SetEnvQuery("testUser", "testEnv", true)
+
+	assert.NoError(t, err)
+}
+
+func TestSetEnvUser(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", UserLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", UserLevel, false, "test"))
+
+	err := manager.SetEnvUser("testUser", "testEnv", true)
+
+	assert.NoError(t, err)
+}
+
+func TestChangeAccess(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", UserLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", UserLevel, true, "test"))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", QueryLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", QueryLevel, false, "test"))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", CarveLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", CarveLevel, false, "test"))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2 AND access_type = $3) AND "user_permissions"."deleted_at" IS NULL ORDER BY "user_permissions"."id" LIMIT $4`)).
+		WithArgs("testUser", "testEnv", AdminLevel, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by"}).
+			AddRow("testUser", AdminLevel, false, "test"))
+
+	envAccess := EnvAccess{
+		User:  true,
+		Query: true,
+		Carve: true,
+		Admin: true,
+	}
+	err := manager.ChangeAccess("testUser", "testEnv", envAccess)
+
+	assert.NoError(t, err)
+}
+
+func TestGetAccess(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE username = $1 AND "user_permissions"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by", "environment"}).
+			AddRow("testUser", AdminLevel, true, "test", "testEnv").
+			AddRow("testUser", UserLevel, true, "test", "testEnv").
+			AddRow("testUser", CarveLevel, false, "test", "testEnv").
+			AddRow("testUser", QueryLevel, false, "test", "testEnv"))
+
+	uAccess, err := manager.GetAccess("testUser")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(uAccess))
+	for k, v := range uAccess {
+		assert.Equal(t, "testEnv", k)
+		assert.Equal(t, true, v.Admin)
+		assert.Equal(t, true, v.User)
+		assert.Equal(t, false, v.Query)
+		assert.Equal(t, false, v.Carve)
+	}
+}
+
+func TestGetEnvAccess(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2) AND "user_permissions"."deleted_at" IS NULL`)).
+		WithArgs("testUser", "testEnv").
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by", "environment"}).
+			AddRow("testUser", AdminLevel, true, "test", "testEnv").
+			AddRow("testUser", UserLevel, true, "test", "testEnv").
+			AddRow("testUser", CarveLevel, false, "test", "testEnv").
+			AddRow("testUser", QueryLevel, false, "test", "testEnv"))
+
+	eAccess, err := manager.GetEnvAccess("testUser", "testEnv")
+
+	assert.NoError(t, err)
+	assert.Equal(t, true, eAccess.Admin)
+	assert.Equal(t, true, eAccess.User)
+	assert.Equal(t, false, eAccess.Query)
+	assert.Equal(t, false, eAccess.Carve)
+}
+
+func TestDeleteEnvPermissions(t *testing.T) {
+	manager, mock := setupTestManagerForPermissions(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "user_permissions" WHERE (username = $1 AND environment = $2) AND "user_permissions"."deleted_at" IS NULL`)).
+		WithArgs("testUser", "testEnv").
+		WillReturnRows(sqlmock.NewRows([]string{"username", "access_type", "access_value", "granted_by", "id"}).
+			AddRow("testUser", AdminLevel, true, "test", 1).
+			AddRow("testUser", QueryLevel, true, "test", 2))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`DELETE FROM "user_permissions" WHERE "user_permissions"."id" = $1`)).
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`DELETE FROM "user_permissions" WHERE "user_permissions"."id" = $1`)).
+		WithArgs(2).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.DeleteEnvPermissions("testUser", "testEnv")
+
+	assert.NoError(t, err)
 }

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUserManager(t *testing.T) {
+func setupTestManager(t *testing.T) (*UserManager, sqlmock.Sqlmock) {
 	conf := config.JSONConfigurationJWT{
 		JWTSecret:     "test",
 		HoursToExpire: 1,
@@ -23,7 +23,6 @@ func TestUserManager(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to open mock sql db, got error: %v", err)
 	}
-	defer mockDB.Close()
 	if mockDB == nil {
 		t.Error("mock db is null")
 	}
@@ -34,264 +33,400 @@ func TestUserManager(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create new postgres database: %v", err)
 	}
-	var manager *UserManager
-	t.Run("CreateUserManager", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1 AND table_type = $2`)).WithArgs("admin_users", "BASE TABLE").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}), sqlmock.NewRows([]string{"RowsAffected"}).AddRow(1).AddRow(1))
-		mock.ExpectExec(`CREATE TABLE "admin_users" .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1 AND table_type = $2`)).WithArgs("user_permissions", "BASE TABLE").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}), sqlmock.NewRows([]string{"RowsAffected"}).AddRow(1).AddRow(1))
-		mock.ExpectExec(`CREATE TABLE "user_permissions" .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).WillReturnResult(sqlmock.NewResult(1, 1))
+	// Set up mock expectations for AutoMigrate before creating the manager
+	// admin_users table
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1 AND table_type = $2`)).
+		WithArgs("admin_users", "BASE TABLE").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
+	mock.ExpectExec(`CREATE TABLE "admin_users" .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 
-		manager = CreateUserManager(_postgres, &conf)
+	// user_permissions table
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1 AND table_type = $2`)).
+		WithArgs("user_permissions", "BASE TABLE").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
+	mock.ExpectExec(`CREATE TABLE "user_permissions" .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS .*`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 
-		assert.NotEqual(t, nil, manager)
-	})
-	t.Run("HashTextWithSalt", func(t *testing.T) {
-		hashed, err := manager.HashTextWithSalt("testText")
-		assert.NoError(t, err)
-		assert.Equal(t, hashed[0:7], "$2a$10$")
-	})
-	t.Run("HashPasswordWithSalt", func(t *testing.T) {
-		hashed, err := manager.HashPasswordWithSalt("testPassword")
-		assert.NoError(t, err)
-		assert.Equal(t, hashed[0:7], "$2a$10$")
-	})
-	t.Run("CheckLoginCredentials", func(t *testing.T) {
-		hashed, err := manager.HashPasswordWithSalt("testPassword")
-		assert.NoError(t, err)
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"email", "username", "pass_hash", "admin", "environment_id"}).AddRow("aa@bb.com", "testUser", hashed, true, 123))
+	manager := CreateUserManager(_postgres, &conf)
+	return manager, mock
+}
 
-		access, user := manager.CheckLoginCredentials("testUser", "testPassword")
+func TestCreateUserManager(t *testing.T) {
+	manager, _ := setupTestManager(t)
+	assert.NotEqual(t, nil, manager)
+}
 
-		assert.Equal(t, true, access)
-		assert.Equal(t, "aa@bb.com", user.Email)
-		assert.Equal(t, "testUser", user.Username)
-		assert.Equal(t, true, user.Admin)
-		assert.Equal(t, 123, int(user.EnvironmentID))
-	})
-	t.Run("CreateCheckToken", func(t *testing.T) {
-		token, tt, err := manager.CreateToken("testUsername", "issuer", 0)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, token)
-		now := time.Now()
-		assert.Equal(t, true, tt.After(now))
-		claims, valid := manager.CheckToken(conf.JWTSecret, token)
-		assert.Equal(t, true, valid)
-		assert.Equal(t, "testUsername", claims.Username)
-	})
-	t.Run("GetUser", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"email", "username", "admin", "environment_id"}).AddRow("aa@bb.com", "testUser", true, 123))
+func TestHashTextWithSalt(t *testing.T) {
+	manager, _ := setupTestManager(t)
+	hashed, err := manager.HashTextWithSalt("testText")
+	assert.NoError(t, err)
+	assert.Equal(t, hashed[0:7], "$2a$10$")
+}
 
-		user, err := manager.Get("testUser")
-		assert.NoError(t, err)
+func TestHashPasswordWithSalt(t *testing.T) {
+	manager, _ := setupTestManager(t)
+	hashed, err := manager.HashPasswordWithSalt("testPassword")
+	assert.NoError(t, err)
+	assert.Equal(t, hashed[0:7], "$2a$10$")
+}
 
-		assert.Equal(t, "aa@bb.com", user.Email)
-		assert.Equal(t, "testUser", user.Username)
-		assert.Equal(t, true, user.Admin)
-		assert.Equal(t, 123, int(user.EnvironmentID))
-	})
-	t.Run("CreateUser", func(t *testing.T) {
-		tt := time.Now()
-		user := AdminUser{
-			Username:      "testUser",
-			Email:         "aa@bb.com",
-			Admin:         true,
-			EnvironmentID: 111,
-		}
-		user.CreatedAt = tt
-		user.UpdatedAt = tt
-		user.TokenExpire = tt
-		user.LastTokenUse = tt
-		user.LastAccess = tt
+func TestCheckLoginCredentials(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	hashed, err := manager.HashPasswordWithSalt("testPassword")
+	assert.NoError(t, err)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "username", "pass_hash", "admin", "environment_id", "service"}).
+			AddRow("aa@bb.com", "testUser", hashed, true, 123, false))
 
-		mock.ExpectBegin()
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`INSERT INTO "admin_users" ("created_at","updated_at","deleted_at","username","email","fullname","pass_hash","api_token","token_expire","admin","uuid","csrf_token","last_ip_address","last_user_agent","last_access","last_token_use","environment_id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18) RETURNING "id"`)).WithArgs(tt, tt, nil, user.Username, user.Email, user.Fullname, user.PassHash, user.APIToken, tt, user.Admin, user.UUID, user.CSRFToken, user.LastIPAddress, user.LastUserAgent, tt, tt, user.EnvironmentID).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
-		mock.ExpectCommit()
-		err := manager.Create(user)
+	access, user := manager.CheckLoginCredentials("testUser", "testPassword")
 
-		assert.NoError(t, err)
+	assert.Equal(t, true, access)
+	assert.Equal(t, "aa@bb.com", user.Email)
+	assert.Equal(t, "testUser", user.Username)
+	assert.Equal(t, true, user.Admin)
+	assert.Equal(t, 123, int(user.EnvironmentID))
+	assert.Equal(t, false, user.Service)
+}
 
-		assert.Equal(t, "aa@bb.com", user.Email)
-		assert.Equal(t, "testUser", user.Username)
-		assert.Equal(t, true, user.Admin)
-		assert.Equal(t, 111, int(user.EnvironmentID))
-	})
-	t.Run("NewUser", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
-		user, err := manager.New("testUser", "testPassword", "aa@bb.com", "Test Name", true)
+func TestCreateCheckToken(t *testing.T) {
+	manager, _ := setupTestManager(t)
+	conf := config.JSONConfigurationJWT{
+		JWTSecret: "test",
+	}
+	token, tt, err := manager.CreateToken("testUsername", "issuer", 0)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token)
+	now := time.Now()
+	assert.Equal(t, true, tt.After(now))
+	claims, valid := manager.CheckToken(conf.JWTSecret, token)
+	assert.Equal(t, true, valid)
+	assert.Equal(t, "testUsername", claims.Username)
+}
 
-		assert.NoError(t, err)
+func TestGetUser(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "username", "admin", "environment_id"}).
+			AddRow("aa@bb.com", "testUser", true, 123))
 
-		assert.Equal(t, "aa@bb.com", user.Email)
-		assert.Equal(t, "testUser", user.Username)
-		assert.Equal(t, true, user.Admin)
-	})
-	t.Run("ExistsUserFalse", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
-		exists := manager.Exists("testUser")
-		assert.Equal(t, false, exists)
-	})
-	t.Run("ExistsUserTrue", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-		exists := manager.Exists("testUser")
-		assert.Equal(t, true, exists)
-	})
-	t.Run("ExistsGetUserTrue", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"email", "username", "admin", "environment_id"}).AddRow("aa@bb.com", "testUser", true, 123))
+	user, err := manager.Get("testUser")
+	assert.NoError(t, err)
 
-		exists, user := manager.ExistsGet("testUser")
+	assert.Equal(t, "aa@bb.com", user.Email)
+	assert.Equal(t, "testUser", user.Username)
+	assert.Equal(t, true, user.Admin)
+	assert.Equal(t, 123, int(user.EnvironmentID))
+}
 
-		assert.Equal(t, true, exists)
-		assert.Equal(t, "aa@bb.com", user.Email)
-		assert.Equal(t, "testUser", user.Username)
-		assert.Equal(t, true, user.Admin)
-		assert.Equal(t, 123, int(user.EnvironmentID))
-	})
-	t.Run("ExistsGetUserFalse", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnError(fmt.Errorf("record not found"))
+func TestCreateUser(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	tt := time.Now()
+	user := AdminUser{
+		Username:      "testUser",
+		Email:         "aa@bb.com",
+		Admin:         true,
+		EnvironmentID: 111,
+	}
+	user.CreatedAt = tt
+	user.UpdatedAt = tt
+	user.TokenExpire = tt
+	user.LastTokenUse = tt
+	user.LastAccess = tt
 
-		exists, user := manager.ExistsGet("testUser")
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`INSERT INTO "admin_users" ("created_at","updated_at","deleted_at","username","email","fullname","pass_hash","api_token","token_expire","admin","service","uuid","csrf_token","last_ip_address","last_user_agent","last_access","last_token_use","environment_id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18) RETURNING "id"`)).
+		WithArgs(tt, tt, nil, user.Username, user.Email, user.Fullname, user.PassHash, user.APIToken, tt, user.Admin, user.Service, user.UUID, user.CSRFToken, user.LastIPAddress, user.LastUserAgent, tt, tt, user.EnvironmentID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
+	mock.ExpectCommit()
+	err := manager.Create(user)
 
-		assert.Equal(t, false, exists)
-		assert.Equal(t, "", user.Email)
-		assert.Equal(t, "", user.Username)
-		assert.Equal(t, false, user.Admin)
-		assert.Equal(t, 0, int(user.EnvironmentID))
-	})
-	t.Run("UserIsAdmin", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE (username = $1 AND admin = $2) AND "admin_users"."deleted_at" IS NULL`)).WithArgs("testUser", true).WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	assert.NoError(t, err)
 
-		admin := manager.IsAdmin("testUser")
+	assert.Equal(t, "aa@bb.com", user.Email)
+	assert.Equal(t, "testUser", user.Username)
+	assert.Equal(t, true, user.Admin)
+	assert.Equal(t, 111, int(user.EnvironmentID))
+}
 
-		assert.Equal(t, true, admin)
-	})
-	t.Run("UserChangeAdmin", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"id", "admin"}).AddRow(1, true))
+func TestNewUser(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
+	user, err := manager.New("testUser", "testPassword", "aa@bb.com", "Test Name", true, false)
 
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "admin_users" SET "admin"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).WithArgs(false, sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
+	assert.NoError(t, err)
 
-		err := manager.ChangeAdmin("testUser", false)
+	assert.Equal(t, "aa@bb.com", user.Email)
+	assert.Equal(t, "testUser", user.Username)
+	assert.Equal(t, true, user.Admin)
+}
 
-		assert.NoError(t, err)
-	})
-	t.Run("UserChangePassword", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+func TestExistsUserFalse(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
+	exists := manager.Exists("testUser")
+	assert.Equal(t, false, exists)
+}
 
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "admin_users" SET "pass_hash"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
+func TestExistsUserTrue(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	exists := manager.Exists("testUser")
+	assert.Equal(t, true, exists)
+}
 
-		err := manager.ChangePassword("testUser", "testPassword")
+func TestExistsGetUserTrue(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"email", "username", "admin", "environment_id"}).
+			AddRow("aa@bb.com", "testUser", true, 123))
 
-		assert.NoError(t, err)
-	})
-	t.Run("UserChangeEmail", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	exists, user := manager.ExistsGet("testUser")
 
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "admin_users" SET "email"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).WithArgs("aa@bb.com", sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
+	assert.Equal(t, true, exists)
+	assert.Equal(t, "aa@bb.com", user.Email)
+	assert.Equal(t, "testUser", user.Username)
+	assert.Equal(t, true, user.Admin)
+	assert.Equal(t, 123, int(user.EnvironmentID))
+}
 
-		err := manager.ChangeEmail("testUser", "aa@bb.com")
+func TestExistsGetUserFalse(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnError(fmt.Errorf("record not found"))
 
-		assert.NoError(t, err)
-	})
-	t.Run("UserChangeFullname", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	exists, user := manager.ExistsGet("testUser")
 
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "admin_users" SET "fullname"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).WithArgs("Test User", sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
+	assert.Equal(t, false, exists)
+	assert.Equal(t, "", user.Email)
+	assert.Equal(t, "", user.Username)
+	assert.Equal(t, false, user.Admin)
+	assert.Equal(t, 0, int(user.EnvironmentID))
+}
 
-		err := manager.ChangeFullname("testUser", "Test User")
+func TestUserIsAdmin(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT count(*) FROM "admin_users" WHERE (username = $1 AND admin = $2) AND "admin_users"."deleted_at" IS NULL`)).
+		WithArgs("testUser", true).
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
 
-		assert.NoError(t, err)
-	})
-	t.Run("UpdateTokenIPAddress", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	admin := manager.IsAdmin("testUser")
 
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "admin_users" SET "updated_at"=$1,"last_ip_address"=$2,"last_token_use"=$3 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $4`)).WithArgs(sqlmock.AnyArg(), "1.2.3.4", sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
+	assert.Equal(t, true, admin)
+}
 
-		err := manager.UpdateTokenIPAddress("1.2.3.4", "testUser")
+func TestUserChangeAdmin(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "admin"}).AddRow(1, true))
 
-		assert.NoError(t, err)
-	})
-	t.Run("UpdateMetadata", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "admin"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).
+		WithArgs(false, sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
 
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "admin_users" SET "updated_at"=$1,"csrf_token"=$2,"last_ip_address"=$3,"last_user_agent"=$4,"last_access"=$5 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $6`)).WithArgs(sqlmock.AnyArg(), "testCSRF", "1.2.3.4", "testUA", sqlmock.AnyArg(), 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
+	err := manager.ChangeAdmin("testUser", false)
 
-		err := manager.UpdateMetadata("1.2.3.4", "testUA", "testUser", "testCSRF")
+	assert.NoError(t, err)
+}
 
-		assert.NoError(t, err)
-	})
-	t.Run("UpdateToken", func(t *testing.T) {
-		tt := time.Now()
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+func TestUserChangeService(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "service"}).AddRow(1, true))
 
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`UPDATE "admin_users" SET "updated_at"=$1,"api_token"=$2,"token_expire"=$3 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $4`)).WithArgs(sqlmock.AnyArg(), "testToken", tt, 1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "service"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).
+		WithArgs(false, sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
 
-		err := manager.UpdateToken("testUser", "testToken", tt)
+	err := manager.ChangeService("testUser", false)
 
-		assert.NoError(t, err)
-	})
-	t.Run("DeleteUser", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT 1`)).WithArgs("testUser").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	assert.NoError(t, err)
+}
 
-		mock.ExpectBegin()
-		mock.ExpectExec(
-			regexp.QuoteMeta(`DELETE FROM "admin_users" WHERE "admin_users"."id" = $1`)).WithArgs(1).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectCommit()
+func TestUserChangePassword(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 
-		err := manager.Delete("testUser")
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "pass_hash"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
 
-		assert.NoError(t, err)
-	})
-	t.Run("GetAllUsers", func(t *testing.T) {
-		mock.ExpectQuery(
-			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE "admin_users"."deleted_at" IS NULL`)).WithArgs().WillReturnRows(sqlmock.NewRows([]string{"email", "username", "admin", "environment_id"}).AddRow("aa@bb.com", "testUser", true, 123))
+	err := manager.ChangePassword("testUser", "testPassword")
 
-		users, err := manager.All()
-		assert.NoError(t, err)
+	assert.NoError(t, err)
+}
 
-		assert.Equal(t, 1, len(users))
-	})
+func TestUserChangeEmail(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "email"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).
+		WithArgs("aa@bb.com", sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.ChangeEmail("testUser", "aa@bb.com")
+
+	assert.NoError(t, err)
+}
+
+func TestUserChangeFullname(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "fullname"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).
+		WithArgs("Test User", sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.ChangeFullname("testUser", "Test User")
+
+	assert.NoError(t, err)
+}
+
+func TestUpdateTokenIPAddress(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "updated_at"=$1,"last_ip_address"=$2,"last_token_use"=$3 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $4`)).
+		WithArgs(sqlmock.AnyArg(), "1.2.3.4", sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.UpdateTokenIPAddress("1.2.3.4", "testUser")
+
+	assert.NoError(t, err)
+}
+
+func TestUpdateMetadata(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "updated_at"=$1,"csrf_token"=$2,"last_ip_address"=$3,"last_user_agent"=$4,"last_access"=$5 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $6`)).
+		WithArgs(sqlmock.AnyArg(), "testCSRF", "1.2.3.4", "testUA", sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.UpdateMetadata("1.2.3.4", "testUA", "testUser", "testCSRF")
+
+	assert.NoError(t, err)
+}
+
+func TestUpdateToken(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	tt := time.Now()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "updated_at"=$1,"api_token"=$2,"token_expire"=$3 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $4`)).
+		WithArgs(sqlmock.AnyArg(), "testToken", tt, 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.UpdateToken("testUser", "testToken", tt)
+
+	assert.NoError(t, err)
+}
+
+func TestDeleteUser(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`DELETE FROM "admin_users" WHERE "admin_users"."id" = $1`)).
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.Delete("testUser")
+
+	assert.NoError(t, err)
+}
+
+func TestGetAllUsers(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE "admin_users"."deleted_at" IS NULL`)).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"email", "username", "admin", "environment_id", "service"}).
+			AddRow("aa@bb.com", "testUser", true, 123, false))
+
+	users, err := manager.All()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(users))
 }


### PR DESCRIPTION
- Adding service users to `osctrl-admin` and `osctrl-api`
- Support to add service users using `osctrl-cli`
- Fixed capitalization errors highlighted by `go staticcheck`
- Fixes in unit tests 