### PR TITLE
Fix for create_release GHA when tagged

### DIFF
--- a/.github/actions/tagged_release/github/action.yml
+++ b/.github/actions/tagged_release/github/action.yml
@@ -51,11 +51,12 @@ runs:
         osctrl-${{ inputs.osctrl_component }}-${{ inputs.release_version_tag }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.exe
 
     ########################### Download osctrl DEB package ###########################
-    - name: Download osctrl binaries
+    - name: Download osctrl DEB package
       if: ${{ inputs.go_os }} == 'linux'
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
         name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}-${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
+        fail-on-not-found: false
 
     ########################### Release ###########################
     - name: Release
@@ -64,5 +65,5 @@ runs:
       with:
         files: |
           osctrl-*.bin
-          osctrl-*.deb
           osctrl-*.exe
+          osctrl-*.deb

--- a/.github/workflows/create_tagged_releases.yml
+++ b/.github/workflows/create_tagged_releases.yml
@@ -100,7 +100,7 @@ jobs:
           osctrl_component: ${{ matrix.components }}
           commit_sha: ${{ steps.vars.outputs.sha_short }}
           osquery_version: ${{ env.OSQUERY_VERSION }}
-          release_version_tag: ${{ steps.vars.outputs.branch }}
+          release_version_tag: ${{ steps.vars.outputs.RELEASE_VERSION }}
 
   create_docker_images:
     needs: [build_and_test]
@@ -223,12 +223,13 @@ jobs:
   create_release:
     needs: [build_and_test, create_deb_packages, push_docker_images]
     runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     strategy:
       matrix:
         components: ["tls", "admin", "api", "cli"]
-        goos: ["linux"]
+        goos: ["linux", "darwin", "windows"]
         goarch: ["amd64", "arm64"]
     steps:
       ########################### Checkout code ###########################


### PR DESCRIPTION
When tagging a release, the job `create_release` was failing due to the push to the `main` branch, and DEB packages being missing.