### PR TITLE
Adding `deps-update` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,6 @@ deps-update:
 ifeq (,$(wildcard go.mod))
 	$(error Missing go.mod file)
 endif
-ifeq (,$(wildcard go.sum))
-	$(error Missing go.sum file)
-endif
 	go get -u ./...
 
 # Install everything

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,16 @@ tidy:
 	make clean_go
 	go mod tidy
 
+# Keep dependencies up to date
+deps-update:
+ifeq (,$(wildcard go.mod))
+	$(error Missing go.mod file)
+endif
+ifeq (,$(wildcard go.sum))
+	$(error Missing go.sum file)
+endif
+	go get -u ./...
+
 # Install everything
 # optional DEST=destination_path
 install:


### PR DESCRIPTION
Adding `deps-update` to the `Makefile` to keep dependencies up to date with the command `make deps-update`.