### PR TITLE
Fix for issue #680 to tag nodes

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1167,8 +1167,13 @@ func init() {
 							Usage:   "Node UUID to be tagged",
 						},
 						&cli.StringFlag{
+							Name:    "env",
+							Aliases: []string{"e"},
+							Usage:   "Environment to be used",
+						},
+						&cli.StringFlag{
 							Name:    "name",
-							Aliases: []string{"n"},
+							Aliases: []string{"n", "tag-value"},
 							Usage:   "Tag name to be used. It will be created if does not exist",
 						},
 						&cli.StringFlag{


### PR DESCRIPTION
Fix for issue #680 that was causing the ability to tag nodes in `osctrl-cli` to fail. Now it should be fixed:

```
./osctrl-cli -d node tag -u "node-uuid" -e dev -n "new-tag"
✅ node was tagged successfully
```