### PR TITLE
Fix for goreleaser error when tagging a new release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -182,6 +182,9 @@ docker_signs:
 
 nfpms:
   - id: osctrl-tls
+    ids:
+      - osctrl-tls
+    package_name: osctrl-tls
     maintainer: jmpsec/osctrl
     description: osctrl TLS component
     homepage: https://github.com/jmpsec/osctrl
@@ -199,6 +202,9 @@ nfpms:
           preremove: deploy/cicd/deb/pre-remove.sh
 
   - id: osctrl-admin
+    ids:
+      - osctrl-admin
+    package_name: osctrl-admin
     maintainer: jmpsec/osctrl
     description: osctrl Admin component
     homepage: https://github.com/jmpsec/osctrl
@@ -216,6 +222,9 @@ nfpms:
           preremove: deploy/cicd/deb/pre-remove.sh
 
   - id: osctrl-api
+    ids:
+      - osctrl-api
+    package_name: osctrl-api
     maintainer: jmpsec/osctrl
     description: osctrl API component
     homepage: https://github.com/jmpsec/osctrl
@@ -233,6 +242,9 @@ nfpms:
           preremove: deploy/cicd/deb/pre-remove.sh
 
   - id: osctrl-cli
+    ids:
+      - osctrl-cli
+    package_name: osctrl-cli
     maintainer: jmpsec/osctrl
     description: osctrl CLI component
     homepage: https://github.com/jmpsec/osctrl

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,7 @@ golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=


### PR DESCRIPTION
Potential fix for tagged release errors using GoReleaser: Example https://github.com/jmpsec/osctrl/actions/runs/26044376278