### PR TITLE
Activity pkg to handle data from nodes and environments

### DIFF
--- a/cmd/tls/handlers/activity_writer.go
+++ b/cmd/tls/handlers/activity_writer.go
@@ -1,0 +1,184 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/activity"
+	"github.com/rs/zerolog/log"
+)
+
+type activityStore interface {
+	IncrementMany(ctx context.Context, events []activity.Event) error
+}
+
+type activityWriter struct {
+	store     activityStore
+	events    chan activity.Event
+	batchSize int
+	timeout   time.Duration
+	stop      chan struct{}
+	done      chan struct{}
+}
+
+func NewActivityWriter(store activityStore, batchSize int, timeout time.Duration, bufferSize int) *activityWriter {
+	if store == nil {
+		return nil
+	}
+	if batchSize <= 0 {
+		batchSize = 1
+	}
+	if timeout <= 0 {
+		timeout = 250 * time.Millisecond
+	}
+	if bufferSize <= 0 {
+		bufferSize = batchSize
+	}
+
+	aw := &activityWriter{
+		store:     store,
+		events:    make(chan activity.Event, bufferSize),
+		batchSize: batchSize,
+		timeout:   timeout,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	go aw.run()
+
+	return aw
+}
+
+func (aw *activityWriter) addEvent(ev activity.Event) {
+	if aw == nil {
+		return
+	}
+
+	select {
+	case aw.events <- ev:
+	default:
+		log.Warn().
+			Str("env", ev.EnvUUID).
+			Str("node", ev.NodeUUID).
+			Msg("dropping node activity event because writer queue is full")
+	}
+}
+
+func (aw *activityWriter) close() {
+	if aw == nil {
+		return
+	}
+
+	select {
+	case <-aw.done:
+		return
+	default:
+	}
+
+	close(aw.stop)
+	<-aw.done
+}
+
+func (aw *activityWriter) run() {
+	defer close(aw.done)
+
+	batch := make([]activity.Event, 0, aw.batchSize)
+	timer := time.NewTimer(aw.timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-aw.stop:
+			aw.flush(aw.drain(batch))
+			return
+		case ev := <-aw.events:
+			batch = append(batch, ev)
+			if len(batch) >= aw.batchSize {
+				aw.flush(batch)
+				batch = batch[:0]
+				resetTimer(timer, aw.timeout)
+			}
+		case <-timer.C:
+			if len(batch) > 0 {
+				aw.flush(batch)
+				batch = batch[:0]
+			}
+			timer.Reset(aw.timeout)
+		}
+	}
+}
+
+func (aw *activityWriter) drain(batch []activity.Event) []activity.Event {
+	for {
+		select {
+		case ev := <-aw.events:
+			batch = append(batch, ev)
+		default:
+			return batch
+		}
+	}
+}
+
+func (aw *activityWriter) flush(batch []activity.Event) {
+	if len(batch) == 0 {
+		return
+	}
+
+	type eventKey struct {
+		envUUID   string
+		nodeUUID  string
+		eventType activity.EventType
+		at        time.Time
+	}
+
+	counts := make(map[eventKey]uint32, len(batch))
+	for _, ev := range batch {
+		if ev.EnvUUID == "" || ev.NodeUUID == "" || ev.Type >= activity.EventTypeCount {
+			continue
+		}
+
+		if ev.Count == 0 {
+			ev.Count = 1
+		}
+
+		at := ev.At.UTC().Truncate(time.Hour)
+		key := eventKey{
+			envUUID:   ev.EnvUUID,
+			nodeUUID:  ev.NodeUUID,
+			eventType: ev.Type,
+			at:        at,
+		}
+		counts[key] += uint32(ev.Count)
+	}
+
+	if len(counts) == 0 {
+		return
+	}
+
+	events := make([]activity.Event, 0, len(counts))
+	for key, count := range counts {
+		if count > uint32(^uint16(0)) {
+			count = uint32(^uint16(0))
+		}
+		events = append(events, activity.Event{
+			EnvUUID:  key.envUUID,
+			NodeUUID: key.nodeUUID,
+			Type:     key.eventType,
+			At:       key.at,
+			Count:    uint16(count),
+		})
+	}
+
+	if err := aw.store.IncrementMany(context.Background(), events); err != nil {
+		log.Err(err).Msg("flushing node activity rollups failed")
+	}
+}
+
+func resetTimer(timer *time.Timer, timeout time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(timeout)
+}

