### PR TITLE
Exposing frontend via nginx for TLS termination in docker dev environment

### DIFF
--- a/deploy/docker/conf/nginx/frontend-dev.conf
+++ b/deploy/docker/conf/nginx/frontend-dev.conf
@@ -1,7 +1,7 @@
 # osctrl-frontend — dev-stack nginx config.
 #
-# HTTP-only on :80 (mapped to host :8088). The legacy admin keeps its TLS
-# server on :8443 so both UIs can run side-by-side for comparison.
+# HTTP-only on :80 inside the docker network. Public access is via
+# osctrl-nginx on :8444, which terminates TLS and proxies requests here.
 #
 # The /api/* upstream points at the dev `osctrl-api` container on 9002 over
 # the docker backend network. Security headers match deploy/nginx/frontend.conf.example
@@ -65,16 +65,6 @@ server {
         proxy_set_header Connection "";
         proxy_read_timeout 120s;
         proxy_send_timeout 120s;
-
-        # The API hardcodes Secure on its session cookies (correct for prod).
-        # In this dev stack the SPA is served over plain HTTP on :8088, so
-        # browsers refuse to attach Secure cookies and the session is lost on
-        # the first authed request after login ("Session expired"). Strip the
-        # Secure flag here so dev works without a TLS reverse proxy.
-        # In production (deploy/nginx/frontend.conf.example) the SPA is
-        # already on HTTPS, so this directive is intentionally absent there.
-        proxy_cookie_flags osctrl_token nosecure;
-        proxy_cookie_flags osctrl_csrf nosecure;
 
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;

--- a/deploy/docker/conf/nginx/osctrl.conf
+++ b/deploy/docker/conf/nginx/osctrl.conf
@@ -63,3 +63,40 @@ server {
     }
 
 }
+
+server {
+    listen 8444 ssl deferred;
+
+    server_tokens off;
+
+    ssl_certificate /etc/ssl/certs/osctrl.crt;
+    ssl_certificate_key /etc/ssl/private/osctrl.key;
+
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 5m;
+
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/ssl/certs/osctrl.crt;
+    resolver 1.1.1.1 8.8.8.8 valid=300s;
+    resolver_timeout 5s;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains";
+    add_header X-Frame-Options DENY;
+
+    location / {
+        proxy_http_version      1.1;
+        proxy_set_header        Connection "";
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_pass              http://osctrl-frontend:80;
+        proxy_read_timeout      120;
+        proxy_send_timeout      120;
+    }
+}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - 8000:80
       - 8443:443
+      - 8444:8444
     networks:
       - default
       - osctrl-dev-backend
@@ -27,6 +28,7 @@ services:
       - osctrl-tls
       - osctrl-admin
       - osctrl-api
+      - osctrl-frontend
 
 
   ######################################### osctrl-tls #########################################
@@ -172,10 +174,10 @@ services:
 
 
   ######################################### osctrl-frontend (React SPA) #########################################
-  # Ships the React admin frontend on http://<host>:8088, side by side with
-  # the legacy admin still served by osctrl-nginx on :8443. Both talk to the
-  # same osctrl-api over the dev backend network so they can be compared on
-  # the same data.
+  # Ships the React admin frontend through osctrl-nginx on
+  # https://<host>:8444 while remaining internal-only on the docker network.
+  # The frontend container still owns the SPA static serving and /api/*
+  # reverse-proxy to osctrl-api.
   #
   # The image is multi-stage: node:20 builds dist/, nginx:alpine serves it
   # + reverse-proxies /api/* to osctrl-api:9002. No volume mount of the
@@ -191,8 +193,6 @@ services:
       dockerfile: deploy/docker/dockerfiles/Dockerfile-dev-frontend
     networks:
       - osctrl-dev-backend
-    ports:
-      - '0.0.0.0:8088:80'
     depends_on:
       - osctrl-api
 


### PR DESCRIPTION
Exposing `osctrl-frontend` via `osctrl-nginx` for TLS termination.