### PR TITLE
api: fine-grained permission control for service account creation

### DIFF
--- a/cmd/api/handlers/users.go
+++ b/cmd/api/handlers/users.go
@@ -160,7 +160,26 @@ func (h *HandlersApi) UserActionHandler(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 		}
-		access := h.Users.GenEnvUserAccess(envs, true, (u.Admin), (u.Admin), (u.Admin))
+		// Determine per-level access. When fine-grained fields are
+		// provided, use them; otherwise fall back to the legacy
+		// behavior where admin implies all access levels.
+		userAcc := true
+		queryAcc := u.Admin
+		carveAcc := u.Admin
+		adminAcc := u.Admin
+		if u.UserAccess != nil {
+			userAcc = *u.UserAccess
+		}
+		if u.QueryAccess != nil {
+			queryAcc = *u.QueryAccess
+		}
+		if u.CarveAccess != nil {
+			carveAcc = *u.CarveAccess
+		}
+		if u.AdminAccess != nil {
+			adminAcc = *u.AdminAccess
+		}
+		access := h.Users.GenEnvUserAccess(envs, userAcc, queryAcc, carveAcc, adminAcc)
 		perms := h.Users.GenPermissions(u.Username, ctx[ctxUser], access)
 		if err := h.Users.CreatePermissions(perms); err != nil {
 			apiErrorResponse(w, "error creating permissions", http.StatusInternalServerError, err)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -170,6 +170,10 @@ type ApiUserRequest struct {
 	NotService   bool     `json:"not_service"`
 	API          bool     `json:"api"`
 	Environments []string `json:"environments"`
+	UserAccess   *bool    `json:"user_access,omitempty"`
+	QueryAccess  *bool    `json:"query_access,omitempty"`
+	CarveAccess  *bool    `json:"carve_access,omitempty"`
+	AdminAccess  *bool    `json:"admin_access,omitempty"`
 }
 
 // NodesPagedResponse is the SPA-canonical paginated response for GET /api/v1/nodes/{env}.


### PR DESCRIPTION
## Summary

- Adds optional `user_access`, `query_access`, `carve_access`, and `admin_access` fields to the user creation API endpoint
- When provided, these override the legacy behavior where all permission levels were derived from the binary `admin` flag
- Enables creating service accounts with specific permission combinations (e.g. read + query for monitoring, read + carve for forensics)

## Backward compatibility

Fields use pointer types (`*bool`) so `nil` (not provided) is distinguishable from `false` (explicitly denied). When none of the new fields are provided, the handler falls back to the existing behavior: `user_access=true`, everything else = `admin` value.

Existing API clients and the CLI continue working unchanged.

## API usage

```bash
POST /api/v1/users/my-monitoring-bot/add
{
  "username": "my-monitoring-bot",
  "password": "secure_password",
  "email": "monitoring@example.com",
  "service": true,
  "admin": false,
  "environments": ["env-uuid"],
  "user_access": true,
  "query_access": true,
  "carve_access": false,
  "admin_access": false
}
```

## Security

The endpoint is already gated behind global admin permission (`AdminLevel` check). Only admins can create users or assign permissions. This change adds granularity to what admins can already do — it does not expand the attack surface.

Closes #774

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/api/... ./pkg/users/...` passes
- [x] Legacy behavior preserved: omitting new fields produces same permissions as before
- [x] Fine-grained: `admin=false` + `query_access=true` creates user with read + query only