--- a/cmd/tls/handlers/activity_writer_test.go
+++ b/cmd/tls/handlers/activity_writer_test.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/activity"
+)
+
+type recordingActivityStore struct {
+	mu      sync.Mutex
+	events  []activity.Event
+	notify  chan struct{}
+	blocked chan struct{}
+	release chan struct{}
+}
+
+func (s *recordingActivityStore) IncrementMany(_ context.Context, events []activity.Event) error {
+	s.mu.Lock()
+	s.events = append(s.events, events...)
+	s.mu.Unlock()
+
+	if s.blocked != nil {
+		select {
+		case s.blocked <- struct{}{}:
+		default:
+		}
+	}
+	if s.notify != nil {
+		select {
+		case s.notify <- struct{}{}:
+		default:
+		}
+	}
+	if s.release != nil {
+		<-s.release
+	}
+
+	return nil
+}
+
+func (s *recordingActivityStore) snapshot() []activity.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]activity.Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+func TestActivityWriterFlushesAggregatedEvents(t *testing.T) {
+	store := &recordingActivityStore{
+		notify: make(chan struct{}, 1),
+	}
+	writer := NewActivityWriter(store, 2, time.Second, 8)
+	defer writer.close()
+
+	now := time.Date(2026, 6, 15, 11, 25, 0, 0, time.UTC)
+	writer.addEvent(activity.Event{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: activity.EventStatus, At: now})
+	writer.addEvent(activity.Event{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: activity.EventStatus, At: now.Add(20 * time.Minute)})
+
+	select {
+	case <-store.notify:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for activity flush")
+	}
+
+	events := store.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 aggregated event, got %+v", events)
+	}
+
+	got := events[0]
+	if got.Count != 2 {
+		t.Fatalf("expected aggregated count 2, got %d", got.Count)
+	}
+	wantAt := time.Date(2026, 6, 15, 11, 0, 0, 0, time.UTC)
+	if !got.At.Equal(wantAt) {
+		t.Fatalf("expected normalized hour %s, got %s", wantAt, got.At)
+	}
+}
+
+func TestActivityWriterDropsWhenQueueIsFullWithoutBlocking(t *testing.T) {
+	store := &recordingActivityStore{
+		blocked: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	writer := NewActivityWriter(store, 1, time.Hour, 1)
+
+	now := time.Date(2026, 6, 15, 11, 0, 0, 0, time.UTC)
+	writer.addEvent(activity.Event{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: activity.EventStatus, At: now})
+
+	select {
+	case <-store.blocked:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first flush to block")
+	}
+
+	writer.addEvent(activity.Event{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: activity.EventStatus, At: now.Add(time.Hour)})
+
+	done := make(chan struct{})
+	go func() {
+		writer.addEvent(activity.Event{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: activity.EventStatus, At: now.Add(2 * time.Hour)})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected addEvent to return immediately when queue is full")
+	}
+
+	close(store.release)
+	writer.close()
+
+	events := store.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 flushed events after dropping one, got %+v", events)
+	}
+}

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -60,6 +60,7 @@ type HandlersTLS struct {
 	SettingsMap     *settings.MapSettings
 	Logs            *logging.LoggerTLS
 	WriteHandler    *batchWriter
+	ActivityWriter  *activityWriter
 	OsqueryValues   *config.YAMLConfigurationOsquery
 	ConfigEndpoints *config.YAMLConfigurationEndpoints
 	DebugHTTP       *zerolog.Logger
@@ -142,6 +143,13 @@ func WithLogs(logs *logging.LoggerTLS) Option {
 func WithWriteHandler(writeHandler *batchWriter) Option {
 	return func(h *HandlersTLS) {
 		h.WriteHandler = writeHandler
+	}
+}
+
+// WithActivityWriter to pass value as option
+func WithActivityWriter(activityWriter *activityWriter) Option {
+	return func(h *HandlersTLS) {
+		h.ActivityWriter = activityWriter
 	}
 }
 

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jmpsec/osctrl/cmd/tls/handlers"
+	"github.com/jmpsec/osctrl/pkg/activity"
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/backend"
 	"github.com/jmpsec/osctrl/pkg/cache"
@@ -228,6 +229,13 @@ func osctrlService() {
 		flagParams.BatchWriter.WriterBufferSize,
 		*nodesmgr,
 	)
+	log.Info().Msg("Initializing activity writer")
+	activityWriter := handlers.NewActivityWriter(
+		activity.NewRedisStore(redis.Client, activity.DefaultPrefix, activity.DefaultRetentionDays, 8*24*time.Hour),
+		512,
+		250*time.Millisecond,
+		8192,
+	)
 	// Initialize service metrics
 	log.Info().Msg("Loading service metrics")
 	// Initialize TLS logger
@@ -305,6 +313,7 @@ func osctrlService() {
 		handlers.WithSettingsMap(&settingsmap),
 		handlers.WithLogs(loggerTLS),
 		handlers.WithWriteHandler(tlsWriter),
+		handlers.WithActivityWriter(activityWriter),
 		handlers.WithOsqueryValues(flagParams.Osquery),
 		handlers.WithConfigEndpoints(flagParams.ConfigEndpoints),
 		handlers.WithDebugHTTP(flagParams.Debug),

--- a/pkg/activity/redis.go
+++ b/pkg/activity/redis.go
@@ -1,0 +1,190 @@
+package activity
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+// RedisStore manages node activity rollups stored as compact Redis day blobs.
+type RedisStore struct {
+	client      *redis.Client
+	prefix      string
+	expireAfter time.Duration
+}
+
+// NewRedisStore builds a Redis-backed rollup store for per-node activity tiles.
+func NewRedisStore(client *redis.Client, prefix string, retentionDays int, expireAfter time.Duration) *RedisStore {
+	if prefix == "" {
+		prefix = DefaultPrefix
+	}
+	if retentionDays <= 0 {
+		retentionDays = DefaultRetentionDays
+	}
+	if expireAfter <= 0 {
+		expireAfter = time.Duration(retentionDays+1) * 24 * time.Hour
+	}
+
+	return &RedisStore{
+		client:      client,
+		prefix:      prefix,
+		expireAfter: expireAfter,
+	}
+}
+
+// IncrementMany batches activity events into hourly counters per UTC day.
+func (s *RedisStore) IncrementMany(ctx context.Context, events []Event) error {
+	type counterKey struct {
+		key    string
+		offset int64
+	}
+
+	aggregated := make(map[counterKey]uint32)
+	for _, event := range events {
+		if event.EnvUUID == "" || event.NodeUUID == "" || event.Type >= EventTypeCount {
+			continue
+		}
+
+		if event.Count == 0 {
+			continue
+		}
+
+		key := counterKey{
+			key:    DayKey(s.prefix, event.EnvUUID, event.NodeUUID, event.At),
+			offset: bitOffset(event.Type, bucketHour(event.At)),
+		}
+		aggregated[key] += uint32(event.Count)
+	}
+
+	if len(aggregated) == 0 {
+		return nil
+	}
+
+	pipe := s.client.Pipeline()
+	expireKeys := make(map[string]struct{})
+	for key, count := range aggregated {
+		pipe.BitField(ctx, key.key, "OVERFLOW", "SAT", "INCRBY", "u16", key.offset, int64(count))
+		expireKeys[key.key] = struct{}{}
+	}
+	for key := range expireKeys {
+		pipe.Expire(ctx, key, s.expireAfter)
+	}
+
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// ReadSeries returns dense node activity series for the requested day window.
+func (s *RedisStore) ReadSeries(ctx context.Context, envUUID string, nodeUUIDs []string, end time.Time, days int) (map[string]NodeTileSeries, error) {
+	if days <= 0 {
+		days = 1
+	}
+
+	start := dayStart(end).Add(-time.Duration(days-1) * 24 * time.Hour)
+	bucketCount := days * BucketsPerDay
+	out := make(map[string]NodeTileSeries, len(nodeUUIDs))
+
+	type dayFetch struct {
+		nodeUUID string
+		dayIndex int
+		cmd      *redis.StringCmd
+	}
+
+	pipe := s.client.Pipeline()
+	fetches := make([]dayFetch, 0, len(nodeUUIDs)*days)
+	for _, nodeUUID := range nodeUUIDs {
+		out[nodeUUID] = NodeTileSeries{
+			Start:         start,
+			BucketSeconds: BucketSeconds,
+			Enroll:        make([]uint16, bucketCount),
+			Config:        make([]uint16, bucketCount),
+			Status:        make([]uint16, bucketCount),
+			Result:        make([]uint16, bucketCount),
+			QueryRead:     make([]uint16, bucketCount),
+			QueryWrite:    make([]uint16, bucketCount),
+			Total:         make([]uint16, bucketCount),
+		}
+
+		for dayIndex := 0; dayIndex < days; dayIndex++ {
+			day := start.Add(time.Duration(dayIndex) * 24 * time.Hour)
+			cmd := pipe.Get(ctx, DayKey(s.prefix, envUUID, nodeUUID, day))
+			fetches = append(fetches, dayFetch{
+				nodeUUID: nodeUUID,
+				dayIndex: dayIndex,
+				cmd:      cmd,
+			})
+		}
+	}
+
+	if len(fetches) == 0 {
+		return out, nil
+	}
+
+	if _, err := pipe.Exec(ctx); err != nil && !errors.Is(err, redis.Nil) {
+		return nil, err
+	}
+
+	for _, fetch := range fetches {
+		blob, err := fetch.cmd.Bytes()
+		if err != nil && !errors.Is(err, redis.Nil) {
+			return nil, err
+		}
+		if len(blob) == 0 {
+			continue
+		}
+
+		decoded := decodeDay(blob)
+		series := out[fetch.nodeUUID]
+		base := fetch.dayIndex * BucketsPerDay
+		for hour := 0; hour < BucketsPerDay; hour++ {
+			idx := base + hour
+			series.Enroll[idx] = decoded[EventEnroll][hour]
+			series.Config[idx] = decoded[EventConfig][hour]
+			series.Status[idx] = decoded[EventStatus][hour]
+			series.Result[idx] = decoded[EventResult][hour]
+			series.QueryRead[idx] = decoded[EventQueryRead][hour]
+			series.QueryWrite[idx] = decoded[EventQueryWrite][hour]
+			series.Total[idx] = saturatingSum(
+				decoded[EventEnroll][hour],
+				decoded[EventConfig][hour],
+				decoded[EventStatus][hour],
+				decoded[EventResult][hour],
+				decoded[EventQueryRead][hour],
+				decoded[EventQueryWrite][hour],
+			)
+		}
+		out[fetch.nodeUUID] = series
+	}
+
+	return out, nil
+}
+
+func decodeDay(blob []byte) [EventTypeCount][BucketsPerDay]uint16 {
+	var out [EventTypeCount][BucketsPerDay]uint16
+
+	for eventType := 0; eventType < EventTypeCount; eventType++ {
+		for hour := 0; hour < BucketsPerDay; hour++ {
+			base := (eventType*BucketsPerDay + hour) * 2
+			if base+1 >= len(blob) {
+				continue
+			}
+			out[eventType][hour] = uint16(blob[base])<<8 | uint16(blob[base+1])
+		}
+	}
+
+	return out
+}
+
+func saturatingSum(values ...uint16) uint16 {
+	var total uint32
+	for _, value := range values {
+		total += uint32(value)
+		if total > uint32(^uint16(0)) {
+			return ^uint16(0)
+		}
+	}
+
+	return uint16(total)
+}

--- a/pkg/activity/redis_test.go
+++ b/pkg/activity/redis_test.go
@@ -1,0 +1,102 @@
+package activity
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDayKeyUsesEnvNodeAndUTCDate(t *testing.T) {
+	loc := time.FixedZone("UTC+2", 2*60*60)
+	day := time.Date(2026, 6, 16, 1, 33, 0, 0, loc)
+
+	got := DayKey("nodeact:v1", "ENV1", "NODE1", day)
+	want := "nodeact:v1:ENV1:NODE1:20260615"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+
+	if got := bucketHour(day); got != 23 {
+		t.Fatalf("expected UTC bucket hour 23, got %d", got)
+	}
+
+	wantDayStart := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	if got := dayStart(day); !got.Equal(wantDayStart) {
+		t.Fatalf("expected UTC day start %s, got %s", wantDayStart, got)
+	}
+}
+
+func TestStoreIncrementManyAndReadSeries(t *testing.T) {
+	client, fake := newTestRedisClient(t)
+	store := NewRedisStore(client, "nodeact:v1", 7, 24*time.Hour)
+
+	ctx := context.Background()
+	end := time.Date(2026, 6, 15, 23, 50, 0, 0, time.UTC)
+	loc := time.FixedZone("UTC+2", 2*60*60)
+
+	err := store.IncrementMany(context.Background(), []Event{
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventStatus, At: time.Date(2026, 6, 14, 23, 20, 0, 0, time.UTC), Count: 2},
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventQueryRead, At: time.Date(2026, 6, 15, 0, 5, 0, 0, time.UTC), Count: 1},
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventResult, At: time.Date(2026, 6, 15, 10, 10, 0, 0, time.UTC), Count: 40000},
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventResult, At: time.Date(2026, 6, 15, 10, 40, 0, 0, time.UTC), Count: 30000},
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventQueryWrite, At: time.Date(2026, 6, 15, 11, 20, 0, 0, time.UTC), Count: 1},
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventEnroll, At: time.Date(2026, 6, 16, 1, 20, 0, 0, loc), Count: 3},
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventConfig, At: time.Date(2026, 6, 15, 11, 20, 0, 0, time.UTC), Count: 0},
+	})
+	if err != nil {
+		t.Fatalf("increment failed: %v", err)
+	}
+
+	out, err := store.ReadSeries(ctx, "ENV1", []string{"NODE1", "NODE2"}, end, 2)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	series := out["NODE1"]
+	if len(series.Total) != 48 {
+		t.Fatalf("expected 48 buckets, got %d", len(series.Total))
+	}
+
+	wantStart := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	if !series.Start.Equal(wantStart) {
+		t.Fatalf("expected start %s, got %s", wantStart, series.Start)
+	}
+
+	if series.Status[23] != 2 || series.Total[23] != 2 {
+		t.Fatalf("expected day 1 hour 23 status bucket to be 2, got status=%d total=%d", series.Status[23], series.Total[23])
+	}
+	if series.QueryRead[24] != 1 || series.Total[24] != 1 {
+		t.Fatalf("expected day 2 hour 0 query-read bucket to be 1, got queryRead=%d total=%d", series.QueryRead[24], series.Total[24])
+	}
+	if series.Result[34] != 65535 || series.Total[34] != 65535 {
+		t.Fatalf("expected saturated result bucket at day 2 hour 10, got result=%d total=%d", series.Result[34], series.Total[34])
+	}
+	if series.QueryWrite[35] != 1 || series.Total[35] != 1 {
+		t.Fatalf("expected day 2 hour 11 query-write bucket to be 1, got queryWrite=%d total=%d", series.QueryWrite[35], series.Total[35])
+	}
+	if series.Enroll[47] != 3 || series.Total[47] != 3 {
+		t.Fatalf("expected UTC-normalized enroll bucket at day 2 hour 23 to be 3, got enroll=%d total=%d", series.Enroll[47], series.Total[47])
+	}
+	if series.Config[35] != 0 {
+		t.Fatalf("expected zero-count config event to be ignored, got %d", series.Config[35])
+	}
+	if series.Total[0] != 0 || series.Total[1] != 0 || series.Total[46] != 0 {
+		t.Fatalf("expected missing buckets to stay zero-filled, got total[0]=%d total[1]=%d total[46]=%d", series.Total[0], series.Total[1], series.Total[46])
+	}
+	if got := fake.expireFor("nodeact:v1:ENV1:NODE1:20260614"); got != 24*time.Hour {
+		t.Fatalf("expected 24h TTL for 20260614 key, got %s", got)
+	}
+	if got := fake.expireFor("nodeact:v1:ENV1:NODE1:20260615"); got != 24*time.Hour {
+		t.Fatalf("expected 24h TTL for 20260615 key, got %s", got)
+	}
+
+	empty := out["NODE2"]
+	if len(empty.Total) != 48 {
+		t.Fatalf("expected NODE2 to have 48 buckets, got %d", len(empty.Total))
+	}
+	for i, value := range empty.Total {
+		if value != 0 {
+			t.Fatalf("expected NODE2 bucket %d to be zero-filled, got %d", i, value)
+		}
+	}
+}

