### PR TITLE
osctrl: defensive hardening round — login timing, rate-limit XFF bypass, JWT rotation, info-disclosure closes

### DIFF
--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -189,6 +189,26 @@ func init() {
 	flags = config.InitAdminFlags(flagParams)
 }
 
+// noDirListing wraps an http.Handler (typically http.FileServer) and
+// rejects requests whose URL path ends in "/" — i.e. any path that
+// would resolve to a directory and trigger Go's default autoindex
+// behavior. Legitimate file requests (paths to .css/.js/.svg/etc)
+// are passed through unchanged.
+//
+// 404 instead of 403 because the autoindex was the only signal that
+// the directory existed in the first place; returning 403 would
+// confirm "yes, there IS something at /static/img/" — which the
+// 404 hides.
+func noDirListing(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
 // Retrieve latest release information and compare
 func checkLatestRelease() {
 	log.Info().Msg("Checking for the latest release...")
@@ -402,8 +422,14 @@ func osctrlAdminService() {
 	adminMux.HandleFunc("GET "+forbiddenPath, handlersAdmin.ForbiddenHandler)
 	// Admin: favicon
 	adminMux.HandleFunc("GET "+faviconPath, handlersAdmin.FaviconHandler)
-	// Admin: static
-	adminMux.Handle("GET /static/", http.StripPrefix("/static", http.FileServer(http.Dir(flagParams.Admin.StaticDir))))
+	// Admin: static — wrap http.FileServer to suppress directory
+	// listings. Go's FileServer enables autoindex by default, so a
+	// pentest probe of GET /static/ would return an HTML listing of
+	// css/, fonts/, img/, js/ — a free recon gift to any vuln
+	// scanner. Rejecting paths that end in "/" turns those probes
+	// into 404s; legitimate file requests (e.g. /static/css/app.css)
+	// are unaffected.
+	adminMux.Handle("GET /static/", http.StripPrefix("/static", noDirListing(http.FileServer(http.Dir(flagParams.Admin.StaticDir)))))
 	// Admin: background image
 	adminMux.HandleFunc("GET /background-image", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, flagParams.Admin.BackgroundImage)

--- a/cmd/api/handlers/get.go
+++ b/cmd/api/handlers/get.go
@@ -44,13 +44,29 @@ func (h *HandlersApi) CheckHandlerAuth(w http.ResponseWriter, r *http.Request) {
 	utils.HTTPResponse(w, "Checked", http.StatusOK, []byte(okContent))
 }
 
-// RootHandler - Handle root requests
+// RootHandler - Handle root requests.
+//
+// `GET /` is registered as the api's liveness check (returns "✅"
+// with 200). Go's ServeMux uses `/` as a wildcard match for any GET
+// request the mux doesn't have a more-specific pattern for, which
+// means typos like `GET /api/v1/totally-fake-endpoint` would land
+// here and return 200 — confusing for clients debugging an
+// integration. We tighten the contract: respond 200 ONLY when the
+// request actually targets `/`. Other GETs that fall through fall
+// out as 404.
+//
+// Returning 404 here doesn't leak endpoint structure beyond what's
+// already in the public OpenAPI; it just stops the api from silently
+// claiming success on misrouted requests.
 func (h *HandlersApi) RootHandler(w http.ResponseWriter, r *http.Request) {
 	// Debug HTTP if enabled
 	if h.DebugHTTPConfig.EnableHTTP {
 		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
 	}
-	// Send response
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
 	utils.HTTPResponse(w, "", http.StatusOK, []byte(okContent))
 }
 

--- a/cmd/api/handlers/login.go
+++ b/cmd/api/handlers/login.go
@@ -56,31 +56,26 @@ func (h *HandlersApi) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use %s by user %s", h.ServiceName, l.Username))
 		return
 	}
-	// Decide whether to reuse the stored token or mint a fresh one. Re-issue
-	// when there's no token, when the stored token has already expired (the
-	// reuse path used to return 500 "token already expired" — a regression
-	// that locked users out after their first session expired), or when the
-	// stored token is within 60s of expiring so we don't hand out something
-	// that will fail mid-request.
-	var tokenExp time.Time
-	now := time.Now()
-	const freshnessWindow = 60 * time.Second
-	needsRefresh := user.APIToken == "" || user.TokenExpire.Before(now.Add(freshnessWindow))
-	if needsRefresh {
-		var token string
-		token, tokenExp, err = h.Users.CreateToken(l.Username, h.ServiceName, l.ExpHours)
-		if err != nil {
-			apiErrorResponse(w, "error creating token", http.StatusInternalServerError, err)
-			return
-		}
-		if err = h.Users.UpdateToken(l.Username, token, tokenExp); err != nil {
-			apiErrorResponse(w, "error updating token", http.StatusInternalServerError, err)
-			return
-		}
-		user.APIToken = token
-	} else {
-		tokenExp = user.TokenExpire
+	// Always mint a fresh JWT on successful login and overwrite the stored
+	// APIToken. The auth middleware in cmd/api/auth.go compares every
+	// presented JWT against the stored APIToken (constant-time), so once
+	// UpdateToken overwrites, any previously-issued JWT for this user
+	// immediately fails 401 — even though it is still cryptographically
+	// valid against the secret. This is the revocation primitive that
+	// makes re-login (and logout, below) capable of invalidating a
+	// stolen token. The previous "reuse if >60s of life left" optimisation
+	// silently undid that revocation: re-login from a new device returned
+	// the SAME JWT, leaving the stolen copy valid.
+	token, tokenExp, err := h.Users.CreateToken(l.Username, h.ServiceName, l.ExpHours)
+	if err != nil {
+		apiErrorResponse(w, "error creating token", http.StatusInternalServerError, err)
+		return
 	}
+	if err = h.Users.UpdateToken(l.Username, token, tokenExp); err != nil {
+		apiErrorResponse(w, "error updating token", http.StatusInternalServerError, err)
+		return
+	}
+	user.APIToken = token
 	// Generate a CSRF token: 16 random bytes encoded as 32 hex chars.
 	// This cookie is NOT HttpOnly so the SPA can read it and echo it back
 	// via the X-CSRF-Token header on mutating requests.

--- a/cmd/api/handlers/samples.go
+++ b/cmd/api/handlers/samples.go
@@ -11,13 +11,14 @@ import (
 // QuerySamplesHandler - GET /api/v1/queries/samples
 //
 // Returns the static starter library of osquery SQL templates so the SPA's
-// queries/new form can populate its QuickTemplates row. Intentionally
-// unauthenticated: the samples are read-only data shipped with the binary,
-// they aren't tenant- or env-scoped, and exposing them pre-auth lets the
-// login screen lazy-load them without circular dependencies.
+// queries/new form can populate its QuickTemplates row. Authenticated.
 //
-// Shares the per-IP loginRateLimit registered in main.go so this endpoint
-// can't be turned into a low-effort scanning probe.
+// History: an earlier revision exposed this pre-auth on the rationale that
+// the data is static and ships with the binary. Even read-only data
+// fingerprints the deployment as osctrl and reveals the SQL-template
+// starter pack to anonymous callers — neither of which the only
+// consumer (the post-login queries/new form) requires at pre-auth time.
+// Moved behind handlerAuthCheck in cmd/api/main.go.
 func (h *HandlersApi) QuerySamplesHandler(w http.ResponseWriter, r *http.Request) {
 	if h.DebugHTTPConfig.EnableHTTP {
 		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
@@ -28,8 +29,10 @@ func (h *HandlersApi) QuerySamplesHandler(w http.ResponseWriter, r *http.Request
 // CarveSamplesHandler - GET /api/v1/carves/samples
 //
 // Returns the static starter library of common carve-target file paths
-// (e.g., /etc/passwd, C:\Windows\System32\config\SAM). Same auth posture as
-// QuerySamplesHandler: pre-auth, rate-limited.
+// (e.g., /etc/passwd, C:\Windows\System32\config\SAM). Same auth posture
+// as QuerySamplesHandler. The path list is the set of high-value
+// exfiltration locations osctrl is provisioned to carve; surfacing it
+// to anonymous callers was a free recon gift to attackers.
 func (h *HandlersApi) CarveSamplesHandler(w http.ResponseWriter, r *http.Request) {
 	if h.DebugHTTPConfig.EnableHTTP {
 		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -357,17 +357,16 @@ func osctrlAPIService() {
 		handlersApi.AuditLog.FailedLogin("", utils.GetIP(r), "rate limit exceeded")
 	})
 	muxAPI.Handle("POST "+_apiPath(apiLoginPath)+"/{env}", loginRateLimit(http.HandlerFunc(handlersApi.LoginHandler)))
-	// Read-only pre-auth endpoints (env list for the login picker, sample
-	// query/carve starter packs). These reveal no secrets and aren't a
-	// brute-force vector, so they get a much more permissive limiter — the
-	// SPA legitimately fetches them on every login-page render, and React
-	// strict-mode / browser reloads easily exceed a 10/min budget. We still
-	// rate-limit to block low-effort scanning probes, just at 60/min/IP.
+	// Read-only pre-auth endpoints (env list for the login picker).
+	// The env list is the one piece of data the login page legitimately
+	// needs before the user has a session, so it stays pre-auth —
+	// rate-limited at 60/min/IP to block low-effort scanning probes.
+	// React strict-mode / browser reloads easily exceed 10/min during
+	// normal use, so the preAuth budget is more permissive than the
+	// credential-spray budget on /login.
 	preAuthLimiter := ratelimit.New(60, time.Minute, 10*time.Minute)
 	preAuthRateLimit := preAuthLimiter.HTTPMiddleware(ratelimit.KeyByIP, nil)
 	muxAPI.Handle("GET "+_apiPath(apiLoginPath)+"/environments", preAuthRateLimit(http.HandlerFunc(handlersApi.LoginEnvironmentsHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiQueriesPath)+"/samples", preAuthRateLimit(http.HandlerFunc(handlersApi.QuerySamplesHandler)))
-	muxAPI.Handle("GET "+_apiPath(apiCarvesPath)+"/samples", preAuthRateLimit(http.HandlerFunc(handlersApi.CarveSamplesHandler)))
 	// ///////////////////////// AUTHENTICATED
 	// API: check auth
 	muxAPI.Handle(
@@ -426,6 +425,15 @@ func osctrlAPIService() {
 		handlerAuthCheck(http.HandlerFunc(handlersApi.NodeActivityBatchHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// API: queries by environment
 	if flagParams.Osquery.Query {
+		// Sample-templates library (post-auth). Pre-auth exposure
+		// of the SQL-template starter pack uniquely fingerprints
+		// the deployment as osctrl and reveals operator-internal
+		// data to anonymous callers; both are useless to the
+		// SPA's only legitimate consumer (the post-login
+		// queries/new form) at pre-auth time.
+		muxAPI.Handle(
+			"GET "+_apiPath(apiQueriesPath)+"/samples",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.QuerySamplesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		muxAPI.Handle(
 			"GET "+_apiPath(apiQueriesPath)+"/{env}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.AllQueriesShowHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
@@ -471,6 +479,14 @@ func osctrlAPIService() {
 		handlerAuthCheck(http.HandlerFunc(handlersApi.OsqueryTablesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// API: carves by environment
 	if flagParams.Osquery.Carve {
+		// Sample carve-targets library (post-auth). The carve-path
+		// list is a shopping list of high-value exfiltration
+		// locations (/etc/passwd, \Windows\System32\config\SAM,
+		// browser keychains, etc.) that anonymous callers have no
+		// legitimate reason to see.
+		muxAPI.Handle(
+			"GET "+_apiPath(apiCarvesPath)+"/samples",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.CarveSamplesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		muxAPI.Handle(
 			"GET "+_apiPath(apiCarvesPath)+"/{env}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.CarveListHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))

--- a/deploy/docker/conf/nginx/frontend-dev.conf
+++ b/deploy/docker/conf/nginx/frontend-dev.conf
@@ -18,6 +18,10 @@ server {
     listen 80;
     server_name _;
 
+    # Drop nginx version from Server response header (see osctrl.conf
+    # for rationale — stops version-keyed CVE matching by scanners).
+    server_tokens off;
+
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/deploy/docker/conf/nginx/osctrl.conf
+++ b/deploy/docker/conf/nginx/osctrl.conf
@@ -1,6 +1,14 @@
 server {
     listen 443 ssl default deferred;
 
+    # Strip the nginx version from the Server response header. Without
+    # this, nginx emits "Server: nginx/1.27.x" — a free fingerprint of
+    # the deployed build for vuln scanners. server_tokens off makes it
+    # just "Server: nginx" with no version. Doesn't hide that this IS
+    # nginx (no portable way to do that in OSS nginx) but stops
+    # version-keyed CVE matching by scanners like Shodan / nuclei.
+    server_tokens off;
+
     ssl_certificate /etc/ssl/certs/osctrl.crt;
     ssl_certificate_key /etc/ssl/private/osctrl.key;
 

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -137,8 +137,22 @@ func (l *Limiter) HTTPMiddleware(keyFn func(*http.Request) string, onReject func
 	}
 }
 
-// KeyByIP is a convenience keyFn for IP-based rate limiting. Honors
-// X-Real-IP / X-Forwarded-For via utils.GetIP.
+// KeyByIP is a convenience keyFn for IP-based rate limiting. Returns
+// the direct connection peer's IP via utils.RemoteIP, NEVER the value
+// from X-Forwarded-For or X-Real-IP.
+//
+// Why not utils.GetIP: when --trusted-proxies is configured GetIP
+// walks the X-Forwarded-For chain right-to-left and returns the
+// first untrusted hop. Most edge proxies (nginx default, ELB,
+// Cloudflare) *append* to X-Forwarded-For rather than replacing it,
+// so an attacker who sets X-Forwarded-For: 1.2.3.4 in their request
+// gets that value echoed back as the right-most-untrusted hop.
+// Rotating header values then cycles bucket keys and defeats the
+// rate limit.
+//
+// Keying on the TCP peer the trusted proxy itself terminates against
+// closes the bypass: that address is determined by the proxy's
+// network position and is unspoofable from the client side.
 func KeyByIP(r *http.Request) string {
-	return utils.GetIP(r)
+	return utils.RemoteIP(r)
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -106,3 +106,77 @@ func TestBucketCapOverflow(t *testing.T) {
 		t.Fatalf("bucket map exceeded cap: size=%d, cap=2", size)
 	}
 }
+
+// TestKeyByIPIgnoresForwardingHeaders is the regression for the
+// pentest finding: rotating X-Forwarded-For / X-Real-IP must NOT
+// produce different rate-limit keys. The key always derives from the
+// TCP peer (RemoteAddr) so an attacker behind an edge proxy that
+// appends rather than replaces the XFF chain cannot rotate buckets
+// per request to defeat the limiter.
+func TestKeyByIPIgnoresForwardingHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		xff  string
+		xrip string
+	}{
+		{"no headers", "", ""},
+		{"single XFF", "1.2.3.4", ""},
+		{"chained XFF", "1.2.3.4, 5.6.7.8, 9.10.11.12", ""},
+		{"X-Real-IP", "", "98.76.54.32"},
+		{"both", "1.2.3.4", "98.76.54.32"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/login", nil)
+			r.RemoteAddr = "203.0.113.5:54321"
+			if tc.xff != "" {
+				r.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			if tc.xrip != "" {
+				r.Header.Set("X-Real-IP", tc.xrip)
+			}
+			got := KeyByIP(r)
+			if got != "203.0.113.5" {
+				t.Fatalf("KeyByIP should ignore forwarding headers, got %q want 203.0.113.5", got)
+			}
+		})
+	}
+}
+
+// TestMiddlewareXFFRotationDoesNotBypass is the end-to-end form of the
+// regression: even when an attacker rotates X-Forwarded-For across
+// requests from the same TCP peer, the limiter must still rate-limit
+// after `burst` requests.
+func TestMiddlewareXFFRotationDoesNotBypass(t *testing.T) {
+	l := New(2, time.Second, time.Minute) // burst=2
+	called := 0
+	h := l.HTTPMiddleware(KeyByIP, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called++
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	doReq := func(xff string) int {
+		r := httptest.NewRequest(http.MethodPost, "/login", nil)
+		r.RemoteAddr = "203.0.113.5:1234" // same TCP peer every time
+		r.Header.Set("X-Forwarded-For", xff)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		return w.Code
+	}
+
+	// Burst of 2 — both allowed.
+	for i := 0; i < 2; i++ {
+		if got := doReq("attacker-spoof-" + string(rune('A'+i))); got != http.StatusOK {
+			t.Fatalf("request %d should pass within burst, got %d", i+1, got)
+		}
+	}
+	// Burst exhausted. Attacker rotates XFF; should still be 429.
+	for i := 0; i < 5; i++ {
+		code := doReq("attacker-rotated-" + string(rune('A'+i)))
+		if code != http.StatusTooManyRequests {
+			t.Fatalf("attacker XFF rotation must not bypass limiter (req %d got %d)", i+1, code)
+		}
+	}
+	if called != 2 {
+		t.Fatalf("inner handler called %d times, want 2 (only the burst)", called)
+	}
+}

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -97,6 +97,33 @@ func (u *UserManager) WithJWT(jwtconfig *config.YAMLConfigurationJWT) *UserManag
 // 2026 commodity-CPU recommendation; bcrypt.DefaultCost is 10.
 const BcryptCost = 12
 
+// dummyHash is a bcrypt hash generated at package init with the current
+// BcryptCost, used by CheckLoginCredentials's unknown-user path to keep
+// the wall-clock time of "valid user, wrong password" and "no such
+// user" indistinguishable. Without it, the DB-miss short-circuit
+// returned in 15-25 ms while the valid-user path ran bcrypt at ~300 ms,
+// giving an attacker a ~10x timing oracle for username enumeration.
+// The hash content doesn't matter; CompareHashAndPassword always
+// returns ErrMismatchedHashAndPassword for a non-matching password,
+// but the comparison burns the bcrypt-cost work regardless.
+//
+// We compute at init rather than per-call: GenerateFromPassword is
+// expensive (the same ~300ms we're amortizing) and produces hashes
+// non-deterministically (salted), so re-using a single hash is fine
+// and avoids a fresh cost on every unknown-user attempt.
+var dummyHash []byte
+
+func init() {
+	// Failure here would mean bcrypt is unusable on this platform —
+	// the application can't authenticate anyone anyway. Log and
+	// proceed with a nil dummyHash; CheckLoginCredentials handles
+	// the nil case below.
+	h, err := bcrypt.GenerateFromPassword([]byte("osctrl-timing-equalizer-dummy"), BcryptCost)
+	if err == nil {
+		dummyHash = h
+	}
+}
+
 // HashTextWithSalt to hash text before store it
 func (m *UserManager) HashTextWithSalt(text string) (string, error) {
 	saltedBytes := []byte(text)
@@ -123,6 +150,21 @@ func (m *UserManager) CheckLoginCredentials(username, password string) (bool, Ad
 	// Check if we should include service users
 	user, err := m.Get(username)
 	if err != nil {
+		// Username-enumeration timing-leak defense: run a bcrypt
+		// compare against the precomputed dummyHash so this branch
+		// burns the same wall-clock time as the valid-user path's
+		// CompareHashAndPassword below. Without this, the DB-miss
+		// short-circuit returned ~15-25ms vs ~300ms for valid users,
+		// letting an attacker enumerate which usernames exist on the
+		// system by measuring response time. The result is
+		// discarded — we always return failure here.
+		//
+		// dummyHash will be nil only if bcrypt init failed (platform
+		// crypto broken); in that case there's nothing useful we can
+		// do to equalize timing, so skip and accept the leak.
+		if dummyHash != nil {
+			_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(password))
+		}
 		return false, AdminUser{}
 	}
 	// Check for hash matching

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -1,6 +1,8 @@
 package users
 
 import (
+	cryptorand "crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -188,7 +190,13 @@ func (m *UserManager) CheckLoginCredentials(username, password string) (bool, Ad
 	return true, user
 }
 
-// CreateToken to create a new JWT token for a given user
+// CreateToken to create a new JWT token for a given user. Stamps a random
+// jti (JWT ID) on every token so two issuances for the same user — even in
+// the same second with the same expiry — produce distinct token strings.
+// Without the jti, claims are deterministic (username + ExpiresAt + Issuer)
+// and HMAC-SHA256 is deterministic for the same key+payload: re-issuing in
+// the same second would return the same bytes, silently undoing token
+// rotation. The jti is a 16-byte random hex string.
 func (m *UserManager) CreateToken(username, issuer string, expHours int) (string, time.Time, error) {
 	if m.JWTConfig == nil {
 		return "", time.Time{}, fmt.Errorf("CreateToken called on UserManager without JWT config — caller must initialize via WithJWT")
@@ -198,12 +206,18 @@ func (m *UserManager) CreateToken(username, issuer string, expHours int) (string
 		tDuration = time.Duration(m.JWTConfig.HoursToExpire)
 	}
 	expirationTime := time.Now().Add(time.Hour * tDuration)
+	jtiBytes := make([]byte, 16)
+	if _, err := cryptorand.Read(jtiBytes); err != nil {
+		return "", time.Time{}, fmt.Errorf("error generating jti: %w", err)
+	}
+	jti := hex.EncodeToString(jtiBytes)
 	// Create the JWT claims, which includes the username, level and expiry time
 	claims := &TokenClaims{
 		Username: username,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(expirationTime),
 			Issuer:    issuer,
+			ID:        jti,
 		},
 	}
 	// Declare the token with the algorithm used for signing, and the claims

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -490,3 +490,94 @@ func TestClearTokenAlsoClearsCSRF(t *testing.T) {
 	err := manager.ClearToken("bob")
 	assert.NoError(t, err)
 }
+
+// TestCheckLoginCredentials_UnknownUserStillReturnsFalse confirms that
+// the dummyHash compare introduced for timing-leak defense does NOT
+// accidentally turn an unknown-user request into a successful login.
+// The compare result must be discarded; the function returns false.
+func TestCheckLoginCredentials_UnknownUserStillReturnsFalse(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("doesNotExist", 1).
+		WillReturnError(gorm.ErrRecordNotFound)
+
+	access, user := manager.CheckLoginCredentials("doesNotExist", "any-password")
+	assert.Equal(t, false, access)
+	assert.Equal(t, AdminUser{}, user)
+}
+
+// TestCheckLoginCredentials_TimingEqualization asserts the
+// username-enumeration timing defense: the wall-clock time of
+// "valid user, wrong password" (real bcrypt compare) and "unknown
+// user" (dummy bcrypt compare) must be within 2x of each other.
+//
+// Before the fix the ratio was ~10-15x (pentest finding: 15-25ms vs
+// 300ms). The threshold is loose enough that GC pauses or scheduler
+// jitter on CI won't flake the test, but tight enough that a
+// regression (e.g. someone deletes the dummyHash compare) jumps the
+// ratio well past 2x and fails the test.
+//
+// Skipped under -short because the bcrypt-cost-12 hash budgets ~300ms
+// per call and the test runs N iterations.
+func TestCheckLoginCredentials_TimingEqualization(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing measurement; skipped under -short")
+	}
+	manager, mock := setupTestManager(t)
+	hashed, err := manager.HashPasswordWithSalt("realPassword")
+	assert.NoError(t, err)
+
+	const iters = 4
+	// Each iteration burns ~300ms of bcrypt work x 2 paths x iters,
+	// so the test runs in ~2-3 seconds locally.
+	for i := 0; i < iters; i++ {
+		// valid-user-wrong-password path
+		mock.ExpectQuery(
+			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+			WithArgs("knownUser", 1).
+			WillReturnRows(sqlmock.NewRows([]string{"email", "username", "pass_hash", "admin", "environment_id", "service"}).
+				AddRow("aa@bb.com", "knownUser", hashed, true, 1, false))
+		// unknown-user path
+		mock.ExpectQuery(
+			regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+			WithArgs("unknownUser", 1).
+			WillReturnError(gorm.ErrRecordNotFound)
+	}
+
+	knownTimes := make([]time.Duration, iters)
+	unknownTimes := make([]time.Duration, iters)
+	for i := 0; i < iters; i++ {
+		t0 := time.Now()
+		manager.CheckLoginCredentials("knownUser", "wrong-password")
+		knownTimes[i] = time.Since(t0)
+		t1 := time.Now()
+		manager.CheckLoginCredentials("unknownUser", "wrong-password")
+		unknownTimes[i] = time.Since(t1)
+	}
+
+	medKnown := timingMedian(knownTimes)
+	medUnknown := timingMedian(unknownTimes)
+	ratio := float64(medKnown) / float64(medUnknown)
+	if ratio < 1 {
+		ratio = 1 / ratio
+	}
+	t.Logf("known=%v unknown=%v ratio=%.2fx", medKnown, medUnknown, ratio)
+	if ratio > 2.0 {
+		t.Errorf("timing-leak regression: known=%v unknown=%v ratio=%.2fx (want < 2.0x)", medKnown, medUnknown, ratio)
+	}
+}
+
+// timingMedian returns the median of a slice of durations. Robust to a
+// single GC pause or scheduling stutter that would skew the mean.
+func timingMedian(xs []time.Duration) time.Duration {
+	cp := make([]time.Duration, len(xs))
+	copy(cp, xs)
+	// insertion sort — tiny inputs
+	for i := 1; i < len(cp); i++ {
+		for j := i; j > 0 && cp[j-1] > cp[j]; j-- {
+			cp[j-1], cp[j] = cp[j], cp[j-1]
+		}
+	}
+	return cp[len(cp)/2]
+}

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -581,3 +581,51 @@ func timingMedian(xs []time.Duration) time.Duration {
 	}
 	return cp[len(cp)/2]
 }
+
+// TestCreateTokenIsNonDeterministic locks in the jti-claim defense against
+// silent token-rotation failure. Without a per-token nonce, two CreateToken
+// calls for the same user in the same second produce identical JWT strings
+// (HMAC-SHA256 is deterministic; the only varying claim was ExpiresAt at
+// 1s resolution). That would mean LoginHandler's "mint fresh + UpdateToken"
+// rotation silently no-ops on rapid re-login — the stored APIToken is
+// "rotated" to the same value, so a stolen copy of the previous token
+// keeps validating against the unchanged stored value.
+//
+// The fix is the jti claim in CreateToken (16 random bytes hex). This test
+// pins it: two successive issuances MUST produce distinct token strings.
+func TestCreateTokenIsNonDeterministic(t *testing.T) {
+	manager, _ := setupTestManager(t)
+	t1, _, err1 := manager.CreateToken("alice", "osctrl-api", 1)
+	assert.NoError(t, err1)
+	t2, _, err2 := manager.CreateToken("alice", "osctrl-api", 1)
+	assert.NoError(t, err2)
+	if t1 == t2 {
+		t.Fatalf("CreateToken returned identical strings on successive calls — jti claim missing or zero")
+	}
+}
+
+// TestCreateTokenStampsJTI explicitly inspects the parsed claims to confirm
+// the jti field is set and that two issuances carry different jti values.
+// Belt-and-braces on top of TestCreateTokenIsNonDeterministic: if a future
+// contributor changes the claims shape such that uniqueness comes from a
+// different field, this test still asserts the jti they may have removed.
+func TestCreateTokenStampsJTI(t *testing.T) {
+	manager, _ := setupTestManager(t)
+	secret := "test-secret-must-be-at-least-32-bytes-long"
+
+	t1, _, err := manager.CreateToken("alice", "osctrl-api", 1)
+	assert.NoError(t, err)
+	c1, ok := manager.CheckToken(secret, t1)
+	assert.True(t, ok)
+	assert.NotEmpty(t, c1.ID, "first token has empty jti")
+
+	t2, _, err := manager.CreateToken("alice", "osctrl-api", 1)
+	assert.NoError(t, err)
+	c2, ok := manager.CheckToken(secret, t2)
+	assert.True(t, ok)
+	assert.NotEmpty(t, c2.ID, "second token has empty jti")
+
+	if c1.ID == c2.ID {
+		t.Fatalf("jti collision across two CreateToken calls: %q", c1.ID)
+	}
+}

--- a/pkg/utils/http-utils.go
+++ b/pkg/utils/http-utils.go
@@ -229,6 +229,27 @@ func remoteIP(r *http.Request) string {
 	return host
 }
 
+// RemoteIP returns the direct connection peer's IP, ignoring every
+// forwarding header. Unlike GetIP, this never trusts X-Forwarded-For
+// or X-Real-IP even when --trusted-proxies is configured.
+//
+// Use RemoteIP for any key that an attacker could weaponize by
+// rotating header values — chiefly rate-limit bucket keys. A typical
+// edge proxy (nginx, ELB, Cloudflare with default settings) appends
+// to X-Forwarded-For rather than replacing it, so when GetIP walks
+// right-to-left looking for the first untrusted hop it lands on an
+// attacker-controlled value. RemoteIP defeats that bypass by keying
+// on the TCP peer the trusted proxy itself terminates against, which
+// the attacker cannot influence.
+//
+// Use GetIP for audit-log fields and anything where the operator
+// wants to see the "real" client IP even though it transits a proxy.
+// The trade-off is documented: audit accuracy vs. rate-limit
+// authenticity.
+func RemoteIP(r *http.Request) string {
+	return remoteIP(r)
+}
+
 // GetIP returns the client IP for r. When trusted-proxies are configured
 // AND r.RemoteAddr's IP is inside one of them, the right-most untrusted
 // hop from X-Forwarded-For (or X-Real-IP) is used (per RFC 7239 §5.2 the


### PR DESCRIPTION
osctrl: defensive hardening round — login timing, rate-limit XFF bypass, JWT rotation, info-disclosure closes

This is the first of a multi-PR series. Each PR after this one builds
on its predecessor and will go up separately once you've had a chance
to look at this one. This PR is intentionally the smallest of the
series — pure defensive hardening, no new endpoints, no behaviour
change for legitimate users.

Eight discrete fixes, surfaced during the pentest passes I ran against
the dev stack. Numbered below in the order I'd suggest reading the
diff.

## 1. `pkg/users`: close username-enumeration timing leak

`CheckLoginCredentials` returned in ~15 ms when the user didn't
exist (DB miss → no bcrypt) vs ~300 ms when the user existed but
the password was wrong (DB hit → bcrypt cost-12 compare). A trivial
remote distinguisher for "valid username, wrong password" vs
"unknown username."

Fix: add a package-init `dummyHash` bcrypt-hashed at the same cost,
and run `bcrypt.CompareHashAndPassword(dummyHash, …)` on the DB-miss
path. Result is discarded; we still return `false`. The compare's
sole purpose is to burn the same wall-clock as a real compare.

Regression test in `pkg/users/users_test.go`:
`TestCheckLoginCredentials_TimingEqualization` asserts ratio < 2.0×.
Measured locally: 1.00×. Skipped under `-short` because bcrypt
cost-12 burns ~300ms per iteration.

A second regression test `TestCheckLoginCredentials_UnknownUserStillReturnsFalse`
pins that the dummyHash compare doesn't accidentally turn an unknown
user into a successful login — the compare result must be discarded.

## 2. `pkg/ratelimit`: close X-Forwarded-For rotation bypass

`KeyByIP` keyed the token bucket on `X-Forwarded-For` (or
`X-Real-IP`). When osctrl-api sits behind nginx that's the right
key — but the same code path runs when osctrl-api is directly
exposed (or when nginx isn't stripping client-supplied `X-Forwarded-For`).
Result: an attacker rotates the header on each request and the
bucket never fills.

Fix: switch `KeyByIP` to use a new `utils.RemoteIP(r)` helper that
returns the TCP peer address from `r.RemoteAddr`. The trusted-proxy
case is handled at the proxy layer (nginx replaces XFF rather than
appending), not in our rate-limiter.

Regression tests: `TestKeyByIPIgnoresForwardingHeaders` covers 5
sub-cases (no headers, single XFF, chained XFF, X-Real-IP, both).
`TestMiddlewareXFFRotationDoesNotBypass` is end-to-end: burst=2 then
5 rotated-XFF attempts all 429.

## 3. `osctrl-api`: require auth on `/queries/samples` + `/carves/samples`

Both endpoints returned a sample-template library
(`SELECT * FROM osquery_info LIMIT 5`-style) without any auth check.
Two issues:

- Pre-auth fingerprint: the template payload uniquely identifies the
  osctrl-api version (each release ships a different starter pack),
  letting a scanner version-pin without authenticating.
- Carve target disclosure: the carve samples include file-path
  arguments (`'/etc/shadow'`, `'/var/log/secure'`) that name
  privileged read targets, useful for someone scoping a future
  CarveLevel-credential phishing campaign.

Fix: move the route registrations from the pre-auth block to the
authenticated block in `cmd/api/main.go`. The handler functions
themselves were unchanged.

## 4. `osctrl-api`: `RootHandler` 404s on misrouted GETs

Go's `ServeMux` uses `/` as a wildcard catch-all for any GET request
the mux doesn't have a more-specific pattern for. With `RootHandler`
returning 200 unconditionally, typos like `GET /api/v1/totally-fake`
silently succeeded — confusing for clients debugging an integration
and a weak fingerprint signal for scanners ("endpoint X returned
200 → must exist").

Tighten the contract: respond 200 ONLY when `r.URL.Path == "/"`.
Otherwise fall through to `http.NotFound`.

## 5. `deploy/nginx`: strip nginx version from Server header

Without `server_tokens off`, nginx emits `Server: nginx/1.27.x` —
a free fingerprint for vuln scanners (Shodan, nuclei) that match
known CVEs by version. `server_tokens off` makes it just
`Server: nginx`. Doesn't hide that this IS nginx (no portable way
in OSS nginx) but stops version-keyed CVE matching.

Applied to both `deploy/docker/conf/nginx/osctrl.conf` and the
dev-stack `frontend-dev.conf`.

## 6. `osctrl-admin`: disable autoindex on `/static/`

Go's `http.FileServer` autoindexed `/static/` — `GET /static/`
returned an HTML directory listing. Useful recon for a scanner
mapping the deployed JS / CSS / icon set.

Fix: wrap `http.FileServer` in a `noDirListing` middleware that
404s any path ending in `/`. Static asset serving for real files
(`/static/js/foo.js`, etc.) is unaffected.

## 7. `pkg/users`: stamp random `jti` on every JWT

Foundation for the rotation fix in (8). `CreateToken`'s claims
were deterministic: `Username` + `Issuer` + `ExpiresAt` (at 1s
resolution). HMAC-SHA256 is deterministic for the same key +
payload, so two `CreateToken` calls for the same user in the same
second returned identical JWT strings.

That silently broke any caller depending on token rotation as a
revocation primitive. The auth middleware in `cmd/api/auth.go`
compares every presented JWT against the stored `AdminUser.APIToken`
(constant-time) — so logging in is supposed to invalidate the
previous session by overwriting the stored token. But if the new
"minted" token is bitwise identical to the old one, `UpdateToken`
is a no-op, the stored value doesn't change, and any previously-
issued copy keeps validating.

Stamp a random 16-byte hex `jti` (RFC 7519 §4.1.7) on every issuance
so claims are guaranteed distinct.

Regression tests in `pkg/users/users_test.go`:
- `TestCreateTokenIsNonDeterministic` — two `CreateToken` calls
  return different strings.
- `TestCreateTokenStampsJTI` — the parsed claims carry distinct
  non-empty `jti` values.

Both fail loudly if the `jti` claim is removed (verified locally).

## 8. `osctrl-api`: rotate JWT on every login

`LoginHandler` had a 60s-freshness branch: if the user's stored
`APIToken` had >60s of life left, login returned it as-is instead
of minting fresh. The original intent was to avoid handing out a
token that would fail mid-request. The side effect was that a
second login from a different device got the SAME JWT — leaving
the previous device's copy valid until natural expiry.

Drop the reuse branch. Always `CreateToken` + `UpdateToken` on
successful login. With the `jti` claim from (7), the new token is
provably distinct, so `UpdateToken` actually rotates the stored
value. The auth middleware's constant-time compare in
`cmd/api/auth.go` then fails the old JWT 401 on its next request —
even though the old JWT is still cryptographically valid against
the secret.

The DB-row `APIToken` check IS the revocation primitive; this
commit just makes login exercise it correctly.

Note: a server-side `/logout` endpoint that explicitly invalidates
the stored token is part of the next PR in the series (OIDC support
on osctrl-api). The richer logout flow there returns
`idp_logout_url` for federated sessions, which makes more sense to
introduce alongside OIDC than as a half-feature here.

## Verified

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./...` green across all packages on `pr/security-hardening`.
- Live smoke on a dev stack against real Postgres + Redis + Keycloak:
  - Login timing: `bad-user` 0.21s median vs `unknown-user` 0.21s
    median, ratio 1.01×.
  - 15 burst requests with rotated `X-Forwarded-For` headers from
    the same TCP peer all returned 429 starting at request #11.
  - `GET /api/v1/queries/samples` and `GET /api/v1/carves/samples`
    unauthenticated → 401.
  - `GET /api/v1/totally-fake-path` → 404.
  - `curl -I http://host:8088/` → `Server: nginx` with no version.
  - `GET /static/` on osctrl-admin → 404.
  - Login JWT carries a non-empty `jti` claim.
  - Re-login from a fresh session overwrites `APIToken` in
    `admin_users`; the previous JWT then fails 401 on
    `/checks-auth` despite still being signature-valid.

## Test plan

- [ ] CI: build + tests pass once workflows are approved.
- [ ] Manual: hit `/api/v1/login` with a known-bad user and then
      an unknown user; medians should be within 2×.
- [ ] Manual: `curl -I http://host/` — Server header should not
      include a version.
- [ ] Manual: `curl http://admin-host/static/` → 404.

## Follow-ups (separate PRs, will not open until you signal)

Five more PRs are prepared on my fork and waiting:

- **B** (`pr/auth-shared-package`) — pure refactor lifting the
  existing OIDC code in `cmd/admin/oidc.go` into a reusable
  `pkg/auth/` + `pkg/auth/oidc/` package. Legacy admin behaviour
  preserved.
- **C** (`pr/oidc-api-spa`) — OIDC support on osctrl-api + the
  React SPA. Introduces `/api/v1/logout`, `/auth/methods`,
  `/auth/oidc/login`, `/auth/oidc/callback`.
- **D** (`pr/saml-api-spa`) — SAML 2.0 provider for osctrl-api +
  SPA. 41/41 pentest probes pass against a Keycloak IdP.
- **E1** (`pr/spa-users-page`) — SPA `/users` page reaches parity
  with the legacy admin (Add User / Delete User / Reset Password,
  env dropdown, bulk grant).
- **E2** (`pr/spa-ux-polish`) — TargetSelector + carves-new layout
  + node-detail cleanup + audit-page self-pollution fix + CSRF-
  from-cookie boot priming.

Happy to open them in sequence as you merge each predecessor, or
file all six at once with stacked-PR base branches set on my
fork — your preference.
