### PR TITLE
Reload frontend build when changes to code

### DIFF
--- a/deploy/docker/conf/dev/air/.air-osctrl-frontend.toml
+++ b/deploy/docker/conf/dev/air/.air-osctrl-frontend.toml
@@ -5,7 +5,7 @@ tmp_dir = "/tmp"
 
 [build]
   bin = "/bin/sh"
-  cmd = "cd /usr/src/app/frontend && npm run build && rm -rf /usr/share/nginx/osctrl-frontend/* && cp -R dist/. /usr/share/nginx/osctrl-frontend/"
+  cmd = "sh /usr/src/app/deploy/docker/conf/dev/air/frontend-dev-build.sh"
   delay = 1000
   exclude_dir = ["tmp", "frontend/dist", "frontend/node_modules"]
   exclude_file = []

--- a/deploy/docker/conf/dev/air/.air-osctrl-frontend.toml
+++ b/deploy/docker/conf/dev/air/.air-osctrl-frontend.toml
@@ -1,0 +1,37 @@
+# Config file for Air in TOML format for osctrl-frontend
+
+root = "."
+tmp_dir = "/tmp"
+
+[build]
+  bin = "/bin/sh"
+  cmd = "cd /usr/src/app/frontend && npm run build && rm -rf /usr/share/nginx/osctrl-frontend/* && cp -R dist/. /usr/share/nginx/osctrl-frontend/"
+  delay = 1000
+  exclude_dir = ["tmp", "frontend/dist", "frontend/node_modules"]
+  exclude_file = []
+  exclude_regex = []
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = "sh /usr/src/app/deploy/docker/conf/dev/air/frontend-dev-run.sh"
+  include_dir = ["frontend"]
+  include_ext = ["ts", "tsx", "js", "jsx", "mjs", "css", "html", "json", "svg", "png", "woff2"]
+  kill_delay = "0s"
+  log = "build-errors.log"
+  send_interrupt = false
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  time = true
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false

--- a/deploy/docker/conf/dev/air/frontend-dev-build.sh
+++ b/deploy/docker/conf/dev/air/frontend-dev-build.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+FRONTEND_DIR="/usr/src/app/frontend"
+DOCROOT="/usr/share/nginx/osctrl-frontend"
+STAMP_FILE="${FRONTEND_DIR}/node_modules/.osctrl-deps.sha256"
+
+cd "$FRONTEND_DIR"
+
+deps_hash() {
+  {
+    sha256sum package.json
+    if [ -f package-lock.json ]; then
+      sha256sum package-lock.json
+    fi
+  } | sha256sum | awk '{print $1}'
+}
+
+CURRENT_HASH="$(deps_hash)"
+INSTALLED_HASH=""
+if [ -f "$STAMP_FILE" ]; then
+  INSTALLED_HASH="$(cat "$STAMP_FILE")"
+fi
+
+if [ ! -d node_modules ] || [ "$CURRENT_HASH" != "$INSTALLED_HASH" ]; then
+  if [ -f package-lock.json ]; then
+    npm ci --no-audit --no-fund
+  else
+    npm install --no-audit --no-fund
+  fi
+  printf '%s' "$CURRENT_HASH" > "$STAMP_FILE"
+fi
+
+npm run build
+
+mkdir -p "$DOCROOT"
+
+find dist -mindepth 1 -maxdepth 1 ! -name index.html -exec cp -R {} "$DOCROOT/" \;
+cp dist/index.html "$DOCROOT/index.html"

--- a/deploy/docker/conf/dev/air/frontend-dev-run.sh
+++ b/deploy/docker/conf/dev/air/frontend-dev-run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /run/nginx /usr/share/nginx/osctrl-frontend
+
+if ! pgrep -x nginx >/dev/null 2>&1; then
+  nginx
+fi
+
+while true; do
+  sleep 3600
+done

--- a/deploy/docker/conf/dev/air/frontend-dev-run.sh
+++ b/deploy/docker/conf/dev/air/frontend-dev-run.sh
@@ -1,12 +1,6 @@
 #!/bin/sh
 set -eu
 
-mkdir -p /run/nginx /usr/share/nginx/osctrl-frontend
+mkdir -p /run/nginx /usr/share/nginx
 
-if ! pgrep -x nginx >/dev/null 2>&1; then
-  nginx
-fi
-
-while true; do
-  sleep 3600
-done
+exec nginx -g 'daemon off;'

--- a/deploy/docker/dockerfiles/Dockerfile-dev-frontend
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-frontend
@@ -23,6 +23,7 @@ RUN rm -f /etc/nginx/http.d/default.conf /etc/nginx/conf.d/default.conf && \
 
 COPY deploy/docker/conf/nginx/frontend-dev.conf /etc/nginx/http.d/osctrl-frontend.conf
 COPY deploy/docker/conf/dev/air/.air-osctrl-frontend.toml /usr/src/app/deploy/docker/conf/dev/air/.air-osctrl-frontend.toml
