### PR TITLE
provision: fix yq and Go installer arch detection on x86_64

### DIFF
--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -399,7 +399,9 @@ function set_motd_centos() {
 function install_go_26() {
   local __version="1.26.3"
   local __arch="$(uname -i)"
-  if [[ "$__arch" == "aarch64" ]]; then
+  if [[ "$__arch" == "x86_64" ]]; then
+    __arch="amd64"
+  elif [[ "$__arch" == "aarch64" ]]; then
     __arch="arm64"
   fi
   local __file="go$__version.linux-$__arch.tar.gz"
@@ -441,7 +443,9 @@ function install_go_26() {
 # Install yq from releases (https://github.com/mikefarah/yq)
 function install_yq() {
   local __arch="$(uname -i)"
-  if [[ "$__arch" == "aarch64" ]]; then
+  if [[ "$__arch" == "x86_64" ]]; then
+    __arch="amd64"
+  elif [[ "$__arch" == "aarch64" ]]; then
     __arch="arm64"
   fi
   local __file="yq_linux_$__arch"


### PR DESCRIPTION
## Summary

- `install_yq()` and `install_go_26()` in `deploy/lib.sh` use `uname -i` to detect architecture
- On Intel systems `uname -i` returns `x86_64`, but both yq and Go release binaries use `amd64` in their filenames
- The existing code only mapped `aarch64 → arm64` but missed `x86_64 → amd64`, causing 404 downloads on Intel

## Fix

Add `x86_64 → amd64` mapping in both functions, alongside the existing `aarch64 → arm64` mapping.

Closes #836

## Test plan

- [x] Verified yq download URL resolves: `https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64`
- [x] Verified Go download URL resolves: `https://dl.google.com/go/go1.26.3.linux-amd64.tar.gz`