### PR TITLE
Fix OSX quick-enroll: stop osqueryd before unload

### DIFF
--- a/pkg/environments/scripts.go
+++ b/pkg/environments/scripts.go
@@ -159,10 +159,7 @@ stopOsquery() {
   fi
   if [ "$_OS" = "darwin" ]; then
     log "Stopping $_OSQUERY_SERVICE_OSX"
-    if launchctl list | grep -qcm1 "$_OSQUERY_SERVICE_OSX"; then
-      sudo launchctl stop "$_OSQUERY_SERVICE_OSX"
-      sudo launchctl unload "$_PLIST_OSX"
-    fi
+    sudo launchctl unload "$_PLIST_OSX" >/dev/null 2>&1 || true
   fi
   if [ "$_OS" = "freebsd" ]; then
     log "Stopping $_OSQUERY_SERVICE_FREEBSD"

--- a/pkg/environments/scripts.go
+++ b/pkg/environments/scripts.go
@@ -160,6 +160,7 @@ stopOsquery() {
   if [ "$_OS" = "darwin" ]; then
     log "Stopping $_OSQUERY_SERVICE_OSX"
     if launchctl list | grep -qcm1 "$_OSQUERY_SERVICE_OSX"; then
+      sudo launchctl stop "$_OSQUERY_SERVICE_OSX"
       sudo launchctl unload "$_PLIST_OSX"
     fi
   fi


### PR DESCRIPTION
Re-enrolling an OSX node with osqueryd already running fails because launchctl unload returns an error when the service is still active. The stopOsquery function on Darwin needs to stop the service before unloading it.

This adds a launchctl stop call before the unload, matching the pattern used on other platforms where the service is stopped before removal.

Fixes #57