### PR TITLE
Fixes for goreleaser CICD to build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
-name: Release
+name: Build a release with GoReleaser
 
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
 
 permissions:
   contents: write
@@ -36,7 +37,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5.0.0
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: latest
@@ -55,7 +56,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3.9.2
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
       - name: Log in to Docker Hub
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,4 +1,4 @@
-name: Test Release
+name: Test a new release with GoReleaser
 
 on:
   push:
@@ -29,7 +29,7 @@ jobs:
           go-version: ${{ env.GOLANG_VERSION }}
 
       - name: Run GoReleaser build
-        uses: goreleaser/goreleaser-action@v5.0.0
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,16 +85,25 @@ builds:
       - -X main.buildDate={{.Date}}
 
 archives:
-  - name_template: >-
+  - id: osctrl
+    allow_different_binary_count: true
+    name_template: >-
       {{ .ProjectName }}-
       {{- title .Os }}-
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    builds:
+      - osctrl-tls
+      - osctrl-admin
+      - osctrl-api
+      - osctrl-cli
     files:
       - README.md
       - LICENSE
-      - CHANGELOG.md
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Several changes to the GoReleaser CICD jobs, to pin dependencies to commit, more descriptive name and allow different number of artifacts to prevent errors