### PR TITLE
Implement deferred Select2 initialization for tag modal

### DIFF
--- a/cmd/admin/templates/table.html
+++ b/cmd/admin/templates/table.html
@@ -411,12 +411,15 @@
           $(this).find('#carve').focus();
         });
 
-        // Select2 initialization
-        var tagsSelect = $('#modal_tags').select2({
-          theme: "classic"
-        });
-        tagsSelect.on("select2:select", function(e){
-          $('#add_tags').append(new Option(e.params.data.text, e.params.data.text));
+        // Deferred Select2 initialization
+        var _tagsSelectReady = false;
+        $('#tagModal').one('shown.bs.modal', function(){
+          if(_tagsSelectReady) return;
+          var tagsSelect = $('#modal_tags').select2({ theme: 'classic' });
+          tagsSelect.on('select2:select', function(e){
+            $('#add_tags').append(new Option(e.params.data.text, e.params.data.text));
+          });
+          _tagsSelectReady = true;
         });
       });
     </script>


### PR DESCRIPTION
https://github.com/jmpsec/osctrl/issues/635

This PR defers the loading of the `select2` function, which significantly reduces UI loading time when handling a large number of nodes.

Initially, I assumed the slowness was caused by loading a large dataset from the database all at once. However, after adding more detailed logs, I realized that this wasn’t the main bottleneck — most of the delay came from loading the `select2` function.

There are two root causes behind the issue:

1. All admin tags are loaded into the browser, even when they aren’t used.
2. The system automatically generates too many unnecessary tags.

This PR addresses the first issue by deferring the loading process. For now, it's okay to open the nodes list with 10k+ nodes.

For the second issue, we should stop generating meaningless tags. Currently, a tag is created for each node’s name and UUID, which are already unique identifiers. Tags should instead be used for grouping nodes — for example, by environment (`dev`, `prod`), region (`westeu`, `westus`), or team/office. Once we remove these unnecessary tags, the UI performance should return to normal.