### PR TITLE
Fix for SAML SP-initiated flow bug #685

### DIFF
--- a/cmd/admin/saml.go
+++ b/cmd/admin/saml.go
@@ -24,6 +24,7 @@ type JSONConfigurationSAML struct {
 	LoginURL     string `json:"loginurl"`
 	LogoutURL    string `json:"logouturl"`
 	JITProvision bool   `json:"jitprovision"`
+	SPInitiated  bool   `json:"spinitiated"`
 }
 
 // Structure to keep all SAML related data


### PR DESCRIPTION
For IdPs that expect a SP-initiated flow, the IdP will never get a SAMLRequest so `invalid data` will be returned and authentication gets stuck. This should fix the problem, outlined in #685 