### PR TITLE
Improved distributed query visibility and control across the query views

### DIFF
--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -237,6 +237,17 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
+	targetRows, err := handlers.BuildQueryTargetRecords(data, manager)
+	if err != nil {
+		apiErrorResponse(w, "error creating query targets", http.StatusInternalServerError, err)
+		return
+	}
+	for _, target := range targetRows {
+		if err := h.Queries.CreateTarget(newQuery.Name, target.Type, target.Value); err != nil {
+			apiErrorResponse(w, "error creating query targets", http.StatusInternalServerError, err)
+			return
+		}
+	}
 	// Update value for expected
 	if err := h.Queries.SetExpected(newQuery.Name, len(targetNodesID), env.ID); err != nil {
 		apiErrorResponse(w, "error setting expected", http.StatusInternalServerError, err)

--- a/frontend/src/features/queries/QueriesListPage.test.tsx
+++ b/frontend/src/features/queries/QueriesListPage.test.tsx
@@ -167,18 +167,30 @@ describe('QueriesListPage', () => {
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByText('q_test_0001')).toBeInTheDocument();
+      expect(screen.getByText('SELECT * FROM osquery_info;')).toBeInTheDocument();
     });
 
     expect(screen.getByText('admin')).toBeInTheDocument();
     expect(screen.getByText('query')).toBeInTheDocument();
+    expect(screen.getAllByText('Active').length).toBeGreaterThan(1);
+  });
+
+  it('renders completed status for completed queries', async () => {
+    mockListQueries.mockResolvedValue(
+      makeResponse({ items: [makeQuery({ active: false, completed: true })] }),
+    );
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('Completed')).toBeInTheDocument();
+    });
   });
 
   it('shows skeleton rows while loading', () => {
     mockListQueries.mockReturnValue(new Promise(() => {}));
     renderWithProviders(makeTestRouter());
     // Data row should not be present while loading
-    expect(screen.queryByText('q_test_0001')).not.toBeInTheDocument();
+    expect(screen.queryByText('SELECT * FROM osquery_info;')).not.toBeInTheDocument();
   });
 
   it('shows empty state when API returns no items', async () => {
@@ -198,7 +210,7 @@ describe('QueriesListPage', () => {
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByText('q_test_0001')).toBeInTheDocument();
+      expect(screen.getByText('SELECT * FROM osquery_info;')).toBeInTheDocument();
     });
 
     const activeTab = screen.getByRole('tab', { name: /^Active$/i });
@@ -217,7 +229,7 @@ describe('QueriesListPage', () => {
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByText('q_test_0001')).toBeInTheDocument();
+      expect(screen.getByText('SELECT * FROM osquery_info;')).toBeInTheDocument();
     });
 
     const checkbox = screen.getByRole('checkbox', { name: /select query q_test_0001/i });
@@ -235,11 +247,28 @@ describe('QueriesListPage', () => {
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByText('q_test_0001')).toBeInTheDocument();
+      expect(screen.getByText('SELECT * FROM osquery_info;')).toBeInTheDocument();
     });
 
-    const link = screen.getByRole('link', { name: 'q_test_0001' });
+    const link = screen.getByRole('link', { name: 'SELECT * FROM osquery_info;' });
     expect(link).toBeInTheDocument();
     expect(link.getAttribute('href')).toContain('queries');
+  });
+
+  it('refresh button refetches the queries table', async () => {
+    const user = userEvent.setup();
+    mockListQueries.mockResolvedValue(makeResponse());
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('SELECT * FROM osquery_info;')).toBeInTheDocument();
+    });
+
+    const callsBeforeRefresh = mockListQueries.mock.calls.length;
+    await user.click(screen.getByRole('button', { name: 'Refresh queries' }));
+
+    await waitFor(() => {
+      expect(mockListQueries.mock.calls.length).toBeGreaterThan(callsBeforeRefresh);
+    });
   });
 });

--- a/frontend/src/features/queries/QueriesListPage.tsx
+++ b/frontend/src/features/queries/QueriesListPage.tsx
@@ -14,6 +14,39 @@ import { Pagination } from '$/components/data/Pagination';
 import { SearchInput } from '$/components/data/SearchInput';
 import { SortableHeader } from '$/components/data/SortableHeader';
 
