### PR TITLE
make: actionable errors for docker_dev + add docker_dev_certs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,16 +240,23 @@ docker_dev_shell_postgres:
 docker_dev_shell_redis:
 	docker exec -it osctrl-redis-dev /bin/sh
 
+# Generate self-signed TLS certificates for docker dev environment
+docker_dev_certs:
+	openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+		-keyout deploy/docker/conf/tls/osctrl.key \
+		-out deploy/docker/conf/tls/osctrl.crt \
+		-config deploy/docker/conf/tls/openssl.cnf
+
 # Build dev docker containers and run them (also generates new certificates)
 docker_dev_build:
 ifeq (,$(wildcard ./.env))
-	$(error Missing .env file)
+	$(error Missing .env file. Run: cp .env.example .env)
 endif
 ifeq (,$(wildcard ./deploy/docker/conf/tls/osctrl.crt))
-	$(error Missing TLS certificate file)
+	$(error Missing TLS certificate file. Run: make docker_dev_certs)
 endif
 ifeq (,$(wildcard ./deploy/docker/conf/tls/osctrl.key))
-	$(error Missing TLS private key file)
+	$(error Missing TLS private key file. Run: make docker_dev_certs)
 endif
 	docker compose -f docker-compose-dev.yml build --provenance=false
 


### PR DESCRIPTION
## Summary
- Updated `docker_dev_build` error messages to tell the operator exactly what to run (`cp .env.example .env` or `make docker_dev_certs`)
- Added a new `docker_dev_certs` Makefile target that generates a self-signed TLS cert/key pair into `deploy/docker/conf/tls/` using the existing `openssl.cnf`

## Test plan
- [ ] Remove `.env` and run `make docker_dev_build` — verify error message says `Run: cp .env.example .env`
- [ ] Remove TLS cert/key and run `make docker_dev_build` — verify error message says `Run: make docker_dev_certs`
- [ ] Run `make docker_dev_certs` — verify `osctrl.crt` and `osctrl.key` are generated in `deploy/docker/conf/tls/`
- [ ] Run `make docker_dev_build` with all prerequisites in place — verify it proceeds to `docker compose build`

Closes #822