### PR TITLE
release: fix multi-arch Docker builds (manifest list export error)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,56 +121,159 @@ changelog:
       - Merge branch
 
 dockers:
+  # osctrl-tls — amd64
   - image_templates:
-      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:{{ .Version }}"
-      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:latest"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:{{ .Version }}-amd64"
     dockerfile: deploy/cicd/docker/Dockerfile-osctrl-tls
     use: buildx
+    goarch: amd64
     skip_push: false
     build_flag_templates:
-      - "--platform={{ if .IsSnapshot }}linux/amd64{{ else }}linux/amd64,linux/arm64{{ end }}"
+      - "--platform=linux/amd64"
     extra_files:
       - dist/osctrl-tls-linux-amd64
-      - dist/osctrl-tls-linux-arm64
-
+  # osctrl-tls — arm64
   - image_templates:
-      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:{{ .Version }}"
-      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:latest"
-    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-admin
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:{{ .Version }}-arm64"
+    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-tls
     use: buildx
+    goarch: arm64
     skip_push: false
     build_flag_templates:
-      - "--platform={{ if .IsSnapshot }}linux/amd64{{ else }}linux/amd64,linux/arm64{{ end }}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - dist/osctrl-tls-linux-arm64
+
+  # osctrl-admin — amd64
+  - image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:{{ .Version }}-amd64"
+    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-admin
+    use: buildx
+    goarch: amd64
+    skip_push: false
+    build_flag_templates:
+      - "--platform=linux/amd64"
     extra_files:
       - dist/osctrl-admin-linux-amd64
+      - cmd/admin/templates
+      - cmd/admin/static
+      - deploy/osquery/data
+  # osctrl-admin — arm64
+  - image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:{{ .Version }}-arm64"
+    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-admin
+    use: buildx
+    goarch: arm64
+    skip_push: false
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    extra_files:
       - dist/osctrl-admin-linux-arm64
       - cmd/admin/templates
       - cmd/admin/static
       - deploy/osquery/data
 
+  # osctrl-api — amd64
   - image_templates:
-      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:{{ .Version }}"
-      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:latest"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:{{ .Version }}-amd64"
     dockerfile: deploy/cicd/docker/Dockerfile-osctrl-api
     use: buildx
+    goarch: amd64
     skip_push: false
     build_flag_templates:
-      - "--platform={{ if .IsSnapshot }}linux/amd64{{ else }}linux/amd64,linux/arm64{{ end }}"
+      - "--platform=linux/amd64"
     extra_files:
       - dist/osctrl-api-linux-amd64
-      - dist/osctrl-api-linux-arm64
-
+  # osctrl-api — arm64
   - image_templates:
-      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}"
-      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:latest"
-    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-cli
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:{{ .Version }}-arm64"
+    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-api
     use: buildx
+    goarch: arm64
     skip_push: false
     build_flag_templates:
-      - "--platform={{ if .IsSnapshot }}linux/amd64{{ else }}linux/amd64,linux/arm64{{ end }}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - dist/osctrl-api-linux-arm64
+
+  # osctrl-cli — amd64
+  - image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-amd64"
+    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-cli
+    use: buildx
+    goarch: amd64
+    skip_push: false
+    build_flag_templates:
+      - "--platform=linux/amd64"
     extra_files:
       - dist/osctrl-cli-linux-amd64
+  # osctrl-cli — arm64
+  - image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-arm64"
+    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-cli
+    use: buildx
+    goarch: arm64
+    skip_push: false
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    extra_files:
       - dist/osctrl-cli-linux-arm64
+
+# docker_manifests fuses per-arch images into a single multi-arch manifest
+# list that `docker pull <image>:<tag>` resolves to the right arch
+# automatically. Without this section, the previous `dockers:` blocks were
+# trying to write a manifest list directly from a single buildx invocation,
+# which the default Docker exporter does not support — that was the
+# `docker exporter does not currently support exporting manifest lists`
+# error on every tagged release back to v0.4.8.
+#
+# skip_push gates the manifest combine on snapshot builds: snapshots
+# don't push individual per-arch images either, so there'd be nothing
+# to combine into a list.
+docker_manifests:
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:latest"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-tls:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:latest"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-admin:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:latest"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-api:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:latest"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
 
 docker_signs:
   - artifacts: all


### PR DESCRIPTION
## Summary

- Every tagged release since v0.4.8 fails at the Docker step with:
  ```
  docker exporter does not currently support exporting manifest lists
  ```
  The root cause is that a single `buildx` invocation with `--platform=linux/amd64,linux/arm64` tries to export a manifest list, which the default Docker exporter does not support.

- **Fix:** split each component's `dockers:` block into two per-arch entries (e.g. `osctrl-tls:<version>-amd64` and `osctrl-tls:<version>-arm64`), then combine them via `docker_manifests:` into the final multi-arch tags (`<version>` and `latest`). `docker pull <image>:<tag>` now resolves the correct arch automatically.

- `skip_push` on manifest entries is gated by `{{ .IsSnapshot }}` so snapshot builds still work without pushing.

## Changes

- `.goreleaser.yml`: 4 multi-platform docker blocks → 8 per-arch blocks + 8 `docker_manifests` entries

## Test plan

- [x] `goreleaser check` validates the config
- [ ] Tag a pre-release and verify Docker images are pushed with correct multi-arch manifests