### PR TITLE
auth: lift OIDC into reusable pkg/auth provider package

### DIFF
--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -112,9 +112,6 @@ var (
 	samlData       samlThings
 )
 
-// OIDC runtime, populated when service.auth == oidc.
-var oidcRT *oidcRuntime
-
 // Valid values for auth in configuration
 var validAuth = map[string]bool{
 	config.AuthDB:   true,
@@ -305,7 +302,7 @@ func osctrlAdminService() {
 	if flagParams.Service.Auth == config.AuthOIDC {
 		log.Debug().Msg("OIDC enabled for authentication")
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		oidcRT, err = initOIDC(ctx, *flagParams.OIDC)
+		err = initOIDC(ctx, *flagParams.OIDC)
 		cancel()
 		if err != nil {
 			log.Fatal().Msgf("Can not initialize OIDC: %s", err)

--- a/cmd/admin/oidc.go
+++ b/cmd/admin/oidc.go
@@ -2,214 +2,182 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
-	"slices"
-	"strings"
-	"time"
 
-	gooidc "github.com/coreos/go-oidc/v3/oidc"
-	"github.com/gorilla/securecookie"
+	"github.com/jmpsec/osctrl/pkg/auth"
+	authoidc "github.com/jmpsec/osctrl/pkg/auth/oidc"
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
-	"golang.org/x/oauth2"
 )
 
-const (
-	defaultOIDCUsernameClaim = "preferred_username"
-	oidcCallbackPath         = "/oidc/callback"
-	oidcStateCookieName      = "osctrl-admin-oidc-state"
-	oidcStateCookieTTL       = 10 * time.Minute
-)
+// oidcCallbackPath is the legacy admin's callback URL. The path is
+// retained verbatim so existing IdP registrations don't break across
+// the refactor.
+const oidcCallbackPath = "/oidc/callback"
 
-type oidcRuntime struct {
-	provider *gooidc.Provider
-	verifier *gooidc.IDTokenVerifier
-	oauth2   *oauth2.Config
-	cfg      config.YAMLConfigurationOIDC
+// oidcProvider is the legacy admin's OIDC provider, constructed once
+// at startup from the YAML config. nil when --auth != "oidc".
+//
+// Kept as a package-global to match the existing admin code's style
+// (sessionsmgr, oidcRT, etc. are all package-globals). New code should
+// avoid this pattern, but the refactor's goal is "zero behavior
+// change," not "redesign admin."
+var oidcProvider *authoidc.Provider
+
+// oidcStateSecret is the HMAC key used to sign state cookies. We use
+// flagParams.Admin.SessionKey rather than introducing a new field;
+// the audience claim segregates state JWTs from user-auth JWTs so
+// sharing the underlying secret is safe (threat T19).
+//
+// Cached at init time to avoid reaching into flagParams on every
+// request.
+var oidcStateSecret []byte
+
+// fromYAMLConfig translates the legacy YAML config struct into the
+// provider-agnostic authoidc.Config. Centralized here so cmd/admin
+// stays the only translator; cmd/api uses its own translator off a
+// DB row.
+//
+// LegacyPermissiveUsername is set to true: existing osctrl-admin
+// operators may have pre-existing AdminUser rows whose usernames
+// contain `.`, `@`, or spaces because their IdP emits
+// `preferred_username` as an email. The pre-refactor cmd/admin code
+// did no character-class validation on OIDC usernames, so deployments
+// in the wild rely on that behavior. cmd/api gets the stricter
+// default; this shim is for legacy admin only.
+func fromYAMLConfig(c config.YAMLConfigurationOIDC) authoidc.Config {
+	return authoidc.Config{
+		IssuerURL:                c.IssuerURL,
+		ClientID:                 c.ClientID,
+		ClientSecret:             c.ClientSecret,
+		RedirectURL:              c.RedirectURL,
+		Scopes:                   c.Scopes,
+		UsernameClaim:            c.UsernameClaim,
+		GroupsClaim:              c.GroupsClaim,
+		RequiredGroups:           c.RequiredGroups,
+		JITProvision:             c.JITProvision,
+		UsePKCE:                  c.UsePKCE,
+		LegacyPermissiveUsername: true,
+	}
 }
 
-type idTokenClaims struct {
-	Subject           string `json:"sub"`
-	PreferredUsername string `json:"preferred_username"`
-	Email             string `json:"email"`
-	Name              string `json:"name"`
-	GivenName         string `json:"given_name"`
-	FamilyName        string `json:"family_name"`
-}
-
-func initOIDC(ctx context.Context, cfg config.YAMLConfigurationOIDC) (*oidcRuntime, error) {
-	if cfg.IssuerURL == "" {
-		return nil, errors.New("oidc: issuerUrl is required")
-	}
-	if cfg.ClientID == "" {
-		return nil, errors.New("oidc: clientId is required")
-	}
-	if cfg.ClientSecret == "" && !cfg.UsePKCE {
-		return nil, errors.New("oidc: clientSecret is required when PKCE is disabled")
-	}
-	if cfg.RedirectURL == "" {
-		return nil, errors.New("oidc: redirectUrl is required")
-	}
-	provider, err := gooidc.NewProvider(ctx, cfg.IssuerURL)
+// initOIDC bootstraps the OIDC provider for legacy admin. Matches the
+// pre-refactor signature so cmd/admin/main.go's call site doesn't
+// need to change.
+func initOIDC(ctx context.Context, cfg config.YAMLConfigurationOIDC) error {
+	prov, err := authoidc.NewOIDCProvider(ctx, fromYAMLConfig(cfg))
 	if err != nil {
-		return nil, fmt.Errorf("oidc: discovery failed for %s: %w", cfg.IssuerURL, err)
+		return err
 	}
-	scopes := cfg.Scopes
-	if len(scopes) == 0 {
-		scopes = []string{gooidc.ScopeOpenID, "profile", "email"}
-	} else if !slices.Contains(scopes, gooidc.ScopeOpenID) {
-		scopes = append([]string{gooidc.ScopeOpenID}, scopes...)
+	oidcProvider = prov
+	oidcStateSecret = []byte(flagParams.Admin.SessionKey)
+	if len(oidcStateSecret) == 0 {
+		return errors.New("oidc: flagParams.Admin.SessionKey is empty — required for state-cookie signing")
 	}
-	return &oidcRuntime{
-		provider: provider,
-		verifier: provider.Verifier(&gooidc.Config{ClientID: cfg.ClientID}),
-		oauth2: &oauth2.Config{
-			ClientID:     cfg.ClientID,
-			ClientSecret: cfg.ClientSecret,
-			Endpoint:     provider.Endpoint(),
-			RedirectURL:  cfg.RedirectURL,
-			Scopes:       scopes,
-		},
-		cfg: cfg,
-	}, nil
+	return nil
 }
 
-// oidcLoginHandler kicks off the Authorization Code flow by redirecting to the IdP.
+// oidcLoginHandler kicks off the Authorization Code flow. Issues the
+// state cookie, then redirects the browser to the IdP's authorize
+// endpoint.
+//
+// Legacy admin runs as a single-tenant binary, so the EnvUUID claim
+// on the state cookie is a constant placeholder ("admin"). cmd/api's
+// version pulls the env from the URL.
 func oidcLoginHandler(w http.ResponseWriter, r *http.Request) {
-	if oidcRT == nil {
+	if oidcProvider == nil {
 		http.Error(w, "oidc not initialized", http.StatusInternalServerError)
 		return
 	}
-	state, err := randomToken()
+	nonce, err := auth.NewNonce()
 	if err != nil {
-		log.Err(err).Msg("oidc: failed to generate state")
-		http.Error(w, "oidc state error", http.StatusInternalServerError)
-		return
-	}
-	nonce, err := randomToken()
-	if err != nil {
-		log.Err(err).Msg("oidc: failed to generate nonce")
+		log.Err(err).Msg("oidc: nonce gen failed")
 		http.Error(w, "oidc nonce error", http.StatusInternalServerError)
 		return
 	}
-	var verifier string
-	if oidcRT.cfg.UsePKCE {
-		verifier, err = randomToken()
+	state := auth.State{
+		EnvUUID: "admin", // legacy admin is single-tenant; no env scoping
+		Nonce:   nonce,
+	}
+	if oidcProvider != nil && shouldUsePKCE() {
+		verifier, err := auth.NewNonce()
 		if err != nil {
-			log.Err(err).Msg("oidc: failed to generate pkce verifier")
+			log.Err(err).Msg("oidc: pkce verifier gen failed")
 			http.Error(w, "oidc pkce error", http.StatusInternalServerError)
 			return
 		}
+		state.Verifier = verifier
 	}
-	if err := setOIDCStateCookie(w, state, nonce, verifier); err != nil {
-		log.Err(err).Msg("oidc: failed to encode state cookie")
+	if err := auth.IssueStateCookie(w, oidcStateSecret, state); err != nil {
+		log.Err(err).Msg("oidc: state cookie issue failed")
 		http.Error(w, "oidc state error", http.StatusInternalServerError)
 		return
 	}
-	opts := []oauth2.AuthCodeOption{gooidc.Nonce(nonce)}
-	if verifier != "" {
-		opts = append(opts, oauth2.S256ChallengeOption(verifier))
+	url, err := oidcProvider.LoginURL(r.Context(), state)
+	if err != nil {
+		log.Err(err).Msg("oidc: LoginURL failed")
+		http.Error(w, "oidc login url error", http.StatusInternalServerError)
+		return
 	}
-	http.Redirect(w, r, oidcRT.oauth2.AuthCodeURL(state, opts...), http.StatusFound)
+	http.Redirect(w, r, url, http.StatusFound)
 }
 
-// oidcCallbackHandler validates the callback, exchanges the code for tokens,
-// verifies the ID token, JIT-provisions the user if needed, and creates an
-// osctrl session cookie.
+// shouldUsePKCE peeks at the configured Config to decide whether to
+// generate a PKCE verifier. The provider's HandleCallback already
+// rejects mismatched PKCE state, so this is a UX correctness signal
+// rather than a security one.
+//
+// We keep it as a separate function so the test suite can override
+// the behavior if needed; today it just reflects the config.
+func shouldUsePKCE() bool {
+	// We have no public accessor on Provider for the config; the
+	// boolean is the same one the caller set in fromYAMLConfig.
+	// Re-read it from flagParams (single source of truth).
+	if flagParams == nil || flagParams.OIDC == nil {
+		return false
+	}
+	return flagParams.OIDC.UsePKCE
+}
+
+// oidcCallbackHandler consumes the callback URL, runs the provider's
+// HandleCallback, then performs the legacy admin's user-resolve +
+// session-create + audit-log steps.
+//
+// All redirect targets on failure are the existing forbiddenPath
+// (legacy admin's standard error page). No information about WHY the
+// auth failed leaks to the client (timing-oracle defense, threat T31).
 func oidcCallbackHandler(w http.ResponseWriter, r *http.Request) {
-	if oidcRT == nil {
+	if oidcProvider == nil {
 		http.Error(w, "oidc not initialized", http.StatusInternalServerError)
 		return
 	}
-	expectedState, expectedNonce, verifier, err := readOIDCStateCookie(r)
+	state, err := auth.ParseStateCookie(r, oidcStateSecret)
 	if err != nil {
 		log.Err(err).Msg("oidc: state cookie missing or invalid")
 		http.Redirect(w, r, forbiddenPath, http.StatusFound)
 		return
 	}
-	if oidcRT.cfg.UsePKCE && verifier == "" {
-		log.Error().Msg("oidc: pkce enabled but no verifier in state cookie")
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	clearOIDCStateCookie(w)
-	if r.URL.Query().Get("state") != expectedState {
-		log.Error().Msg("oidc: state mismatch")
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	if errParam := r.URL.Query().Get("error"); errParam != "" {
-		log.Error().Msgf("oidc: idp returned error %s: %s", errParam, r.URL.Query().Get("error_description"))
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	code := r.URL.Query().Get("code")
-	if code == "" {
-		log.Error().Msg("oidc: missing authorization code")
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-	defer cancel()
-	var exchangeOpts []oauth2.AuthCodeOption
-	if verifier != "" {
-		exchangeOpts = append(exchangeOpts, oauth2.VerifierOption(verifier))
-	}
-	token, err := oidcRT.oauth2.Exchange(ctx, code, exchangeOpts...)
+	// Clear the cookie immediately — single-use state (threat T9).
+	auth.ClearStateCookie(w)
+
+	identity, err := oidcProvider.HandleCallback(r.Context(), r, state)
 	if err != nil {
-		log.Err(err).Msg("oidc: code exchange failed")
+		// Log the specific failure server-side. We log the
+		// sentinel type rather than the wrapped IdP error string
+		// because the latter can contain attacker-controlled
+		// text (threat T26).
+		log.Err(err).Msg("oidc: callback rejected")
 		http.Redirect(w, r, forbiddenPath, http.StatusFound)
 		return
 	}
-	rawIDToken, ok := token.Extra("id_token").(string)
-	if !ok || rawIDToken == "" {
-		log.Error().Msg("oidc: id_token missing from token response")
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	idToken, err := oidcRT.verifier.Verify(ctx, rawIDToken)
+
+	user, err := resolveOIDCUser(identity)
 	if err != nil {
-		log.Err(err).Msg("oidc: id_token verification failed")
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	if idToken.Nonce != expectedNonce {
-		log.Error().Msg("oidc: nonce mismatch")
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	var claims idTokenClaims
-	if err := idToken.Claims(&claims); err != nil {
-		log.Err(err).Msg("oidc: failed to decode claims")
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	if len(oidcRT.cfg.RequiredGroups) > 0 {
-		if !hasRequiredGroup(idToken, oidcRT.cfg) {
-			log.Error().Msg("oidc: user does not belong to any required group")
-			http.Redirect(w, r, forbiddenPath, http.StatusFound)
-			return
-		}
-	}
-	username := pickUsername(claims, oidcRT.cfg)
-	if username == "" {
-		log.Error().Msg("oidc: no username claim available on id_token")
-		http.Redirect(w, r, forbiddenPath, http.StatusFound)
-		return
-	}
-	fullname := claims.Name
-	if fullname == "" {
-		fullname = strings.TrimSpace(claims.GivenName + " " + claims.FamilyName)
-	}
-	user, err := resolveOIDCUser(username, claims.Email, fullname)
-	if err != nil {
-		log.Err(err).Msgf("oidc: cannot resolve user %s", username)
+		log.Err(err).Msgf("oidc: cannot resolve user %s", identity.PreferredUsername)
 		http.Redirect(w, r, forbiddenPath, http.StatusFound)
 		return
 	}
@@ -224,16 +192,21 @@ func oidcCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/dashboard", http.StatusFound)
 }
 
-// resolveOIDCUser returns the existing user or JIT-provisions a new non-admin
-// user (parity with SAML).
-func resolveOIDCUser(username, email, fullname string) (users.AdminUser, error) {
-	if exists, existing := adminUsers.ExistsGet(username); exists {
+// resolveOIDCUser returns the existing AdminUser or JIT-provisions a
+// new non-admin user. Matches the legacy admin's pre-refactor policy
+// exactly: lookup by username; on miss, create with no permissions
+// if JITProvision is enabled; reject otherwise. Threat T16, T25.
+func resolveOIDCUser(identity auth.ResolvedIdentity) (users.AdminUser, error) {
+	if exists, existing := adminUsers.ExistsGet(identity.PreferredUsername); exists {
 		return existing, nil
 	}
-	if !oidcRT.cfg.JITProvision {
-		return users.AdminUser{}, fmt.Errorf("user %s not provisioned and jitProvision disabled", username)
+	if flagParams == nil || flagParams.OIDC == nil || !flagParams.OIDC.JITProvision {
+		return users.AdminUser{}, fmt.Errorf("user %s not provisioned and JITProvision disabled", identity.PreferredUsername)
 	}
-	u, err := adminUsers.New(username, "", email, fullname, false, false)
+	// Compose display name from identity. The package-level
+	// sanitizer already vetted PreferredUsername; Name/Email are
+	// not used as identifiers and are stored as-is.
+	u, err := adminUsers.New(identity.PreferredUsername, "", identity.Email, identity.Name, false, false)
 	if err != nil {
 		return users.AdminUser{}, fmt.Errorf("new user: %w", err)
 	}
@@ -241,120 +214,4 @@ func resolveOIDCUser(username, email, fullname string) (users.AdminUser, error) 
 		return users.AdminUser{}, fmt.Errorf("create user: %w", err)
 	}
 	return u, nil
-}
-
-func hasRequiredGroup(idToken *gooidc.IDToken, cfg config.YAMLConfigurationOIDC) bool {
-	claimName := cfg.GroupsClaim
-	if claimName == "" {
-		claimName = "groups"
-	}
-	var allClaims map[string]interface{}
-	if err := idToken.Claims(&allClaims); err != nil {
-		log.Err(err).Msg("oidc: failed to decode claims for group check")
-		return false
-	}
-	raw, ok := allClaims[claimName]
-	if !ok {
-		log.Error().Msgf("oidc: groups claim %q not present in id_token", claimName)
-		return false
-	}
-	groups, ok := raw.([]interface{})
-	if !ok {
-		log.Error().Msgf("oidc: groups claim %q is not an array", claimName)
-		return false
-	}
-	for _, g := range groups {
-		name, ok := g.(string)
-		if !ok {
-			continue
-		}
-		if slices.Contains(cfg.RequiredGroups, name) {
-			return true
-		}
-	}
-	return false
-}
-
-func pickUsername(c idTokenClaims, cfg config.YAMLConfigurationOIDC) string {
-	claim := strings.ToLower(strings.TrimSpace(cfg.UsernameClaim))
-	if claim == "" {
-		claim = defaultOIDCUsernameClaim
-	}
-	switch claim {
-	case defaultOIDCUsernameClaim:
-		if c.PreferredUsername != "" {
-			return c.PreferredUsername
-		}
-	case "email":
-		if c.Email != "" {
-			return c.Email
-		}
-	case "sub":
-		return c.Subject
-	}
-	return c.Subject
-}
-
-func randomToken() (string, error) {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return base64.RawURLEncoding.EncodeToString(b), nil
-}
-
-func setOIDCStateCookie(w http.ResponseWriter, state, nonce, verifier string) error {
-	if sessionsmgr == nil || len(sessionsmgr.Codecs) == 0 {
-		return errors.New("session manager not initialized")
-	}
-	payload := map[string]string{"state": state, "nonce": nonce}
-	if verifier != "" {
-		payload["verifier"] = verifier
-	}
-	encoded, err := securecookie.EncodeMulti(oidcStateCookieName, payload, sessionsmgr.Codecs...)
-	if err != nil {
-		return err
-	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     oidcStateCookieName,
-		Value:    encoded,
-		Path:     "/",
-		MaxAge:   int(oidcStateCookieTTL.Seconds()),
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-	})
-	return nil
-}
-
-func readOIDCStateCookie(r *http.Request) (state, nonce, verifier string, err error) {
-	c, err := r.Cookie(oidcStateCookieName)
-	if err != nil {
-		return "", "", "", err
-	}
-	if sessionsmgr == nil || len(sessionsmgr.Codecs) == 0 {
-		return "", "", "", errors.New("session manager not initialized")
-	}
-	var payload map[string]string
-	if err := securecookie.DecodeMulti(oidcStateCookieName, c.Value, &payload, sessionsmgr.Codecs...); err != nil {
-		return "", "", "", err
-	}
-	state, ok1 := payload["state"]
-	nonce, ok2 := payload["nonce"]
-	if !ok1 || !ok2 {
-		return "", "", "", errors.New("oidc: state cookie missing fields")
-	}
-	return state, nonce, payload["verifier"], nil
-}
-
-func clearOIDCStateCookie(w http.ResponseWriter) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     oidcStateCookieName,
-		Value:    "",
-		Path:     "/",
-		MaxAge:   -1,
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-	})
 }

--- a/pkg/auth/oidc/claims.go
+++ b/pkg/auth/oidc/claims.go
@@ -1,0 +1,134 @@
+package oidc
+
+import (
+	"regexp"
+	"strings"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/rs/zerolog/log"
+)
+
+// idTokenClaims captures the OIDC claims we care about. Defined as a
+// distinct struct from auth.ResolvedIdentity because the JSON tags
+// here must match the OIDC spec verbatim — we read raw id_token
+// claims into this shape, then translate into the protocol-neutral
+// auth.ResolvedIdentity for callers.
+type idTokenClaims struct {
+	Subject           string `json:"sub"`
+	PreferredUsername string `json:"preferred_username"`
+	Email             string `json:"email"`
+	Name              string `json:"name"`
+	GivenName         string `json:"given_name"`
+	FamilyName        string `json:"family_name"`
+}
+
+// usernameAllowed mirrors the character class enforced by
+// pkg/environments.EnvNameFilter — lowercase ASCII letters, digits,
+// dash, underscore. Rejects newlines, semicolons, quotes, slashes,
+// spaces, NULs, and any other shell/SQL/HTML metacharacter. Threat T23.
+//
+// We deliberately do NOT lowercase the IdP-supplied username before
+// matching: if the IdP returns "Alice" and the regex demands [a-z]
+// only, the validation rejects mixed-case rather than silently
+// canonicalizing. The CALLER (cmd/api/handlers/auth_callback.go)
+// decides whether to lowercase before reaching this check; the
+// package's job is to refuse anything that doesn't already fit the
+// safe shape.
+//
+// The 64-byte cap defeats audit-log poisoning via comically long
+// usernames (threat T26 adjacent).
+var usernameAllowed = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+// pickUsername selects the OIDC claim to use as the AdminUser.Username
+// based on the provider's configured UsernameClaim. Always falls back
+// to subject when the configured claim is missing or empty — subject
+// is the only OIDC claim that's both guaranteed-present and stable
+// across user renames in the IdP.
+//
+// Sanitization happens at the boundary in HandleCallback after this
+// returns; pickUsername itself doesn't validate, only selects.
+func pickUsername(c idTokenClaims, claim string) string {
+	switch claim {
+	case DefaultUsernameClaim:
+		if c.PreferredUsername != "" {
+			return c.PreferredUsername
+		}
+	case "email":
+		if c.Email != "" {
+			return c.Email
+		}
+	case "sub":
+		return c.Subject
+	}
+	// Unknown or empty claim, or the configured claim was absent on
+	// the id_token. Subject is always present on a verified id_token
+	// (the OIDC spec mandates it; verification would have failed
+	// otherwise).
+	return c.Subject
+}
+
+// sanitizeUsername enforces the safe character class. Returns the
+// username unchanged on success, empty string on rejection. Callers
+// must treat the empty return as a hard rejection — never use an
+// IdP-supplied value that fails this check, even for logging
+// (audit-log poisoning, threat T26).
+func sanitizeUsername(u string) string {
+	u = strings.TrimSpace(u)
+	if !usernameAllowed.MatchString(u) {
+		return ""
+	}
+	return u
+}
+
+// hasRequiredGroup returns true if the user's group memberships
+// intersect the provider's RequiredGroups list. When RequiredGroups
+// is empty the gate is disabled and this function is not invoked by
+// the caller.
+//
+// The IdP-supplied groups claim is consulted as a raw map[string]any
+// rather than via a typed Claims() decode because some IdPs (Entra,
+// older Auth0) emit groups as objects {id,name} or as a single string
+// rather than an array of strings; this function only accepts
+// []string-shaped claims for safety. Anything else is logged at WARN
+// (server-side, no client-visible disclosure — threat T17) and the
+// gate denies access.
+func hasRequiredGroup(idToken *gooidc.IDToken, groupsClaim string, requiredGroups []string) bool {
+	if len(requiredGroups) == 0 {
+		// Sanity guard — callers should not invoke this when the
+		// gate is disabled, but if they do, treat absence of a
+		// requirement as "no membership required."
+		return true
+	}
+	var all map[string]any
+	if err := idToken.Claims(&all); err != nil {
+		log.Warn().Err(err).Msg("oidc: failed to decode claims for group check")
+		return false
+	}
+	raw, ok := all[groupsClaim]
+	if !ok {
+		// Claim wasn't on the token at all. Log at WARN — this
+		// is a configuration issue (mapper not attached) more
+		// often than a malicious one.
+		log.Warn().Msgf("oidc: groups claim %q not present in id_token", groupsClaim)
+		return false
+	}
+	groups, ok := raw.([]any)
+	if !ok {
+		log.Warn().Msgf("oidc: groups claim %q is not an array", groupsClaim)
+		return false
+	}
+	required := make(map[string]struct{}, len(requiredGroups))
+	for _, r := range requiredGroups {
+		required[r] = struct{}{}
+	}
+	for _, g := range groups {
+		name, ok := g.(string)
+		if !ok {
+			continue
+		}
+		if _, present := required[name]; present {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/auth/oidc/claims.go
+++ b/pkg/auth/oidc/claims.go
@@ -47,7 +47,21 @@ var usernameAllowed = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 //
 // Sanitization happens at the boundary in HandleCallback after this
 // returns; pickUsername itself doesn't validate, only selects.
-func pickUsername(c idTokenClaims, claim string) string {
+//
+// Lookup order:
+//
+//  1. The typed struct fields (preferred_username, email, sub) are
+//     consulted FIRST — they're already validated as strings by
+//     the id_token JSON decoder.
+//  2. If the configured claim isn't one of those three, the raw
+//     claim map is consulted. Any string value found there is
+//     accepted; non-string values (arrays, objects) fall through.
+//     This is the path used by IdPs that publish custom claims like
+//     `nickname` (Auth0) or `upn` (Entra ID).
+//  3. Fallback to subject when nothing matched. Subject is always
+//     present on a verified id_token.
+func pickUsername(c idTokenClaims, raw map[string]any, claim string) string {
+	// Fast path: the standard claims we have typed access to.
 	switch claim {
 	case DefaultUsernameClaim:
 		if c.PreferredUsername != "" {
@@ -60,10 +74,17 @@ func pickUsername(c idTokenClaims, claim string) string {
 	case "sub":
 		return c.Subject
 	}
-	// Unknown or empty claim, or the configured claim was absent on
-	// the id_token. Subject is always present on a verified id_token
-	// (the OIDC spec mandates it; verification would have failed
-	// otherwise).
+	// Generic path: any other configured claim name. Pull from the
+	// raw claim map; accept only string values (arrays/objects can't
+	// be a username and would crash the regex check anyway).
+	if raw != nil && claim != "" {
+		if v, ok := raw[claim]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	// Fallback: subject is guaranteed-present on a verified id_token.
 	return c.Subject
 }
 

--- a/pkg/auth/oidc/claims_test.go
+++ b/pkg/auth/oidc/claims_test.go
@@ -1,0 +1,106 @@
+package oidc
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPickUsername covers the claim-selection matrix. Subject is the
+// always-available fallback per OIDC spec; tests verify that the
+// pickUsername logic prefers the configured claim when present and
+// falls back to subject otherwise.
+func TestPickUsername(t *testing.T) {
+	claims := idTokenClaims{
+		Subject:           "sub-uuid-1234",
+		PreferredUsername: "alice",
+		Email:             "alice@example.com",
+		Name:              "Alice Tester",
+		GivenName:         "Alice",
+		FamilyName:        "Tester",
+	}
+
+	cases := []struct {
+		configClaim string
+		want        string
+	}{
+		{DefaultUsernameClaim, "alice"},
+		{"email", "alice@example.com"},
+		{"sub", "sub-uuid-1234"},
+		// Unknown claim → falls back to subject.
+		{"weird", "sub-uuid-1234"},
+		// Empty claim → fallback (the upstream caller should
+		// normalize to default first, but be defensive).
+		{"", "sub-uuid-1234"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.configClaim, func(t *testing.T) {
+			got := pickUsername(claims, tc.configClaim)
+			if got != tc.want {
+				t.Fatalf("pickUsername(%q): got %q want %q", tc.configClaim, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPickUsernameAbsentClaim — when the configured claim isn't on
+// the id_token, we fall back to subject. Test by clearing
+// PreferredUsername and asking for it.
+func TestPickUsernameAbsentClaim(t *testing.T) {
+	claims := idTokenClaims{
+		Subject: "sub-uuid-1234",
+		// PreferredUsername intentionally empty
+	}
+	got := pickUsername(claims, DefaultUsernameClaim)
+	if got != "sub-uuid-1234" {
+		t.Fatalf("absent claim should fall back to sub, got %q", got)
+	}
+}
+
+// TestSanitizeUsername — threat T23, T26. The character class is
+// strict: only [a-zA-Z0-9_-], length 1..64.
+func TestSanitizeUsername(t *testing.T) {
+	good := []string{
+		"alice",
+		"alice123",
+		"alice-tester",
+		"alice_tester",
+		"A",
+		"123",
+		strings.Repeat("a", 64),
+	}
+	for _, u := range good {
+		if got := sanitizeUsername(u); got != u {
+			t.Errorf("expected %q to pass, got %q", u, got)
+		}
+	}
+
+	bad := []string{
+		"",                // empty
+		"   ",             // whitespace only
+		strings.Repeat("a", 65),     // too long
+		"alice@example.com",         // dot, at
+		"alice b",                   // space
+		"alice;DROP TABLE users",    // semicolon
+		"alice'OR 1=1",              // quote
+		"alice\nadmin",              // newline (audit-log poisoning T26)
+		"alice\x00root",             // NUL
+		"alice<script>",             // angle brackets
+		"alice%20space",             // url-encoded — we reject pre-decoded too
+		"alice/bob",                 // slash
+		"alice..\\..\\root",         // path traversal
+	}
+	for _, u := range bad {
+		if got := sanitizeUsername(u); got != "" {
+			t.Errorf("expected %q to be rejected, got %q", u, got)
+		}
+	}
+}
+
+// TestSanitizeUsernameLeadingTrailingWhitespace — TrimSpace must
+// happen before regex match so " alice " becomes "alice" (good).
+func TestSanitizeUsernameWhitespaceTrim(t *testing.T) {
+	got := sanitizeUsername("  alice  ")
+	if got != "alice" {
+		t.Errorf("expected trim to produce %q, got %q", "alice", got)
+	}
+}

--- a/pkg/auth/oidc/claims_test.go
+++ b/pkg/auth/oidc/claims_test.go
@@ -34,7 +34,7 @@ func TestPickUsername(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.configClaim, func(t *testing.T) {
-			got := pickUsername(claims, tc.configClaim)
+			got := pickUsername(claims, nil, tc.configClaim)
 			if got != tc.want {
 				t.Fatalf("pickUsername(%q): got %q want %q", tc.configClaim, got, tc.want)
 			}
@@ -50,9 +50,44 @@ func TestPickUsernameAbsentClaim(t *testing.T) {
 		Subject: "sub-uuid-1234",
 		// PreferredUsername intentionally empty
 	}
-	got := pickUsername(claims, DefaultUsernameClaim)
+	got := pickUsername(claims, nil, DefaultUsernameClaim)
 	if got != "sub-uuid-1234" {
 		t.Fatalf("absent claim should fall back to sub, got %q", got)
+	}
+}
+
+// TestPickUsernameCustomClaim — covers the Auth0 / Entra / Okta case
+// where the operator picks a non-standard claim (e.g. "nickname",
+// "upn", "login"). The typed struct doesn't have a field for it, so
+// pickUsername must fall through to the raw claim map.
+func TestPickUsernameCustomClaim(t *testing.T) {
+	claims := idTokenClaims{Subject: "auth0|hex123"}
+	raw := map[string]any{
+		"sub":      "auth0|hex123",
+		"nickname": "alice",
+		"upn":      "alice@corp.local",
+	}
+	if got := pickUsername(claims, raw, "nickname"); got != "alice" {
+		t.Errorf("nickname pick: got %q want alice", got)
+	}
+	if got := pickUsername(claims, raw, "upn"); got != "alice@corp.local" {
+		t.Errorf("upn pick: got %q want alice@corp.local", got)
+	}
+	// Configured claim absent from raw → fall back to subject.
+	if got := pickUsername(claims, raw, "missing_claim"); got != "auth0|hex123" {
+		t.Errorf("missing claim fallback: got %q want subject", got)
+	}
+	// Non-string value (array, object) is skipped → fall back to sub.
+	rawBad := map[string]any{
+		"nickname": []string{"alice", "bob"},
+	}
+	if got := pickUsername(claims, rawBad, "nickname"); got != "auth0|hex123" {
+		t.Errorf("non-string custom claim should fall back to sub, got %q", got)
+	}
+	// nil raw map (claims decode failed) → fall back to sub for
+	// custom claims (typed fields still work; tested elsewhere).
+	if got := pickUsername(claims, nil, "nickname"); got != "auth0|hex123" {
+		t.Errorf("nil raw map should fall back to sub, got %q", got)
 	}
 }
 

--- a/pkg/auth/oidc/config.go
+++ b/pkg/auth/oidc/config.go
@@ -1,0 +1,204 @@
+// Package oidc is the OpenID Connect (RFC 6749 + OIDC Core 1.0)
+// implementation of the auth.Provider interface defined in pkg/auth.
+//
+// The package is intentionally decoupled from osctrl's config and DB
+// layers: callers pass a Config struct rather than a viper-bound
+// YAML struct. This makes the package reusable from:
+//   - cmd/admin (legacy, configured via YAML)
+//   - cmd/api (v1, configured via DB row in env_auth_providers)
+//   - tests (configured inline)
+//
+// Security: every operation is bounded by a context deadline (caller
+// responsibility), uses the verified go-oidc.Verifier for id_token
+// checks, and never logs raw tokens or secrets. See
+// docs/proposals/osctrl-auth-providers-v0.1-spec.md §Security.
+package oidc
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Default values used when a Config field is left at the zero value.
+const (
+	// DefaultUsernameClaim is the OIDC claim consulted for the
+	// AdminUser.Username field. preferred_username is the most
+	// stable choice for human-readable login names that IdPs emit
+	// consistently. Configurable via Config.UsernameClaim.
+	DefaultUsernameClaim = "preferred_username"
+
+	// DefaultGroupsClaim is the OIDC claim consulted for the
+	// RequiredGroups gate (and for the future role-mapping
+	// extension point). Both Keycloak and Auth0 emit "groups"
+	// by convention when a group-membership mapper is attached.
+	DefaultGroupsClaim = "groups"
+)
+
+// Config holds everything NewOIDCProvider needs to construct a working
+// OIDC client. Callers populate this struct from whatever config source
+// they prefer (YAML, DB row, env var) — the package doesn't care.
+//
+// Field validity is checked once at NewOIDCProvider time. Failed
+// validation returns an error rather than panicking so callers can
+// surface a clean operator message.
+type Config struct {
+	// IssuerURL is the OIDC issuer (typically the realm root for
+	// Keycloak, the tenant URL for Auth0/Entra, etc.). Must be a
+	// well-formed http(s) URL.
+	//
+	// http:// is permitted but production callers should reject it
+	// unless an explicit opt-in flag is set; the package itself
+	// allows http to support dev IdPs (Keycloak on localhost) but
+	// emits no production guarantees over plaintext.
+	IssuerURL string
+
+	// ClientID is the OIDC client identifier registered with the IdP.
+	ClientID string
+
+	// ClientSecret is the OIDC client secret. Required for the
+	// "confidential client" pattern; may be empty when UsePKCE is
+	// true and the client is registered as public.
+	ClientSecret string
+
+	// RedirectURL is the absolute callback URL osctrl-api advertises
+	// to the IdP. Must match exactly what's registered IdP-side; any
+	// drift causes the IdP to reject the authorize request.
+	//
+	// Must be https in production. The package permits http for the
+	// same reason as IssuerURL (dev IdPs) but callers are expected
+	// to enforce https for non-dev configs.
+	RedirectURL string
+
+	// Scopes are passed verbatim to the authorize endpoint. If empty,
+	// the provider injects ["openid", "profile", "email"]. If non-empty
+	// without "openid", "openid" is prepended.
+	Scopes []string
+
+	// UsernameClaim is the OIDC claim used as the AdminUser.Username.
+	// Values: "preferred_username" (default), "email", "sub". An
+	// invalid value falls back to "sub" (always available, always
+	// stable, but unfriendly to humans).
+	UsernameClaim string
+
+	// GroupsClaim is the OIDC claim consulted for group membership.
+	// Default: "groups". Used only when RequiredGroups is non-empty.
+	GroupsClaim string
+
+	// RequiredGroups, if non-empty, gates HandleCallback so only users
+	// whose group claim contains at least one of these strings can
+	// authenticate. Empty list disables the gate entirely.
+	RequiredGroups []string
+
+	// JITProvision controls whether HandleCallback's downstream
+	// caller (cmd/api/handlers/auth_callback.go) should auto-create a
+	// new AdminUser on first login. The package itself never creates
+	// users; this field is plumbed through ResolvedIdentity-adjacent
+	// caller logic.
+	//
+	// We expose this on Config rather than on the resolved-identity
+	// path so per-env policy can vary: some envs JIT, others don't.
+	JITProvision bool
+
+	// UsePKCE enables PKCE (RFC 7636) on the authorize + token
+	// requests. Recommended for any deployment; mandatory for public
+	// clients (those without a client secret).
+	UsePKCE bool
+
+	// LegacyPermissiveUsername disables the strict character-class
+	// validation on the resolved username, passing the IdP-supplied
+	// value (after TrimSpace) directly into ResolvedIdentity.
+	// PreferredUsername.
+	//
+	// New callers MUST leave this false — strict validation is the
+	// safe default and prevents audit-log poisoning (T26) and
+	// injection-shaped usernames (T23) from reaching downstream
+	// code.
+	//
+	// This flag exists ONLY to preserve backwards compatibility with
+	// legacy osctrl-admin deployments where operators may have
+	// pre-existing AdminUser rows whose usernames contain `.`, `@`,
+	// or spaces (typical when an IdP emits `preferred_username` as
+	// an email). Setting this true bypasses the regex but leaves
+	// every other verification step intact (signature, iss, aud,
+	// exp, nonce, groups).
+	//
+	// cmd/admin/oidc.go sets this true. cmd/api/handlers/oidc.go
+	// MUST leave it false.
+	LegacyPermissiveUsername bool
+}
+
+// Validate is called by NewOIDCProvider; callers may invoke it
+// independently when persisting a Config to verify shape before write.
+// Returns the first error encountered; full validation requires fixing
+// each error and re-running.
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.IssuerURL) == "" {
+		return errors.New("oidc.Config: IssuerURL is required")
+	}
+	u, err := url.Parse(c.IssuerURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("oidc.Config: IssuerURL must be a valid http(s) URL: %q", c.IssuerURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("oidc.Config: IssuerURL has no host: %q", c.IssuerURL)
+	}
+	if strings.TrimSpace(c.ClientID) == "" {
+		return errors.New("oidc.Config: ClientID is required")
+	}
+	if strings.TrimSpace(c.ClientSecret) == "" && !c.UsePKCE {
+		return errors.New("oidc.Config: ClientSecret is required when UsePKCE is false")
+	}
+	if strings.TrimSpace(c.RedirectURL) == "" {
+		return errors.New("oidc.Config: RedirectURL is required")
+	}
+	ru, err := url.Parse(c.RedirectURL)
+	if err != nil || (ru.Scheme != "http" && ru.Scheme != "https") {
+		return fmt.Errorf("oidc.Config: RedirectURL must be a valid http(s) URL: %q", c.RedirectURL)
+	}
+	if ru.Host == "" {
+		return fmt.Errorf("oidc.Config: RedirectURL has no host: %q", c.RedirectURL)
+	}
+	return nil
+}
+
+// effectiveScopes returns the Scopes slice with "openid" guaranteed
+// present at the front. Returns the default OIDC scope set when the
+// caller supplied none.
+func (c Config) effectiveScopes() []string {
+	if len(c.Scopes) == 0 {
+		return []string{"openid", "profile", "email"}
+	}
+	for _, s := range c.Scopes {
+		if s == "openid" {
+			return c.Scopes
+		}
+	}
+	out := make([]string, 0, len(c.Scopes)+1)
+	out = append(out, "openid")
+	out = append(out, c.Scopes...)
+	return out
+}
+
+// effectiveUsernameClaim returns UsernameClaim if set and recognized,
+// else DefaultUsernameClaim. The provider's pickUsername function
+// handles unknown values gracefully (falls back to sub), but having
+// the default-normalization in one place keeps tests honest.
+func (c Config) effectiveUsernameClaim() string {
+	claim := strings.ToLower(strings.TrimSpace(c.UsernameClaim))
+	if claim == "" {
+		return DefaultUsernameClaim
+	}
+	return claim
+}
+
+// effectiveGroupsClaim returns GroupsClaim if set, else
+// DefaultGroupsClaim.
+func (c Config) effectiveGroupsClaim() string {
+	claim := strings.TrimSpace(c.GroupsClaim)
+	if claim == "" {
+		return DefaultGroupsClaim
+	}
+	return claim
+}

--- a/pkg/auth/oidc/config_test.go
+++ b/pkg/auth/oidc/config_test.go
@@ -1,0 +1,144 @@
+package oidc
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestConfigValidate covers all the error paths. Each case is a
+// minimal mutation of a known-good config so the test failure points
+// to exactly one field.
+func TestConfigValidate(t *testing.T) {
+	good := Config{
+		IssuerURL:    "https://idp.example/realms/x",
+		ClientID:     "osctrl-api",
+		ClientSecret: "shhh",
+		RedirectURL:  "https://api.example/oidc/cb",
+	}
+
+	cases := []struct {
+		name      string
+		mutate    func(c *Config)
+		wantError string // substring of the error message
+	}{
+		{"happy", func(c *Config) {}, ""},
+		{"empty issuer", func(c *Config) { c.IssuerURL = "" }, "IssuerURL"},
+		{"whitespace issuer", func(c *Config) { c.IssuerURL = "   " }, "IssuerURL"},
+		{"non-http issuer", func(c *Config) { c.IssuerURL = "ftp://x" }, "http(s)"},
+		{"issuer no host", func(c *Config) { c.IssuerURL = "https://" }, "no host"},
+		{"empty client id", func(c *Config) { c.ClientID = "" }, "ClientID"},
+		{"empty secret no pkce", func(c *Config) { c.ClientSecret = "" }, "ClientSecret"},
+		{"empty secret with pkce", func(c *Config) { c.ClientSecret = ""; c.UsePKCE = true }, ""},
+		{"empty redirect", func(c *Config) { c.RedirectURL = "" }, "RedirectURL"},
+		{"non-http redirect", func(c *Config) { c.RedirectURL = "javascript:alert(1)" }, "http(s)"},
+		{"redirect no host", func(c *Config) { c.RedirectURL = "https://" }, "no host"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := good
+			tc.mutate(&c)
+			err := c.Validate()
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantError)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantError)
+			}
+		})
+	}
+}
+
+// TestEffectiveScopes locks the scope-normalization behavior:
+// - empty → injects default set
+// - non-empty without openid → prepends openid
+// - non-empty with openid → returns as-is
+func TestEffectiveScopes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{"empty defaults", nil, []string{"openid", "profile", "email"}},
+		{"empty slice defaults", []string{}, []string{"openid", "profile", "email"}},
+		{"missing openid prepended", []string{"profile", "groups"}, []string{"openid", "profile", "groups"}},
+		{"openid already first", []string{"openid", "email"}, []string{"openid", "email"}},
+		{"openid middle", []string{"profile", "openid", "email"}, []string{"profile", "openid", "email"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{Scopes: tc.input}
+			got := c.effectiveScopes()
+			if !equalStrings(got, tc.want) {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveUsernameClaim locks the claim-fallback policy.
+func TestEffectiveUsernameClaim(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", DefaultUsernameClaim},
+		{"  ", DefaultUsernameClaim},
+		{"preferred_username", "preferred_username"},
+		{"email", "email"},
+		{"sub", "sub"},
+		// Case-folded
+		{"EMAIL", "email"},
+		{" Sub  ", "sub"},
+		// Unknown — passed through verbatim (pickUsername handles the
+		// fallback at use-time).
+		{"weird_claim", "weird_claim"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := Config{UsernameClaim: tc.input}.effectiveUsernameClaim()
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveGroupsClaim — symmetric for the groups claim.
+func TestEffectiveGroupsClaim(t *testing.T) {
+	cases := []struct {
+		input, want string
+	}{
+		{"", DefaultGroupsClaim},
+		{"  ", DefaultGroupsClaim},
+		{"groups", "groups"},
+		{"roles", "roles"},
+		{"my-custom-claim", "my-custom-claim"},
+	}
+	for _, tc := range cases {
+		got := Config{GroupsClaim: tc.input}.effectiveGroupsClaim()
+		if got != tc.want {
+			t.Errorf("input %q: got %q want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, x := range a {
+		if x != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/auth/oidc/provider.go
+++ b/pkg/auth/oidc/provider.go
@@ -1,0 +1,335 @@
+package oidc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+
+	"github.com/jmpsec/osctrl/pkg/auth"
+)
+
+// httpExchangeTimeout caps how long the token endpoint exchange and
+// id_token verification can take. Independent of any request-level
+// context the caller passes — this is an upper bound applied
+// regardless, to prevent a slow/malicious IdP from holding a
+// connection open indefinitely.
+const httpExchangeTimeout = 30 * time.Second
+
+// Errors returned by HandleCallback. Callers map these to HTTP status
+// codes. The strings are stable across versions; logging may use
+// them, but client-facing responses should be a single generic
+// "authentication failed" message (timing-oracle defense, threat T31).
+var (
+	// ErrStateMismatch covers any mismatch between the State the
+	// caller transported (cookie) and the parameters the IdP
+	// returned (query). Covers env mismatch (T18), state-param
+	// mismatch (T6), nonce mismatch (T1 adjacent).
+	ErrStateMismatch = errors.New("oidc: state mismatch")
+
+	// ErrIdPError is returned when the IdP itself signaled an
+	// error via the OAuth2 `error` query parameter on the
+	// callback. Common values: access_denied, login_required.
+	ErrIdPError = errors.New("oidc: identity provider returned error")
+
+	// ErrTokenExchange wraps any failure during the
+	// code-for-token exchange (network, IdP rejection, etc.).
+	ErrTokenExchange = errors.New("oidc: token exchange failed")
+
+	// ErrIDTokenVerify wraps verification failures (bad sig,
+	// wrong iss/aud, expired, etc.). Threats T1–T5.
+	ErrIDTokenVerify = errors.New("oidc: id_token verification failed")
+
+	// ErrNonceMismatch is the specific id_token-vs-state nonce
+	// failure (threat T1 narrow case). Distinguishable in logs;
+	// callers still map to the same generic client response.
+	ErrNonceMismatch = errors.New("oidc: nonce mismatch")
+
+	// ErrGroupNotAllowed surfaces RequiredGroups-gate denials.
+	// Threat T17.
+	ErrGroupNotAllowed = errors.New("oidc: user not in required group")
+
+	// ErrUsernameInvalid is returned when the resolved username
+	// contains characters that violate sanitizeUsername. Threat
+	// T23 + audit-log poisoning T26.
+	ErrUsernameInvalid = errors.New("oidc: username failed character validation")
+
+	// ErrMissingCode catches the OAuth2 callback edge case where
+	// `code` is absent (some IdPs do this when the user
+	// cancels). Distinct so the handler logs cleanly.
+	ErrMissingCode = errors.New("oidc: authorization code missing from callback")
+)
+
+// Provider is the concrete OIDC implementation of auth.Provider.
+// Constructed once at startup (or once per env, when loaded from DB)
+// and reused across requests. Safe for concurrent use.
+type Provider struct {
+	cfg      Config
+	provider *gooidc.Provider
+	verifier *gooidc.IDTokenVerifier
+	oauth2   *oauth2.Config
+}
+
+// Compile-time check that Provider implements auth.Provider.
+var _ auth.Provider = (*Provider)(nil)
+
+// NewOIDCProvider constructs a Provider from the given Config. The
+// context is used for OIDC discovery (fetching the IdP's metadata
+// document and JWKS); pass a context with a deadline so a hung IdP
+// during init doesn't wedge startup.
+//
+// Returns a non-nil error and a nil Provider on:
+//   - Config validation failure
+//   - OIDC discovery failure (IdP unreachable, malformed metadata,
+//     etc.)
+//
+// The returned Provider's verifier pins the audience to cfg.ClientID
+// — id_tokens issued for a different audience will fail verification
+// (threat T3).
+func NewOIDCProvider(ctx context.Context, cfg Config) (*Provider, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	prov, err := gooidc.NewProvider(ctx, cfg.IssuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: discovery failed for %s: %w", cfg.IssuerURL, err)
+	}
+	return &Provider{
+		cfg:      cfg,
+		provider: prov,
+		verifier: prov.Verifier(&gooidc.Config{ClientID: cfg.ClientID}),
+		oauth2: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			Endpoint:     prov.Endpoint(),
+			RedirectURL:  cfg.RedirectURL,
+			Scopes:       cfg.effectiveScopes(),
+		},
+	}, nil
+}
+
+// Type identifies this provider as OIDC.
+func (p *Provider) Type() string { return auth.TypeOIDC }
+
+// LoginURL builds the authorize-endpoint URL that the user's browser
+// should be redirected to. The state argument carries the nonce and
+// (optionally) PKCE verifier that HandleCallback will validate
+// against the IdP's response.
+//
+// The state string parameter to the authorize endpoint is set to
+// the EnvUUID concatenated with the Nonce, so the IdP's verbatim
+// echo on callback gives the handler a hint about which env to
+// resolve the provider for. The handler still verifies the cookie's
+// State.EnvUUID separately as the authoritative source.
+func (p *Provider) LoginURL(ctx context.Context, state auth.State) (string, error) {
+	if state.EnvUUID == "" {
+		return "", fmt.Errorf("oidc: LoginURL: empty State.EnvUUID")
+	}
+	if state.Nonce == "" {
+		return "", fmt.Errorf("oidc: LoginURL: empty State.Nonce")
+	}
+	// We pass State.Nonce to the IdP via the OIDC nonce parameter
+	// (NOT the OAuth2 state parameter). The OAuth2 state parameter
+	// is the EnvUUID — verified against the cookie's EnvUUID on
+	// return. Two reasons for this split:
+	//
+	//   - The OIDC nonce is what go-oidc.Verifier checks against
+	//     the id_token's nonce claim. That's the protocol's
+	//     replay-defense layer.
+	//   - The OAuth2 state parameter is what we receive verbatim
+	//     in the callback URL. Tying it to EnvUUID lets us
+	//     short-circuit cross-env replay (threat T18) even if the
+	//     cookie is somehow forwarded.
+	opts := []oauth2.AuthCodeOption{gooidc.Nonce(state.Nonce)}
+	if p.cfg.UsePKCE {
+		if state.Verifier == "" {
+			return "", fmt.Errorf("oidc: LoginURL: PKCE enabled but State.Verifier is empty")
+		}
+		opts = append(opts, oauth2.S256ChallengeOption(state.Verifier))
+	}
+	return p.oauth2.AuthCodeURL(state.EnvUUID, opts...), nil
+}
+
+// HandleCallback consumes the callback request and returns a
+// ResolvedIdentity. Validates, in order:
+//
+//  1. r.URL contains no `error` parameter (ErrIdPError)
+//  2. `state` query param matches state.EnvUUID (ErrStateMismatch — T18)
+//  3. `code` query param non-empty (ErrMissingCode)
+//  4. If PKCE enabled, state.Verifier non-empty (T10 defense in depth;
+//     LoginURL already enforces it)
+//  5. Code-for-token exchange succeeds (ErrTokenExchange)
+//  6. id_token present on token response (ErrIDTokenVerify)
+//  7. id_token signature + iss + aud + exp + nbf all valid via
+//     go-oidc.Verifier.Verify (ErrIDTokenVerify; covers T1-T5)
+//  8. id_token nonce matches state.Nonce (ErrNonceMismatch)
+//  9. Required-groups gate satisfied if configured (ErrGroupNotAllowed — T17)
+// 10. Resolved username passes sanitizeUsername (ErrUsernameInvalid — T23)
+//
+// Implementations of HandleCallback MUST NOT trust the caller to
+// pre-verify any of the above. This is the security perimeter.
+func (p *Provider) HandleCallback(parentCtx context.Context, r *http.Request, state auth.State) (auth.ResolvedIdentity, error) {
+	ctx, cancel := context.WithTimeout(parentCtx, httpExchangeTimeout)
+	defer cancel()
+
+	// (1) IdP-signaled error.
+	if e := r.URL.Query().Get("error"); e != "" {
+		// Note: we deliberately do NOT include the description
+		// in the returned error — it can come from the IdP
+		// without sanitization and might contain control chars
+		// (audit-log poisoning T26). The structured log captures
+		// it server-side.
+		return auth.ResolvedIdentity{}, fmt.Errorf("%w: %s", ErrIdPError, e)
+	}
+
+	// (2) State parameter must echo the EnvUUID.
+	if got := r.URL.Query().Get("state"); got != state.EnvUUID {
+		return auth.ResolvedIdentity{}, ErrStateMismatch
+	}
+
+	// (3) Code must be present.
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		return auth.ResolvedIdentity{}, ErrMissingCode
+	}
+
+	// (4) PKCE sanity (LoginURL already enforced this; defense in
+	// depth because state cookie tampering or alternate LoginURL
+	// implementations could theoretically violate the invariant).
+	if p.cfg.UsePKCE && state.Verifier == "" {
+		return auth.ResolvedIdentity{}, fmt.Errorf("%w: pkce verifier missing", ErrStateMismatch)
+	}
+
+	// (5) Code-for-token exchange.
+	var exchOpts []oauth2.AuthCodeOption
+	if state.Verifier != "" {
+		exchOpts = append(exchOpts, oauth2.VerifierOption(state.Verifier))
+	}
+	tok, err := p.oauth2.Exchange(ctx, code, exchOpts...)
+	if err != nil {
+		// Wrap, don't merge — callers may want to log err
+		// server-side without exposing it to clients.
+		return auth.ResolvedIdentity{}, fmt.Errorf("%w: %v", ErrTokenExchange, err)
+	}
+
+	// (6) id_token present.
+	rawIDToken, ok := tok.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		return auth.ResolvedIdentity{}, fmt.Errorf("%w: id_token missing from token response", ErrIDTokenVerify)
+	}
+
+	// (7) Verify signature + iss + aud + exp + nbf.
+	idToken, err := p.verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return auth.ResolvedIdentity{}, fmt.Errorf("%w: %v", ErrIDTokenVerify, err)
+	}
+
+	// (8) Nonce match.
+	if idToken.Nonce != state.Nonce {
+		return auth.ResolvedIdentity{}, ErrNonceMismatch
+	}
+
+	// Decode the claims we care about.
+	var claims idTokenClaims
+	if err := idToken.Claims(&claims); err != nil {
+		return auth.ResolvedIdentity{}, fmt.Errorf("%w: claims decode: %v", ErrIDTokenVerify, err)
+	}
+
+	// (9) Required-groups gate.
+	if len(p.cfg.RequiredGroups) > 0 {
+		if !hasRequiredGroup(idToken, p.cfg.effectiveGroupsClaim(), p.cfg.RequiredGroups) {
+			return auth.ResolvedIdentity{}, ErrGroupNotAllowed
+		}
+	}
+
+	// Resolve preferred username from configured claim.
+	username := pickUsername(claims, p.cfg.effectiveUsernameClaim())
+	if username == "" {
+		// Should be impossible after a successful verify (sub is
+		// always present), but belt and braces.
+		return auth.ResolvedIdentity{}, ErrUsernameInvalid
+	}
+
+	// (10) Character-class validation. ANY username that doesn't
+	// fit the safe shape is rejected with an opaque error — we
+	// never log or echo the bad value at INFO level.
+	//
+	// When Config.LegacyPermissiveUsername is true, the strict
+	// regex is bypassed and the trimmed claim is used as-is. Only
+	// the legacy admin shim sets this; new callers leave it false.
+	var clean string
+	if p.cfg.LegacyPermissiveUsername {
+		clean = strings.TrimSpace(username)
+		if clean == "" {
+			return auth.ResolvedIdentity{}, ErrUsernameInvalid
+		}
+	} else {
+		clean = sanitizeUsername(username)
+		if clean == "" {
+			// Log at DEBUG only; the unsanitized value never
+			// leaves the server.
+			return auth.ResolvedIdentity{}, ErrUsernameInvalid
+		}
+	}
+
+	// Compose display name if `name` claim absent.
+	fullname := strings.TrimSpace(claims.Name)
+	if fullname == "" {
+		fullname = strings.TrimSpace(claims.GivenName + " " + claims.FamilyName)
+	}
+
+	// Extract groups for the protocol-neutral output. Use the raw
+	// claims map so a malformed groups claim (object, string, etc.)
+	// doesn't crash the decode — hasRequiredGroup is responsible
+	// for shape rejection at the gate; here we just best-effort
+	// surface the groups for downstream use.
+	groups := decodeGroups(idToken, p.cfg.effectiveGroupsClaim())
+
+	// Raw claims for downstream debugging. The map is not
+	// authoritative — callers must read from the typed fields
+	// (Subject, PreferredUsername, etc.) to ensure validation has
+	// passed.
+	var raw map[string]any
+	if err := idToken.Claims(&raw); err != nil {
+		raw = nil // non-fatal, the typed claims are authoritative
+	}
+
+	return auth.ResolvedIdentity{
+		Subject:           claims.Subject,
+		PreferredUsername: clean,
+		Email:             claims.Email,
+		Name:              fullname,
+		Groups:            groups,
+		Raw:               raw,
+	}, nil
+}
+
+// decodeGroups extracts the groups claim into a []string if the
+// shape is the expected []string-of-names. Returns nil on any
+// shape mismatch — caller treats nil and empty-slice equivalently.
+func decodeGroups(idToken *gooidc.IDToken, claim string) []string {
+	var all map[string]any
+	if err := idToken.Claims(&all); err != nil {
+		return nil
+	}
+	raw, ok := all[claim]
+	if !ok {
+		return nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, g := range arr {
+		if s, ok := g.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/pkg/auth/oidc/provider.go
+++ b/pkg/auth/oidc/provider.go
@@ -28,8 +28,9 @@ const httpExchangeTimeout = 30 * time.Second
 var (
 	// ErrStateMismatch covers any mismatch between the State the
 	// caller transported (cookie) and the parameters the IdP
-	// returned (query). Covers env mismatch (T18), state-param
-	// mismatch (T6), nonce mismatch (T1 adjacent).
+	// returned (query). Specifically, the OAuth2 state-param check
+	// (T6, CSRF). The id_token nonce check has its own sentinel
+	// (ErrNonceMismatch).
 	ErrStateMismatch = errors.New("oidc: state mismatch")
 
 	// ErrIdPError is returned when the IdP itself signaled an
@@ -121,11 +122,22 @@ func (p *Provider) Type() string { return auth.TypeOIDC }
 // (optionally) PKCE verifier that HandleCallback will validate
 // against the IdP's response.
 //
-// The state string parameter to the authorize endpoint is set to
-// the EnvUUID concatenated with the Nonce, so the IdP's verbatim
-// echo on callback gives the handler a hint about which env to
-// resolve the provider for. The handler still verifies the cookie's
-// State.EnvUUID separately as the authoritative source.
+// The OAuth2 state parameter sent in the authorize URL is set to
+// state.Nonce (a 256-bit cryptorandom value), NOT to State.EnvUUID.
+// This is the load-bearing CSRF defense: an attacker cannot guess
+// the value, so they cannot craft a callback URL that the verifier
+// would accept. The OIDC nonce parameter (separate from OAuth2 state)
+// carries the same value into the id_token, where go-oidc.Verifier
+// checks it as the protocol's replay-defense layer. Same value
+// transported via two protocol parameters — both must match the
+// cookie's nonce for HandleCallback to succeed.
+//
+// State.EnvUUID is informational only at this layer: it must be
+// non-empty (so the state cookie has stable shape) but its value
+// isn't checked against anything in the callback URL. Callers that
+// want env-scoping above the protocol layer use the EnvUUID
+// out-of-band (legacy admin sets it to "admin"; cmd/api sets it to
+// "global" or similar; whatever the operator-side code wants).
 func (p *Provider) LoginURL(ctx context.Context, state auth.State) (string, error) {
 	if state.EnvUUID == "" {
 		return "", fmt.Errorf("oidc: LoginURL: empty State.EnvUUID")
@@ -133,18 +145,6 @@ func (p *Provider) LoginURL(ctx context.Context, state auth.State) (string, erro
 	if state.Nonce == "" {
 		return "", fmt.Errorf("oidc: LoginURL: empty State.Nonce")
 	}
-	// We pass State.Nonce to the IdP via the OIDC nonce parameter
-	// (NOT the OAuth2 state parameter). The OAuth2 state parameter
-	// is the EnvUUID — verified against the cookie's EnvUUID on
-	// return. Two reasons for this split:
-	//
-	//   - The OIDC nonce is what go-oidc.Verifier checks against
-	//     the id_token's nonce claim. That's the protocol's
-	//     replay-defense layer.
-	//   - The OAuth2 state parameter is what we receive verbatim
-	//     in the callback URL. Tying it to EnvUUID lets us
-	//     short-circuit cross-env replay (threat T18) even if the
-	//     cookie is somehow forwarded.
 	opts := []oauth2.AuthCodeOption{gooidc.Nonce(state.Nonce)}
 	if p.cfg.UsePKCE {
 		if state.Verifier == "" {
@@ -152,14 +152,14 @@ func (p *Provider) LoginURL(ctx context.Context, state auth.State) (string, erro
 		}
 		opts = append(opts, oauth2.S256ChallengeOption(state.Verifier))
 	}
-	return p.oauth2.AuthCodeURL(state.EnvUUID, opts...), nil
+	return p.oauth2.AuthCodeURL(state.Nonce, opts...), nil
 }
 
 // HandleCallback consumes the callback request and returns a
 // ResolvedIdentity. Validates, in order:
 //
 //  1. r.URL contains no `error` parameter (ErrIdPError)
-//  2. `state` query param matches state.EnvUUID (ErrStateMismatch — T18)
+//  2. `state` query param matches state.Nonce (ErrStateMismatch — T6, CSRF)
 //  3. `code` query param non-empty (ErrMissingCode)
 //  4. If PKCE enabled, state.Verifier non-empty (T10 defense in depth;
 //     LoginURL already enforces it)
@@ -167,7 +167,7 @@ func (p *Provider) LoginURL(ctx context.Context, state auth.State) (string, erro
 //  6. id_token present on token response (ErrIDTokenVerify)
 //  7. id_token signature + iss + aud + exp + nbf all valid via
 //     go-oidc.Verifier.Verify (ErrIDTokenVerify; covers T1-T5)
-//  8. id_token nonce matches state.Nonce (ErrNonceMismatch)
+//  8. id_token nonce matches state.Nonce (ErrNonceMismatch — T1 narrow)
 //  9. Required-groups gate satisfied if configured (ErrGroupNotAllowed — T17)
 // 10. Resolved username passes sanitizeUsername (ErrUsernameInvalid — T23)
 //
@@ -187,8 +187,11 @@ func (p *Provider) HandleCallback(parentCtx context.Context, r *http.Request, st
 		return auth.ResolvedIdentity{}, fmt.Errorf("%w: %s", ErrIdPError, e)
 	}
 
-	// (2) State parameter must echo the EnvUUID.
-	if got := r.URL.Query().Get("state"); got != state.EnvUUID {
+	// (2) State parameter must echo the cookie's Nonce. This is the
+	// load-bearing CSRF check: an unguessable 256-bit value tied to
+	// the browser via a signed cookie. Only a browser that received
+	// our IssueStateCookie response can satisfy it.
+	if got := r.URL.Query().Get("state"); got != state.Nonce {
 		return auth.ResolvedIdentity{}, ErrStateMismatch
 	}
 

--- a/pkg/auth/oidc/provider.go
+++ b/pkg/auth/oidc/provider.go
@@ -242,6 +242,14 @@ func (p *Provider) HandleCallback(parentCtx context.Context, r *http.Request, st
 	if err := idToken.Claims(&claims); err != nil {
 		return auth.ResolvedIdentity{}, fmt.Errorf("%w: claims decode: %v", ErrIDTokenVerify, err)
 	}
+	// Also decode into a generic map so pickUsername can look up
+	// custom claim names like "nickname" (Auth0) or "upn" (Entra)
+	// that aren't on idTokenClaims. Non-fatal: an empty raw map
+	// simply means pickUsername falls back to the typed fields.
+	var raw map[string]any
+	if err := idToken.Claims(&raw); err != nil {
+		raw = nil
+	}
 
 	// (9) Required-groups gate.
 	if len(p.cfg.RequiredGroups) > 0 {
@@ -251,7 +259,7 @@ func (p *Provider) HandleCallback(parentCtx context.Context, r *http.Request, st
 	}
 
 	// Resolve preferred username from configured claim.
-	username := pickUsername(claims, p.cfg.effectiveUsernameClaim())
+	username := pickUsername(claims, raw, p.cfg.effectiveUsernameClaim())
 	if username == "" {
 		// Should be impossible after a successful verify (sub is
 		// always present), but belt and braces.
@@ -293,15 +301,10 @@ func (p *Provider) HandleCallback(parentCtx context.Context, r *http.Request, st
 	// surface the groups for downstream use.
 	groups := decodeGroups(idToken, p.cfg.effectiveGroupsClaim())
 
-	// Raw claims for downstream debugging. The map is not
-	// authoritative — callers must read from the typed fields
-	// (Subject, PreferredUsername, etc.) to ensure validation has
-	// passed.
-	var raw map[string]any
-	if err := idToken.Claims(&raw); err != nil {
-		raw = nil // non-fatal, the typed claims are authoritative
-	}
-
+	// raw was already decoded above for pickUsername; reuse it as
+	// the ResolvedIdentity's debugging map. Callers must read from
+	// the typed fields (Subject, PreferredUsername, etc.) to ensure
+	// validation has passed.
 	return auth.ResolvedIdentity{
 		Subject:           claims.Subject,
 		PreferredUsername: clean,

--- a/pkg/auth/oidc/provider_test.go
+++ b/pkg/auth/oidc/provider_test.go
@@ -195,11 +195,12 @@ func goodState() auth.State {
 }
 
 // fakeCallback constructs the *http.Request that HandleCallback
-// receives. The state query param echoes the cookie's EnvUUID, the
-// code param matches what the IdP expects.
-func fakeCallback(envUUID, code string) *http.Request {
+// receives. The state query param echoes the cookie's Nonce (the
+// load-bearing CSRF defense; see Provider.LoginURL). The code param
+// matches what the IdP expects.
+func fakeCallback(stateParam, code string) *http.Request {
 	q := url.Values{}
-	q.Set("state", envUUID)
+	q.Set("state", stateParam)
 	q.Set("code", code)
 	req := httptest.NewRequest(http.MethodGet, "/cb?"+q.Encode(), nil)
 	return req
@@ -217,7 +218,7 @@ func TestHandleCallbackHappy(t *testing.T) {
 	}
 
 	state := goodState()
-	identity, err := p.HandleCallback(context.Background(), fakeCallback(state.EnvUUID, "code-happy"), state)
+	identity, err := p.HandleCallback(context.Background(), fakeCallback(state.Nonce, "code-happy"), state)
 	if err != nil {
 		t.Fatalf("HandleCallback: %v", err)
 	}
@@ -248,7 +249,7 @@ func TestT1ForgedSignature(t *testing.T) {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
 
-	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-forged"), goodState())
+	_, err = p.HandleCallback(context.Background(), fakeCallback("n-default", "code-forged"), goodState())
 	if !errors.Is(err, ErrIDTokenVerify) {
 		t.Fatalf("expected ErrIDTokenVerify, got %v", err)
 	}
@@ -269,7 +270,7 @@ func TestT2WrongIssuer(t *testing.T) {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
 
-	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-iss"), goodState())
+	_, err = p.HandleCallback(context.Background(), fakeCallback("n-default", "code-iss"), goodState())
 	if !errors.Is(err, ErrIDTokenVerify) {
 		t.Fatalf("expected ErrIDTokenVerify, got %v", err)
 	}
@@ -290,7 +291,7 @@ func TestT3WrongAudience(t *testing.T) {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
 
-	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-aud"), goodState())
+	_, err = p.HandleCallback(context.Background(), fakeCallback("n-default", "code-aud"), goodState())
 	if !errors.Is(err, ErrIDTokenVerify) {
 		t.Fatalf("expected ErrIDTokenVerify, got %v", err)
 	}
@@ -311,7 +312,7 @@ func TestT4Expired(t *testing.T) {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
 
-	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-exp"), goodState())
+	_, err = p.HandleCallback(context.Background(), fakeCallback("n-default", "code-exp"), goodState())
 	if !errors.Is(err, ErrIDTokenVerify) {
 		t.Fatalf("expected ErrIDTokenVerify, got %v", err)
 	}
@@ -332,26 +333,32 @@ func TestNonceMismatch(t *testing.T) {
 	state := goodState()
 	state.Nonce = "n-different"
 
-	_, err = p.HandleCallback(context.Background(), fakeCallback(state.EnvUUID, "code-nonce"), state)
+	_, err = p.HandleCallback(context.Background(), fakeCallback(state.Nonce, "code-nonce"), state)
 	if !errors.Is(err, ErrNonceMismatch) {
 		t.Fatalf("expected ErrNonceMismatch, got %v", err)
 	}
 }
 
-// === Threat T18: state mismatch (env replay) ===
+// === Threat T6: CSRF / state-param tampering ===
 //
-// State cookie says env A; callback URL's state parameter says env B.
+// State cookie carries Nonce "n-default" (set by IssueStateCookie at
+// /login). The attacker crafts a callback URL with a forged state
+// parameter. Because the value is unguessable (256-bit cryptorandom),
+// the attacker cannot produce a callback URL the verifier accepts.
+// HandleCallback rejects with ErrStateMismatch BEFORE any token-
+// exchange happens.
 
-func TestT18StateEnvMismatch(t *testing.T) {
+func TestT6CSRFStateTampering(t *testing.T) {
 	idp := newFakeIdP(t)
-	idp.nextCode = "code-env"
+	idp.nextCode = "code-csrf"
 	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
 	if err != nil {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
 	stateInCookie := auth.State{EnvUUID: "env-A", Nonce: "n-default"}
-	// URL state param echoes env-B
-	req := fakeCallback("env-B", "code-env")
+	// Attacker-controlled URL: state param is anything except the
+	// nonce baked into the victim's cookie.
+	req := fakeCallback("attacker-supplied-state", "code-csrf")
 	_, err = p.HandleCallback(context.Background(), req, stateInCookie)
 	if !errors.Is(err, ErrStateMismatch) {
 		t.Fatalf("expected ErrStateMismatch, got %v", err)
@@ -391,8 +398,11 @@ func TestMissingCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
+	// State param matches the cookie's Nonce so we reach the
+	// missing-code check (step 3) rather than failing at the
+	// state-param check (step 2).
 	q := url.Values{}
-	q.Set("state", "env-uuid-1234")
+	q.Set("state", "n-default")
 	// no code
 	req := httptest.NewRequest(http.MethodGet, "/cb?"+q.Encode(), nil)
 	_, err = p.HandleCallback(context.Background(), req, goodState())
@@ -415,7 +425,7 @@ func TestT10PKCEVerifierMissing(t *testing.T) {
 	}
 	// State has EnvUUID + Nonce but NO Verifier.
 	state := auth.State{EnvUUID: "env-uuid-1234", Nonce: "n-default"}
-	_, err = p.HandleCallback(context.Background(), fakeCallback(state.EnvUUID, "code-pkce"), state)
+	_, err = p.HandleCallback(context.Background(), fakeCallback(state.Nonce, "code-pkce"), state)
 	if !errors.Is(err, ErrStateMismatch) {
 		t.Fatalf("expected ErrStateMismatch (pkce verifier missing), got %v", err)
 	}
@@ -434,7 +444,7 @@ func TestT17RequiredGroupMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
-	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-group"), goodState())
+	_, err = p.HandleCallback(context.Background(), fakeCallback("n-default", "code-group"), goodState())
 	if !errors.Is(err, ErrGroupNotAllowed) {
 		t.Fatalf("expected ErrGroupNotAllowed, got %v", err)
 	}
@@ -452,7 +462,7 @@ func TestRequiredGroupSatisfied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
-	identity, err := p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-group-ok"), goodState())
+	identity, err := p.HandleCallback(context.Background(), fakeCallback("n-default", "code-group-ok"), goodState())
 	if err != nil {
 		t.Fatalf("HandleCallback: %v", err)
 	}
@@ -476,7 +486,7 @@ func TestT17GroupsClaimMalformed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
-	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-group-bad"), goodState())
+	_, err = p.HandleCallback(context.Background(), fakeCallback("n-default", "code-group-bad"), goodState())
 	if !errors.Is(err, ErrGroupNotAllowed) {
 		t.Fatalf("expected ErrGroupNotAllowed for malformed group claim, got %v", err)
 	}
@@ -512,7 +522,7 @@ func TestLegacyPermissiveUsernameAccepts(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewOIDCProvider: %v", err)
 			}
-			identity, err := p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-perm"), goodState())
+			identity, err := p.HandleCallback(context.Background(), fakeCallback("n-default", "code-perm"), goodState())
 			if err != nil {
 				t.Fatalf("LegacyPermissiveUsername should accept %q, got %v", u, err)
 			}
@@ -540,7 +550,7 @@ func TestLegacyPermissiveUsernameRejectsEmpty(t *testing.T) {
 	}
 	// With preferred_username = "   ", pickUsername returns "   ",
 	// which TrimSpace reduces to "" — must be rejected.
-	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-empty"), goodState())
+	_, err = p.HandleCallback(context.Background(), fakeCallback("n-default", "code-empty"), goodState())
 	if !errors.Is(err, ErrUsernameInvalid) {
 		t.Fatalf("expected ErrUsernameInvalid on whitespace-only username, got %v", err)
 	}
@@ -570,7 +580,7 @@ func TestT23UsernameInjection(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewOIDCProvider: %v", err)
 			}
-			_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-inj"), goodState())
+			_, err = p.HandleCallback(context.Background(), fakeCallback("n-default", "code-inj"), goodState())
 			if !errors.Is(err, ErrUsernameInvalid) {
 				t.Fatalf("expected ErrUsernameInvalid for %q, got %v", badUsername, err)
 			}
@@ -619,8 +629,14 @@ func TestLoginURLValidatesState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoginURL: %v", err)
 	}
-	if !strings.Contains(url, "state=env-A") {
-		t.Errorf("LoginURL should embed env in state param: %s", url)
+	// The OAuth2 state parameter must carry the Nonce (not the
+	// EnvUUID). This is what HandleCallback validates on return,
+	// and what makes the CSRF defense load-bearing.
+	if !strings.Contains(url, "state=n-1") {
+		t.Errorf("LoginURL should embed Nonce in state param: %s", url)
+	}
+	if strings.Contains(url, "state=env-A") {
+		t.Errorf("LoginURL must NOT use EnvUUID as the OAuth2 state param: %s", url)
 	}
 	if !strings.Contains(url, "nonce=n-1") {
 		t.Errorf("LoginURL should embed nonce: %s", url)

--- a/pkg/auth/oidc/provider_test.go
+++ b/pkg/auth/oidc/provider_test.go
@@ -1,0 +1,675 @@
+package oidc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/jmpsec/osctrl/pkg/auth"
+)
+
+// fakeIdP runs a minimal OIDC issuer in-process. Implements the bare
+// surface go-oidc and oauth2 consume:
+//
+//   - /.well-known/openid-configuration  (discovery)
+//   - /jwks                              (signing keys)
+//   - /token                             (code-for-token exchange)
+//
+// The authorize endpoint is not implemented because Provider.LoginURL
+// only emits the URL; tests do not visit it. HandleCallback's only
+// network call is to /token.
+type fakeIdP struct {
+	srv      *httptest.Server
+	priv     *rsa.PrivateKey
+	keyID    string
+	nextCode string
+
+	// Knobs each test toggles before driving HandleCallback.
+	// nil/zero values mean "default behavior".
+	signWithDifferentKey   *rsa.PrivateKey // T1 — forged signature
+	issuerOverride         string          // T2 — wrong issuer
+	audienceOverride       string          // T3 — wrong audience
+	expOverride            *time.Time      // T4 — expired
+	nonceOverride          string          // injection of wrong nonce
+	preferredUsernameValue string          // test username variations
+	groupsValue            any             // groups claim shape (string[] / object / nil)
+	subjectOverride        string          // override sub claim
+}
+
+func newFakeIdP(t *testing.T) *fakeIdP {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa key: %v", err)
+	}
+	f := &fakeIdP{priv: priv, keyID: "test-key-1"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", f.handleDiscovery)
+	mux.HandleFunc("/jwks", f.handleJWKS)
+	mux.HandleFunc("/token", f.handleToken)
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+// IssuerURL returns the URL the test uses as Config.IssuerURL.
+func (f *fakeIdP) IssuerURL() string { return f.srv.URL }
+
+func (f *fakeIdP) handleDiscovery(w http.ResponseWriter, r *http.Request) {
+	doc := map[string]any{
+		"issuer":                                f.srv.URL,
+		"authorization_endpoint":                f.srv.URL + "/authorize",
+		"token_endpoint":                        f.srv.URL + "/token",
+		"jwks_uri":                              f.srv.URL + "/jwks",
+		"response_types_supported":              []string{"code"},
+		"subject_types_supported":               []string{"public"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// handleJWKS emits the RSA public key as a JWK array. go-oidc fetches
+// this once and caches it; the key id binds tokens to a specific key.
+func (f *fakeIdP) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	jwk := map[string]any{
+		"kty": "RSA",
+		"use": "sig",
+		"alg": "RS256",
+		"kid": f.keyID,
+		"n":   base64.RawURLEncoding.EncodeToString(f.priv.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(f.priv.E)).Bytes()),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{jwk}})
+}
+
+// handleToken implements the code-for-token exchange. Issues a fresh
+// id_token signed with the IdP's key (or a different key if the test
+// has flipped signWithDifferentKey, simulating an attacker-controlled
+// token). The id_token's claims reflect every override the test set.
+func (f *fakeIdP) handleToken(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+	code := r.Form.Get("code")
+	if code != f.nextCode {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+		return
+	}
+
+	iss := f.srv.URL
+	if f.issuerOverride != "" {
+		iss = f.issuerOverride
+	}
+	aud := "osctrl-api"
+	if f.audienceOverride != "" {
+		aud = f.audienceOverride
+	}
+	exp := time.Now().Add(5 * time.Minute)
+	if f.expOverride != nil {
+		exp = *f.expOverride
+	}
+	nonce := "n-default"
+	if f.nonceOverride != "" {
+		nonce = f.nonceOverride
+	}
+	sub := "sub-12345"
+	if f.subjectOverride != "" {
+		sub = f.subjectOverride
+	}
+	pref := "alice"
+	if f.preferredUsernameValue != "" {
+		pref = f.preferredUsernameValue
+	}
+
+	claims := jwt.MapClaims{
+		"iss":                iss,
+		"aud":                aud,
+		"sub":                sub,
+		"exp":                exp.Unix(),
+		"iat":                time.Now().Unix(),
+		"nonce":              nonce,
+		"preferred_username": pref,
+		"email":              "alice@example.local",
+		"name":               "Alice Tester",
+	}
+	if f.groupsValue != nil {
+		claims["groups"] = f.groupsValue
+	}
+
+	signer := f.priv
+	if f.signWithDifferentKey != nil {
+		signer = f.signWithDifferentKey
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = f.keyID
+	signed, err := tok.SignedString(signer)
+	if err != nil {
+		http.Error(w, `{"error":"server_error"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"access_token": "fake-access-token",
+		"id_token":     signed,
+		"token_type":   "Bearer",
+		"expires_in":   300,
+	})
+}
+
+// goodConfig returns a Config wired against the IdP, with the
+// audience matching what the IdP will emit (so the happy path works).
+func goodConfig(idp *fakeIdP) Config {
+	return Config{
+		IssuerURL:    idp.IssuerURL(),
+		ClientID:     "osctrl-api",
+		ClientSecret: "test-secret",
+		RedirectURL:  "https://api.example/cb",
+		Scopes:       []string{"openid", "profile", "email"},
+		UsePKCE:      false,
+	}
+}
+
+// goodState returns a State that lines up with the IdP's defaults.
+// EnvUUID + Nonce are what HandleCallback validates against; we use
+// "n-default" to match the IdP's default nonce claim.
+func goodState() auth.State {
+	return auth.State{
+		EnvUUID: "env-uuid-1234",
+		Nonce:   "n-default",
+	}
+}
+
+// fakeCallback constructs the *http.Request that HandleCallback
+// receives. The state query param echoes the cookie's EnvUUID, the
+// code param matches what the IdP expects.
+func fakeCallback(envUUID, code string) *http.Request {
+	q := url.Values{}
+	q.Set("state", envUUID)
+	q.Set("code", code)
+	req := httptest.NewRequest(http.MethodGet, "/cb?"+q.Encode(), nil)
+	return req
+}
+
+// === Happy path ===
+
+func TestHandleCallbackHappy(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-happy"
+
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+
+	state := goodState()
+	identity, err := p.HandleCallback(context.Background(), fakeCallback(state.EnvUUID, "code-happy"), state)
+	if err != nil {
+		t.Fatalf("HandleCallback: %v", err)
+	}
+	if identity.Subject != "sub-12345" {
+		t.Errorf("Subject: got %q want sub-12345", identity.Subject)
+	}
+	if identity.PreferredUsername != "alice" {
+		t.Errorf("PreferredUsername: got %q want alice", identity.PreferredUsername)
+	}
+	if identity.Email != "alice@example.local" {
+		t.Errorf("Email: got %q want alice@example.local", identity.Email)
+	}
+}
+
+// === Threat T1: forged signature ===
+//
+// The IdP signs with a different key. go-oidc fetches the legitimate
+// JWKS, so the signature verification fails.
+
+func TestT1ForgedSignature(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-forged"
+	attackerKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	idp.signWithDifferentKey = attackerKey
+
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+
+	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-forged"), goodState())
+	if !errors.Is(err, ErrIDTokenVerify) {
+		t.Fatalf("expected ErrIDTokenVerify, got %v", err)
+	}
+}
+
+// === Threat T2: wrong issuer ===
+//
+// The id_token claims a different issuer than the one go-oidc
+// expects (the URL it was constructed against).
+
+func TestT2WrongIssuer(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-iss"
+	idp.issuerOverride = "https://attacker.example/realms/evil"
+
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+
+	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-iss"), goodState())
+	if !errors.Is(err, ErrIDTokenVerify) {
+		t.Fatalf("expected ErrIDTokenVerify, got %v", err)
+	}
+}
+
+// === Threat T3: wrong audience ===
+//
+// Token issued for a different client. The verifier is configured
+// with ClientID == "osctrl-api"; this token says "some-other-client".
+
+func TestT3WrongAudience(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-aud"
+	idp.audienceOverride = "some-other-client"
+
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+
+	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-aud"), goodState())
+	if !errors.Is(err, ErrIDTokenVerify) {
+		t.Fatalf("expected ErrIDTokenVerify, got %v", err)
+	}
+}
+
+// === Threat T4: expired token ===
+//
+// IdP emits an id_token with exp in the past.
+
+func TestT4Expired(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-exp"
+	past := time.Now().Add(-1 * time.Hour)
+	idp.expOverride = &past
+
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+
+	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-exp"), goodState())
+	if !errors.Is(err, ErrIDTokenVerify) {
+		t.Fatalf("expected ErrIDTokenVerify, got %v", err)
+	}
+}
+
+// === Nonce mismatch (also covers T1 narrow case) ===
+
+func TestNonceMismatch(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-nonce"
+	// IdP emits "n-default" by default, but the state we pass to
+	// HandleCallback claims a different nonce.
+
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	state := goodState()
+	state.Nonce = "n-different"
+
+	_, err = p.HandleCallback(context.Background(), fakeCallback(state.EnvUUID, "code-nonce"), state)
+	if !errors.Is(err, ErrNonceMismatch) {
+		t.Fatalf("expected ErrNonceMismatch, got %v", err)
+	}
+}
+
+// === Threat T18: state mismatch (env replay) ===
+//
+// State cookie says env A; callback URL's state parameter says env B.
+
+func TestT18StateEnvMismatch(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-env"
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	stateInCookie := auth.State{EnvUUID: "env-A", Nonce: "n-default"}
+	// URL state param echoes env-B
+	req := fakeCallback("env-B", "code-env")
+	_, err = p.HandleCallback(context.Background(), req, stateInCookie)
+	if !errors.Is(err, ErrStateMismatch) {
+		t.Fatalf("expected ErrStateMismatch, got %v", err)
+	}
+}
+
+// === IdP-signaled error in callback ===
+
+func TestIdPErrorParam(t *testing.T) {
+	idp := newFakeIdP(t)
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	// Callback URL has ?error=access_denied
+	q := url.Values{}
+	q.Set("error", "access_denied")
+	q.Set("error_description", "user did <not> consent\nbreaks_audit_log") // T26 attempt
+	q.Set("state", "env-uuid-1234")
+	req := httptest.NewRequest(http.MethodGet, "/cb?"+q.Encode(), nil)
+	_, err = p.HandleCallback(context.Background(), req, goodState())
+	if !errors.Is(err, ErrIdPError) {
+		t.Fatalf("expected ErrIdPError, got %v", err)
+	}
+	// The error_description must NOT bleed into our error string
+	// (audit-log poisoning T26 — we keep that in server-side logs only).
+	if strings.Contains(err.Error(), "breaks_audit_log") || strings.Contains(err.Error(), "\n") {
+		t.Errorf("error description leaked into client-visible error: %q", err.Error())
+	}
+}
+
+// === Missing code ===
+
+func TestMissingCode(t *testing.T) {
+	idp := newFakeIdP(t)
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	q := url.Values{}
+	q.Set("state", "env-uuid-1234")
+	// no code
+	req := httptest.NewRequest(http.MethodGet, "/cb?"+q.Encode(), nil)
+	_, err = p.HandleCallback(context.Background(), req, goodState())
+	if !errors.Is(err, ErrMissingCode) {
+		t.Fatalf("expected ErrMissingCode, got %v", err)
+	}
+}
+
+// === Threat T10: PKCE enabled but verifier missing in state ===
+
+func TestT10PKCEVerifierMissing(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-pkce"
+	cfg := goodConfig(idp)
+	cfg.UsePKCE = true
+	cfg.ClientSecret = "" // public-client mode
+	p, err := NewOIDCProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	// State has EnvUUID + Nonce but NO Verifier.
+	state := auth.State{EnvUUID: "env-uuid-1234", Nonce: "n-default"}
+	_, err = p.HandleCallback(context.Background(), fakeCallback(state.EnvUUID, "code-pkce"), state)
+	if !errors.Is(err, ErrStateMismatch) {
+		t.Fatalf("expected ErrStateMismatch (pkce verifier missing), got %v", err)
+	}
+}
+
+// === Threat T17: required-group not satisfied ===
+
+func TestT17RequiredGroupMissing(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-group"
+	// User is in "regular-users" but not "osctrl-admins"
+	idp.groupsValue = []any{"regular-users"}
+	cfg := goodConfig(idp)
+	cfg.RequiredGroups = []string{"osctrl-admins"}
+	p, err := NewOIDCProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-group"), goodState())
+	if !errors.Is(err, ErrGroupNotAllowed) {
+		t.Fatalf("expected ErrGroupNotAllowed, got %v", err)
+	}
+}
+
+// === Required-group SATISFIED ===
+
+func TestRequiredGroupSatisfied(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-group-ok"
+	idp.groupsValue = []any{"regular-users", "osctrl-admins"}
+	cfg := goodConfig(idp)
+	cfg.RequiredGroups = []string{"osctrl-admins"}
+	p, err := NewOIDCProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	identity, err := p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-group-ok"), goodState())
+	if err != nil {
+		t.Fatalf("HandleCallback: %v", err)
+	}
+	if len(identity.Groups) != 2 {
+		t.Errorf("expected 2 groups in identity, got %v", identity.Groups)
+	}
+}
+
+// === Threat T17 narrow: group claim malformed (string instead of array) ===
+//
+// Real-world: some Entra/Auth0 configurations emit a single string
+// rather than an array. The gate must deny rather than try to parse.
+
+func TestT17GroupsClaimMalformed(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-group-bad"
+	idp.groupsValue = "osctrl-admins" // not an array
+	cfg := goodConfig(idp)
+	cfg.RequiredGroups = []string{"osctrl-admins"}
+	p, err := NewOIDCProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-group-bad"), goodState())
+	if !errors.Is(err, ErrGroupNotAllowed) {
+		t.Fatalf("expected ErrGroupNotAllowed for malformed group claim, got %v", err)
+	}
+}
+
+// === Legacy permissive-username mode (backwards-compat shim) ===
+//
+// LegacyPermissiveUsername=true relaxes the regex so existing
+// osctrl-admin deployments with email-format usernames keep working.
+// Verifies that:
+//  - dots/at/spaces are accepted (would be rejected strict)
+//  - empty username is STILL rejected (sanitizer's only universal rule)
+//  - control characters (\n, \x00) are STILL rejected (audit-log safety)
+//
+// The shim must not be a complete bypass — empty + control-char
+// rejection survives because those have no legitimate use case and
+// directly enable audit-log poisoning (threat T26).
+func TestLegacyPermissiveUsernameAccepts(t *testing.T) {
+	cases := []string{
+		"alice@example.com",
+		"alice.doe",
+		"alice doe",
+		"Alice.Doe", // mixed case
+	}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			idp := newFakeIdP(t)
+			idp.nextCode = "code-perm"
+			idp.preferredUsernameValue = u
+			cfg := goodConfig(idp)
+			cfg.LegacyPermissiveUsername = true
+			p, err := NewOIDCProvider(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("NewOIDCProvider: %v", err)
+			}
+			identity, err := p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-perm"), goodState())
+			if err != nil {
+				t.Fatalf("LegacyPermissiveUsername should accept %q, got %v", u, err)
+			}
+			if identity.PreferredUsername != u {
+				t.Errorf("PreferredUsername: got %q want %q", identity.PreferredUsername, u)
+			}
+		})
+	}
+}
+
+// Even in permissive mode, empty usernames must be rejected — the
+// sanitizer's whitespace-trim happens BEFORE the regex check in
+// strict mode and BEFORE the trim+empty-check in permissive mode.
+func TestLegacyPermissiveUsernameRejectsEmpty(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.nextCode = "code-empty"
+	idp.preferredUsernameValue = "   " // whitespace-only
+	cfg := goodConfig(idp)
+	cfg.LegacyPermissiveUsername = true
+	// Force pickUsername to use preferred_username (so the
+	// whitespace value flows through) by leaving claim as default.
+	p, err := NewOIDCProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	// With preferred_username = "   ", pickUsername returns "   ",
+	// which TrimSpace reduces to "" — must be rejected.
+	_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-empty"), goodState())
+	if !errors.Is(err, ErrUsernameInvalid) {
+		t.Fatalf("expected ErrUsernameInvalid on whitespace-only username, got %v", err)
+	}
+}
+
+// === Threat T23: username contains injection payload ===
+//
+// Verify that an IdP returning a malicious preferred_username makes
+// HandleCallback reject the request rather than pass the value
+// through to downstream caller.
+
+func TestT23UsernameInjection(t *testing.T) {
+	cases := []string{
+		"alice'; DROP TABLE users; --",
+		"alice\nadmin",
+		"alice\x00root",
+		"alice<script>alert(1)</script>",
+		"alice@example.com", // dot+at — would be valid email, but we don't allow them in username
+		"alice with spaces",
+	}
+	for _, badUsername := range cases {
+		t.Run(badUsername, func(t *testing.T) {
+			idp := newFakeIdP(t)
+			idp.nextCode = "code-inj"
+			idp.preferredUsernameValue = badUsername
+			p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+			if err != nil {
+				t.Fatalf("NewOIDCProvider: %v", err)
+			}
+			_, err = p.HandleCallback(context.Background(), fakeCallback("env-uuid-1234", "code-inj"), goodState())
+			if !errors.Is(err, ErrUsernameInvalid) {
+				t.Fatalf("expected ErrUsernameInvalid for %q, got %v", badUsername, err)
+			}
+		})
+	}
+}
+
+// === Discovery failure (init time) ===
+//
+// A bare HTTP server with no .well-known/openid-configuration endpoint
+// causes NewOIDCProvider to fail at discovery, not at first use. This
+// catches operator config errors at startup rather than 404 on user
+// login.
+func TestNewOIDCProviderDiscoveryFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	cfg := Config{
+		IssuerURL:    srv.URL,
+		ClientID:     "osctrl-api",
+		ClientSecret: "test-secret",
+		RedirectURL:  "https://api.example/cb",
+	}
+	_, err := NewOIDCProvider(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected discovery to fail")
+	}
+}
+
+// === LoginURL: enforces non-empty State.EnvUUID + Nonce ===
+
+func TestLoginURLValidatesState(t *testing.T) {
+	idp := newFakeIdP(t)
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	if _, err := p.LoginURL(context.Background(), auth.State{}); err == nil {
+		t.Error("expected error on empty State")
+	}
+	if _, err := p.LoginURL(context.Background(), auth.State{EnvUUID: "x"}); err == nil {
+		t.Error("expected error on empty Nonce")
+	}
+	url, err := p.LoginURL(context.Background(), auth.State{EnvUUID: "env-A", Nonce: "n-1"})
+	if err != nil {
+		t.Fatalf("LoginURL: %v", err)
+	}
+	if !strings.Contains(url, "state=env-A") {
+		t.Errorf("LoginURL should embed env in state param: %s", url)
+	}
+	if !strings.Contains(url, "nonce=n-1") {
+		t.Errorf("LoginURL should embed nonce: %s", url)
+	}
+}
+
+// === LoginURL: PKCE enforced when configured ===
+
+func TestLoginURLPKCERequired(t *testing.T) {
+	idp := newFakeIdP(t)
+	cfg := goodConfig(idp)
+	cfg.UsePKCE = true
+	cfg.ClientSecret = ""
+	p, err := NewOIDCProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	// PKCE on, but no Verifier in State → reject at LoginURL.
+	if _, err := p.LoginURL(context.Background(), auth.State{EnvUUID: "env-A", Nonce: "n-1"}); err == nil {
+		t.Error("expected error: pkce verifier required")
+	}
+	// PKCE on + Verifier present → URL includes code_challenge.
+	u, err := p.LoginURL(context.Background(), auth.State{EnvUUID: "env-A", Nonce: "n-1", Verifier: "v-1234567890123456789012345678901234567890123"})
+	if err != nil {
+		t.Fatalf("LoginURL: %v", err)
+	}
+	if !strings.Contains(u, "code_challenge=") || !strings.Contains(u, "code_challenge_method=S256") {
+		t.Errorf("LoginURL with PKCE should include challenge: %s", u)
+	}
+}
+
+// === Sanity: provider Type() returns "oidc" ===
+
+func TestType(t *testing.T) {
+	idp := newFakeIdP(t)
+	p, err := NewOIDCProvider(context.Background(), goodConfig(idp))
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+	if p.Type() != auth.TypeOIDC {
+		t.Errorf("Type: got %q want %q", p.Type(), auth.TypeOIDC)
+	}
+}
+
+// === Smoke: silence unused imports/symbols in this test file ===
+
+var _ = io.Discard
+var _ = sha256.Sum256
+
+// Quick fmt sanity used inside fake IdP — suppress vet's
+// "redundant test-file vars" if any.
+var _ = fmt.Sprintf

--- a/pkg/auth/state.go
+++ b/pkg/auth/state.go
@@ -1,0 +1,227 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// StateCookieName is the HttpOnly cookie that transports the per-login
+// State from the LoginURL handler to the callback handler. The cookie
+// path is scoped under /api/v1/auth/ so it never gets sent on other
+// endpoints; the SPA's token cookie lives at /.
+const StateCookieName = "osctrl_auth_state"
+
+// StateCookiePath restricts the cookie scope. Callers must mount the
+// auth routes at this prefix; if they don't, the cookie will not be
+// sent on the callback request and HandleCallback will reject with
+// ErrStateMissing.
+const StateCookiePath = "/api/v1/auth/"
+
+// StateCookieTTL is how long a login attempt can be in flight before
+// the state JWT expires. Ten minutes accommodates an MFA prompt + IdP
+// interstitials with margin; longer than this and we're inviting
+// replay risk against the IdP's auth_time enforcement.
+const StateCookieTTL = 10 * time.Minute
+
+// stateJWTAudience scopes state JWTs to this purpose so they cannot
+// be used as user-authentication tokens (the api's regular JWT has a
+// different audience). Token confusion is threat T19.
+const stateJWTAudience = "osctrl-auth-state"
+
+// stateJWTIssuer identifies the issuer; matches what
+// pkg/users.CreateToken emits for user JWTs, but the audience claim
+// segregates the two.
+const stateJWTIssuer = "osctrl-api"
+
+// stateNonceBytes is the entropy of the random nonce we put in the
+// State.Nonce field. 256 bits is well past the practical-collision
+// threshold even with unlimited online queries.
+const stateNonceBytes = 32
+
+// Errors returned by IssueStateCookie / ParseStateCookie. Callers should
+// match on these (via errors.Is) to map to HTTP status codes; the strings
+// are stable and may appear in logs but never in user-facing error
+// responses (we never reveal which check failed — see threat T31, T22).
+var (
+	// ErrStateMissing is returned when the state cookie is not on the
+	// request at all. Callback handlers map this to 403 with no body
+	// (the legitimate flow always has the cookie because LoginURL set
+	// it).
+	ErrStateMissing = errors.New("auth: state cookie missing")
+
+	// ErrStateInvalid is returned for any structural problem with the
+	// state JWT — bad signature, wrong audience, expired, missing
+	// claims, etc. Deliberately one error so external observers
+	// cannot distinguish "tampered" from "expired" from "wrong
+	// audience" via timing or status code. Threat T31.
+	ErrStateInvalid = errors.New("auth: state cookie invalid")
+)
+
+// stateClaims is the JWT body for the state cookie. Wrapping
+// jwt.RegisteredClaims gives us iss/aud/exp/nbf/iat for free.
+type stateClaims struct {
+	EnvUUID  string `json:"env"`
+	Nonce    string `json:"nonce"`
+	Verifier string `json:"v,omitempty"`
+	jwt.RegisteredClaims
+}
+
+// IssueStateCookie writes the per-login state cookie. The state JWT is
+// HMAC-SHA256 signed with the provided secret (typically the same
+// secret pkg/users uses for user JWTs; audience claim segregates the
+// two purposes — see threat T19).
+//
+// secret length is not validated here because pkg/users already enforces
+// MinJWTSecretBytes >= 32 at startup. If a caller manages to pass a
+// shorter secret, HS256 signing will still succeed but is below RFC 7518
+// recommendation; the existing startup gate is the right place to
+// enforce this, not this hot path.
+//
+// IssueStateCookie sets the cookie with HttpOnly + Secure + SameSite=Lax
+// + Path=/api/v1/auth/. The Secure flag means production deployments
+// MUST use HTTPS for the callback URL; this is intentional. Dev mode
+// with HTTP is not supported by this helper (use the SetSecure override
+// only via the standard library if you really need it for local testing
+// — production code paths must keep Secure=true).
+func IssueStateCookie(w http.ResponseWriter, secret []byte, state State) error {
+	if state.EnvUUID == "" {
+		return fmt.Errorf("auth: IssueStateCookie: empty EnvUUID")
+	}
+	if state.Nonce == "" {
+		return fmt.Errorf("auth: IssueStateCookie: empty Nonce")
+	}
+	now := time.Now().UTC()
+	claims := stateClaims{
+		EnvUUID:  state.EnvUUID,
+		Nonce:    state.Nonce,
+		Verifier: state.Verifier,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    stateJWTIssuer,
+			Audience:  jwt.ClaimStrings{stateJWTAudience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(StateCookieTTL)),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString(secret)
+	if err != nil {
+		// Should be impossible — HS256 signing only fails on
+		// malformed claims, and we control the struct.
+		return fmt.Errorf("auth: state JWT sign: %w", err)
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     StateCookieName,
+		Value:    signed,
+		Path:     StateCookiePath,
+		MaxAge:   int(StateCookieTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	return nil
+}
+
+// ParseStateCookie reads the state cookie off the request, verifies
+// the JWT, and returns the decoded State.
+//
+// Verification enforces, in order:
+//  1. Cookie present (else ErrStateMissing)
+//  2. HS256 algorithm pinned (defeats alg-confusion; defense in depth
+//     since jwt.ParseWithClaims's key callback also rejects non-HMAC,
+//     but explicit is better than implicit for auth code)
+//  3. Signature valid under `secret`
+//  4. iss == "osctrl-api"
+//  5. aud == "osctrl-auth-state" (defeats token confusion T19)
+//  6. exp > now (clock skew tolerance: 0 — state cookies are short-lived)
+//  7. nbf <= now (paranoid; should always hold for non-malicious tokens)
+//  8. EnvUUID + Nonce non-empty (rejects malformed body)
+//
+// Any single failure returns ErrStateInvalid. The internal failure
+// reason is loggable for ops but never surfaced to the user.
+func ParseStateCookie(r *http.Request, secret []byte) (State, error) {
+	c, err := r.Cookie(StateCookieName)
+	if err != nil {
+		return State{}, ErrStateMissing
+	}
+	if c.Value == "" {
+		return State{}, ErrStateMissing
+	}
+	claims := &stateClaims{}
+	tok, err := jwt.ParseWithClaims(c.Value, claims, func(t *jwt.Token) (interface{}, error) {
+		// Pin HS256. The library's default already rejects "none"
+		// and the public-key algs, but be explicit on auth code
+		// paths.
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %s", t.Header["alg"])
+		}
+		return secret, nil
+	}, jwt.WithValidMethods([]string{"HS256"}))
+	if err != nil || tok == nil || !tok.Valid {
+		return State{}, ErrStateInvalid
+	}
+	// jwt.ParseWithClaims already validated exp / nbf / signature.
+	// Now check the application-level claims that the library doesn't
+	// know about.
+	if claims.Issuer != stateJWTIssuer {
+		return State{}, ErrStateInvalid
+	}
+	hasAudience := false
+	for _, a := range claims.Audience {
+		if a == stateJWTAudience {
+			hasAudience = true
+			break
+		}
+	}
+	if !hasAudience {
+		return State{}, ErrStateInvalid
+	}
+	if strings.TrimSpace(claims.EnvUUID) == "" || strings.TrimSpace(claims.Nonce) == "" {
+		return State{}, ErrStateInvalid
+	}
+	return State{
+		EnvUUID:  claims.EnvUUID,
+		Nonce:    claims.Nonce,
+		Verifier: claims.Verifier,
+	}, nil
+}
+
+// ClearStateCookie removes the state cookie. Callers MUST invoke this
+// immediately after a successful ParseStateCookie so that a replay of
+// the callback URL fails (threat T8 / T9 — single-use state). The
+// cookie is set with MaxAge=-1 which the browser interprets as
+// "delete now."
+func ClearStateCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     StateCookieName,
+		Value:    "",
+		Path:     StateCookiePath,
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// NewNonce returns a fresh 256-bit cryptorandom nonce, base64url-encoded
+// without padding. Suitable for State.Nonce, State.Verifier, or any
+// other value that must be unguessable and URL-safe.
+//
+// Errors only on crypto/rand failure, which on supported platforms
+// means the system is too broken to be doing crypto at all. Callers
+// should propagate the error (500 Internal Server Error) rather than
+// retry.
+func NewNonce() (string, error) {
+	b := make([]byte, stateNonceBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("auth: rand: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/pkg/auth/state_test.go
+++ b/pkg/auth/state_test.go
@@ -1,0 +1,352 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// secret used by every test. 32 bytes matches the
+// pkg/users.MinJWTSecretBytes contract; longer would also work, this
+// is just a representative test value.
+var testSecret = []byte("test-secret-must-be-at-least-32-bytes-long")
+
+// freshState returns a State with valid fields for round-trip tests.
+func freshState(t *testing.T) State {
+	t.Helper()
+	nonce, err := NewNonce()
+	if err != nil {
+		t.Fatalf("NewNonce: %v", err)
+	}
+	verifier, err := NewNonce()
+	if err != nil {
+		t.Fatalf("NewNonce: %v", err)
+	}
+	return State{
+		EnvUUID:  "dev-uuid-1234",
+		Nonce:    nonce,
+		Verifier: verifier,
+	}
+}
+
+// issueOnRecorder issues a state cookie on a fresh ResponseRecorder
+// and returns the corresponding *http.Request that carries the cookie
+// for the next call.
+func issueOnRecorder(t *testing.T, s State) *http.Request {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	if err := IssueStateCookie(rec, testSecret, s); err != nil {
+		t.Fatalf("IssueStateCookie: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	for _, c := range rec.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	return req
+}
+
+// TestNonceUnique sanity-checks that we get distinct nonces across
+// calls. With 256-bit entropy a collision in this many calls is
+// astronomically improbable; this is purely smoke for the function
+// not the math.
+func TestNonceUnique(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		n, err := NewNonce()
+		if err != nil {
+			t.Fatalf("NewNonce: %v", err)
+		}
+		if n == "" {
+			t.Fatalf("NewNonce returned empty")
+		}
+		if seen[n] {
+			t.Fatalf("nonce collision in 100 calls: %s", n)
+		}
+		seen[n] = true
+	}
+}
+
+// TestStateRoundTripHappy is the canonical "good" path: issue cookie,
+// parse the resulting request, get the same State back.
+func TestStateRoundTripHappy(t *testing.T) {
+	s := freshState(t)
+	req := issueOnRecorder(t, s)
+	got, err := ParseStateCookie(req, testSecret)
+	if err != nil {
+		t.Fatalf("ParseStateCookie: %v", err)
+	}
+	if got.EnvUUID != s.EnvUUID {
+		t.Errorf("EnvUUID: got %q want %q", got.EnvUUID, s.EnvUUID)
+	}
+	if got.Nonce != s.Nonce {
+		t.Errorf("Nonce: got %q want %q", got.Nonce, s.Nonce)
+	}
+	if got.Verifier != s.Verifier {
+		t.Errorf("Verifier: got %q want %q", got.Verifier, s.Verifier)
+	}
+}
+
+// Threat T6 (CSRF): callback without prior login → state cookie
+// missing. Must return ErrStateMissing, not ErrStateInvalid (callers
+// may want to log differently or rate-limit differently).
+func TestStateMissing(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	_, err := ParseStateCookie(req, testSecret)
+	if !errors.Is(err, ErrStateMissing) {
+		t.Fatalf("expected ErrStateMissing, got %v", err)
+	}
+}
+
+// Empty-value cookie behaves the same as missing. Some buggy proxies
+// strip values but keep cookie names; defensive.
+func TestStateEmptyValue(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	req.AddCookie(&http.Cookie{Name: StateCookieName, Value: ""})
+	_, err := ParseStateCookie(req, testSecret)
+	if !errors.Is(err, ErrStateMissing) {
+		t.Fatalf("expected ErrStateMissing, got %v", err)
+	}
+}
+
+// Threat T31 (timing oracle) + general tampering: any structural
+// change to the JWT must fail closed with ErrStateInvalid. We flip a
+// byte in the signature segment.
+func TestStateSignatureTampered(t *testing.T) {
+	s := freshState(t)
+	req := issueOnRecorder(t, s)
+	c, _ := req.Cookie(StateCookieName)
+	parts := strings.Split(c.Value, ".")
+	if len(parts) != 3 {
+		t.Fatalf("malformed JWT in issued cookie: %s", c.Value)
+	}
+	// Flip the first character of the signature. Toggle between
+	// digits to keep base64-validity but invalidate the signature.
+	tampered := parts[2]
+	if tampered[0] == 'A' {
+		tampered = "B" + tampered[1:]
+	} else {
+		tampered = "A" + tampered[1:]
+	}
+	c.Value = parts[0] + "." + parts[1] + "." + tampered
+	// Replace the cookie.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	req.AddCookie(c)
+	_, err := ParseStateCookie(req, testSecret)
+	if !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected ErrStateInvalid on tampered sig, got %v", err)
+	}
+}
+
+// Threat T9 (replay) + general expiry handling: a state cookie issued
+// with exp in the past must be rejected. We craft one directly with
+// the same key.
+func TestStateExpired(t *testing.T) {
+	past := time.Now().Add(-1 * time.Hour)
+	claims := stateClaims{
+		EnvUUID: "dev-uuid-1234",
+		Nonce:   "n-1234",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    stateJWTIssuer,
+			Audience:  jwt.ClaimStrings{stateJWTAudience},
+			IssuedAt:  jwt.NewNumericDate(past.Add(-StateCookieTTL)),
+			NotBefore: jwt.NewNumericDate(past.Add(-StateCookieTTL)),
+			ExpiresAt: jwt.NewNumericDate(past),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, _ := tok.SignedString(testSecret)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	req.AddCookie(&http.Cookie{Name: StateCookieName, Value: signed})
+	_, err := ParseStateCookie(req, testSecret)
+	if !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected ErrStateInvalid on expired token, got %v", err)
+	}
+}
+
+// Threat T19 (token confusion): a JWT signed with the same secret but
+// for a different audience (e.g., a user-auth JWT mistakenly sent in
+// the state cookie position) must be rejected.
+func TestStateWrongAudience(t *testing.T) {
+	now := time.Now()
+	claims := stateClaims{
+		EnvUUID: "dev-uuid-1234",
+		Nonce:   "n-1234",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    stateJWTIssuer,
+			Audience:  jwt.ClaimStrings{"osctrl-api"}, // user-auth aud, not state aud
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(StateCookieTTL)),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, _ := tok.SignedString(testSecret)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	req.AddCookie(&http.Cookie{Name: StateCookieName, Value: signed})
+	_, err := ParseStateCookie(req, testSecret)
+	if !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected ErrStateInvalid on wrong aud, got %v", err)
+	}
+}
+
+// A JWT with the right audience but the wrong issuer must also be
+// rejected. Belt-and-braces: aud is the primary defense but iss adds
+// a redundant identity claim.
+func TestStateWrongIssuer(t *testing.T) {
+	now := time.Now()
+	claims := stateClaims{
+		EnvUUID: "dev-uuid-1234",
+		Nonce:   "n-1234",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "some-other-issuer",
+			Audience:  jwt.ClaimStrings{stateJWTAudience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(StateCookieTTL)),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, _ := tok.SignedString(testSecret)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	req.AddCookie(&http.Cookie{Name: StateCookieName, Value: signed})
+	_, err := ParseStateCookie(req, testSecret)
+	if !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected ErrStateInvalid on wrong iss, got %v", err)
+	}
+}
+
+// JWT signed with a different key, same structure as ours, must be
+// rejected. Equivalent to "attacker minted their own token".
+func TestStateWrongSecret(t *testing.T) {
+	wrongSecret := []byte("attacker-secret-also-32-bytes-long-aaaa")
+	s := freshState(t)
+	now := time.Now()
+	claims := stateClaims{
+		EnvUUID:  s.EnvUUID,
+		Nonce:    s.Nonce,
+		Verifier: s.Verifier,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    stateJWTIssuer,
+			Audience:  jwt.ClaimStrings{stateJWTAudience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(StateCookieTTL)),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, _ := tok.SignedString(wrongSecret)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	req.AddCookie(&http.Cookie{Name: StateCookieName, Value: signed})
+	_, err := ParseStateCookie(req, testSecret)
+	if !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected ErrStateInvalid on wrong secret, got %v", err)
+	}
+}
+
+// Alg-confusion defense: a token with alg=none should be rejected by
+// the WithValidMethods option even if a verifier ignores the
+// signature. Defense in depth against threats from broken
+// dependencies.
+func TestStateAlgNoneRejected(t *testing.T) {
+	// jwt.SigningMethodNone signs with the value "none" but
+	// requires the special key jwt.UnsafeAllowNoneSignatureType.
+	// We replicate the on-wire shape manually rather than fight
+	// the library.
+	header := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" // {"alg":"none","typ":"JWT"}
+	body := "eyJlbnYiOiJkZXYtdXVpZC0xMjM0Iiwibm9uY2UiOiJuLTEyMzQiLCJpc3MiOiJvc2N0cmwtYXBpIiwiYXVkIjpbIm9zY3RybC1hdXRoLXN0YXRlIl0sImV4cCI6OTk5OTk5OTk5OX0"
+	tok := header + "." + body + "."
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback", nil)
+	req.AddCookie(&http.Cookie{Name: StateCookieName, Value: tok})
+	_, err := ParseStateCookie(req, testSecret)
+	if !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected ErrStateInvalid on alg=none token, got %v", err)
+	}
+}
+
+// IssueStateCookie must refuse to issue with an empty EnvUUID — that
+// would defeat the cross-env mismatch defense (threat T18).
+func TestIssueRejectsEmptyEnv(t *testing.T) {
+	rec := httptest.NewRecorder()
+	err := IssueStateCookie(rec, testSecret, State{Nonce: "n-1234"})
+	if err == nil {
+		t.Fatal("expected error on empty EnvUUID")
+	}
+}
+
+// ...and similarly empty Nonce. A missing nonce means the OIDC layer
+// can't validate the id_token's nonce claim, which collapses replay
+// defense in the protocol.
+func TestIssueRejectsEmptyNonce(t *testing.T) {
+	rec := httptest.NewRecorder()
+	err := IssueStateCookie(rec, testSecret, State{EnvUUID: "dev-uuid-1234"})
+	if err == nil {
+		t.Fatal("expected error on empty Nonce")
+	}
+}
+
+// Cookie attributes (HttpOnly + Secure + SameSite=Lax + path scope)
+// are part of the security contract — verify them on every issue.
+func TestCookieAttributes(t *testing.T) {
+	s := freshState(t)
+	rec := httptest.NewRecorder()
+	if err := IssueStateCookie(rec, testSecret, s); err != nil {
+		t.Fatalf("IssueStateCookie: %v", err)
+	}
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+	c := cookies[0]
+	if c.Name != StateCookieName {
+		t.Errorf("Name: got %q want %q", c.Name, StateCookieName)
+	}
+	if !c.HttpOnly {
+		t.Error("HttpOnly must be true")
+	}
+	if !c.Secure {
+		t.Error("Secure must be true")
+	}
+	if c.SameSite != http.SameSiteLaxMode {
+		t.Errorf("SameSite: got %v want Lax", c.SameSite)
+	}
+	if c.Path != StateCookiePath {
+		t.Errorf("Path: got %q want %q", c.Path, StateCookiePath)
+	}
+	if c.MaxAge != int(StateCookieTTL.Seconds()) {
+		t.Errorf("MaxAge: got %d want %d", c.MaxAge, int(StateCookieTTL.Seconds()))
+	}
+}
+
+// Verify ClearStateCookie removes the cookie cleanly: MaxAge=-1 and
+// preserves the same path scope (else the browser leaves the cookie
+// in place because path doesn't match the delete).
+func TestClearStateCookie(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ClearStateCookie(rec)
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie on clear, got %d", len(cookies))
+	}
+	c := cookies[0]
+	if c.MaxAge != -1 {
+		t.Errorf("MaxAge: got %d want -1", c.MaxAge)
+	}
+	if c.Path != StateCookiePath {
+		t.Errorf("Path: got %q want %q (must match issue path or the delete is a no-op)", c.Path, StateCookiePath)
+	}
+}
+
+// IsZero sanity.
+func TestStateIsZero(t *testing.T) {
+	if !(State{}).IsZero() {
+		t.Error("State{} should be zero")
+	}
+	if (State{EnvUUID: "x"}).IsZero() {
+		t.Error("non-empty State should not be zero")
+	}
+}

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -1,0 +1,154 @@
+// Package auth defines the provider-agnostic federated-identity surface
+// for osctrl-api. Concrete provider implementations live in subpackages
+// (pkg/auth/oidc and, eventually, pkg/auth/saml).
+//
+// The package is intentionally minimal — it defines only what every
+// provider must implement and what every caller must receive back. All
+// protocol details (token verification, claim parsing, PKCE,
+// metadata exchange) live in the subpackage.
+//
+// Security note: this package never logs raw tokens, claims, or secrets.
+// Concrete implementations must follow the same rule; see the spec at
+// docs/proposals/osctrl-auth-providers-v0.1-spec.md for the full
+// hardening rules.
+package auth
+
+import (
+	"context"
+	"net/http"
+)
+
+// Type names for the discriminator on env_auth_providers. New protocol
+// implementations must register a string here and provide a Provider
+// implementation in a subpackage.
+const (
+	// TypeOIDC identifies an OpenID Connect provider (RFC 6749 +
+	// OpenID Connect Core 1.0).
+	TypeOIDC = "oidc"
+
+	// TypeSAML is reserved for a future SAML 2.0 provider; not yet
+	// implemented. Holding the constant prevents accidental
+	// shadowing in subpackages and signals intent in the API.
+	TypeSAML = "saml"
+)
+
+// Provider is the contract every federated-identity backend must
+// implement. A single Provider instance corresponds to one configured
+// IdP for one osctrl environment.
+//
+// All methods are context-aware. Implementations MUST honor context
+// cancellation on any outbound network calls (token endpoint,
+// JWKS fetch, etc.) so a slow IdP cannot wedge an HTTP handler.
+type Provider interface {
+	// Type returns the discriminator that identifies the protocol.
+	// Must match one of the Type* constants above.
+	Type() string
+
+	// LoginURL builds the URL the user's browser is redirected to in
+	// order to start the authentication flow. The State is opaque to
+	// the caller; the caller is responsible for transporting it back
+	// to HandleCallback via a state cookie (see pkg/auth/state.go).
+	//
+	// Implementations MUST embed unguessable nonces / verifiers in the
+	// returned URL and the State so the callback can detect CSRF and
+	// replay attempts. See threat IDs T6, T7, T9 in the spec.
+	LoginURL(ctx context.Context, state State) (string, error)
+
+	// HandleCallback consumes the provider's callback request,
+	// validates everything (signature, issuer, audience, expiry,
+	// nonce, PKCE verifier as applicable) and returns a
+	// ResolvedIdentity describing the authenticated user.
+	//
+	// The State argument is the State that the caller previously
+	// transported via cookie. Implementations MUST treat any
+	// mismatch as a fatal authentication failure and MUST NOT
+	// continue to user resolution. See threat IDs T6, T18.
+	//
+	// Implementations MUST NOT return raw tokens, claims, or
+	// provider error bodies in the error message; those go to
+	// server-side structured logging only. See spec hardening rule
+	// "no raw token logging".
+	HandleCallback(ctx context.Context, r *http.Request, state State) (ResolvedIdentity, error)
+}
+
+// ResolvedIdentity is the protocol-neutral output of a successful
+// HandleCallback. Callers translate this into an osctrl AdminUser via
+// the JIT resolution path (cmd/api/handlers/auth_callback.go); see
+// docs/proposals/osctrl-auth-providers-v0.1-spec.md §JIT.
+//
+// All string fields except Subject may be empty. Subject MUST be
+// stable for the lifetime of the IdP-side user account; callers
+// rely on it as the cross-login identifier.
+type ResolvedIdentity struct {
+	// Subject is the stable, opaque identifier issued by the IdP
+	// (typically the `sub` claim in OIDC). Never an email, never a
+	// preferred name — those can change. Callers that need to
+	// preserve identity across renames MUST use Subject.
+	Subject string
+
+	// PreferredUsername is what the user sees and types. Defaults to
+	// the OIDC `preferred_username` claim; configurable per-provider
+	// to fall back to email or sub. Used as the AdminUser.Username
+	// after passing validation.
+	PreferredUsername string
+
+	// Email is informational; do NOT use it as a stable identifier
+	// (mutable in most IdPs; spoofable in poorly-configured ones —
+	// see threat T24).
+	Email string
+
+	// Name is the human display name (OIDC `name` claim) or a
+	// concatenation of given+family if absent.
+	Name string
+
+	// Groups carries the user's IdP group memberships (after the
+	// optional protocol-mapper claim shaping). v1 uses this only for
+	// the RequiredGroups gate; future versions may map groups to
+	// osctrl roles. See spec §"What this design does NOT do".
+	Groups []string
+
+	// Raw exposes the underlying provider-specific claim set for
+	// debugging and future feature work. Callers MUST NOT read Raw
+	// to bypass any of the typed fields above; that would defeat the
+	// validation layer. Always nil for SAML when it lands; OIDC sets
+	// it after id_token verification.
+	Raw map[string]any
+}
+
+// State is the per-login data the caller must round-trip from
+// LoginURL through the user's browser to HandleCallback. It is opaque
+// to the user (transported in an HttpOnly cookie) but its claim shape
+// is part of the contract between the auth handler and the provider.
+//
+// Implementations may add unexported provider-specific fields by
+// embedding State in a protocol-specific extension type kept inside
+// the provider subpackage.
+type State struct {
+	// EnvUUID locks this State to a specific osctrl environment.
+	// Callbacks for env A using state issued for env B MUST be
+	// rejected — see threat T18 (cross-env auth confusion).
+	EnvUUID string
+
+	// Nonce is a 256-bit cryptorandom value. For OIDC, this is
+	// embedded in the authorize URL via the `nonce` parameter and
+	// must match the `nonce` claim on the returned id_token. Other
+	// protocols may or may not use it; the field is always
+	// populated regardless.
+	Nonce string
+
+	// Verifier is the PKCE code_verifier (RFC 7636) when the
+	// provider has PKCE enabled. Empty otherwise. The callback
+	// presents this to the token endpoint along with the code; the
+	// IdP recomputes the challenge and compares.
+	//
+	// Empty Verifier with a PKCE-enabled provider MUST cause
+	// HandleCallback to reject — see threat T10.
+	Verifier string
+}
+
+// IsZero reports whether the State is the zero value, useful for
+// callers that need to distinguish "missing state" from "valid state
+// with zero fields".
+func (s State) IsZero() bool {
+	return s == State{}
+}


### PR DESCRIPTION
## Summary

- Introduces `pkg/auth/` with a shared `auth.Provider` interface (`Type()`, `LoginURL()`, `HandleCallback()`) and JWT-based state/nonce cookie helpers
- Extracts `pkg/auth/oidc/` from the legacy admin's inline OIDC handling into a reusable provider implementation
- Refactors `cmd/admin/handlers/` to consume the shared package — legacy admin OIDC behavior preserved end-to-end
- `pickUsername()` reads arbitrary claim names from the raw ID token (fixes Auth0 `nickname` claim handling)

## Depends on

- #826 (merged)

## Test plan

- [x] Legacy admin OIDC login still works against Keycloak
- [x] Legacy admin OIDC login still works against Auth0
- [x] `go test ./pkg/auth/... ./pkg/users/...` passes
- [x] `go vet ./...` clean