+function QueryStatusBadge({
+  q,
+}: {
+  q: { active: boolean; completed: boolean; expired: boolean; deleted: boolean };
+}) {
+  if (q.deleted) return <ListBadge variant="danger" label="Deleted" />;
+  if (q.expired) return <ListBadge variant="warning" label="Expired" />;
+  if (q.completed) return <ListBadge variant="success" label="Completed" />;
+  if (q.active) return <ListBadge variant="info" label="Active" />;
+  return <ListBadge variant="dim" label="Unknown" />;
+}
+
+function ListBadge({
+  variant,
+  label,
+}: {
+  variant: 'success' | 'warning' | 'danger' | 'info' | 'dim';
+  label: string;
+}) {
+  const cls = {
+    success:
+      'bg-[rgba(var(--success-r),var(--success-g),var(--success-b),0.12)] text-[color:var(--success)]',
+    warning:
+      'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)]',
+    danger:
+      'bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.12)] text-[color:var(--danger)]',
+    info: 'bg-[rgba(var(--info-r),var(--info-g),var(--info-b),0.12)] text-[color:var(--info)]',
+    dim: 'bg-[color:var(--bg-2)] text-[color:var(--text-3)]',
+  }[variant];
+
+  return <span className={cn('px-2 py-0.5 rounded-full text-xs font-medium', cls)}>{label}</span>;
+}
+
 // ---------------------------------------------------------------------------
 // Status tabs config
 // ---------------------------------------------------------------------------
