### PR TITLE
Skip adding the commit sha in DEB package

### DIFF
--- a/.github/actions/build/dpkg/action.yml
+++ b/.github/actions/build/dpkg/action.yml
@@ -55,7 +55,7 @@ runs:
         package: osctrl-${{ inputs.osctrl_component }}
         package_root: ".debpkg-osctrl-${{ inputs.osctrl_component }}-${{ inputs.commit_sha }}-${{ inputs.go_os }}-${{ inputs.go_arch }}"
         maintainer: jmpsec/osctrl
-        version: ${{ github.ref }} # refs/tags/v*.*.*
+        version: ${{ inputs.release_version_tag }}
         arch: ${{ inputs.go_arch }}
         desc: "DEB package for osctrl-${OSCTRL_COMPONENT}-${OSCTRL_VERSION} Commit SHA: ${COMMIT_SHA}"
 
@@ -71,11 +71,21 @@ runs:
         desc: "DEB package for osctrl-${OSCTRL_COMPONENT}-${OSCTRL_VERSION} Commit SHA: ${COMMIT_SHA}"
 
     ########################### Upload DEBs ###########################
+    - name: Debug DEB package creation
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "DEB package file name: ${{ steps.create_deb_tagged_pkgs.outputs.file_name }}"
+        echo "Release version tag: ${{ inputs.release_version_tag }}"
+        echo "Component: ${{ inputs.osctrl_component }}"
+        echo "Arch: ${{ inputs.go_arch }}"
+        ls -la *.deb || echo "No DEB files found"
+      shell: bash
+
     - name: Upload osctrl DEBs for tagged version
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}-${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
+        name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}_${{ inputs.go_arch }}.deb
         path: ${{ steps.create_deb_tagged_pkgs.outputs.file_name }}
         retention-days: 10
 

--- a/.github/actions/tagged_release/github/action.yml
+++ b/.github/actions/tagged_release/github/action.yml
@@ -51,13 +51,20 @@ runs:
         osctrl-${{ inputs.osctrl_component }}-${{ inputs.release_version_tag }}-${{ inputs.go_os }}-${{ inputs.go_arch }}.exe
 
     ########################### Download osctrl DEB package ###########################
+    - name: List available artifacts
+      if: ${{ inputs.go_os }} == 'linux'
+      run: |
+        echo "Looking for DEB package: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}_${{ inputs.go_arch }}.deb"
+        echo "Release version tag: ${{ inputs.release_version_tag }}"
+        echo "Component: ${{ inputs.osctrl_component }}"
+        echo "Arch: ${{ inputs.go_arch }}"
+      shell: bash
+
     - name: Download osctrl DEB package
       if: ${{ inputs.go_os }} == 'linux'
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
-        name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}-${{ inputs.commit_sha }}_${{ inputs.go_arch }}.deb
-        fail-on-not-found: false
-        continue-on-error: true
+        name: osctrl-${{ inputs.osctrl_component }}_${{ inputs.release_version_tag }}_${{ inputs.go_arch }}.deb
 
     ########################### Release ###########################
     - name: Release


### PR DESCRIPTION
Having the commit SHA in the generated DEB package was making the `create_release` pipeline to fail due to missing file.