--- a/pkg/activity/redis_test_helpers_test.go
+++ b/pkg/activity/redis_test_helpers_test.go
@@ -1,0 +1,219 @@
+package activity
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+func newTestRedisClient(t *testing.T) (*redis.Client, *fakeRedisStore) {
+	t.Helper()
+
+	store := &fakeRedisStore{
+		values:  make(map[string][]byte),
+		expires: make(map[string]time.Duration),
+	}
+	client := redis.NewClient(&redis.Options{
+		Addr:     "fake-redis",
+		PoolSize: 1,
+		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			serverConn, clientConn := net.Pipe()
+			go serveFakeRedis(serverConn, store)
+			return clientConn, nil
+		},
+	})
+
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	return client, store
+}
+
+type fakeRedisStore struct {
+	mu      sync.Mutex
+	values  map[string][]byte
+	expires map[string]time.Duration
+}
+
+func serveFakeRedis(conn net.Conn, store *fakeRedisStore) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	for {
+		args, err := readRESPArray(reader)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				_, _ = conn.Write([]byte("-ERR read failed\r\n"))
+			}
+			return
+		}
+		if len(args) == 0 {
+			_, _ = conn.Write([]byte("-ERR empty command\r\n"))
+			return
+		}
+
+		if err := handleFakeRedisCommand(conn, store, args); err != nil {
+			_, _ = conn.Write([]byte("-ERR " + err.Error() + "\r\n"))
+			return
+		}
+	}
+}
+
+func handleFakeRedisCommand(conn net.Conn, store *fakeRedisStore, args []string) error {
+	switch strings.ToUpper(args[0]) {
+	case "BITFIELD":
+		if len(args) != 8 {
+			return fmt.Errorf("unexpected BITFIELD args: %v", args)
+		}
+		key := args[1]
+		offset, err := strconv.Atoi(args[6])
+		if err != nil {
+			return err
+		}
+		increment, err := strconv.Atoi(args[7])
+		if err != nil {
+			return err
+		}
+
+		value := store.incrByU16(key, offset, increment)
+		_, err = fmt.Fprintf(conn, "*1\r\n:%d\r\n", value)
+		return err
+
+	case "EXPIRE":
+		if len(args) != 3 {
+			return fmt.Errorf("unexpected EXPIRE args: %v", args)
+		}
+		seconds, err := strconv.Atoi(args[2])
+		if err != nil {
+			return err
+		}
+		store.expire(args[1], time.Duration(seconds)*time.Second)
+		_, err = conn.Write([]byte(":1\r\n"))
+		return err
+
+	case "GET":
+		if len(args) != 2 {
+			return fmt.Errorf("unexpected GET args: %v", args)
+		}
+		value, ok := store.get(args[1])
+		if !ok {
+			_, err := conn.Write([]byte("$-1\r\n"))
+			return err
+		}
+		_, err := fmt.Fprintf(conn, "$%d\r\n", len(value))
+		if err != nil {
+			return err
+		}
+		_, err = conn.Write(append(value, []byte("\r\n")...))
+		return err
+
+	case "PING":
+		_, err := conn.Write([]byte("+PONG\r\n"))
+		return err
+
+	default:
+		return fmt.Errorf("unsupported command %q", args[0])
+	}
+}
+
+func (s *fakeRedisStore) incrByU16(key string, bitOffset int, increment int) uint16 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	byteOffset := bitOffset / 8
+	buf := append([]byte(nil), s.values[key]...)
+	if len(buf) < byteOffset+2 {
+		buf = append(buf, make([]byte, byteOffset+2-len(buf))...)
+	}
+
+	current := uint16(buf[byteOffset])<<8 | uint16(buf[byteOffset+1])
+	next := int(current) + increment
+	if next > int(^uint16(0)) {
+		next = int(^uint16(0))
+	}
+	if next < 0 {
+		next = 0
+	}
+
+	value := uint16(next)
+	buf[byteOffset] = byte(value >> 8)
+	buf[byteOffset+1] = byte(value)
+	s.values[key] = buf
+
+	return value
+}
+
+func (s *fakeRedisStore) expire(key string, ttl time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.expires[key] = ttl
+}
+
+func (s *fakeRedisStore) expireFor(key string) time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.expires[key]
+}
+
+func (s *fakeRedisStore) get(key string) ([]byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	value, ok := s.values[key]
+	if !ok {
+		return nil, false
+	}
+	return append([]byte(nil), value...), true
+}
+
+func readRESPArray(reader *bufio.Reader) ([]string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	if len(line) < 3 || line[0] != '*' {
+		return nil, fmt.Errorf("unexpected RESP header %q", line)
+	}
+
+	count, err := strconv.Atoi(strings.TrimSpace(line[1:]))
+	if err != nil {
+		return nil, err
+	}
+
+	args := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		sizeLine, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		if len(sizeLine) < 3 || sizeLine[0] != '$' {
+			return nil, fmt.Errorf("unexpected bulk header %q", sizeLine)
+		}
+
+		size, err := strconv.Atoi(strings.TrimSpace(sizeLine[1:]))
+		if err != nil {
+			return nil, err
+		}
+
+		buf := make([]byte, size+2)
+		if _, err := io.ReadFull(reader, buf); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf[:size]))
+	}
+
+	return args, nil
+}