@@ -181,6 +214,22 @@ export function QueriesListPage() {
         </div>
 
         <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            disabled={isFetching}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-md',
+              'border border-[color:var(--border)] text-[color:var(--text-2)]',
+              'hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors',
+              'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+            aria-label="Refresh queries"
+          >
+            Refresh
+          </button>
+
           {/* New query button */}
           <Link
             to="/_app/env/$env/queries/new"
@@ -260,6 +309,12 @@ export function QueriesListPage() {
                 scope="col"
                 className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide"
               >
+                Status
+              </th>
+              <th
+                scope="col"
+                className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide"
+              >
                 Type
               </th>
               <SortableHeader
@@ -283,12 +338,12 @@ export function QueriesListPage() {
           <tbody data-stale={isFetching && !isLoading ? 'true' : undefined}>
             {/* Loading skeleton */}
             {isLoading &&
-              Array.from({ length: 10 }).map((_, i) => <SkeletonRow key={i} cells={6} />)}
+              Array.from({ length: 10 }).map((_, i) => <SkeletonRow key={i} cells={7} />)}
 
             {/* Error state */}
             {isError && !isLoading && (
               <tr>
-                <td colSpan={6}>
+                <td colSpan={7}>
                   <EmptyState
                     icon={
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -314,7 +369,7 @@ export function QueriesListPage() {
             {/* Empty state */}
             {!isLoading && !isError && items.length === 0 && (
               <tr>
-                <td colSpan={6}>
+                <td colSpan={7}>
                   <EmptyState
                     icon={
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -376,7 +431,7 @@ export function QueriesListPage() {
                       />
                     </td>
 
-                    {/* Name — link-blue, navigates to detail */}
+                    {/* Query text — link-blue, navigates to detail by internal name */}
                     <td className="px-4 py-3">
                       <Link
                         to="/_app/env/$env/queries/$name"
@@ -386,14 +441,20 @@ export function QueriesListPage() {
                           'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
                           'rounded text-sm font-medium font-mono-tabular',
                         )}
+                        title={item.query}
                       >
-                        {item.name}
+                        {item.query}
                       </Link>
                     </td>
 
                     {/* Creator */}
                     <td className="px-4 py-3 text-[color:var(--text-2)] text-xs">
                       {item.creator}
+                    </td>
+
+                    {/* Status */}
+                    <td className="px-4 py-3">
+                      <QueryStatusBadge q={item} />
                     </td>
 
                     {/* Type chip */}

--- a/frontend/src/features/queries/QueryDetailPage.test.tsx
+++ b/frontend/src/features/queries/QueryDetailPage.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRouter,
+  createRoute,
+  createRootRoute,
+  RouterProvider,
+  Outlet,
+} from '@tanstack/react-router';
+import { QueryDetailPage } from './QueryDetailPage';
+import type { DistributedQuery, QueryResultsResponse } from '$/api/types';
+
+const mockGetQuery = vi.fn<() => Promise<DistributedQuery>>();
+const mockListQueryResults = vi.fn<() => Promise<QueryResultsResponse>>();
+const mockActOnQuery = vi.fn<() => Promise<{ message: string }>>();
+const mockListNodes = vi.fn<() => Promise<{ items: Array<{ uuid: string; hostname: string; localname: string }> }>>();
+
+vi.mock('$/api/queries', () => ({
+  getQuery: (...args: unknown[]) => mockGetQuery(...(args as [])),
+  listQueryResults: (...args: unknown[]) => mockListQueryResults(...(args as [])),
+  getQueryResultsCSVUrl: () => '/download.csv',
+  actOnQuery: (...args: unknown[]) => mockActOnQuery(...(args as [])),
+}));
+
+vi.mock('$/api/nodes', () => ({
+  listNodes: (...args: unknown[]) => mockListNodes(...(args as [])),
+}));
+
+vi.mock('$/api/client', () => ({
+  isAuthenticated: () => true,
+  getCsrfToken: () => 'test-csrf',
+  setCsrfToken: vi.fn(),
+  AuthError: class AuthError extends Error {
+    readonly status = 401;
+    constructor() {
+      super('Unauthorized');
+    }
+  },
+}));
+
+function makeQuery(overrides: Partial<DistributedQuery> = {}): DistributedQuery {
+  return {
+    id: 1,
+    created_at: new Date(Date.now() - 60_000).toISOString(),
+    updated_at: new Date().toISOString(),
+    name: 'q_test_0001',
+    creator: 'admin',
+    query: 'SELECT 1;',
+    expected: 10,
+    executions: 3,
+    errors: 0,
+    active: true,
+    hidden: false,
+    protected: false,
+    completed: false,
+    deleted: false,
+    expired: false,
+    type: 'query',
+    path: '',
+    environment_id: 1,
+    extra_data: '',
+    expiration: '0001-01-01T00:00:00Z',
+    target: '',
+    targets: [{ type: 'environment', value: 'test-env' }],
+    ...overrides,
+  };
+}
+
+function makeResults(): QueryResultsResponse {
+  return {
+    items: [],
+    page: 1,
+    page_size: 50,
+    total_items: 0,
+    total_pages: 0,
+  };
+}
+
+function makeTestRouter(initialPath = '/_app/env/test-env/queries/q_test_0001') {
+  const rootRoute = createRootRoute({ component: Outlet });
+  const appRoute = createRoute({ getParentRoute: () => rootRoute, path: '/_app', component: Outlet });
+  const envRoute = createRoute({ getParentRoute: () => appRoute, path: 'env/$env', component: Outlet });
+  const listRoute = createRoute({
+    getParentRoute: () => envRoute,
+    path: 'queries',
+    component: () => <div data-testid="queries-page">queries</div>,
+  });
+  const detailRoute = createRoute({
+    getParentRoute: () => envRoute,
+    path: 'queries/$name',
+    component: QueryDetailPage,
+  });
+  const loginRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/login',
+    component: () => <div data-testid="login">login</div>,
+  });
+  const routeTree = rootRoute.addChildren([
+    appRoute.addChildren([envRoute.addChildren([listRoute, detailRoute])]),
+    loginRoute,
+  ]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('QueryDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetQuery.mockResolvedValue(makeQuery());
+    mockListQueryResults.mockResolvedValue(makeResults());
+    mockListNodes.mockResolvedValue({ items: [] });
+    mockActOnQuery.mockResolvedValue({ message: 'ok' });
+  });
+
+  it('shows a complete button for incomplete queries and triggers the action', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(makeTestRouter());
+
+    const button = await screen.findByRole('button', { name: 'Complete query' });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockActOnQuery).toHaveBeenCalledWith('test-env', 'q_test_0001', 'complete');
+    });
+  });
+
+  it('hides the complete button for completed queries', async () => {
+    mockGetQuery.mockResolvedValue(makeQuery({ active: false, completed: true }));
+    renderWithProviders(makeTestRouter());
+
+    await screen.findByText('SELECT 1;');
+    expect(screen.queryByRole('button', { name: 'Complete query' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/queries/QueryDetailPage.tsx
+++ b/frontend/src/features/queries/QueryDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate, useSearch, Link } from '@tanstack/react-router';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getQuery, listQueryResults, getQueryResultsCSVUrl } from '$/api/queries';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getQuery, listQueryResults, getQueryResultsCSVUrl, actOnQuery } from '$/api/queries';
 import { listNodes } from '$/api/nodes';
 import { AuthError } from '$/api/client';
 import { formatRelative } from '$/lib/time';
@@ -82,6 +82,14 @@ export function QueryDetailPage() {
   });
 
   const qc = useQueryClient();
+  const completeMutation = useMutation({
+    mutationFn: () => actOnQuery(env, name, 'complete'),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['query', env, name] });
+      void qc.invalidateQueries({ queryKey: ['query-results', env, name] });
+      void qc.invalidateQueries({ queryKey: ['queries', env] });
+    },
+  });
 
   // Paginated query results
   const {
@@ -217,6 +225,25 @@ export function QueryDetailPage() {
             {query.expiration && !query.expiration.startsWith('0001') && (
               <span>Expires: <strong className="text-[color:var(--text-1)]" title={query.expiration}>{formatRelative(query.expiration)}</strong></span>
             )}
+          </div>
+        )}
+
+        {query && !query.completed && !query.deleted && (
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => completeMutation.mutate()}
+              disabled={completeMutation.isPending}
+              className={cn(
+                'px-3 py-1.5 text-xs font-medium rounded-md',
+                'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
+                'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+              )}
+              aria-label="Complete query"
+            >
+              {completeMutation.isPending ? 'Completing…' : 'Complete query'}
+            </button>
           </div>
         )}
 

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -26,6 +26,11 @@ type Managers struct {
 	Tags  *tags.TagManager
 }
 
+type QueryTargetRecord struct {
+	Type  string
+	Value string
+}
+
 // CreateQueryCarve - Create On-demand Query or Carve, to be used in osctrl-admin or osctrl-api
 func CreateQueryCarve(data ProcessingQuery, manager Managers, newQuery queries.DistributedQuery) ([]uint, error) {
 	var expected []uint
@@ -127,4 +132,32 @@ func CreateQueryCarve(data ProcessingQuery, manager Managers, newQuery queries.D
 		targetNodesID = utils.Intersect(targetNodesID, expected)
 	}
 	return targetNodesID, nil
+}
+
+func BuildQueryTargetRecords(data ProcessingQuery, manager Managers) ([]QueryTargetRecord, error) {
+	targets := []QueryTargetRecord{}
+	appendTargets := func(targetType string, values []string) {
+		for _, value := range values {
+			if value != "" {
+				targets = append(targets, QueryTargetRecord{Type: targetType, Value: value})
+			}
+		}
+	}
+
+	appendTargets(nodes.EnvironmentSelector, data.Envs)
+	appendTargets(nodes.PlatformSelector, data.Platforms)
+	appendTargets("uuid", data.UUIDs)
+	appendTargets("host", data.Hosts)
+	appendTargets("tag", data.Tags)
+
+	if len(targets) > 0 {
+		return targets, nil
+	}
+
+	env, err := manager.Envs.GetByID(data.EnvID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting environment by ID: %w", err)
+	}
+
+	return []QueryTargetRecord{{Type: nodes.EnvironmentSelector, Value: env.Name}}, nil
 }

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -61,3 +61,40 @@ func TestCreateQueryCarveWithoutTargetsIncludesAllEnvironmentNodes(t *testing.T)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []uint{1, 2}, targetNodesID)
 }
