### PR TITLE
Tagging node using `osctrl-api`

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -245,6 +245,9 @@ func osctrlAPIService() {
 		"POST "+_apiPath(apiNodesPath)+"/{env}/delete",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.DeleteNodeHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	muxAPI.Handle(
+		"POST "+_apiPath(apiNodesPath)+"/{env}/tag",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.TagNodeHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
+	muxAPI.Handle(
 		"POST "+_apiPath(apiNodesPath)+"/lookup",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.LookupNodeHandler), flagParams.ConfigValues.Auth, flagParams.JWTConfigValues.JWTSecret))
 	// API: queries by environment

--- a/cmd/cli/api-node.go
+++ b/cmd/cli/api-node.go
@@ -61,7 +61,26 @@ func (api *OsctrlAPI) DeleteNode(env, identifier string) error {
 }
 
 // TagNode to tag node in osctrl
-func (api *OsctrlAPI) TagNode(env, identifier, tag string) error {
+func (api *OsctrlAPI) TagNode(env, identifier, tag string, tagType uint) error {
+	t := types.ApiNodeTagRequest{
+		UUID: identifier,
+		Tag:  tag,
+		Type: tagType,
+	}
+	var r types.ApiGenericResponse
+	reqURL := path.Join(api.Configuration.URL, APIPath, APINodes, env, "tag")
+	jsonMessage, err := json.Marshal(t)
+	if err != nil {
+		return fmt.Errorf("error marshaling data - %w", err)
+	}
+	jsonParam := bytes.NewReader(jsonMessage)
+	rawN, err := api.PostGeneric(reqURL, jsonParam)
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(rawN))
+	}
+	if err := json.Unmarshal(rawN, &r); err != nil {
+		return fmt.Errorf("can not parse body - %w", err)
+	}
 	return nil
 }
 

--- a/cmd/cli/node.go
+++ b/cmd/cli/node.go
@@ -178,7 +178,7 @@ func tagNode(c *cli.Context) error {
 			return fmt.Errorf("error tagging - %w", err)
 		}
 	} else if apiFlag {
-		if err := osctrlAPI.TagNode(env, uuid, tag); err != nil {
+		if err := osctrlAPI.TagNode(env, uuid, tag, tagTypeInt); err != nil {
 			return fmt.Errorf("error tagging node - %w", err)
 		}
 	}

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -304,6 +304,59 @@ paths:
       security:
         - Authorization:
             - admin
+  /nodes/{env}/tag:
+    post:
+      tags:
+        - nodes
+      summary: Tags node
+      description: Tags an existing node by identifier (UUID, hostname or localname)
+      operationId: TagNodeHandler
+      parameters:
+        - name: env
+          in: path
+          description: Name or UUID of the requested osctrl environment
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApiNodeTagRequest"
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiGenericResponse"
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        403:
+          description: no access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        404:
+          description: no nodes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        500:
+          description: error tagging node
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+      security:
+        - Authorization:
+            - admin
   /nodes/lookup:
     post:
       tags:
@@ -2081,6 +2134,16 @@ components:
       properties:
         uuid:
           type: string
+    ApiNodeTagRequest:
+      type: object
+      properties:
+        uuid:
+          type: string
+        tag:
+          type: string
+        type:
+          type: integer
+          format: int32
     DistributedQuery:
       type: object
       properties:

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -34,6 +34,10 @@ const (
 	ActionEdit string = "edit"
 	// ActionRemove as action to remove a tag
 	ActionRemove string = "remove"
+	// ActionTag as action to tag a node
+	ActionTag string = "tag"
+	// ActionUntag as action to untag a node
+	ActionUntag string = "untag"
 )
 
 // AdminTag to hold all tags

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -66,6 +66,13 @@ type ApiNodeGenericRequest struct {
 	UUID string `json:"uuid"`
 }
 
+// ApiNodeTagRequest to receive tag node requests
+type ApiNodeTagRequest struct {
+	UUID string `json:"uuid"`
+	Tag  string `json:"tag"`
+	Type uint   `json:"type"`
+}
+
 // ApiLoginRequest to receive login requests
 type ApiLoginRequest struct {
 	Username string `json:"username"`


### PR DESCRIPTION
Tagging nodes using `osctrl-cli`, without direct access to the database, it uses the `osctrl-api` component. This code adds the ability to tag nodes in `osctrl-api`.