### PR TITLE
Fix race condition in IncExecution and IncError

### DIFF
--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -439,24 +439,28 @@ func (q *Queries) GetTargets(name string) ([]DistributedQueryTarget, error) {
 
 // IncExecution to increase the execution count for this query
 func (q *Queries) IncExecution(name string, envid uint) error {
-	query, err := q.Get(name, envid)
-	if err != nil {
-		return err
+	result := q.DB.Model(&DistributedQuery{}).
+		Where("name = ? AND environment_id = ?", name, envid).
+		UpdateColumn("executions", gorm.Expr("executions + ?", 1))
+	if result.Error != nil {
+		return result.Error
 	}
-	if err := q.DB.Model(&query).Update("executions", query.Executions+1).Error; err != nil {
-		return err
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("query %s not found for environment %d", name, envid)
 	}
 	return nil
 }
 
 // IncError to increase the error count for this query
 func (q *Queries) IncError(name string, envid uint) error {
-	query, err := q.Get(name, envid)
-	if err != nil {
-		return err
+	result := q.DB.Model(&DistributedQuery{}).
+		Where("name = ? AND environment_id = ?", name, envid).
+		UpdateColumn("errors", gorm.Expr("errors + ?", 1))
+	if result.Error != nil {
+		return result.Error
 	}
-	if err := q.DB.Model(&query).Update("errors", query.Errors+1).Error; err != nil {
-		return err
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("query %s not found for environment %d", name, envid)
 	}
 	return nil
 }


### PR DESCRIPTION
The previous implementation had a race condition where multiple goroutines could read the same counter value, increment it, and write back, causing lost updates under concurrent load.

The read-modify-write cycle allowed this scenario:
1. Thread A reads: executions = 5
2. Thread B reads: executions = 5 (same value)
3. Thread A writes: executions = 6
4. Thread B writes: executions = 6 (should be 7)

Fixed by using atomic database operations with gorm.Expr to perform the increment directly in SQL:

```sql
UPDATE distributed_queries SET executions = executions + 1 WHERE ...
```

This ensures thread-safe atomic increments even under concurrent load, matching the pattern used for IncExpected in the same file.