### PR TITLE
Fixed distributed queries and status led

### DIFF
--- a/cmd/api/handlers/stats.go
+++ b/cmd/api/handlers/stats.go
@@ -45,6 +45,7 @@ type StatsResponse struct {
 	TotalNodes    int64 `json:"total_nodes"`
 	ActiveNodes   int64 `json:"active_nodes"`
 	InactiveNodes int64 `json:"inactive_nodes"`
+	InactiveHours int64 `json:"inactive_hours"`
 	// TotalActiveQueries counts standard query-type active queries (excludes carves).
 	TotalActiveQueries int `json:"total_active_queries"`
 	// TotalActiveCarves counts active carve-type queries.
@@ -102,7 +103,10 @@ func (h *HandlersApi) StatsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hours := h.Settings.InactiveHours(settings.NoEnvironmentID)
-	out := StatsResponse{Environments: make([]EnvStats, 0, len(allEnvs))}
+	out := StatsResponse{
+		InactiveHours: hours,
+		Environments:  make([]EnvStats, 0, len(allEnvs)),
+	}
 
 	for _, e := range allEnvs {
 		// Filter to envs the user can actually see.

--- a/frontend/src/api/stats.test.ts
+++ b/frontend/src/api/stats.test.ts
@@ -18,6 +18,7 @@ const STUB_RESPONSE: StatsResponse = {
   total_nodes: 10,
   active_nodes: 7,
   inactive_nodes: 3,
+  inactive_hours: 72,
   total_active_queries: 2,
   total_active_carves: 1,
   platform_counts: { linux: 6, darwin: 2, windows: 2, other: 0 },

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -29,6 +29,7 @@ export interface StatsResponse {
   total_nodes: number;
   active_nodes: number;
   inactive_nodes: number;
+  inactive_hours: number;
   total_active_queries: number;
   total_active_carves: number;
   /** Cross-env aggregate (sum of every env.platform_counts the user can see). */

--- a/frontend/src/features/dashboard/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.test.tsx
@@ -53,6 +53,7 @@ function makeStatsResponse(overrides: Partial<StatsResponse> = {}): StatsRespons
     total_nodes: 10,
     active_nodes: 7,
     inactive_nodes: 3,
+    inactive_hours: 72,
     total_active_queries: 2,
     total_active_carves: 1,
     platform_counts: { linux: 6, darwin: 2, windows: 2, other: 0 },
@@ -171,9 +172,18 @@ describe('DashboardPage', () => {
 
     await waitFor(() => expect(screen.getByText('Active Nodes')).toBeInTheDocument());
 
-    expect(screen.getByText('Inactive ≥ 24h')).toBeInTheDocument();
+    expect(screen.getByText('Inactive ≥ 72h')).toBeInTheDocument();
     expect(screen.getByText('Active Queries')).toBeInTheDocument();
     expect(screen.getByText('Forensic Carves')).toBeInTheDocument();
+  });
+
+  it('uses the backend stats threshold for inactive labeling', async () => {
+    mockGetStats.mockResolvedValue(makeStatsResponse({ inactive_hours: 168 }));
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => expect(screen.getByText('Active Nodes')).toBeInTheDocument());
+
+    expect(screen.getByText('Inactive ≥ 168h')).toBeInTheDocument();
   });
 
   it('renders one tile per environment', async () => {

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -25,6 +25,7 @@ import { EmptyState } from '$/components/data/EmptyState';
 import { StatusPip } from '$/components/data/StatusPip';
 import { cn } from '$/lib/cn';
 import { formatRelative } from '$/lib/time';
+import { DEFAULT_INACTIVE_HOURS, isNodeActive } from '$/lib/node-status';
 
 // ---------------------------------------------------------------------------
 // Aggregated 24h activity series, derived from the env-activity endpoint.
@@ -1089,6 +1090,7 @@ export function DashboardPage() {
     refetchInterval: 30_000,
     refetchIntervalInBackground: false,
   });
+  const inactiveHours = data?.inactive_hours ?? DEFAULT_INACTIVE_HOURS;
 
   const [palette, setPaletteEntry, resetPalette] = useChartPalette();
 
@@ -1265,8 +1267,6 @@ export function DashboardPage() {
     activeQueriesPerEnv.length > 0 &&
     activeQueriesPerEnv.some((r) => r.isLoading);
 
-  const ACTIVE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
-
   return (
     <div className="flex flex-col gap-5 px-6 py-6 max-w-[1400px] mx-auto w-full">
 
@@ -1430,7 +1430,7 @@ export function DashboardPage() {
                 polarity="up-good"
               />
               <KpiCard
-                label="Inactive ≥ 24h"
+                label={`Inactive ≥ ${inactiveHours}h`}
                 value={data?.inactive_nodes ?? 0}
                 sparkline={fleet12.config}
                 halo="warning"
@@ -1701,8 +1701,7 @@ export function DashboardPage() {
               </div>
             ) : (
               recentNodes.items.map((node) => {
-                const isActive =
-                  Date.now() - new Date(node.last_seen).getTime() < ACTIVE_THRESHOLD_MS;
+                const isActive = isNodeActive(node.last_seen, inactiveHours);
                 return (
                   <EnrollRow
                     key={node.uuid}

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -13,6 +13,7 @@ import {
 import { NodeDetailPage } from './NodeDetailPage';
 import type { OsqueryNode } from '$/api/types';
 import type { NodeActivityBucket, NodeTileSeries } from '$/api/stats';
+import type { SettingValue } from '$/api/settings';
 
 const mockGetNode = vi.fn<() => Promise<OsqueryNode>>();
 const mockListNodeLogs = vi.fn<() => Promise<unknown>>();
@@ -21,6 +22,7 @@ const mockGetMe = vi.fn<() => Promise<unknown>>();
 const mockListEnvironments = vi.fn<() => Promise<Array<{ name: string; uuid: string }>>>();
 const mockGetNodeActivity = vi.fn<() => Promise<NodeActivityBucket[]>>();
 const mockGetNodeActivityTiles = vi.fn<() => Promise<NodeTileSeries>>();
+const mockListServiceSettings = vi.fn<() => Promise<SettingValue[]>>();
 
 vi.mock('$/api/nodes', () => ({
   getNode: (...args: unknown[]) => mockGetNode(...(args as [])),
@@ -44,6 +46,10 @@ vi.mock('$/api/stats', async () => {
     getNodeActivityTiles: (...args: unknown[]) => mockGetNodeActivityTiles(...(args as [])),
   };
 });
+
+vi.mock('$/api/settings', () => ({
+  listServiceSettings: (...args: unknown[]) => mockListServiceSettings(...(args as [])),
+}));
 
 vi.mock('$/api/client', () => ({
   isAuthenticated: () => true,
@@ -195,6 +201,7 @@ describe('NodeDetailPage', () => {
       query_write: [],
       total: [],
     });
+    mockListServiceSettings.mockResolvedValue([]);
   });
 
   it('shows node activity in the default details view and removes the separate activity tab', async () => {
@@ -218,6 +225,18 @@ describe('NodeDetailPage', () => {
         '6h',
         450,
       );
+    });
+  });
+
+  it('keeps a node active when it was seen within the backend default 72 hour window', async () => {
+    mockGetNode.mockResolvedValue(
+      makeNode({ last_seen: new Date(Date.now() - 48 * 3600_000).toISOString() }),
+    );
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('Active')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -18,7 +18,8 @@ import {
 } from '$/api/stats';
 import { AuthError } from '$/api/client';
 import type { NodeLogEntry } from '$/api/types';
-import { formatRelative, formatAbsolute, isWithinHours, formatBucketAgo } from '$/lib/time';
+import { formatRelative, formatAbsolute, formatBucketAgo } from '$/lib/time';
+import { isNodeActive, useInactiveHours } from '$/lib/node-status';
 import { cn } from '$/lib/cn';
 import { StatusPip } from '$/components/data/StatusPip';
 import { Skeleton } from '$/components/data/Skeleton';
@@ -518,6 +519,7 @@ const TABS = [
 export function NodeDetailPage() {
   const { env, uuid } = useParams({ from: '/_app/env/$env/nodes/$uuid' as const });
   const navigate = useNavigate();
+  const inactiveHours = useInactiveHours();
   const [activeTab, setActiveTab] = useState<Tab>('details');
   const [activityInterval, setActivityInterval] = useState<ActivityInterval>('6h');
   const [copiedNodeKey, setCopiedNodeKey] = useState(false);
@@ -676,7 +678,7 @@ export function NodeDetailPage() {
     return null;
   }
 
-  const isActive = node ? isWithinHours(node.last_seen, 24) : false;
+  const isActive = node ? isNodeActive(node.last_seen, inactiveHours) : false;
 
   return (
     <div className="flex flex-col h-full min-h-0 px-6 py-4 max-w-5xl mx-auto w-full">

--- a/frontend/src/features/nodes/NodesTablePage.test.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.test.tsx
@@ -13,14 +13,20 @@ import {
 import { NodesTablePage } from './NodesTablePage';
 import { nodesSearchSchema } from '$/routes/_app/env/$env/nodes';
 import type { NodesPagedResponse } from '$/api/types';
+import type { SettingValue } from '$/api/settings';
 
 // ---------------------------------------------------------------------------
 // Mock the nodes API module
 // ---------------------------------------------------------------------------
 const mockListNodes = vi.fn<() => Promise<NodesPagedResponse>>();
+const mockListServiceSettings = vi.fn<() => Promise<SettingValue[]>>();
 
 vi.mock('$/api/nodes', () => ({
   listNodes: (...args: unknown[]) => mockListNodes(...(args as [])),
+}));
+
+vi.mock('$/api/settings', () => ({
+  listServiceSettings: (...args: unknown[]) => mockListServiceSettings(...(args as [])),
 }));
 
 vi.mock('$/api/client', () => ({
@@ -146,6 +152,7 @@ function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
 describe('NodesTablePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockListServiceSettings.mockResolvedValue([]);
   });
 
   it('renders node rows after loading', async () => {
@@ -236,5 +243,26 @@ describe('NodesTablePage', () => {
     const link = screen.getByRole('link', { name: 'web-server-01' });
     expect(link).toBeInTheDocument();
     expect(link.getAttribute('href')).toContain('nodes');
+  });
+
+  it('shows a node as active when it was seen within the backend default 72 hour window', async () => {
+    mockListNodes.mockResolvedValue(
+      makeResponse({
+        items: [
+          {
+            ...makeResponse().items[0],
+            last_seen: new Date(Date.now() - 48 * 3600_000).toISOString(),
+          },
+        ],
+      }),
+    );
+    const router = makeTestRouter();
+    renderWithProviders(router);
+
+    await waitFor(() => {
+      expect(screen.getByText('web-server-01')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('active')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/nodes/NodesTablePage.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.tsx
@@ -8,7 +8,8 @@ import { getMe } from '$/api/users';
 import { listEnvironments } from '$/api/environments';
 import { AuthError } from '$/api/client';
 import type { NodeSort, SortDir, NodeStatus, NodesPagedResponse, AdminTag } from '$/api/types';
-import { formatRelative, formatBytes, isWithinHours } from '$/lib/time';
+import { formatRelative, formatBytes } from '$/lib/time';
+import { isNodeActive, useInactiveHours } from '$/lib/node-status';
 import { cn } from '$/lib/cn';
 import { StatusBadge } from '$/components/data/StatusBadge';
 import { SkeletonRow } from '$/components/data/Skeleton';
@@ -336,6 +337,7 @@ export function NodesTablePage() {
   const { env } = useParams({ from: '/_app/env/$env/nodes' });
   const search = useSearch({ from: '/_app/env/$env/nodes' });
   const navigate = useNavigate({ from: '/_app/env/$env/nodes' });
+  const inactiveHours = useInactiveHours();
 
   const status: NodeStatus = search.status ?? 'all';
   const q: string = search.q ?? '';
@@ -754,7 +756,7 @@ export function NodesTablePage() {
             {!isLoading &&
               !isError &&
               nodes.map((node) => {
-                const isActive = isWithinHours(node.last_seen, 24);
+                const isActive = isNodeActive(node.last_seen, inactiveHours);
                 const isSelected = selectedUuids.has(node.uuid);
 
                 return (

--- a/frontend/src/lib/node-status.ts
+++ b/frontend/src/lib/node-status.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { listServiceSettings, type SettingValue } from '$/api/settings';
+import { isWithinHours } from '$/lib/time';
+
+export const DEFAULT_INACTIVE_HOURS = 72;
+
+function normalizeSettingName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+export function getInactiveHoursFromSettings(settings?: SettingValue[]): number {
+  const match = settings?.find((setting) => normalizeSettingName(setting.Name) === 'inactivehours');
+  if (!match || match.Type !== 'integer' || !Number.isFinite(match.Integer) || match.Integer <= 0) {
+    return DEFAULT_INACTIVE_HOURS;
+  }
+  return match.Integer;
+}
+
+export function isNodeActive(lastSeen: string, inactiveHours = DEFAULT_INACTIVE_HOURS): boolean {
+  return isWithinHours(lastSeen, inactiveHours);
+}
+
+export function useInactiveHours(): number {
+  const { data } = useQuery({
+    queryKey: ['settings', 'admin'],
+    queryFn: () => listServiceSettings('admin'),
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  return getInactiveHoursFromSettings(data);
+}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -30,15 +30,15 @@ type Managers struct {
 func CreateQueryCarve(data ProcessingQuery, manager Managers, newQuery queries.DistributedQuery) ([]uint, error) {
 	var expected []uint
 	targetNodesID := []uint{}
-	// No targets specified — default to all active nodes in the environment
+	// No targets specified — default to all nodes in the environment
 	if len(data.Envs) == 0 && len(data.Platforms) == 0 && len(data.UUIDs) == 0 && len(data.Hosts) == 0 && len(data.Tags) == 0 {
 		env, err := manager.Envs.GetByID(data.EnvID)
 		if err != nil {
 			return targetNodesID, fmt.Errorf("error getting environment by ID: %w", err)
 		}
-		allNodes, err := manager.Nodes.GetByEnv(env.Name, nodes.ActiveNodes, data.InactiveHours)
+		allNodes, err := manager.Nodes.GetByEnv(env.Name, nodes.AllNodes, data.InactiveHours)
 		if err != nil {
-			return targetNodesID, fmt.Errorf("error getting all active nodes: %w", err)
+			return targetNodesID, fmt.Errorf("error getting all nodes: %w", err)
 		}
 		for _, n := range allNodes {
 			targetNodesID = append(targetNodesID, n.ID)

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCreateQueryCarveWithoutTargetsIncludesAllEnvironmentNodes(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	envs := environments.CreateEnvironment(db)
+	nodeManager := nodes.CreateNodes(db)
+
+	env := envs.Empty("dev", "dev.example.com")
+	require.NoError(t, envs.Create(&env))
+
+	now := time.Now()
+	fixtures := []nodes.OsqueryNode{
+		{
+			UUID:          "NODE-1",
+			Environment:   env.Name,
+			EnvironmentID: env.ID,
+			LastSeen:      now,
+		},
+		{
+			UUID:          "NODE-2",
+			Environment:   env.Name,
+			EnvironmentID: env.ID,
+			LastSeen:      now.Add(-72 * time.Hour),
+		},
+		{
+			UUID:          "NODE-3",
+			Environment:   "other",
+			EnvironmentID: env.ID + 1,
+			LastSeen:      now,
+		},
+	}
+	for _, node := range fixtures {
+		require.NoError(t, db.Create(&node).Error)
+	}
+
+	targetNodesID, err := CreateQueryCarve(
+		ProcessingQuery{
+			EnvID:         env.ID,
+			InactiveHours: 24,
+		},
+		Managers{
+			Envs:  envs,
+			Nodes: nodeManager,
+		},
+		queries.DistributedQuery{},
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint{1, 2}, targetNodesID)
+}

--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -278,7 +278,10 @@ func (n *NodeManager) SearchByField(fieldType, term, target string, hours int64,
 func (n *NodeManager) GetByPlatform(envID uint, platform, target string, hours int64) ([]OsqueryNode, error) {
 	var nodes []OsqueryNode
 	// Build query with base condition
-	query := n.DB.Where("platform = ? AND environment_id = ?", platform, envID)
+	query := n.DB.Where("environment_id = ?", envID)
+	if platform != AllNodes {
+		query = query.Where("platform = ?", platform)
+	}
 	// Apply active/inactive filtering
 	query = ApplyNodeTarget(query, target, hours)
 	// Execute query

--- a/pkg/nodes/nodes_test.go
+++ b/pkg/nodes/nodes_test.go
@@ -1,6 +1,13 @@
 package nodes
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
 
 // TestSortableColumnsAllowlist verifies that every entry in SortableColumns
 // maps to a non-empty database column name and that the SPA-critical keys
@@ -74,4 +81,24 @@ func TestSafeOrderExpr(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetByPlatformAllReturnsAllPlatformNodes(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	manager := CreateNodes(db)
+	now := time.Now()
+	nodes := []OsqueryNode{
+		{UUID: "NODE-1", Platform: "linux", EnvironmentID: 7, LastSeen: now},
+		{UUID: "NODE-2", Platform: "windows", EnvironmentID: 7, LastSeen: now},
+		{UUID: "NODE-3", Platform: "darwin", EnvironmentID: 99, LastSeen: now},
+	}
+	for _, node := range nodes {
+		require.NoError(t, db.Create(&node).Error)
+	}
+
+	got, err := manager.GetByPlatform(7, AllNodes, ActiveNodes, 24)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
 }

--- a/pkg/queries/queries_test.go
+++ b/pkg/queries/queries_test.go
@@ -163,6 +163,8 @@ func TestCreateNodeQueries(t *testing.T) {
 	assert.Len(t, nodeQueries, 2, "Expected 2 node queries to be created")
 	assert.Equal(t, nodeIDs[0], nodeQueries[0].NodeID, "First NodeID does not match expected value")
 	assert.Equal(t, nodeIDs[1], nodeQueries[1].NodeID, "Second NodeID does not match expected value")
+	assert.Equal(t, queries.DistributedQueryStatusPending, nodeQueries[0].Status, "First node query should be pending so tls/read can deliver it")
+	assert.Equal(t, queries.DistributedQueryStatusPending, nodeQueries[1].Status, "Second node query should be pending so tls/read can deliver it")
 
 	// Test error handling
 	t.Run("EmptyNodeList", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix distributed query targeting and align node activity status across the UI with the backend’s inactivity threshold.

## What changed

- Fixed empty distributed-query targeting so “no target selected” includes all nodes in the environment
- Fixed platform targeting for the `all` platform bucket
- Added backend regression tests around query target selection and pending node-query creation
- Added shared frontend node-status logic based on the configured inactivity window
- Updated node detail, nodes table, and dashboard views to use consistent active/inactive status rules
- Added `inactive_hours` to `/api/v1/stats` so the dashboard uses the exact backend threshold for:
  - the `Inactive ≥ Nh` KPI label
  - recent enrollment active/inactive badges
- Added frontend regression tests for node status rendering and stats typing

## Why

There were two related issues:
- distributed queries could miss intended nodes because default/“all” targeting paths were too narrow
- the frontend could label nodes as inactive even when the backend still considered them active

This change makes query fanout and UI activity status consistent with backend behavior.