### PR TITLE
frontend: responsive sidenav — mobile drawer + desktop icon-rail collapse

### DIFF
--- a/frontend/src/components/chrome/AppShell.tsx
+++ b/frontend/src/components/chrome/AppShell.tsx
@@ -10,10 +10,21 @@ interface AppShellProps {
   username?: string;
 }
 
+const NAV_COLLAPSED_KEY = 'osctrl.sidenav-collapsed';
+
 export function AppShell({ children, username }: AppShellProps) {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
+  const [navCollapsed, setNavCollapsed] = useState(
+    () => localStorage.getItem(NAV_COLLAPSED_KEY) === '1',
+  );
   const pathname = useRouterState().location.pathname;
+
+  function toggleNavCollapsed() {
+    const next = !navCollapsed;
+    setNavCollapsed(next);
+    localStorage.setItem(NAV_COLLAPSED_KEY, next ? '1' : '0');
+  }
 
   // Global ⌘K / Ctrl-K toggle. Listener lives at the shell level so any
   // authenticated page can hit it without re-binding. Escape also closes
@@ -40,8 +51,13 @@ export function AppShell({ children, username }: AppShellProps) {
 
   return (
     <div className="flex min-h-screen bg-[color:var(--bg-0)]">
-      {/* Desktop rail — hidden on phones in favor of the drawer below. */}
-      <SideNav className="hidden md:flex" />
+      {/* Desktop rail — hidden on phones in favor of the drawer below.
+          Collapsible to an icon-only strip; preference persists. */}
+      <SideNav
+        className="hidden md:flex"
+        collapsed={navCollapsed}
+        onToggleCollapse={toggleNavCollapsed}
+      />
 
       {/* Mobile off-canvas drawer. Kept mounted so the slide/fade can
           animate both ways; pointer-events gate off interaction while

--- a/frontend/src/components/chrome/AppShell.tsx
+++ b/frontend/src/components/chrome/AppShell.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
+import { useRouterState } from '@tanstack/react-router';
+import { cn } from '$/lib/cn';
 import { SideNav } from './SideNav';
 import { TopBar } from './TopBar';
 import { CommandPalette } from './CommandPalette';
@@ -10,25 +12,68 @@ interface AppShellProps {
 
 export function AppShell({ children, username }: AppShellProps) {
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [navOpen, setNavOpen] = useState(false);
+  const pathname = useRouterState().location.pathname;
 
   // Global ⌘K / Ctrl-K toggle. Listener lives at the shell level so any
-  // authenticated page can hit it without re-binding.
+  // authenticated page can hit it without re-binding. Escape also closes
+  // the mobile nav drawer from here for the same reason.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
         e.preventDefault();
         setPaletteOpen((o) => !o);
       }
+      if (e.key === 'Escape') {
+        setNavOpen(false);
+      }
     }
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  // Navigating anywhere dismisses the mobile drawer — covers nav links,
+  // the env switcher, and command-palette jumps in one place.
+  useEffect(() => {
+    setNavOpen(false);
+  }, [pathname]);
+
   return (
     <div className="flex min-h-screen bg-[color:var(--bg-0)]">
-      <SideNav />
+      {/* Desktop rail — hidden on phones in favor of the drawer below. */}
+      <SideNav className="hidden md:flex" />
+
+      {/* Mobile off-canvas drawer. Kept mounted so the slide/fade can
+          animate both ways; pointer-events gate off interaction while
+          closed. The SideNav instance shares React Query caches with the
+          desktop one, so the duplicate mount costs no extra requests. */}
+      <div
+        className={cn('fixed inset-0 z-40 md:hidden', !navOpen && 'pointer-events-none')}
+        aria-hidden={!navOpen}
+      >
+        <div
+          className={cn(
+            'absolute inset-0 bg-black/50 transition-opacity duration-200',
+            navOpen ? 'opacity-100' : 'opacity-0',
+          )}
+          onClick={() => setNavOpen(false)}
+        />
+        <div
+          className={cn(
+            'absolute inset-y-0 left-0 transition-transform duration-200 ease-out',
+            navOpen ? 'translate-x-0' : '-translate-x-full',
+          )}
+        >
+          <SideNav className="h-full overflow-y-auto shadow-[4px_0_24px_rgba(0,0,0,0.4)]" />
+        </div>
+      </div>
+
       <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-        <TopBar username={username} onCommandPalette={() => setPaletteOpen(true)} />
+        <TopBar
+          username={username}
+          onCommandPalette={() => setPaletteOpen(true)}
+          onMenuToggle={() => setNavOpen((o) => !o)}
+        />
         <main className="flex-1 overflow-auto">{children}</main>
       </div>
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />

--- a/frontend/src/components/chrome/EnvSwitcher.tsx
+++ b/frontend/src/components/chrome/EnvSwitcher.tsx
@@ -14,7 +14,7 @@ import { DropdownMenu } from '$/components/primitives/DropdownMenu';
 import { listEnvironments, type TLSEnvironment } from '$/api/environments';
 import { isAuthenticated } from '$/api/client';
 
-export function EnvSwitcher() {
+export function EnvSwitcher({ compact }: { compact?: boolean } = {}) {
   const navigate = useNavigate();
   const params = useParams({ strict: false });
   const routerState = useRouterState();
@@ -50,36 +50,40 @@ export function EnvSwitcher() {
       <DropdownMenu.Trigger asChild>
         <button
           className={cn(
-            'flex items-center justify-between gap-2 w-full',
+            'flex items-center gap-2 w-full',
+            compact ? 'justify-center' : 'justify-between',
             'px-2 py-1.5 rounded-md text-sm',
             'text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)]',
             'transition-colors duration-[120ms] focus-visible:outline focus-visible:outline-2',
             'focus-visible:outline-offset-1 focus-visible:outline-[color:var(--signal)]',
           )}
           aria-label="Switch environment"
+          title={compact ? `Environment: ${active?.name ?? 'none selected'}` : undefined}
         >
-          <span className="flex items-center gap-2 truncate">
+          <span className={cn('flex items-center gap-2 truncate', compact && 'justify-center')}>
             <span
               className={cn(
-                'inline-block w-[7px] h-[7px] rounded-full',
+                'inline-block w-[7px] h-[7px] rounded-full flex-shrink-0',
                 active?.accept_enrolls
                   ? 'bg-[color:var(--success)]'
                   : 'bg-[color:var(--text-3)]',
               )}
             />
-            <span className="font-medium truncate">
+            <span className={cn('font-medium truncate', compact && 'sr-only')}>
               {active?.name ?? (isLoading ? 'loading…' : 'select environment')}
             </span>
           </span>
-          <svg
-            className="w-3.5 h-3.5 text-[color:var(--text-3)] flex-shrink-0"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <path d="M6 9l6 6 6-6" />
-          </svg>
+          {!compact && (
+            <svg
+              className="w-3.5 h-3.5 text-[color:var(--text-3)] flex-shrink-0"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          )}
         </button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content align="start" className="min-w-[200px]">

--- a/frontend/src/components/chrome/SideNav.tsx
+++ b/frontend/src/components/chrome/SideNav.tsx
@@ -165,7 +165,7 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
       // gradient is preserved via the linear-gradient layered on top
       // of the SVG — the SVG sits at the bottom of the stack.
       className={cn(
-        'sidenav-circuit shrink-0 flex flex-col border-r border-[color:var(--border)] px-2 py-3',
+        'sidenav-circuit relative shrink-0 flex flex-col border-r border-[color:var(--border)] px-2 py-3',
         'transition-[width] duration-200 ease-out',
         collapsed ? 'w-14' : 'w-60',
         className,
@@ -440,7 +440,9 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
       )}
 
       {/* Collapse toggle — desktop rail only (the mobile drawer never
-          passes onToggleCollapse; it always renders full width). */}
+          passes onToggleCollapse; it always renders full width).
+          Floats on the rail's right border at mid-height so it's
+          reachable without scrolling regardless of nav length. */}
       {onToggleCollapse && (
         <button
           type="button"
@@ -448,23 +450,24 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
           aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
           title={collapsed ? 'Expand navigation' : 'Collapse navigation'}
           className={cn(
-            'mt-auto flex items-center gap-2 px-2 py-1.5 rounded-md text-sm',
-            collapsed && 'justify-center',
-            'text-[color:var(--text-3)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)]',
+            'absolute top-1/2 -translate-y-1/2 -right-3 z-20',
+            'w-6 h-6 rounded-full flex items-center justify-center',
+            'border border-[color:var(--border)] bg-[color:var(--bg-1)]',
+            'text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:border-[color:var(--signal)]',
+            'shadow-[0_1px_4px_rgba(0,0,0,0.25)]',
             'transition-colors duration-[120ms]',
-            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[color:var(--signal)]',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
           )}
         >
           <svg
-            className={cn('w-4 h-4 flex-shrink-0 transition-transform duration-200', collapsed && 'rotate-180')}
+            className={cn('w-3.5 h-3.5 transition-transform duration-200', collapsed && 'rotate-180')}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
-            strokeWidth="1.75"
+            strokeWidth="2"
           >
-            <path d="M11 17l-5-5 5-5M18 17l-5-5 5-5" />
+            <path d="M14 17l-5-5 5-5" />
           </svg>
-          <span className={collapsed ? 'sr-only' : undefined}>Collapse</span>
         </button>
       )}
     </aside>

--- a/frontend/src/components/chrome/SideNav.tsx
+++ b/frontend/src/components/chrome/SideNav.tsx
@@ -12,12 +12,14 @@ interface NavItemProps {
   to?: string;
   href?: string;
   icon: React.ReactNode;
+  collapsed?: boolean;
   children: React.ReactNode;
 }
 
-function NavItem({ active, to, href, icon, children }: NavItemProps) {
+function NavItem({ active, to, href, icon, collapsed, children }: NavItemProps) {
   const className = cn(
     'flex items-center gap-2 px-2 py-1.5 rounded-md text-sm',
+    collapsed && 'justify-center',
     'transition-colors duration-[120ms] ease-out',
     'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[color:var(--signal)]',
     active
@@ -29,16 +31,19 @@ function NavItem({ active, to, href, icon, children }: NavItemProps) {
       : 'text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)]',
   );
 
+  // In collapsed (icon-rail) mode the label moves to a native tooltip +
+  // sr-only text, so the item stays accessible and hover-discoverable.
+  const title = collapsed && typeof children === 'string' ? children : undefined;
   const content = (
     <>
       <span className="w-4 h-4 flex-shrink-0">{icon}</span>
-      {children}
+      <span className={collapsed ? 'sr-only' : undefined}>{children}</span>
     </>
   );
 
   if (to) {
     return (
-      <Link to={to} aria-current={active ? 'page' : undefined} className={className}>
+      <Link to={to} aria-current={active ? 'page' : undefined} className={className} title={title}>
         {content}
       </Link>
     );
@@ -49,6 +54,7 @@ function NavItem({ active, to, href, icon, children }: NavItemProps) {
       href={href ?? '#'}
       aria-current={active ? 'page' : undefined}
       className={className}
+      title={title}
     >
       {content}
     </a>
@@ -63,7 +69,15 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function SideNav({ className }: { className?: string } = {}) {
+interface SideNavProps {
+  className?: string;
+  /** Desktop icon-rail mode: labels collapse to tooltips, rail narrows. */
+  collapsed?: boolean;
+  /** Renders the collapse/expand chevron at the rail's foot when provided. */
+  onToggleCollapse?: () => void;
+}
+
+export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps = {}) {
   const routerState = useRouterState();
   const pathname = routerState.location.pathname;
   const params = useParams({ strict: false });
@@ -151,7 +165,9 @@ export function SideNav({ className }: { className?: string } = {}) {
       // gradient is preserved via the linear-gradient layered on top
       // of the SVG — the SVG sits at the bottom of the stack.
       className={cn(
-        'sidenav-circuit w-60 shrink-0 flex flex-col border-r border-[color:var(--border)] px-2 py-3',
+        'sidenav-circuit shrink-0 flex flex-col border-r border-[color:var(--border)] px-2 py-3',
+        'transition-[width] duration-200 ease-out',
+        collapsed ? 'w-14' : 'w-60',
         className,
       )}
     >
@@ -161,13 +177,17 @@ export function SideNav({ className }: { className?: string } = {}) {
           the app shell. Font sizes are tuned down a step versus the
           login card because the sidenav rail is narrower (~240px). */}
       <div className="flex flex-col items-center px-2 py-3 mb-4">
-        <Logo size={40} decorative />
-        <div className="mt-2 font-wordmark text-lg font-bold tracking-tight text-[color:var(--text-1)] leading-none">
-          osctrl
-        </div>
-        <div className="mt-1 text-[10px] font-mono-tabular text-[color:var(--text-3)] uppercase tracking-[0.1em] leading-none">
-          Osquery Control
-        </div>
+        <Logo size={collapsed ? 28 : 40} decorative />
+        {!collapsed && (
+          <>
+            <div className="mt-2 font-wordmark text-lg font-bold tracking-tight text-[color:var(--text-1)] leading-none">
+              osctrl
+            </div>
+            <div className="mt-1 text-[10px] font-mono-tabular text-[color:var(--text-3)] uppercase tracking-[0.1em] leading-none">
+              Osquery Control
+            </div>
+          </>
+        )}
       </div>
 
       {/* Overview section.
@@ -176,9 +196,14 @@ export function SideNav({ className }: { className?: string } = {}) {
           user with limited permissions only sees what they can
           actually use. Super-admins bypass every gate (isSuperAdmin
           short-circuits all of them to true above). */}
-      <SectionLabel>Overview</SectionLabel>
+      {collapsed ? (
+        <div className="mx-2 mb-2 border-t border-[color:var(--border)]" aria-hidden />
+      ) : (
+        <SectionLabel>Overview</SectionLabel>
+      )}
       <nav className="space-y-0.5 mb-4">
         <NavItem
+          collapsed={collapsed}
           active={isDashboardActive}
           to="/_app/"
           icon={
@@ -191,6 +216,7 @@ export function SideNav({ className }: { className?: string } = {}) {
         </NavItem>
         {canSeeEnv && (
           <NavItem
+            collapsed={collapsed}
             active={isNodesActive}
             to={nodesPath}
             icon={
@@ -205,6 +231,7 @@ export function SideNav({ className }: { className?: string } = {}) {
         )}
         {canQuery && (
           <NavItem
+            collapsed={collapsed}
             active={isQueriesActive}
             to={queriesPath}
             icon={
@@ -218,6 +245,7 @@ export function SideNav({ className }: { className?: string } = {}) {
         )}
         {canQuery && (
           <NavItem
+            collapsed={collapsed}
             active={isSavedQueriesActive}
             to={savedQueriesPath}
             icon={
@@ -231,6 +259,7 @@ export function SideNav({ className }: { className?: string } = {}) {
         )}
         {canCarve && (
           <NavItem
+            collapsed={collapsed}
             active={isCarvesActive}
             to={carvesPath}
             icon={
@@ -244,6 +273,7 @@ export function SideNav({ className }: { className?: string } = {}) {
         )}
         {canManageEnv && (
           <NavItem
+            collapsed={collapsed}
             active={isTagsActive}
             to={tagsPath}
             icon={
@@ -257,6 +287,7 @@ export function SideNav({ className }: { className?: string } = {}) {
         )}
         {canManageEnv && (
           <NavItem
+            collapsed={collapsed}
             active={isEnrollActive}
             to={enrollPath}
             icon={
@@ -271,6 +302,7 @@ export function SideNav({ className }: { className?: string } = {}) {
         )}
         {canManageEnv && (
           <NavItem
+            collapsed={collapsed}
             active={isConfigActive}
             to={configPath}
             icon={
@@ -290,6 +322,7 @@ export function SideNav({ className }: { className?: string } = {}) {
             force-clamps the username filter to the requester
             server-side). The label changes to reflect that scope. */}
         <NavItem
+          collapsed={collapsed}
           active={isAuditActive}
           to="/_app/audit"
           icon={
@@ -304,13 +337,17 @@ export function SideNav({ className }: { className?: string } = {}) {
       </nav>
 
       {/* Environments section */}
-      <div className="flex items-center justify-between px-2 py-1">
-        <span className="text-[10px] font-mono-tabular uppercase tracking-[0.12em] text-[color:var(--text-3)] select-none">
-          Environments
-        </span>
-      </div>
+      {collapsed ? (
+        <div className="mx-2 mb-2 border-t border-[color:var(--border)]" aria-hidden />
+      ) : (
+        <div className="flex items-center justify-between px-2 py-1">
+          <span className="text-[10px] font-mono-tabular uppercase tracking-[0.12em] text-[color:var(--text-3)] select-none">
+            Environments
+          </span>
+        </div>
+      )}
       <div className="mb-4">
-        <EnvSwitcher />
+        <EnvSwitcher compact={collapsed} />
       </div>
 
       {/* Admin section.
@@ -325,9 +362,14 @@ export function SideNav({ className }: { className?: string } = {}) {
           non-admin case. */}
       {isSuperAdmin ? (
         <>
-          <SectionLabel>Admin</SectionLabel>
+          {collapsed ? (
+            <div className="mx-2 mb-2 border-t border-[color:var(--border)]" aria-hidden />
+          ) : (
+            <SectionLabel>Admin</SectionLabel>
+          )}
           <nav className="space-y-0.5">
             <NavItem
+              collapsed={collapsed}
               active={isUsersActive}
               to="/_app/users"
               icon={
@@ -340,6 +382,7 @@ export function SideNav({ className }: { className?: string } = {}) {
               Operators
             </NavItem>
             <NavItem
+              collapsed={collapsed}
               active={isProfileActive}
               to="/_app/profile"
               icon={
@@ -352,6 +395,7 @@ export function SideNav({ className }: { className?: string } = {}) {
               Profile
             </NavItem>
             <NavItem
+              collapsed={collapsed}
               active={isEnvironmentsActive}
               to="/_app/environments"
               icon={
@@ -364,6 +408,7 @@ export function SideNav({ className }: { className?: string } = {}) {
               Environments
             </NavItem>
             <NavItem
+              collapsed={collapsed}
               active={isSettingsActive}
               to="/_app/settings/admin"
               icon={
@@ -379,6 +424,7 @@ export function SideNav({ className }: { className?: string } = {}) {
       ) : (
         <nav className="space-y-0.5">
           <NavItem
+            collapsed={collapsed}
             active={isProfileActive}
             to="/_app/profile"
             icon={
@@ -391,6 +437,35 @@ export function SideNav({ className }: { className?: string } = {}) {
             Profile
           </NavItem>
         </nav>
+      )}
+
+      {/* Collapse toggle — desktop rail only (the mobile drawer never
+          passes onToggleCollapse; it always renders full width). */}
+      {onToggleCollapse && (
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+          title={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+          className={cn(
+            'mt-auto flex items-center gap-2 px-2 py-1.5 rounded-md text-sm',
+            collapsed && 'justify-center',
+            'text-[color:var(--text-3)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)]',
+            'transition-colors duration-[120ms]',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[color:var(--signal)]',
+          )}
+        >
+          <svg
+            className={cn('w-4 h-4 flex-shrink-0 transition-transform duration-200', collapsed && 'rotate-180')}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+          >
+            <path d="M11 17l-5-5 5-5M18 17l-5-5 5-5" />
+          </svg>
+          <span className={collapsed ? 'sr-only' : undefined}>Collapse</span>
+        </button>
       )}
     </aside>
   );

--- a/frontend/src/components/chrome/SideNav.tsx
+++ b/frontend/src/components/chrome/SideNav.tsx
@@ -63,7 +63,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function SideNav() {
+export function SideNav({ className }: { className?: string } = {}) {
   const routerState = useRouterState();
   const pathname = routerState.location.pathname;
   const params = useParams({ strict: false });
@@ -150,7 +150,10 @@ export function SideNav() {
       // similar density. The teal sheen from the previous background
       // gradient is preserved via the linear-gradient layered on top
       // of the SVG — the SVG sits at the bottom of the stack.
-      className="sidenav-circuit w-60 shrink-0 flex flex-col border-r border-[color:var(--border)] px-2 py-3"
+      className={cn(
+        'sidenav-circuit w-60 shrink-0 flex flex-col border-r border-[color:var(--border)] px-2 py-3',
+        className,
+      )}
     >
       {/* Wordmark — mirrors the login card header (stacked logo +
           "osctrl" wordmark + "OSQUERY CONTROL" tagline) so the brand

--- a/frontend/src/components/chrome/TopBar.tsx
+++ b/frontend/src/components/chrome/TopBar.tsx
@@ -11,22 +11,43 @@ interface TopBarProps {
   breadcrumbs?: BreadcrumbSegment[];
   username?: string;
   onCommandPalette?: () => void;
+  onMenuToggle?: () => void;
 }
 
 export function TopBar({
   breadcrumbs = [{ label: 'Command Center' }],
   username,
   onCommandPalette,
+  onMenuToggle,
 }: TopBarProps) {
   return (
     <header
       className={cn(
         'topbar-glass',
-        'h-14 flex items-center gap-3 px-6',
+        'h-14 flex items-center gap-3 px-4 md:px-6',
         'border-b border-[color:var(--border)]',
         'sticky top-0 z-30',
       )}
     >
+      {/* Hamburger — phones only; the rail is always visible at md+. */}
+      {onMenuToggle && (
+        <button
+          type="button"
+          onClick={onMenuToggle}
+          aria-label="Open navigation menu"
+          className={cn(
+            'md:hidden -ml-1 p-1.5 rounded-md',
+            'text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)]',
+            'transition-colors duration-[120ms]',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+          )}
+        >
+          <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      )}
+
       {/* Breadcrumbs */}
       <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-[13px] min-w-0">
         {breadcrumbs.map((seg, idx) => {
@@ -74,8 +95,8 @@ export function TopBar({
               <circle cx="11" cy="11" r="8" />
               <path d="M21 21l-4.35-4.35" />
             </svg>
-            <span>Search</span>
-            <kbd className="font-mono-tabular text-[10px] text-[color:var(--text-3)]">⌘K</kbd>
+            <span className="hidden md:inline">Search</span>
+            <kbd className="hidden md:inline font-mono-tabular text-[10px] text-[color:var(--text-3)]">⌘K</kbd>
           </button>
         )}
         <ThemeToggle />


### PR DESCRIPTION
## Summary

Makes the SPA's side navigation responsive and collapsible:

**Mobile (<768px)**
- The nav rail is hidden and replaced by a hamburger button in the top bar that opens the same `SideNav` as an off-canvas drawer (dimmed backdrop, 200ms slide-in).
- The drawer closes on navigation (nav links, env switcher, command-palette jumps), backdrop tap, or Escape.
- Top-bar padding tightens and the Search button collapses to icon-only to fit small screens.

**Desktop (≥768px)**
- A circular chevron floating on the rail's right border at mid-height (always visible, no scrolling needed) collapses the rail from 240px to a 56px icon-only strip.
- In collapsed mode: labels become native tooltips + `sr-only` text, section headers become dividers, the wordmark reduces to the logo, and the env switcher shrinks to its status dot while keeping the full dropdown.
- The preference persists in `localStorage` (`osctrl.sidenav-collapsed`).

No functionality is removed in either mode — every nav item, the env switcher, and all permission gating behave exactly as before.

## Test plan

- [x] `npm run check` (tsc) clean
- [x] `npm test` — 22 files / 106 tests pass
- [x] `npm run build` clean
- [x] Verified live on a deployed stack: phone drawer open/close/navigate, desktop collapse/expand with persistence across reloads, dark + light themes