### PR TITLE
Fix for issue #688 env query access can not see queries

### DIFF
--- a/cmd/admin/handlers/json-carves.go
+++ b/cmd/admin/handlers/json-carves.go
@@ -54,13 +54,6 @@ func (h *HandlersAdmin) JSONCarvesHandler(w http.ResponseWriter, r *http.Request
 	if h.DebugHTTPConfig.Enabled {
 		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
-	// Get context data
-	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
-	// Check permissions
-	if !h.Users.CheckPermissions(ctx[sessions.CtxUser], users.CarveLevel, users.NoEnvironment) {
-		log.Info().Msgf("%s has insuficient permissions", ctx[sessions.CtxUser])
-		return
-	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -71,6 +64,13 @@ func (h *HandlersAdmin) JSONCarvesHandler(w http.ResponseWriter, r *http.Request
 	env, err := h.Envs.Get(envVar)
 	if err != nil {
 		log.Err(err).Msgf("error getting environment %s", envVar)
+		return
+	}
+	// Get context data
+	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
+	// Check permissions
+	if !h.Users.CheckPermissions(ctx[sessions.CtxUser], users.CarveLevel, env.UUID) {
+		log.Info().Msgf("%s has insuficient permissions", ctx[sessions.CtxUser])
 		return
 	}
 	// Extract target

--- a/cmd/admin/handlers/json-queries.go
+++ b/cmd/admin/handlers/json-queries.go
@@ -126,13 +126,6 @@ func (h *HandlersAdmin) JSONQueryHandler(w http.ResponseWriter, r *http.Request)
 	if h.DebugHTTPConfig.Enabled {
 		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
-	// Get context data
-	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
-	// Check permissions
-	if !h.Users.CheckPermissions(ctx[sessions.CtxUser], users.QueryLevel, users.NoEnvironment) {
-		log.Info().Msgf("%s has insuficient permissions", ctx[sessions.CtxUser])
-		return
-	}
 	// Extract environment
 	envVar := r.PathValue("env")
 	if envVar == "" {
@@ -143,6 +136,13 @@ func (h *HandlersAdmin) JSONQueryHandler(w http.ResponseWriter, r *http.Request)
 	env, err := h.Envs.Get(envVar)
 	if err != nil {
 		log.Err(err).Msgf("error getting environment %s", envVar)
+		return
+	}
+	// Get context data
+	ctx := r.Context().Value(sessions.ContextKey(sessions.CtxSession)).(sessions.ContextValue)
+	// Check permissions
+	if !h.Users.CheckPermissions(ctx[sessions.CtxUser], users.QueryLevel, env.UUID) {
+		log.Info().Msgf("%s has insuficient permissions", ctx[sessions.CtxUser])
 		return
 	}
 	// Extract target

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -358,7 +358,7 @@ func osctrlAdminService() {
 		handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONLogsHandler), flagParams.ConfigValues.Auth))
 	// Admin: JSON data for query logs
 	adminMux.Handle(
-		"GET /json/query/{name}",
+		"GET /json/query/{env}/{name}",
 		handlerAuthCheck(http.HandlerFunc(handlersAdmin.JSONQueryLogsHandler), flagParams.ConfigValues.Auth))
 	// Admin: JSON data for sidebar stats
 	adminMux.Handle(

--- a/cmd/admin/templates/queries-logs.html
+++ b/cmd/admin/templates/queries-logs.html
@@ -129,7 +129,7 @@
           searching : true,
           processing : true,
           ajax : {
-            url: "/json/query/{{ .Name }}",
+            url: "/json/query/{{ .EnvUUID }}/{{ .Name }}",
             dataSrc: function(json) {
               $('#status-card-header').removeClass("bg-danger");
               return json.data;


### PR DESCRIPTION
Fix for issue #688 to display the query list and results to users that are environment admins or have query access. It also prevents queries and carves to be deleted, only allowing that action to global admins.