### PR TITLE
Fix error in cicd pipeline due to DEB package creation error for cli

### DIFF
--- a/.github/workflows/build_and_test_main_merge.yml
+++ b/.github/workflows/build_and_test_main_merge.yml
@@ -67,9 +67,9 @@ jobs:
   create_deb_packages:
     strategy:
       matrix:
-        components: ["tls", "admin", "api", "cli"]
+        components: ["tls", "admin", "api"]
         goos: ["linux"]
-        goarch: ["amd64"]
+        goarch: ["amd64", "arm64"]
     needs: [build_and_test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create_tagged_releases.yml
+++ b/.github/workflows/create_tagged_releases.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        components: ["tls", "admin", "api", "cli"]
+        components: ["tls", "admin", "api"]
         goos: ["linux"]
         goarch: ["amd64", "arm64"]
     steps:


### PR DESCRIPTION
Remove the creation of a DEB package for `osctrl-cli` to fix the CICD pipeline