### PR TITLE
Fix for cosign format due to multiple tags

### DIFF
--- a/.github/actions/tagged_release/docker/codesign/action.yml
+++ b/.github/actions/tagged_release/docker/codesign/action.yml
@@ -58,8 +58,7 @@ runs:
     - name: Verify the signed published Docker image
       shell: bash
       run: |
-        # Parse space-separated tags and digests
-        IFS=' ' read -ra TAGS <<< "${{ inputs.docker_tags }}"
+        # Parse space-separated digests
         IFS=' ' read -ra DIGESTS <<< "${{ inputs.docker_image_digests }}"
 
         for digest in "${DIGESTS[@]}"

--- a/.github/actions/tagged_release/docker/codesign/action.yml
+++ b/.github/actions/tagged_release/docker/codesign/action.yml
@@ -45,27 +45,29 @@ runs:
     - name: Sign the published Docker image
       shell: bash
       run: |
-        for tag in "${{ inputs.docker_tags }}"
+        # Parse space-separated tags and digests
+        IFS=' ' read -ra TAGS <<< "${{ inputs.docker_tags }}"
+        IFS=' ' read -ra DIGESTS <<< "${{ inputs.docker_image_digests }}"
+
+        for digest in "${DIGESTS[@]}"
         do
-          IMAGE_NAME="${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}:$tag"
-          for digest in "${{ inputs.docker_image_digests }}"
-          do
-            cosign sign --yes docker.io/$IMAGE_NAME@sha256:$digest
-          done
+          IMAGE_NAME="${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}"
+          cosign sign --yes docker.io/$IMAGE_NAME@sha256:$digest
         done
 
     ########################### Verify signed image using keyless cosign ###########################
     - name: Verify the signed published Docker image
       shell: bash
       run: |
-        for tag in "${{ inputs.docker_tags }}"
+        # Parse space-separated tags and digests
+        IFS=' ' read -ra TAGS <<< "${{ inputs.docker_tags }}"
+        IFS=' ' read -ra DIGESTS <<< "${{ inputs.docker_image_digests }}"
+
+        for digest in "${DIGESTS[@]}"
         do
-          IMAGE_NAME="${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}:$tag"
-          for digest in "${{ inputs.docker_image_digests }}"
-          do
-            cosign verify \
-              --certificate-identity-regexp="https://github.com/${{ github.repository }}/.github/workflows/.*" \
-              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-              docker.io/$IMAGE_NAME@sha256:$digest
-          done
+          IMAGE_NAME="${{ inputs.docker_hub_org }}/osctrl-${{ inputs.osctrl_component }}"
+          cosign verify \
+            --certificate-identity-regexp="https://github.com/${{ github.repository }}/.github/workflows/.*" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            docker.io/$IMAGE_NAME@sha256:$digest
         done

--- a/.github/actions/tagged_release/docker/codesign/action.yml
+++ b/.github/actions/tagged_release/docker/codesign/action.yml
@@ -45,8 +45,7 @@ runs:
     - name: Sign the published Docker image
       shell: bash
       run: |
-        # Parse space-separated tags and digests
-        IFS=' ' read -ra TAGS <<< "${{ inputs.docker_tags }}"
+        # Parse space-separated digests
         IFS=' ' read -ra DIGESTS <<< "${{ inputs.docker_image_digests }}"
 
         for digest in "${DIGESTS[@]}"


### PR DESCRIPTION
The parameters for `cosign` command had an incorrect format due to multiple tags.