### PR TITLE
Fix for `--version` in `osctrl-api` and `osctrl-cli`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,9 +61,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
+      - -X main.buildVersion={{.Version}}
+      - -X main.buildCommit={{.Commit}}
+      - -X main.buildDate={{.Date}}
 
   - id: osctrl-cli
     main: ./cmd/cli
@@ -80,9 +80,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
+      - -X main.buildVersion={{.Version}}
+      - -X main.buildCommit={{.Commit}}
+      - -X main.buildDate={{.Date}}
 
 archives:
   - name_template: >-

--- a/Makefile
+++ b/Makefile
@@ -60,19 +60,19 @@ admin-static:
 
 # Build API
 api:
-	go build -o $(OUTPUT)/$(API_NAME) $(API_CODE)
+	go build $(BUILD_ARGS) -o $(OUTPUT)/$(API_NAME) $(API_CODE)
 
 # Build API statically
 api-static:
-	go build $(STATIC_ARGS) -o $(OUTPUT)/$(API_NAME) -a $(API_CODE)
+	go build $(BUILD_ARGS) $(STATIC_ARGS) -o $(OUTPUT)/$(API_NAME) -a $(API_CODE)
 
 # Build the CLI
 cli:
-	go build -o $(OUTPUT)/$(CLI_NAME) $(CLI_CODE)
+	go build $(BUILD_ARGS) -o $(OUTPUT)/$(CLI_NAME) $(CLI_CODE)
 
 # Build the CLI statically
 cli-static:
-	go build $(STATIC_ARGS) -o $(OUTPUT)/$(CLI_NAME) -a $(CLI_CODE)
+	go build $(BUILD_ARGS) $(STATIC_ARGS) -o $(OUTPUT)/$(CLI_NAME) -a $(CLI_CODE)
 
 # Clean the dist directory
 clean-dist:
@@ -292,7 +292,7 @@ release:
 release-test:
 	make release-build
 	@echo "Testing built binaries..."
-	@for binary in dist/osctrl-*; do \
+	@for binary in $(DIST)/osctrl-*; do \
 		if [ -f "$$binary" ] && [ -x "$$binary" ]; then \
 			echo "Testing $$binary"; \
 			$$binary --version || $$binary version || echo "No version flag available"; \

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -35,6 +35,13 @@ const (
 	defaultApiConfigFile = projectName + "-api.json"
 )
 
+// Build-time metadata (overridden via -ldflags "-X main.buildVersion=... -X main.buildCommit=... -X main.buildDate=...")
+var (
+	buildVersion = appVersion
+	buildCommit  = "unknown"
+	buildDate    = "unknown"
+)
+
 const (
 	// Values for output format
 	jsonFormat   = "json"
@@ -1875,9 +1882,19 @@ func main() {
 	app = cli.NewApp()
 	app.Name = appName
 	app.Usage = appUsage
-	app.Version = appVersion
+	app.Version = buildVersion
 	app.Description = appDescription
 	app.Flags = flags
+	// Customize version output (supports `--version` and `version` command)
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s version=%s commit=%s date=%s\n", appName, buildVersion, buildCommit, buildDate)
+	}
+	// Add -v alias to the global --version flag
+	cli.VersionFlag = &cli.BoolFlag{
+		Name:    "version",
+		Aliases: []string{"v"},
+		Usage:   "Print version information",
+	}
 	app.Commands = commands
 	app.Action = cliAction
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
Fix for `osctrl-api` and `osctrl-cli` to print out the version and exit when issuing the `-v`, `--version` flag. Also adding metadata to build.