+
+func TestBuildQueryTargetRecordsWithoutTargetsUsesEnvironment(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	envs := environments.CreateEnvironment(db)
+	env := envs.Empty("dev", "dev.example.com")
+	require.NoError(t, envs.Create(&env))
+
+	targets, err := BuildQueryTargetRecords(
+		ProcessingQuery{EnvID: env.ID},
+		Managers{Envs: envs},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []QueryTargetRecord{{Type: nodes.EnvironmentSelector, Value: env.Name}}, targets)
+}
+
+func TestBuildQueryTargetRecordsPreservesExplicitTargets(t *testing.T) {
+	targets, err := BuildQueryTargetRecords(
+		ProcessingQuery{
+			Envs:      []string{"prod"},
+			Platforms: []string{"linux"},
+			UUIDs:     []string{"UUID-1"},
+			Hosts:     []string{"host-1"},
+			Tags:      []string{"critical"},
+		},
+		Managers{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []QueryTargetRecord{
+		{Type: nodes.EnvironmentSelector, Value: "prod"},
+		{Type: nodes.PlatformSelector, Value: "linux"},
+		{Type: "uuid", Value: "UUID-1"},
+		{Type: "host", Value: "host-1"},
+		{Type: "tag", Value: "critical"},
+	}, targets)
+}

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -560,6 +560,18 @@ func (q *Queries) UpdateQueryStatus(queryName string, nodeID uint, statusCode in
 	if err := q.DB.Model(&nodeQuery).Updates(map[string]interface{}{"status": result}).Error; err != nil {
 		return err
 	}
+
+	var pending int64
+	if err := q.DB.Model(&NodeQuery{}).
+		Where("query_id = ? AND status = ?", query.ID, DistributedQueryStatusPending).
+		Count(&pending).Error; err != nil {
+		return err
+	}
+	if pending == 0 {
+		if err := q.DB.Model(&query).Updates(map[string]interface{}{"completed": true, "active": false}).Error; err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/queries/queries_test.go
+++ b/pkg/queries/queries_test.go
@@ -47,6 +47,7 @@ func setupTestData(t *testing.T, db *gorm.DB) (*queries.Queries, []nodes.Osquery
 		ID:            1,
 		Name:          "test_query",
 		Query:         "SELECT * FROM osquery_info;",
+		Active:        true,
 		EnvironmentID: 1,
 		Expiration:    time.Now().Add(24 * time.Hour),
 	}
@@ -144,6 +145,33 @@ func TestUpdateQueryStatus(t *testing.T) {
 			assert.Equal(t, tc.expected, updatedNodeQuery.Status, "Status does not match expected value")
 		})
 	}
+}
+
+func TestUpdateQueryStatusCompletesParentQueryWhenAllTargetsFinish(t *testing.T) {
+	db := testDB(t)
+	q, nodes, query := setupTestData(t, db)
+
+	relations := []queries.NodeQuery{
+		{NodeID: nodes[0].ID, QueryID: query.ID, Status: queries.DistributedQueryStatusPending},
+		{NodeID: nodes[1].ID, QueryID: query.ID, Status: queries.DistributedQueryStatusPending},
+	}
+	for _, relation := range relations {
+		require.NoError(t, db.Create(&relation).Error)
+	}
+
+	require.NoError(t, q.UpdateQueryStatus(query.Name, nodes[0].ID, 0))
+
+	var afterFirst queries.DistributedQuery
+	require.NoError(t, db.First(&afterFirst, query.ID).Error)
+	assert.False(t, afterFirst.Completed, "query should remain incomplete while one target is still pending")
+	assert.True(t, afterFirst.Active, "query should remain active while one target is still pending")
+
+	require.NoError(t, q.UpdateQueryStatus(query.Name, nodes[1].ID, 0))
+
+	var afterSecond queries.DistributedQuery
+	require.NoError(t, db.First(&afterSecond, query.ID).Error)
+	assert.True(t, afterSecond.Completed, "query should be marked completed when all targets are terminal")
+	assert.False(t, afterSecond.Active, "query should no longer be active when all targets are terminal")
 }
 
 func TestCreateNodeQueries(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR improves distributed query visibility and control across the React query views, and tightens backend query lifecycle handling so query state and targets stay in sync.

## What changed

### Query list UX
- Display the SQL text instead of the generated internal query name in the queries table
- Add a dedicated status column so active, completed, expired, and deleted queries are obvious at a glance
- Add a manual `Refresh` button to refetch the queries table on demand

### Query detail UX
- Add a `Complete query` button for queries that are still in progress
- Refresh query metadata and results after completing a query
- Surface query target chips in the detail view, including full-environment targets

### Backend query lifecycle
- Mark the parent distributed query as completed/inactive once all node query records leave the pending state
- Persist query target records when a query is created
- When a query targets the whole environment, store that environment target explicitly so the UI can display it correctly

## Why

These changes fix a few operator-facing gaps:
- queries could finish on all nodes but still appear active
- query lists showed internal names instead of the SQL operators actually recognize
- full-environment targets were not visible in the detail view
- there was no quick way to manually complete or refresh query views

## Testing

- `go test ./pkg/handlers ./pkg/queries`
- `cd frontend && node node_modules/.ignored/vitest/vitest.mjs run src/features/queries/QueryDetailPage.test.tsx src/features/queries/QueriesListPage.test.tsx`
- `cd frontend && node node_modules/.ignored/vitest/vitest.mjs run src/features/queries/QueriesListPage.test.tsx`
- `cd frontend && node node_modules/.ignored/typescript/bin/tsc -p tsconfig.json --noEmit`

## Notes

- The target persistence fix applies to newly created queries. Older queries created before target rows were stored will still have incomplete target metadata.