### PR TITLE
Ability to have custom tags

### DIFF
--- a/cmd/admin/handlers/post.go
+++ b/cmd/admin/handlers/post.go
@@ -961,7 +961,8 @@ func (h *HandlersAdmin) EnvsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 				ctx[sessions.CtxUser],
 				env.ID,
 				false,
-				tags.TagTypeEnv); err != nil {
+				tags.TagTypeEnv,
+				""); err != nil {
 				adminErrorResponse(w, "error generating tag", http.StatusInternalServerError, err)
 				return
 			}
@@ -1261,7 +1262,7 @@ func (h *HandlersAdmin) TagsPOSTHandler(w http.ResponseWriter, r *http.Request) 
 			adminErrorResponse(w, "error adding tag", http.StatusInternalServerError, fmt.Errorf("tag %s already exists", t.Name))
 			return
 		}
-		if err := h.Tags.NewTag(t.Name, t.Description, t.Color, t.Icon, ctx[sessions.CtxUser], env.ID, false, t.TagType); err != nil {
+		if err := h.Tags.NewTag(t.Name, t.Description, t.Color, t.Icon, ctx[sessions.CtxUser], env.ID, false, t.TagType, t.Custom); err != nil {
 			adminErrorResponse(w, "error with new tag", http.StatusInternalServerError, err)
 			return
 		}
@@ -1357,7 +1358,7 @@ func (h *HandlersAdmin) TagNodesPOSTHandler(w http.ResponseWriter, r *http.Reque
 	}
 	// Processing the list of tags to add and all nodes to tag
 	for _, n := range toBeProcessed {
-		if err := h.Tags.TagNodeMulti(t.TagsAdd, n, ctx[sessions.CtxUser], false); err != nil {
+		if err := h.Tags.TagNodeMulti(t.TagsAdd, n, ctx[sessions.CtxUser], false, ""); err != nil {
 			adminErrorResponse(w, "error with tag", http.StatusInternalServerError, err)
 			return
 		}

--- a/cmd/admin/handlers/types-requests.go
+++ b/cmd/admin/handlers/types-requests.go
@@ -137,6 +137,8 @@ type TagsRequest struct {
 	Icon        string `json:"icon"`
 	Environment string `json:"environment"`
 	TagType     uint   `json:"tagtype"`
+	Custom      string `json:"custom"`
+	Cohort      bool   `json:"cohort"`
 }
 
 // TagNodesRequest to receive a tag for nodes

--- a/cmd/admin/static/js/tags.js
+++ b/cmd/admin/static/js/tags.js
@@ -10,6 +10,7 @@ function createTag() {
   $("#tag_description").val("");
   $("#tag_icon").val("");
   $("#tag_env").val("");
+  $("#tag_custom").val("");
   $("#createEditTagModal").modal();
 }
 
@@ -41,6 +42,7 @@ function confirmCreateTag() {
   var _color = $("#tag_color").val();
   var _icon = $("#tag_icon").val();
   var _env = $("#tag_env").val();
+  var _custom = $("#tag_custom").val();
   var _tagtype = parseInt($("#tag_type").val());
   var data = {
     csrftoken: _csrftoken,
@@ -51,6 +53,7 @@ function confirmCreateTag() {
     icon: _icon,
     environment: _env,
     tagtype: _tagtype,
+    custom: _custom,
   };
   sendPostRequest(data, _url, _url, false);
 }
@@ -64,6 +67,7 @@ function confirmEditTag() {
   var _icon = $("#tag_icon").val();
   var _env = $("#tag_env").val();
   var _tagtype = parseInt($("#tag_type").val());
+  var _custom = $("#tag_custom").val();
   var data = {
     csrftoken: _csrftoken,
     action: "edit",
@@ -73,6 +77,7 @@ function confirmEditTag() {
     icon: _icon,
     environment: _env,
     tagtype: _tagtype,
+    custom: _custom,
   };
   sendPostRequest(data, _url, _url, false);
 }

--- a/cmd/admin/templates/tags.html
+++ b/cmd/admin/templates/tags.html
@@ -22,7 +22,7 @@
 
             <div class="card mt-2">
               <div class="card-header">
-                <i class="fas fa-tag"></i> All Tags</b>
+                <i class="fas fa-tag"></i><b>All Tags</b>
 
                   <div class="card-header-actions">
                     <div class="row">
@@ -136,7 +136,16 @@
                           <option value="2">Platform</option>
                           <option value="3">Localname</option>
                           <option value="4">Custom</option>
+                          <option value="5">Unknown</option>
+                          <option value="6">Tag</option>
+                          <option value="7">Hostname</option>
                         </select>
+                      </div>
+                    </div>
+                    <div class="form-group row">
+                      <label class="col-md-2 col-form-label" for="tag_custom">Custom Tag: </label>
+                      <div class="col-md-4">
+                        <input class="form-control" name="tag_custom" id="tag_custom" type="text" autocomplete="off">
                       </div>
                     </div>
                   </div>

--- a/cmd/api/handlers/nodes.go
+++ b/cmd/api/handlers/nodes.go
@@ -258,7 +258,7 @@ func (h *HandlersApi) TagNodeHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	if err := h.Tags.TagNode(t.Tag, n, ctx[ctxUser], false, t.Type); err != nil {
+	if err := h.Tags.TagNode(t.Tag, n, ctx[ctxUser], false, t.Type, t.Custom); err != nil {
 		apiErrorResponse(w, "error tagging node", http.StatusInternalServerError, err)
 		return
 	}

--- a/cmd/api/handlers/tags.go
+++ b/cmd/api/handlers/tags.go
@@ -166,7 +166,7 @@ func (h *HandlersApi) TagsActionHandler(w http.ResponseWriter, r *http.Request) 
 			apiErrorResponse(w, "error adding tag", http.StatusInternalServerError, fmt.Errorf("tag %s already exists", t.Name))
 			return
 		}
-		if err := h.Tags.NewTag(t.Name, t.Description, t.Color, t.Icon, ctx[ctxUser], env.ID, false, t.TagType); err != nil {
+		if err := h.Tags.NewTag(t.Name, t.Description, t.Color, t.Icon, ctx[ctxUser], env.ID, false, t.TagType, t.Custom); err != nil {
 			apiErrorResponse(w, "error with new tag", http.StatusInternalServerError, err)
 			return
 		}

--- a/cmd/cli/api-node.go
+++ b/cmd/cli/api-node.go
@@ -61,11 +61,12 @@ func (api *OsctrlAPI) DeleteNode(env, identifier string) error {
 }
 
 // TagNode to tag node in osctrl
-func (api *OsctrlAPI) TagNode(env, identifier, tag string, tagType uint) error {
+func (api *OsctrlAPI) TagNode(env, identifier, tag string, tagType uint, custom string) error {
 	t := types.ApiNodeTagRequest{
-		UUID: identifier,
-		Tag:  tag,
-		Type: tagType,
+		UUID:   identifier,
+		Tag:    tag,
+		Type:   tagType,
+		Custom: custom,
 	}
 	var r types.ApiGenericResponse
 	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APINodes, env, "tag"))

--- a/cmd/cli/api-tag.go
+++ b/cmd/cli/api-tag.go
@@ -53,17 +53,17 @@ func (api *OsctrlAPI) GetTag(env, name string) (tags.AdminTag, error) {
 }
 
 // AddTag to add a tag to osctrl
-func (api *OsctrlAPI) AddTag(envUUID, name, color, icon, description string, tagType uint) (types.ApiGenericResponse, error) {
+func (api *OsctrlAPI) AddTag(env, name, color, icon, description string, tagType uint, custom string) (types.ApiGenericResponse, error) {
 	var r types.ApiGenericResponse
 	t := types.ApiTagsRequest{
 		Name:        name,
 		Description: description,
 		Color:       color,
 		Icon:        icon,
-		EnvUUID:     envUUID,
+		Env:         env,
 		TagType:     tagType,
 	}
-	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APITags, envUUID, tags.ActionAdd))
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APITags, env, tags.ActionAdd))
 	jsonMessage, err := json.Marshal(t)
 	if err != nil {
 		return r, fmt.Errorf("error marshaling data - %w", err)
@@ -80,13 +80,13 @@ func (api *OsctrlAPI) AddTag(envUUID, name, color, icon, description string, tag
 }
 
 // DeleteTag to delete a tag from osctrl
-func (api *OsctrlAPI) DeleteTag(envUUID, name string) (types.ApiGenericResponse, error) {
+func (api *OsctrlAPI) DeleteTag(env, name string) (types.ApiGenericResponse, error) {
 	var r types.ApiGenericResponse
 	t := types.ApiTagsRequest{
-		Name:    name,
-		EnvUUID: envUUID,
+		Name: name,
+		Env:  env,
 	}
-	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APITags, envUUID, tags.ActionRemove))
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APITags, env, tags.ActionRemove))
 	jsonMessage, err := json.Marshal(t)
 	if err != nil {
 		return r, fmt.Errorf("error marshaling data - %w", err)
@@ -103,17 +103,17 @@ func (api *OsctrlAPI) DeleteTag(envUUID, name string) (types.ApiGenericResponse,
 }
 
 // EditTag to edit a tag from osctrl
-func (api *OsctrlAPI) EditTag(envUUID, name, color, icon, description string, tagType uint) (types.ApiGenericResponse, error) {
+func (api *OsctrlAPI) EditTag(env, name, color, icon, description string, tagType uint) (types.ApiGenericResponse, error) {
 	var r types.ApiGenericResponse
 	t := types.ApiTagsRequest{
 		Name:        name,
 		Description: description,
 		Color:       color,
 		Icon:        icon,
-		EnvUUID:     envUUID,
+		Env:         env,
 		TagType:     tagType,
 	}
-	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APITags, envUUID, tags.ActionEdit))
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APITags, env, tags.ActionEdit))
 	jsonMessage, err := json.Marshal(t)
 	if err != nil {
 		return r, fmt.Errorf("error marshaling data - %w", err)

--- a/cmd/cli/environment.go
+++ b/cmd/cli/environment.go
@@ -69,7 +69,8 @@ func addEnvironment(c *cli.Context) error {
 				appName,
 				newEnv.ID,
 				false,
-				tags.TagTypeEnv); err != nil {
+				tags.TagTypeEnv,
+				tags.TagCustomEnv); err != nil {
 				return err
 			}
 			// Generate flags

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1196,8 +1196,13 @@ func init() {
 						&cli.StringFlag{
 							Name:    "tag-type",
 							Aliases: []string{"type"},
-							Value:   "custom",
-							Usage:   "Tag type to be used. It can be 'env', 'uuid', 'localname' and 'custom'",
+							Value:   "",
+							Usage:   "Tag type to be used. It can be 'env', 'uuid', 'localname' or a custom value",
+						},
+						&cli.StringFlag{
+							Name:    "custom",
+							Aliases: []string{"tag-custom", "c"},
+							Usage:   "Custom tag value to be used, if tag-type is set to 'custom'",
 						},
 					},
 					Action: cliWrapper(tagNode),
@@ -1571,9 +1576,9 @@ func init() {
 							Usage:   "Tage name to be used",
 						},
 						&cli.StringFlag{
-							Name:    "env-uuid",
+							Name:    "env",
 							Aliases: []string{"e"},
-							Usage:   "Environment UUID to be used",
+							Usage:   "Environment UUID or name to be used",
 						},
 						&cli.StringFlag{
 							Name:    "icon",

--- a/cmd/cli/node.go
+++ b/cmd/cli/node.go
@@ -156,14 +156,24 @@ func tagNode(c *cli.Context) error {
 		os.Exit(1)
 	}
 	tagType := c.String("tag-type")
-	tagTypeInt := tags.TagTypeCustom
+	tagCustom := c.String("custom")
+	var tagTypeInt uint
 	switch tagType {
-	case "env":
+	case tags.TagTypeEnvStr:
 		tagTypeInt = tags.TagTypeEnv
-	case "uuid":
+	case tags.TagTypeUUIDStr:
 		tagTypeInt = tags.TagTypeUUID
-	case "localname":
+	case tags.TagTypeLocalnameStr:
 		tagTypeInt = tags.TagTypeLocalname
+	case tags.TagTypeHostnameStr:
+		tagTypeInt = tags.TagTypeHostname
+	case tags.TagTypePlatformStr:
+		tagTypeInt = tags.TagTypePlatform
+	case tags.TagTypeTagStr:
+		tagTypeInt = tags.TagTypeTag
+	default:
+		tagTypeInt = tags.TagTypeCustom
+
 	}
 	if dbFlag {
 		e, err := envs.Get(env)
@@ -174,11 +184,11 @@ func tagNode(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("error get uuid - %w", err)
 		}
-		if err := tagsmgr.TagNode(tag, n, appName, false, tagTypeInt); err != nil {
+		if err := tagsmgr.TagNode(tag, n, appName, false, tagTypeInt, tagCustom); err != nil {
 			return fmt.Errorf("error tagging - %w", err)
 		}
 	} else if apiFlag {
-		if err := osctrlAPI.TagNode(env, uuid, tag, tagTypeInt); err != nil {
+		if err := osctrlAPI.TagNode(env, uuid, tag, tagTypeInt, tagCustom); err != nil {
 			return fmt.Errorf("error tagging node - %w", err)
 		}
 	}

--- a/cmd/cli/tag.go
+++ b/cmd/cli/tag.go
@@ -48,7 +48,7 @@ func tagToData(t tags.AdminTag, m environments.MapEnvByID, header []string) [][]
 
 func addTag(c *cli.Context) error {
 	// Get values from flags
-	env := c.String("env-uuid")
+	env := c.String("env")
 	if env == "" {
 		fmt.Println("❌ environment is required")
 		os.Exit(1)
@@ -67,18 +67,19 @@ func addTag(c *cli.Context) error {
 		icon = tags.DefaultTagIcon
 	}
 	description := c.String("description")
-	tagType := c.String("tag-type")
+	tagType := tags.TagTypeParser(c.String("tag-type"))
+	custom := c.String("custom")
 	if dbFlag {
 		e, err := envs.Get(env)
 		if err != nil {
 			return fmt.Errorf("❌ error env get - %w", err)
 		}
 		// TODO - Use the correct user
-		if err := tagsmgr.NewTag(name, description, color, icon, appName, e.ID, false, tags.TagTypeParser(tagType)); err != nil {
+		if err := tagsmgr.NewTag(name, description, color, icon, appName, e.ID, false, tagType, custom); err != nil {
 			return fmt.Errorf("❌ %w", err)
 		}
 	} else if apiFlag {
-		_, err := osctrlAPI.AddTag(env, name, color, icon, description, tags.TagTypeParser(tagType))
+		_, err := osctrlAPI.AddTag(env, name, color, icon, description, tagType, custom)
 		if err != nil {
 			return fmt.Errorf("❌ %w", err)
 		}

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -2596,6 +2596,8 @@ components:
         TagType:
           type: integer
           format: uint32
+        Custom:
+          type: string
     ApiLookupRequest:
       type: object
       properties:

--- a/pkg/tags/utils.go
+++ b/pkg/tags/utils.go
@@ -8,20 +8,22 @@ import (
 )
 
 const (
-	// TagTypeEnvironmentStr is the tag type for environment
-	TagTypeEnvironmentStr = "Environment"
 	// TagTypeEnvStr is the tag type for shortened environment
-	TagTypeEnvStr = "Env"
+	TagTypeEnvStr = "env"
 	// TagTypeUUIDStr is the tag type for UUID
-	TagTypeUUIDStr = "UUID"
+	TagTypeUUIDStr = "uuid"
 	// TagTypePlatformStr is the tag type for platform
-	TagTypePlatformStr = "Platform"
+	TagTypePlatformStr = "platform"
 	// TagTypeLocalnameStr is the tag type for localname
-	TagTypeLocalnameStr = "Localname"
+	TagTypeLocalnameStr = "localname"
+	// TagTypeHostnameStr is the tag type for hostname
+	TagTypeHostnameStr = "hostname"
 	// TagTypeCustomStr is the tag type for custom
-	TagTypeCustomStr = "Custom"
+	TagTypeCustomStr = "custom"
 	// TagTypeUnknownStr is the tag type for unknown
-	TagTypeUnknownStr = "Unknown"
+	TagTypeUnknownStr = "unknown"
+	// TagTypeTagStr is the tag type for tag
+	TagTypeTagStr = "tag"
 )
 
 // Helper to generate a random color in hex for HTML
@@ -47,13 +49,15 @@ func GetHex(num int) string {
 func TagTypeDecorator(tagType uint) string {
 	switch tagType {
 	case TagTypeEnv:
-		return TagTypeEnvironmentStr
+		return TagTypeEnvStr
 	case TagTypeUUID:
 		return TagTypeUUIDStr
 	case TagTypePlatform:
 		return TagTypePlatformStr
 	case TagTypeLocalname:
 		return TagTypeLocalnameStr
+	case TagTypeHostname:
+		return TagTypeHostnameStr
 	case TagTypeCustom:
 		return TagTypeCustomStr
 	default:
@@ -77,4 +81,28 @@ func TagTypeParser(tagType string) uint {
 	default:
 		return TagTypeUnknown
 	}
+}
+
+// Helper to define the custom tag value based on the type
+func SetCustomTag(tagType uint, custom string) string {
+	var tagCustom string
+	switch tagType {
+	case TagTypeEnv:
+		tagCustom = TagCustomEnv
+	case TagTypeUUID:
+		tagCustom = TagCustomUUID
+	case TagTypePlatform:
+		tagCustom = TagCustomPlatform
+	case TagTypeLocalname:
+		tagCustom = TagCustomLocalname
+	case TagTypeCustom:
+		tagCustom = custom
+	case TagTypeUnknown:
+		tagCustom = TagCustomUnknown
+	case TagTypeTag:
+		tagCustom = TagCustomTag
+	default:
+		tagCustom = TagCustomTag
+	}
+	return tagCustom
 }

--- a/pkg/tags/utils_test.go
+++ b/pkg/tags/utils_test.go
@@ -19,20 +19,28 @@ func TestGetHex(t *testing.T) {
 }
 
 func TestTagTypeDecorator(t *testing.T) {
-	assert.Equal(t, "Environment", TagTypeDecorator(0))
-	assert.Equal(t, "UUID", TagTypeDecorator(1))
-	assert.Equal(t, "Platform", TagTypeDecorator(2))
-	assert.Equal(t, "Localname", TagTypeDecorator(3))
-	assert.Equal(t, "Custom", TagTypeDecorator(4))
-	assert.Equal(t, "Unknown", TagTypeDecorator(5))
+	assert.Equal(t, "env", TagTypeDecorator(0))
+	assert.Equal(t, "uuid", TagTypeDecorator(1))
+	assert.Equal(t, "platform", TagTypeDecorator(2))
+	assert.Equal(t, "localname", TagTypeDecorator(3))
+	assert.Equal(t, "custom", TagTypeDecorator(4))
+	assert.Equal(t, "unknown", TagTypeDecorator(5))
 }
 
 func TestTagTypeParser(t *testing.T) {
-	assert.Equal(t, uint(0), TagTypeParser("Env"))
-	assert.Equal(t, uint(1), TagTypeParser("UUID"))
-	assert.Equal(t, uint(2), TagTypeParser("Platform"))
-	assert.Equal(t, uint(3), TagTypeParser("Localname"))
-	assert.Equal(t, uint(4), TagTypeParser("Custom"))
-	assert.Equal(t, uint(5), TagTypeParser("Unknown"))
-	assert.Equal(t, uint(5), TagTypeParser("Invalid"))
+	assert.Equal(t, uint(0), TagTypeParser("env"))
+	assert.Equal(t, uint(1), TagTypeParser("uuid"))
+	assert.Equal(t, uint(2), TagTypeParser("platform"))
+	assert.Equal(t, uint(3), TagTypeParser("localname"))
+	assert.Equal(t, uint(4), TagTypeParser("custom"))
+	assert.Equal(t, uint(5), TagTypeParser("unknown"))
+}
+
+func TestTagCustom(t *testing.T) {
+	assert.Equal(t, "env", SetCustomTag(0, "CUSTOM-VALUE"))
+	assert.Equal(t, "uuid", SetCustomTag(1, "CUSTOM-VALUE"))
+	assert.Equal(t, "platform", SetCustomTag(2, "CUSTOM-VALUE"))
+	assert.Equal(t, "localname", SetCustomTag(3, "CUSTOM-VALUE"))
+	assert.Equal(t, "CUSTOM-VALUE", SetCustomTag(4, "CUSTOM-VALUE"))
+	assert.Equal(t, "unknown", SetCustomTag(5, "CUSTOM-VALUE"))
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -68,9 +68,10 @@ type ApiNodeGenericRequest struct {
 
 // ApiNodeTagRequest to receive tag node requests
 type ApiNodeTagRequest struct {
-	UUID string `json:"uuid"`
-	Tag  string `json:"tag"`
-	Type uint   `json:"type"`
+	UUID   string `json:"uuid"`
+	Tag    string `json:"tag"`
+	Type   uint   `json:"type"`
+	Custom string `json:"custom"`
 }
 
 // ApiLoginRequest to receive login requests
@@ -120,8 +121,9 @@ type ApiTagsRequest struct {
 	Description string `json:"description"`
 	Color       string `json:"color"`
 	Icon        string `json:"icon"`
-	EnvUUID     string `json:"env_uuid"`
+	Env         string `json:"env"`
 	TagType     uint   `json:"tagtype"`
+	Custom      string `json:"custom"`
 }
 
 // ApiLookupRequest to receive lookup requests


### PR DESCRIPTION
Better structure for tags and ability to have a custom value that is fully configured. The view in `osctrl-admin` still needs more work and the field `custom_tag` is all lowercase now. So live osctrl instances may need some changes to adjust that with an statement such as:

```
UPDATE admin_tags
SET custom_tag = LOWER(custom_tag)
WHERE custom_tag IS NOT NULL;
```