--- a/pkg/activity/types.go
+++ b/pkg/activity/types.go
@@ -1,0 +1,68 @@
+package activity
+
+import (
+	"fmt"
+	"time"
+)
+
+// Default rollup settings and bucket layout.
+const (
+	DefaultPrefix        = "nodeact:v1"
+	DefaultRetentionDays = 7
+	BucketSeconds        = 3600
+	BucketsPerDay        = 24
+	EventTypeCount       = 6
+)
+
+// EventType identifies the activity counter family stored in a bucket.
+type EventType uint8
+
+// Supported activity event types.
+const (
+	EventEnroll EventType = iota
+	EventConfig
+	EventStatus
+	EventResult
+	EventQueryRead
+	EventQueryWrite
+)
+
+// Event is one activity increment for a node at a specific point in time.
+type Event struct {
+	EnvUUID  string
+	NodeUUID string
+	Type     EventType
+	At       time.Time
+	Count    uint16
+}
+
+// NodeTileSeries is a dense activity series ready for node tile rendering.
+type NodeTileSeries struct {
+	Start         time.Time `json:"start"`
+	BucketSeconds int       `json:"bucket_seconds"`
+	Enroll        []uint16  `json:"enroll"`
+	Config        []uint16  `json:"config"`
+	Status        []uint16  `json:"status"`
+	Result        []uint16  `json:"result"`
+	QueryRead     []uint16  `json:"query_read"`
+	QueryWrite    []uint16  `json:"query_write"`
+	Total         []uint16  `json:"total"`
+}
+
+// DayKey returns the Redis key for one node's UTC activity day blob.
+func DayKey(prefix, envUUID, nodeUUID string, day time.Time) string {
+	return fmt.Sprintf("%s:%s:%s:%s", prefix, envUUID, nodeUUID, day.UTC().Format("20060102"))
+}
+
+func bucketHour(t time.Time) int {
+	return t.UTC().Hour()
+}
+
+func dayStart(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func bitOffset(eventType EventType, hour int) int64 {
+	return int64((int(eventType)*BucketsPerDay + hour) * 16)
+}


### PR DESCRIPTION
Adding new pkg activity to keep data from nodes to store in the cache metadata such as last config, status, result, query-read and query-write. It will be used to decorate the frontend.