### PR TITLE
Fix for `--version` in `osctrl-tls`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,9 +25,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
+      - -X main.buildVersion={{.Version}}
+      - -X main.buildCommit={{.Commit}}
+      - -X main.buildDate={{.Date}}
 
   - id: osctrl-admin
     main: ./cmd/admin

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ OUTPUT = bin
 DIST = dist
 
 STATIC_ARGS = -ldflags "-linkmode external -extldflags -static"
-BUILD_ARGS = -ldflags "-X 'main.buildCommit=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
+BUILD_ARGS = -ldflags "-X 'main.buildCommit=$(shell git rev-parse HEAD)' -X 'main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'"
 
 .PHONY: build static clean tls admin cli api release release-build release-check release-init clean-dist
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ OUTPUT = bin
 DIST = dist
 
 STATIC_ARGS = -ldflags "-linkmode external -extldflags -static"
+BUILD_ARGS = -ldflags "-X 'main.buildCommit=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
 
 .PHONY: build static clean tls admin cli api release release-build release-check release-init clean-dist
 
@@ -43,11 +44,11 @@ static:
 
 # Build TLS endpoint
 tls:
-	go build -o $(OUTPUT)/$(TLS_NAME) $(TLS_CODE)
+	go build $(BUILD_ARGS) -o $(OUTPUT)/$(TLS_NAME) $(TLS_CODE)
 
 # Build TLS endpoint statically
 tls-static:
-	go build $(STATIC_ARGS) -o $(OUTPUT)/$(TLS_NAME) -a $(TLS_CODE)
+	go build $(BUILD_ARGS) $(STATIC_ARGS) -o $(OUTPUT)/$(TLS_NAME) -a $(TLS_CODE)
 
 # Build Admin UI
 admin:
@@ -289,9 +290,9 @@ release:
 
 # Build and test release locally
 release-test:
-	release-build
+	make release-build
 	@echo "Testing built binaries..."
-	@for binary in dist/*/osctrl-*; do \
+	@for binary in dist/osctrl-*; do \
 		if [ -f "$$binary" ] && [ -x "$$binary" ]; then \
 			echo "Testing $$binary"; \
 			$$binary --version || $$binary version || echo "No version flag available"; \

--- a/cmd/tls/settings.go
+++ b/cmd/tls/settings.go
@@ -12,24 +12,24 @@ func loadingSettings(mgr *settings.Settings, cfg config.JSONConfigurationService
 	// Check if service settings for accelerated seconds is ready
 	if !mgr.IsValue(config.ServiceTLS, settings.AcceleratedSeconds, settings.NoEnvironmentID) {
 		if err := mgr.NewIntegerValue(config.ServiceTLS, settings.AcceleratedSeconds, int64(defaultAccelerate), settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to configuration: %w", settings.AcceleratedSeconds, err)
+			return fmt.Errorf("failed to add %s to configuration: %w", settings.AcceleratedSeconds, err)
 		}
 	}
 	// Check if service settings for environments refresh is ready
 	if !mgr.IsValue(config.ServiceTLS, settings.RefreshEnvs, settings.NoEnvironmentID) {
 		if err := mgr.NewIntegerValue(config.ServiceTLS, settings.RefreshEnvs, int64(defaultRefresh), settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to configuration: %w", settings.RefreshEnvs, err)
+			return fmt.Errorf("failed to add %s to configuration: %w", settings.RefreshEnvs, err)
 		}
 	}
 	// Check if service settings for enroll/remove oneliner links is ready
 	if !mgr.IsValue(config.ServiceTLS, settings.OnelinerExpiration, settings.NoEnvironmentID) {
 		if err := mgr.NewBooleanValue(config.ServiceTLS, settings.OnelinerExpiration, defaultOnelinerExpiration, settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("Failed to add %s to configuration: %w", settings.OnelinerExpiration, err)
+			return fmt.Errorf("failed to add %s to configuration: %w", settings.OnelinerExpiration, err)
 		}
 	}
 	// Write JSON config to settings
 	if err := mgr.SetTLSJSON(cfg, settings.NoEnvironmentID); err != nil {
-		return fmt.Errorf("Failed to add JSON values to configuration: %w", err)
+		return fmt.Errorf("failed to add JSON values to configuration: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fix for `osctrl-tls` to print out the version and exit when issuing the `-v`, `--version` flag. Also adding metadata to build.