### PR TITLE
Removed legacy port from dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ The docker development stack exposes:
 
 - `https://localhost:8444` for the frontend
 - `https://localhost:8443` for the legacy `osctrl-admin` HTML interface
-- `https://localhost:8000` redirecting to HTTPS where applicable
 
 For frontend-only development details, see [frontend/README.md](./frontend/README.md).
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,7 +5,6 @@ services:
     image: nginx:${NGINX_VERSION}
     restart: unless-stopped
     ports:
-      - 8000:80
       - 8443:443
       - 8444:8444
     networks:


### PR DESCRIPTION
Legacy port `8000` in Docker development environment was no longer used.