### PR TITLE
Fix for active nodes being displayed as inactive

### DIFF
--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -262,11 +262,6 @@ func (n *NodeManager) GetStatsByEnv(environment string, hours int64) (StatsData,
 	return GetStats(n.DB, EnvironmentSelector, environment, hours)
 }
 
-// GetStatsByPlatform to populate table stats about nodes by platform
-func (n *NodeManager) GetStatsByPlatform(platform string, hours int64) (StatsData, error) {
-	return GetStats(n.DB, PlatformSelector, platform, hours)
-}
-
 // UpdateMetadataByUUID to update node metadata by UUID
 func (n *NodeManager) UpdateMetadataByUUID(uuid string, metadata NodeMetadata) error {
 	// Retrieve node

--- a/pkg/nodes/utils_test.go
+++ b/pkg/nodes/utils_test.go
@@ -311,7 +311,7 @@ func TestGetStats(t *testing.T) {
 	// Verify our test setup
 	var count int64
 	db.Model(&OsqueryNode{}).Count(&count)
-	require.Equal(t, int64(5), count, "Should have 6 test nodes in database")
+	require.Equal(t, int64(5), count, "Should have 5 test nodes in database")
 
 	// Test cases
 	tests := []struct {

--- a/pkg/nodes/utils_test.go
+++ b/pkg/nodes/utils_test.go
@@ -268,15 +268,9 @@ func TestGetStats(t *testing.T) {
 	// Clear database to ensure clean state
 	db.Exec("DELETE FROM osquery_nodes")
 
-	// Create test nodes with different environments and platforms using the enhanced createMockNode
+	// Create test nodes with different environments using the enhanced createMockNode
 
 	// Platform: darwin - 2 active, 1 inactive
-	createMockNode(t, db, testNodeParams{
-		UUID:     "ACTIVE-DARWIN-1",
-		Platform: "darwin",
-		LastSeen: refTime.Add(-1 * time.Hour), // 1 hour ago (active)
-	})
-
 	createMockNode(t, db, testNodeParams{
 		UUID:        "ACTIVE-DARWIN-2",
 		Platform:    "darwin",
@@ -317,7 +311,7 @@ func TestGetStats(t *testing.T) {
 	// Verify our test setup
 	var count int64
 	db.Model(&OsqueryNode{}).Count(&count)
-	require.Equal(t, int64(6), count, "Should have 6 test nodes in database")
+	require.Equal(t, int64(5), count, "Should have 6 test nodes in database")
 
 	// Test cases
 	tests := []struct {
@@ -327,28 +321,6 @@ func TestGetStats(t *testing.T) {
 		hours         int64
 		expectedStats StatsData
 	}{
-		{
-			name:   "Stats for darwin platform",
-			column: "platform",
-			value:  "darwin",
-			hours:  24,
-			expectedStats: StatsData{
-				Total:    3,
-				Active:   2,
-				Inactive: 1,
-			},
-		},
-		{
-			name:   "Stats for windows platform",
-			column: "platform",
-			value:  "windows",
-			hours:  24,
-			expectedStats: StatsData{
-				Total:    3,
-				Active:   1,
-				Inactive: 2,
-			},
-		},
 		{
 			name:   "Stats for prod environment",
 			column: "environment",
@@ -373,8 +345,8 @@ func TestGetStats(t *testing.T) {
 		},
 		{
 			name:   "Stats for non-existent value",
-			column: "platform",
-			value:  "linux",
+			column: "environment",
+			value:  "nonexistent",
 			hours:  24,
 			expectedStats: StatsData{
 				Total:    0,


### PR DESCRIPTION
Some cleanup for platform stats, no longer needed. Fix for unit tests and node tables were wrongly reporting active nodes as inactive.