### PR TITLE
Cleaner install of go in `provision.sh`

### DIFF
--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -407,7 +407,15 @@ function install_go_25() {
   if ! [[ -d "/usr/local/go" ]]; then
     log  "Installing Golang $__version"
     # Create a temporary folder
-    local __tmpdir=$(mktemp -d /tmp/go-install-XXXXXX)
+    local __tmpdir
+    __tmpdir=$(mktemp -d /tmp/go-install-XXXXXX) || {
+      _log "Failed to create temporary directory for Go installation"
+      return 1
+    }
+    if [[ -z "$__tmpdir" || ! -d "$__tmpdir" ]]; then
+      _log "Temporary directory for Go installation is invalid: '$__tmpdir'"
+      return 1
+    fi
     cd "$__tmpdir"
 
     # Download and extract in temp folder


### PR DESCRIPTION
Cleaner installation of golang in `provision.sh` to prevent leaving artifacts in the current directory.