### PR TITLE
Configuration endpoints to receive osquery configuration from gitOps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: go-unit-tests
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.62.2
+    rev: v2.11.4
     hooks:
       - id: golangci-lint
         args: [--config=.golangci.yml]

--- a/cmd/admin/handlers/post.go
+++ b/cmd/admin/handlers/post.go
@@ -442,6 +442,11 @@ func (h *HandlersAdmin) ConfPOSTHandler(w http.ResponseWriter, r *http.Request) 
 		adminErrorResponse(w, "invalid CSRF token", http.StatusInternalServerError, nil)
 		return
 	}
+	// Check if configuration is read-only
+	if h.OsqueryValues.ReadOnly {
+		adminErrorResponse(w, "configuration is read-only", http.StatusForbidden, nil)
+		return
+	}
 	if c.ConfigurationB64 != "" {
 		// Base64 decode received configuration
 		// TODO verify configuration

--- a/cmd/admin/templates/conf.html
+++ b/cmd/admin/templates/conf.html
@@ -100,7 +100,7 @@
 
                 {{ if $leftmeta.OsqueryValues.ReadOnly }}
                   <div class="alert alert-warning py-2 mb-2" role="alert">
-                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled by server configuration.
                   </div>
                 {{ end }}
                 <textarea id="options_conf" name="options_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Options }}</textarea>

--- a/cmd/admin/templates/conf.html
+++ b/cmd/admin/templates/conf.html
@@ -98,7 +98,12 @@
               </div>
               <div class="card-body">
 
-                <textarea id="options_conf" name="options_conf">{{ .Environment.Options }}</textarea>
+                {{ if $leftmeta.OsqueryValues.ReadOnly }}
+                  <div class="alert alert-warning py-2 mb-2" role="alert">
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                  </div>
+                {{ end }}
+                <textarea id="options_conf" name="options_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Options }}</textarea>
                 <div class="row">
                   <div class="col-md-12">
                     <button id="options_json_status_color" class="text-left btn btn-sm btn-square btn-block btn-success disabled">
@@ -136,7 +141,12 @@
               </div>
               <div class="card-body">
 
-                <textarea id="schedule_conf" name="schedule_conf">{{ .Environment.Schedule }}</textarea>
+                {{ if $leftmeta.OsqueryValues.ReadOnly }}
+                  <div class="alert alert-warning py-2 mb-2" role="alert">
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                  </div>
+                {{ end }}
+                <textarea id="schedule_conf" name="schedule_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Schedule }}</textarea>
                 <div class="row">
                   <div class="col-md-12">
                     <button id="schedule_json_status_color" class="text-left btn btn-sm btn-square btn-block btn-success disabled">
@@ -170,7 +180,12 @@
               </div>
               <div class="card-body">
 
-                <textarea id="packs_conf" name="packs_conf">{{ .Environment.Packs }}</textarea>
+                {{ if $leftmeta.OsqueryValues.ReadOnly }}
+                  <div class="alert alert-warning py-2 mb-2" role="alert">
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                  </div>
+                {{ end }}
+                <textarea id="packs_conf" name="packs_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Packs }}</textarea>
                 <div class="row">
                   <div class="col-md-12">
                     <button id="packs_json_status_color" class="text-left btn btn-sm btn-square btn-block btn-success disabled">
@@ -204,7 +219,12 @@
               </div>
               <div class="card-body">
 
-                <textarea id="atc_conf" name="atc_conf">{{ .Environment.ATC }}</textarea>
+                {{ if $leftmeta.OsqueryValues.ReadOnly }}
+                  <div class="alert alert-warning py-2 mb-2" role="alert">
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                  </div>
+                {{ end }}
+                <textarea id="atc_conf" name="atc_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.ATC }}</textarea>
                 <div class="row">
                   <div class="col-md-12">
                     <button id="atc_json_status_color" class="text-left btn btn-sm btn-square btn-block btn-success disabled">
@@ -238,7 +258,12 @@
               </div>
               <div class="card-body">
 
-                <textarea id="decorators_conf" name="decorators_conf">{{ .Environment.Decorators }}</textarea>
+                {{ if $leftmeta.OsqueryValues.ReadOnly }}
+                  <div class="alert alert-warning py-2 mb-2" role="alert">
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                  </div>
+                {{ end }}
+                <textarea id="decorators_conf" name="decorators_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Decorators }}</textarea>
                 <div class="row">
                   <div class="col-md-12">
                     <button id="decorators_json_status_color" class="text-left btn btn-sm btn-square btn-block btn-success disabled">
@@ -272,7 +297,12 @@
               </div>
               <div class="card-body">
 
-                <textarea id="final_conf" name="final_conf">{{ .Environment.Configuration }}</textarea>
+                {{ if $leftmeta.OsqueryValues.ReadOnly }}
+                  <div class="alert alert-warning py-2 mb-2" role="alert">
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                  </div>
+                {{ end }}
+                <textarea id="final_conf" name="final_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Configuration }}</textarea>
                 <div class="row">
                   <div class="col-md-12">
                     <button id="conf_json_status_color" class="text-left btn btn-sm btn-square btn-block btn-success disabled">
@@ -311,6 +341,11 @@
     <script src="/static/js/configuration.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {
+        var isReadOnly = {{ if $leftmeta.OsqueryValues.ReadOnly }}true{{ else }}false{{ end }};
+        if (isReadOnly) {
+          $('.main button').prop("disabled", true).addClass("disabled");
+        }
+
         // Codemirror editor for configuration
         // JSON validity check when content is changed
         var editorConfiguration = CodeMirror.fromTextArea(document.getElementById("final_conf"), {
@@ -318,7 +353,7 @@
           lineNumbers: true,
           styleActiveLine: true,
           matchBrackets: true,
-          readOnly: false
+          readOnly: isReadOnly
         });
         $('#final_conf').data('CodeMirrorInstance', editorConfiguration);
         editorConfiguration.on('change', function(_editor){
@@ -361,7 +396,7 @@
           lineNumbers: true,
           styleActiveLine: true,
           matchBrackets: true,
-          readOnly: false
+          readOnly: isReadOnly
         });
         $('#options_conf').data('CodeMirrorInstance', editorOptions);
         editorOptions.on('change', function(_editor){
@@ -407,7 +442,7 @@
           lineNumbers: true,
           styleActiveLine: true,
           matchBrackets: true,
-          readOnly: false
+          readOnly: isReadOnly
         });
         $('#schedule_conf').data('CodeMirrorInstance', editorSchedule);
         editorSchedule.on('change', function(_editor){
@@ -452,7 +487,7 @@
           lineNumbers: true,
           styleActiveLine: true,
           matchBrackets: true,
-          readOnly: false
+          readOnly: isReadOnly
         });
         $('#packs_conf').data('CodeMirrorInstance', editorPacks);
         editorPacks.on('change', function(_editor){
@@ -495,7 +530,7 @@
           lineNumbers: true,
           styleActiveLine: true,
           matchBrackets: true,
-          readOnly: false
+          readOnly: isReadOnly
         });
         $('#atc_conf').data('CodeMirrorInstance', editorATC);
         editorATC.on('change', function(_editor){
@@ -538,7 +573,7 @@
           lineNumbers: true,
           styleActiveLine: true,
           matchBrackets: true,
-          readOnly: false
+          readOnly: isReadOnly
         });
         $('#decorators_conf').data('CodeMirrorInstance', editorDecorators);
         editorDecorators.on('change', function(_editor){

--- a/cmd/admin/templates/conf.html
+++ b/cmd/admin/templates/conf.html
@@ -143,7 +143,7 @@
 
                 {{ if $leftmeta.OsqueryValues.ReadOnly }}
                   <div class="alert alert-warning py-2 mb-2" role="alert">
-                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled by server configuration.
                   </div>
                 {{ end }}
                 <textarea id="schedule_conf" name="schedule_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Schedule }}</textarea>
@@ -182,7 +182,7 @@
 
                 {{ if $leftmeta.OsqueryValues.ReadOnly }}
                   <div class="alert alert-warning py-2 mb-2" role="alert">
-                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled by server configuration.
                   </div>
                 {{ end }}
                 <textarea id="packs_conf" name="packs_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Packs }}</textarea>
@@ -221,7 +221,7 @@
 
                 {{ if $leftmeta.OsqueryValues.ReadOnly }}
                   <div class="alert alert-warning py-2 mb-2" role="alert">
-                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled by server configuration.
                   </div>
                 {{ end }}
                 <textarea id="atc_conf" name="atc_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.ATC }}</textarea>
@@ -260,7 +260,7 @@
 
                 {{ if $leftmeta.OsqueryValues.ReadOnly }}
                   <div class="alert alert-warning py-2 mb-2" role="alert">
-                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled by server configuration.
                   </div>
                 {{ end }}
                 <textarea id="decorators_conf" name="decorators_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Decorators }}</textarea>
@@ -299,7 +299,7 @@
 
                 {{ if $leftmeta.OsqueryValues.ReadOnly }}
                   <div class="alert alert-warning py-2 mb-2" role="alert">
-                    <i class="fas fa-lock mr-1"></i> Editing is disabled for this environment.
+                    <i class="fas fa-lock mr-1"></i> Editing is disabled by server configuration.
                   </div>
                 {{ end }}
                 <textarea id="final_conf" name="final_conf" {{ if $leftmeta.OsqueryValues.ReadOnly }}readonly{{ end }}>{{ .Environment.Configuration }}</textarea>

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -60,6 +60,7 @@ type HandlersTLS struct {
 	Logs            *logging.LoggerTLS
 	WriteHandler    *batchWriter
 	OsqueryValues   *config.YAMLConfigurationOsquery
+	ConfigEndpoints *config.YAMLConfigurationEndpoints
 	DebugHTTP       *zerolog.Logger
 	DebugHTTPConfig *config.YAMLConfigurationDebug
 }
@@ -149,6 +150,14 @@ func WithOsqueryValues(values *config.YAMLConfigurationOsquery) Option {
 	}
 }
 
+// WithConfigEndpoints to pass configuration endpoints values
+func WithConfigEndpoints(endpoints *config.YAMLConfigurationEndpoints) Option {
+	return func(h *HandlersTLS) {
+		h.ConfigEndpoints = endpoints
+	}
+}
+
+// WithDebugHTTP to pass debug HTTP configuration values
 func WithDebugHTTP(cfg *config.YAMLConfigurationDebug) Option {
 	return func(h *HandlersTLS) {
 		h.DebugHTTPConfig = cfg

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -1,8 +1,11 @@
 package handlers
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1062,4 +1065,114 @@ func (h *HandlersTLS) EnrollPackageHandler(w http.ResponseWriter, r *http.Reques
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
 		return
 	}
+}
+
+// OsqueryConfigEndpointHandler - Function to handle the osquery configuration endpoint
+func (h *HandlersTLS) OsqueryConfigEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	// Retrieve environment variable
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		utils.HTTPResponse(w, "", http.StatusBadRequest, []byte(""))
+		return
+	}
+	// To prevent abuse, check if the received UUID is valid
+	if !utils.CheckUUID(envVar) {
+		utils.HTTPResponse(w, "", http.StatusBadRequest, []byte(""))
+		return
+	}
+	// Extract secret
+	secretVar := r.PathValue("secret")
+	if secretVar == "" {
+		utils.HTTPResponse(w, "", http.StatusBadRequest, []byte(""))
+		return
+	}
+	confirmed := false
+	integrityCheck := false
+	for _, confEndpoint := range *h.ConfigEndpoints {
+		if confEndpoint.Environment == envVar && confEndpoint.Secret == secretVar {
+			confirmed = true
+			integrityCheck = confEndpoint.IntegrityCheck
+			break
+		}
+	}
+	if !confirmed {
+		utils.HTTPResponse(w, "", http.StatusForbidden, []byte(""))
+		return
+	}
+	// If we are here, the secret is confirmed, so we can proceed to get the environment
+	env, err := h.Envs.GetByUUID(envVar)
+	if err != nil {
+		log.Err(err).Msg("error getting environment")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	// Debug HTTP
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	// Decode read POST body
+	var o types.OsqueryConfigRequest
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Err(err).Msg("error reading POST body")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	if err := json.Unmarshal(body, &o); err != nil {
+		log.Err(err).Msg("error parsing POST body")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	// Decode base64 configuration
+	configDecoded, err := base64.StdEncoding.DecodeString(o.Configuration)
+	if err != nil {
+		log.Err(err).Msg("error decoding base64 configuration")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	// Unzip configuration
+	gzipReader, err := gzip.NewReader(bytes.NewReader(configDecoded))
+	if err != nil {
+		log.Err(err).Msg("error decoding gzip configuration")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	defer gzipReader.Close()
+	configuration, err := io.ReadAll(gzipReader)
+	if err != nil {
+		log.Err(err).Msg("error reading unzipped configuration")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	// Verify integrity of the configuration using the provided hash
+	if integrityCheck {
+		hash := sha256.Sum256(configuration)
+		if o.Integrity != fmt.Sprintf("%x", hash) {
+			log.Err(err).Msg("configuration integrity check failed")
+			utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+			return
+		}
+	}
+	// Parse configuration
+	cnf, err := h.Envs.GenStructConf(configuration)
+	if err != nil {
+		log.Err(err).Msg("error parsing configuration")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	// Update full configuration
+	if err := h.Envs.UpdateConfiguration(env.UUID, cnf); err != nil {
+		log.Err(err).Msg("error saving configuration")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	// Update all configuration parts
+	if err := h.Envs.UpdateConfigurationParts(env.UUID, cnf); err != nil {
+		log.Err(err).Msg("error saving configuration parts")
+		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	response := TLSResponse{Message: "configuration saved successfully"}
+	// Send response
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, response)
 }

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -1138,10 +1138,17 @@ func (h *HandlersTLS) OsqueryConfigEndpointHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	defer gzipReader.Close()
-	configuration, err := io.ReadAll(gzipReader)
+	const maxConfigSize = 500 * 1024
+	limitedReader := io.LimitReader(gzipReader, maxConfigSize+1)
+	configuration, err := io.ReadAll(limitedReader)
 	if err != nil {
 		log.Err(err).Msg("error reading unzipped configuration")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		return
+	}
+	if len(configuration) > maxConfigSize {
+		log.Error().Msg("unzipped configuration is larger than 500KB")
+		utils.HTTPResponse(w, "", http.StatusRequestEntityTooLarge, []byte(""))
 		return
 	}
 	// Verify integrity of the configuration using the provided hash

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -1147,9 +1147,13 @@ func (h *HandlersTLS) OsqueryConfigEndpointHandler(w http.ResponseWriter, r *htt
 	// Verify integrity of the configuration using the provided hash
 	if integrityCheck {
 		hash := sha256.Sum256(configuration)
-		if o.Integrity != fmt.Sprintf("%x", hash) {
-			log.Err(err).Msg("configuration integrity check failed")
-			utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
+		computedIntegrity := fmt.Sprintf("%x", hash)
+		if o.Integrity != computedIntegrity {
+			log.Warn().
+				Str("expected_integrity", o.Integrity).
+				Str("computed_integrity", computedIntegrity).
+				Msg("configuration integrity check failed")
+			utils.HTTPResponse(w, "", http.StatusBadRequest, []byte(""))
 			return
 		}
 	}

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -106,14 +106,15 @@ func loadYAMLConfiguration(file string) (config.TLSConfiguration, error) {
 func init() {
 	// Initialize default flagParams
 	flagParams = &config.ServiceParameters{
-		Service:     &config.YAMLConfigurationService{},
-		DB:          &config.YAMLConfigurationDB{},
-		BatchWriter: &config.YAMLConfigurationWriter{},
-		Redis:       &config.YAMLConfigurationRedis{},
-		Osquery:     &config.YAMLConfigurationOsquery{},
-		Osctrld:     &config.YAMLConfigurationOsctrld{},
-		Metrics:     &config.YAMLConfigurationMetrics{},
-		TLS:         &config.YAMLConfigurationTLS{},
+		Service:         &config.YAMLConfigurationService{},
+		DB:              &config.YAMLConfigurationDB{},
+		BatchWriter:     &config.YAMLConfigurationWriter{},
+		Redis:           &config.YAMLConfigurationRedis{},
+		Osquery:         &config.YAMLConfigurationOsquery{},
+		Osctrld:         &config.YAMLConfigurationOsctrld{},
+		ConfigEndpoints: &config.YAMLConfigurationEndpoints{},
+		Metrics:         &config.YAMLConfigurationMetrics{},
+		TLS:             &config.YAMLConfigurationTLS{},
 		Logger: &config.YAMLConfigurationLogger{
 			DB:       &config.YAMLConfigurationDB{},
 			S3:       &config.S3Logger{},
@@ -283,6 +284,7 @@ func osctrlService() {
 		handlers.WithLogs(loggerTLS),
 		handlers.WithWriteHandler(tlsWriter),
 		handlers.WithOsqueryValues(flagParams.Osquery),
+		handlers.WithConfigEndpoints(flagParams.ConfigEndpoints),
 		handlers.WithDebugHTTP(flagParams.Debug),
 	)
 	// ///////////////////////// ALL CONTENT IS UNAUTHENTICATED FOR TLS
@@ -328,6 +330,12 @@ func osctrlService() {
 		muxTLS.HandleFunc("POST /{env}/"+environments.DefaultVerifyPath, handlersTLS.VerifyHandler)
 		// TLS: osctrld retrieve script to install/remove osquery
 		muxTLS.HandleFunc("POST /{env}/{action}/{platform}/"+environments.DefaultScriptPath, handlersTLS.ScriptHandler)
+	}
+
+	// Enable configuration endpoints if passed via YAML configuration
+	if flagParams.ConfigEndpoints != nil && len(*flagParams.ConfigEndpoints) > 0 {
+		log.Info().Msgf("Enabling %d configuration endpoints", len(*flagParams.ConfigEndpoints))
+		muxTLS.HandleFunc("POST /{env}/{secret}/"+environments.DefaultConfigEndpointPath, handlersTLS.OsqueryConfigEndpointHandler)
 	}
 
 	// ////////////////////////////// Everything is ready at this point!

--- a/cmd/tls/utils.go
+++ b/cmd/tls/utils.go
@@ -69,6 +69,7 @@ func loadedYAMLToServiceParams(yml config.TLSConfiguration, loadedFile string) *
 		BatchWriter:       &yml.BatchWriter,
 		Redis:             &yml.Redis,
 		Osquery:           &yml.Osquery,
+		ConfigEndpoints:   &yml.ConfigEndpoints,
 		Osctrld:           &yml.Osctrld,
 		Metrics:           &yml.Metrics,
 		TLS:               &yml.TLS,

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -57,6 +57,8 @@ type ServiceParameters struct {
 	Redis *YAMLConfigurationRedis
 	// osquery configuration values
 	Osquery *YAMLConfigurationOsquery
+	// Config endpoints configuration values
+	ConfigEndpoints *YAMLConfigurationEndpoints
 	// osctrld configuration values
 	Osctrld *YAMLConfigurationOsctrld
 	// Metrics configuration values
@@ -668,6 +670,13 @@ func initOsqueryFlags(params *ServiceParameters) []cli.Flag {
 			Usage:       "Enable remote tls carver for osquery",
 			Sources:     cli.EnvVars("OSQUERY_CARVE"),
 			Destination: &params.Osquery.Carve,
+		},
+		&cli.BoolFlag{
+			Name:        "read-only-configuration",
+			Value:       false,
+			Usage:       "Disable configuration changes via admin or api services",
+			Sources:     cli.EnvVars("OSQUERY_READ_ONLY"),
+			Destination: &params.Osquery.ReadOnly,
 		},
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -67,17 +67,18 @@ const (
 
 // TLSConfiguration to hold osctrl-tls configuration values
 type TLSConfiguration struct {
-	Service     YAMLConfigurationService `mapstructure:"service"`
-	DB          YAMLConfigurationDB      `mapstructure:"db"`
-	BatchWriter YAMLConfigurationWriter  `mapstructure:"batchWriter"`
-	Redis       YAMLConfigurationRedis   `mapstructure:"redis"`
-	Osquery     YAMLConfigurationOsquery `mapstructure:"osquery"`
-	Osctrld     YAMLConfigurationOsctrld `mapstructure:"osctrld"`
-	Metrics     YAMLConfigurationMetrics `mapstructure:"metrics"`
-	TLS         YAMLConfigurationTLS     `mapstructure:"tls"`
-	Logger      YAMLConfigurationLogger  `mapstructure:"logger"`
-	Carver      YAMLConfigurationCarver  `mapstructure:"carver"`
-	Debug       YAMLConfigurationDebug   `mapstructure:"debug"`
+	Service         YAMLConfigurationService   `mapstructure:"service"`
+	DB              YAMLConfigurationDB        `mapstructure:"db"`
+	BatchWriter     YAMLConfigurationWriter    `mapstructure:"batchWriter"`
+	Redis           YAMLConfigurationRedis     `mapstructure:"redis"`
+	Osquery         YAMLConfigurationOsquery   `mapstructure:"osquery"`
+	ConfigEndpoints YAMLConfigurationEndpoints `mapstructure:"configEndpoints"`
+	Osctrld         YAMLConfigurationOsctrld   `mapstructure:"osctrld"`
+	Metrics         YAMLConfigurationMetrics   `mapstructure:"metrics"`
+	TLS             YAMLConfigurationTLS       `mapstructure:"tls"`
+	Logger          YAMLConfigurationLogger    `mapstructure:"logger"`
+	Carver          YAMLConfigurationCarver    `mapstructure:"carver"`
+	Debug           YAMLConfigurationDebug     `mapstructure:"debug"`
 }
 
 // AdminConfiguration to hold osctrl-admin configuration values
@@ -154,6 +155,17 @@ type YAMLConfigurationOsquery struct {
 	Config     bool   `yaml:"config"`
 	Query      bool   `yaml:"query"`
 	Carve      bool   `yaml:"carve"`
+	ReadOnly   bool   `yaml:"readOnly"`
+}
+
+// YAMLConfigurationEndpoints to hold the configuration endpoints that will receive osquery configuration updates
+type YAMLConfigurationEndpoints []YAMLConfigurationEndpoint
+
+// YAMLConfigurationEndpoint to hold each endpoint that will receive osquery configuration updates
+type YAMLConfigurationEndpoint struct {
+	Environment    string `yaml:"environment"`
+	Secret         string `yaml:"secret"`
+	IntegrityCheck bool   `yaml:"integrityCheck"`
 }
 
 // YAMLConfigurationMetrics to hold the metrics configuration values

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -12,17 +12,18 @@ import (
 // Helper to generate an example TLS configuration file
 func GenerateTLSConfigFile(path string, cfg *ServiceParameters, overwrite bool) error {
 	cfgTLS := TLSConfiguration{
-		Service:     *cfg.Service,
-		DB:          *cfg.DB,
-		Redis:       *cfg.Redis,
-		BatchWriter: *cfg.BatchWriter,
-		Osquery:     *cfg.Osquery,
-		Osctrld:     *cfg.Osctrld,
-		Metrics:     *cfg.Metrics,
-		TLS:         *cfg.TLS,
-		Logger:      *cfg.Logger,
-		Carver:      *cfg.Carver,
-		Debug:       *cfg.Debug,
+		Service:         *cfg.Service,
+		DB:              *cfg.DB,
+		Redis:           *cfg.Redis,
+		BatchWriter:     *cfg.BatchWriter,
+		Osquery:         *cfg.Osquery,
+		ConfigEndpoints: *cfg.ConfigEndpoints,
+		Osctrld:         *cfg.Osctrld,
+		Metrics:         *cfg.Metrics,
+		TLS:             *cfg.TLS,
+		Logger:          *cfg.Logger,
+		Carver:          *cfg.Carver,
+		Debug:           *cfg.Debug,
 	}
 	return GenerateGenericConfigFile(path, cfgTLS, overwrite)
 }

--- a/pkg/environments/environments.go
+++ b/pkg/environments/environments.go
@@ -47,6 +47,8 @@ const (
 	DefaultVerifyPath string = "osctrld-verify"
 	// DefaultScriptPath
 	DefaultScriptPath string = "osctrld-script"
+	// DefaultConfigEndpointPath
+	DefaultConfigEndpointPath string = "osquery-config"
 )
 
 // TLSEnvironment to hold each of the TLS environment

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -43,6 +43,12 @@ type ScriptRequest struct {
 	Certificate string `json:"certificate"`
 }
 
+// OsqueryConfigRequest to receive osquery configuration requests
+type OsqueryConfigRequest struct {
+	Configuration string `json:"configuration"`
+	Integrity     string `json:"integrity"`
+}
+
 // ApiDistributedQueryRequest to receive query requests
 type ApiDistributedQueryRequest struct {
 	UUIDs        []string `json:"uuid_list"`


### PR DESCRIPTION
Implementation of #746 and adding configuration endpoints to `osctrl-tls` to receive osquery configuration per environment, so it can be integrated in a gitOps flow. It disables the ability to edit configurations via `osctrl-admin`.