### PR TITLE
Makefile job to merge develop into main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,3 +359,11 @@ release-test:
 			$$binary --version || $$binary version || echo "No version flag available"; \
 		fi; \
 	done
+
+# Merge locally develop into main, usually to prepare for release
+develop-merge:
+	git pull
+	git checkout main
+	git pull origin main
+	git merge develop
+	git push origin main


### PR DESCRIPTION
Adding job to `Makefile` to merge `develop` into `main`, usually before new release.