+COPY deploy/docker/conf/dev/air/frontend-dev-build.sh /usr/src/app/deploy/docker/conf/dev/air/frontend-dev-build.sh
 COPY deploy/docker/conf/dev/air/frontend-dev-run.sh /usr/src/app/deploy/docker/conf/dev/air/frontend-dev-run.sh
 
 EXPOSE 80

--- a/deploy/docker/dockerfiles/Dockerfile-dev-frontend
+++ b/deploy/docker/dockerfiles/Dockerfile-dev-frontend
@@ -1,34 +1,30 @@
 # Dev-stack Dockerfile for osctrl-frontend.
 #
-# Same multi-stage shape as Dockerfile-osctrl-frontend — node build → nginx:alpine
-# — but ships the HTTP-only dev nginx config so it can run side-by-side with the
-# legacy admin (which already owns :8443 for TLS in this stack).
-#
-# Built and run via docker-compose-dev.yml as service `osctrl-frontend`. Not
-# meant for production; use Dockerfile-osctrl-frontend for that.
+# Unlike the production image, this one runs node + nginx + air in the
+# same container so edits under frontend/ trigger an automatic rebuild of
+# the static bundle served through osctrl-nginx on :8444.
 
-# -------- Stage 1: build --------
-FROM node:22-alpine AS build
+FROM node:22-alpine
 
-WORKDIR /app/frontend
+WORKDIR /usr/src/app/frontend
+
+RUN apk add --no-cache go nginx
+RUN GOBIN=/usr/local/bin go install github.com/cosmtrek/air@v1.49.0
 
 COPY frontend/package.json frontend/package-lock.json* ./
 
 RUN if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; \
     else npm install --no-audit --no-fund; fi
 
-COPY frontend/ ./
+WORKDIR /usr/src/app
 
-RUN npm run build
+RUN rm -f /etc/nginx/http.d/default.conf /etc/nginx/conf.d/default.conf && \
+    mkdir -p /usr/share/nginx/osctrl-frontend /run/nginx
 
-# -------- Stage 2: nginx --------
-FROM nginx:alpine
-
-RUN rm -f /etc/nginx/conf.d/default.conf
-
-COPY --from=build /app/frontend/dist /usr/share/nginx/osctrl-frontend
-COPY deploy/docker/conf/nginx/frontend-dev.conf /etc/nginx/conf.d/osctrl-frontend.conf
+COPY deploy/docker/conf/nginx/frontend-dev.conf /etc/nginx/http.d/osctrl-frontend.conf
+COPY deploy/docker/conf/dev/air/.air-osctrl-frontend.toml /usr/src/app/deploy/docker/conf/dev/air/.air-osctrl-frontend.toml
+COPY deploy/docker/conf/dev/air/frontend-dev-run.sh /usr/src/app/deploy/docker/conf/dev/air/frontend-dev-run.sh
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["air", "-c", "/usr/src/app/deploy/docker/conf/dev/air/.air-osctrl-frontend.toml"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -175,14 +175,13 @@ services:
   ######################################### osctrl-frontend (React SPA) #########################################
   # Ships the React admin frontend through osctrl-nginx on
   # https://<host>:8444 while remaining internal-only on the docker network.
-  # The frontend container still owns the SPA static serving and /api/*
-  # reverse-proxy to osctrl-api.
+  # The frontend container owns the SPA static serving and /api/*
+  # reverse-proxy to osctrl-api, while air rebuilds dist/ when files in
+  # frontend/ change.
   #
-  # The image is multi-stage: node:20 builds dist/, nginx:alpine serves it
-  # + reverse-proxies /api/* to osctrl-api:9002. No volume mount of the
-  # host tree — changes to frontend/ require
-  # `docker compose build osctrl-frontend` (no hot reload here; use
-  # `npm run dev` directly for that).
+  # Source is bind-mounted into the container. node_modules stays in a
+  # Docker volume so the host mount does not shadow container-installed
+  # dependencies.
   osctrl-frontend:
     container_name: 'osctrl-frontend-dev'
     image: 'osctrl-frontend-dev:${OSCTRL_VERSION}'
@@ -192,6 +191,17 @@ services:
       dockerfile: deploy/docker/dockerfiles/Dockerfile-dev-frontend
     networks:
       - osctrl-dev-backend
+    volumes:
+      - .:/usr/src/app:rw,delegated
+      - frontend-osctrl-dev-node-modules:/usr/src/app/frontend/node_modules
+    develop:
+      watch:
+        - path: ./deploy/docker/dockerfiles/Dockerfile-dev-frontend
+          action: rebuild
+        - path: ./frontend/package.json
+          action: rebuild
+        - path: ./frontend/package-lock.json
+          action: rebuild
     depends_on:
       - osctrl-api
 
@@ -394,6 +404,7 @@ networks:
 volumes:
   postgres-osctrl-dev-db:
   redis-osctrl-dev-data:
+  frontend-osctrl-dev-node-modules:
   osquery-osctrl-dev-1-data:
   osquery-osctrl-dev-1-conf:
   osquery-osctrl-dev-2-data:


### PR DESCRIPTION
Same behavior as the other services (`osctrl-tls`, `osctrl-api`, `osctrl-admin`) and reload the service in the Docker development environment when codes detected under `frontend/`.