### PR TITLE
Customization of background and branding images

### DIFF
--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -150,7 +150,7 @@ func loadConfiguration(file, service string) (config.JSONConfigurationService, e
 }
 
 // Function to load the configuration from a single YAML file
-func loadConfigurationYAML(file string) (config.AdminConfiguration, error) {
+/*func loadConfigurationYAML(file string) (config.AdminConfiguration, error) {
 	var cfg config.AdminConfiguration
 	// Load file and read config
 	viper.SetConfigFile(file)
@@ -160,7 +160,7 @@ func loadConfigurationYAML(file string) (config.AdminConfiguration, error) {
 	}
 	// No errors!
 	return cfg, nil
-}
+}*/
 
 // Initialization code
 func init() {
@@ -357,13 +357,13 @@ func osctrlAdminService() {
 	// Admin: static
 	adminMux.Handle("GET /static/", http.StripPrefix("/static", http.FileServer(http.Dir(flagParams.StaticFiles))))
 	// Admin: background image
-	adminMux.HandleFunc("GET /background.png", func(w http.ResponseWriter, r *http.Request) {
+	adminMux.HandleFunc("GET /background-image", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, flagParams.BackgroundImage)
 	})
 	// ///////////////////////// AUTHENTICATED CONTENT
 	// Admin: branding image
 	adminMux.Handle(
-		"GET /branding.png",
+		"GET /branding-image",
 		handlerAuthCheck(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				http.ServeFile(w, r, flagParams.BrandingImage)

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -356,8 +356,21 @@ func osctrlAdminService() {
 	adminMux.HandleFunc("GET "+faviconPath, handlersAdmin.FaviconHandler)
 	// Admin: static
 	adminMux.Handle("GET /static/", http.StripPrefix("/static", http.FileServer(http.Dir(flagParams.StaticFiles))))
-
+	// Admin: background image
+	adminMux.HandleFunc("GET /background.png", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, flagParams.BackgroundImage)
+	})
 	// ///////////////////////// AUTHENTICATED CONTENT
+	// Admin: branding image
+	adminMux.Handle(
+		"GET /branding.png",
+		handlerAuthCheck(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.ServeFile(w, r, flagParams.BrandingImage)
+			}),
+			flagParams.ConfigValues.Auth,
+		),
+	)
 	// Admin: JSON data for environments
 	adminMux.Handle(
 		"GET /json/environment/{env}/{target}",

--- a/cmd/admin/static/css/custom.css
+++ b/cmd/admin/static/css/custom.css
@@ -16,7 +16,7 @@
 }
 
 .navbar-brand {
-  background-image: url("/branding.png");
+  background-image: url("/branding-image");
   background-position: 50% 50%;
   background-repeat: no-repeat;
   background-size: 100%;
@@ -69,7 +69,7 @@ input[type=text]#carve {
 
 body {
   font-family: 'Bai Jamjuree', sans-serif;
-  background-image: url("/background.png");
+  background-image: url("/background-image");
   background-attachment: fixed;
 }
 

--- a/cmd/admin/static/css/custom.css
+++ b/cmd/admin/static/css/custom.css
@@ -16,7 +16,7 @@
 }
 
 .navbar-brand {
-  background-image: url("/static/img/brand.png");
+  background-image: url("/branding.png");
   background-position: 50% 50%;
   background-repeat: no-repeat;
   background-size: 100%;
@@ -69,7 +69,7 @@ input[type=text]#carve {
 
 body {
   font-family: 'Bai Jamjuree', sans-serif;
-  background-image: url("/static/img/circuit.svg");
+  background-image: url("/background.png");
   background-attachment: fixed;
 }
 

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -37,6 +37,10 @@ const (
 	defTemplatesFolder string = "./tmpl_admin"
 	// Default carved files folder
 	defCarvedFolder string = "./carved_files/"
+	// Default background image file
+	defBackgroundImageFile string = defStaticFilesFolder + "/img/circuit.svg"
+	// Default branding image file
+	defBrandingImageFile string = defStaticFilesFolder + "/img/brand.png"
 	// Default DB configuration file
 	defDBConfigurationFile string = "config/db.json"
 	// Default redis configuration file
@@ -97,6 +101,10 @@ type ServiceFlagParams struct {
 	CarvedDir string
 	// Optimize UI
 	OptimizeUI bool
+	// Branding image file
+	BrandingImage string
+	// Background image file
+	BackgroundImage string
 
 	// Debug HTTP configuration values
 	DebugHTTPValues DebugHTTPConfiguration
@@ -817,6 +825,22 @@ func initAdminFlags(params *ServiceFlagParams) []cli.Flag {
 			Usage:       "Optimize the load of data in the UI. Used in deployments with a large number of nodes.",
 			EnvVars:     []string{"OPTIMIZE_UI"},
 			Destination: &params.OptimizeUI,
+		},
+		&cli.StringFlag{
+			Name:        "background-image",
+			Aliases:     []string{"bg-img", "background"},
+			Value:       defBackgroundImageFile,
+			Usage:       "Background image file for all the pages in the osctrl-admin UI",
+			EnvVars:     []string{"BACKGROUND_IMAGE"},
+			Destination: &params.BackgroundImage,
+		},
+		&cli.StringFlag{
+			Name:        "branding-image",
+			Aliases:     []string{"brand-img", "branding"},
+			Value:       defBrandingImageFile,
+			Usage:       "Branding image file for the osctrl-admin UI. Use an image with 450x130 pixels for best results.",
+			EnvVars:     []string{"BRANDING_IMAGE"},
+			Destination: &params.BrandingImage,
 		},
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -199,11 +199,13 @@ type YAMLConfigurationCarver struct {
 
 // YAMLConfigurationAdmin to hold admin UI specific configuration values
 type YAMLConfigurationAdmin struct {
-	SessionKey    string `yaml:"sessionKey"`
-	StaticDir     string `yaml:"staticDir"`
-	StaticOffline bool   `yaml:"keyFile"`
-	TemplatesDir  string `yaml:"templatesDir"`
-	OptimizeUI    bool   `yaml:"optimizeUI"`
+	SessionKey      string `yaml:"sessionKey"`
+	StaticDir       string `yaml:"staticDir"`
+	StaticOffline   bool   `yaml:"keyFile"`
+	TemplatesDir    string `yaml:"templatesDir"`
+	OptimizeUI      bool   `yaml:"optimizeUI"`
+	BrandingImage   string `yaml:"brandingImage"`
+	BackgroundImage string `yaml:"backgroundImage"`
 }
 
 // YAMLConfigurationDebug to hold the debug configuration values


### PR DESCRIPTION
Implementation of #660 

Added two new parameters to `osctrl-admin` to customize the background and branding images.