### PR TITLE
Improved carves visibility and control across the carve views

### DIFF
--- a/cmd/api/handlers/carves.go
+++ b/cmd/api/handlers/carves.go
@@ -23,6 +23,33 @@ import (
 	"gorm.io/gorm"
 )
 
+func deriveCarveStatus(query queries.DistributedQuery, files []carves.CarvedFile) string {
+	if query.Deleted {
+		return "DELETED"
+	}
+	if query.Expired {
+		return "EXPIRED"
+	}
+	if query.Completed {
+		return "COMPLETED"
+	}
+	if len(files) == 0 {
+		return "ACTIVE"
+	}
+
+	allCompleted := query.Expected > 0 && len(files) >= query.Expected
+	for _, file := range files {
+		if file.Status != carves.StatusCompleted {
+			allCompleted = false
+			break
+		}
+	}
+	if allCompleted {
+		return "COMPLETED"
+	}
+	return "PENDING"
+}
+
 // carveFileView projects a CarvedFile row into the SPA-canonical envelope.
 // time.Time stays as time.Time so JSON-encoded output is RFC3339.
 func carveFileView(c carves.CarvedFile) types.CarveFileView {
@@ -115,7 +142,22 @@ func (h *HandlersApi) CarveShowHandler(w http.ResponseWriter, r *http.Request) {
 		views = append(views, carveFileView(f))
 	}
 
-	resp := types.CarveDetailResponse{Query: q, Files: views}
+	targets := []types.QueryTargetView{}
+	if rows, terr := h.Queries.GetTargets(name); terr == nil {
+		for _, t := range rows {
+			targets = append(targets, types.QueryTargetView{Type: t.Type, Value: t.Value})
+		}
+	} else {
+		log.Debug().Err(terr).Msgf("carve targets fetch failed for %s", name)
+	}
+
+	resp := types.CarveDetailResponse{
+		Query: types.DistributedQueryView{
+			DistributedQuery: q,
+			Targets:          targets,
+		},
+		Files: views,
+	}
 	log.Debug().Msgf("Returned carve %s (%d files)", name, len(views))
 	h.AuditLog.Visit(ctx[ctxUser], r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], env.ID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, resp)
@@ -259,6 +301,14 @@ func (h *HandlersApi) CarveListHandler(w http.ResponseWriter, r *http.Request) {
 	if items == nil {
 		items = []queries.DistributedQuery{}
 	}
+	for i := range items {
+		files, ferr := h.Carves.GetByQuery(items[i].Name, env.ID)
+		if ferr != nil {
+			apiErrorResponse(w, "error getting carve files", http.StatusInternalServerError, ferr)
+			return
+		}
+		items[i].CarveStatus = deriveCarveStatus(items[i], files)
+	}
 	var totalPages int
 	if result.TotalItems > 0 {
 		totalPages = int((result.TotalItems + int64(pageSize) - 1) / int64(pageSize))
@@ -373,6 +423,17 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 		if err := h.Queries.CreateNodeQueries(targetNodesID, newQuery.ID); err != nil {
 			log.Err(err).Msgf("error creating node queries for carve %s", newQuery.Name)
 			apiErrorResponse(w, "error creating node queries", http.StatusInternalServerError, err)
+			return
+		}
+	}
+	targetRows, err := handlers.BuildQueryTargetRecords(data, manager)
+	if err != nil {
+		apiErrorResponse(w, "error creating carve targets", http.StatusInternalServerError, err)
+		return
+	}
+	for _, target := range targetRows {
+		if err := h.Queries.CreateTarget(newQuery.Name, target.Type, target.Value); err != nil {
+			apiErrorResponse(w, "error creating carve targets", http.StatusInternalServerError, err)
 			return
 		}
 	}

--- a/cmd/tls/handlers/carves.go
+++ b/cmd/tls/handlers/carves.go
@@ -7,6 +7,36 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func (h *HandlersTLS) syncCompletedCarveQuery(sessionID string) error {
+	carve, err := h.Carves.GetBySession(sessionID)
+	if err != nil {
+		return err
+	}
+
+	query, err := h.Queries.Get(carve.QueryName, carve.EnvironmentID)
+	if err != nil {
+		return err
+	}
+	if query.Completed || query.Deleted || query.Expired {
+		return nil
+	}
+
+	files, err := h.Carves.GetByQuery(carve.QueryName, carve.EnvironmentID)
+	if err != nil {
+		return err
+	}
+	if query.Expected <= 0 || len(files) < query.Expected {
+		return nil
+	}
+	for _, file := range files {
+		if file.Status != carves.StatusCompleted {
+			return nil
+		}
+	}
+
+	return h.Queries.Complete(carve.QueryName, carve.EnvironmentID)
+}
+
 // ProcessCarveWrite - Function to process the scheduling of file carves from a node
 func (h *HandlersTLS) ProcessCarveWrite(req types.QueryCarveScheduled, queryName, nodeKey, environment string) error {
 	// Retrieve node
@@ -85,6 +115,8 @@ func (h *HandlersTLS) ProcessCarveBlock(req types.CarveBlockRequest, environment
 		}
 		if err := h.Carves.ChangeStatus(carves.StatusCompleted, req.SessionID); err != nil {
 			log.Err(err).Msg("error completing carve")
+		} else if err := h.syncCompletedCarveQuery(req.SessionID); err != nil {
+			log.Err(err).Msg("error syncing completed carve query")
 		}
 	} else {
 		if err := h.Carves.ChangeStatus(carves.StatusInProgress, req.SessionID); err != nil {

--- a/cmd/tls/handlers/carves_test.go
+++ b/cmd/tls/handlers/carves_test.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/carves"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSyncCompletedCarveQueryCompletesParentWhenAllTargetsFinish(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	queryManager := queries.CreateQueries(db)
+	carveManager := carves.CreateFileCarves(db, "", nil)
+
+	query := queries.DistributedQuery{
+		Name:          "carve_test_1",
+		Query:         "SELECT * FROM carves WHERE carve=1 AND path = '/tmp/file';",
+		Type:          queries.CarveQueryType,
+		Active:        true,
+		Expected:      2,
+		EnvironmentID: 1,
+		Expiration:    time.Now().Add(time.Hour),
+	}
+	require.NoError(t, queryManager.Create(&query))
+
+	files := []carves.CarvedFile{
+		{
+			CarveID:       "carve-1",
+			RequestID:     "req-1",
+			SessionID:     "session-1",
+			QueryName:     query.Name,
+			UUID:          "node-1",
+			NodeID:        1,
+			Environment:   "dev",
+			Path:          "/tmp/file",
+			Status:        carves.StatusCompleted,
+			EnvironmentID: query.EnvironmentID,
+		},
+		{
+			CarveID:       "carve-2",
+			RequestID:     "req-2",
+			SessionID:     "session-2",
+			QueryName:     query.Name,
+			UUID:          "node-2",
+			NodeID:        2,
+			Environment:   "dev",
+			Path:          "/tmp/file",
+			Status:        carves.StatusCompleted,
+			EnvironmentID: query.EnvironmentID,
+		},
+	}
+	for _, file := range files {
+		require.NoError(t, carveManager.CreateCarve(file))
+	}
+
+	h := &HandlersTLS{
+		Queries: queryManager,
+		Carves:  carveManager,
+	}
+
+	require.NoError(t, h.syncCompletedCarveQuery("session-1"))
+
+	updated, err := queryManager.Get(query.Name, query.EnvironmentID)
+	require.NoError(t, err)
+	assert.True(t, updated.Completed)
+	assert.False(t, updated.Active)
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -151,6 +151,7 @@ export interface DistributedQuery {
   extra_data: string;
   expiration: string;
   target: string;
+  carve_status?: string;
   /**
    * Targets the query was launched against — populated by
    * GET /queries/{env}/{name}; list endpoints leave it out so it may

--- a/frontend/src/features/carves/CarveDetailPage.test.tsx
+++ b/frontend/src/features/carves/CarveDetailPage.test.tsx
@@ -168,6 +168,22 @@ describe('CarveDetailPage', () => {
     expect(screen.getByText('test-env')).toBeInTheDocument();
   });
 
+  it('renders a Refresh button that reloads the carve', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(makeTestRouter());
+
+    // The carve loads on mount.
+    await screen.findByText('/etc/hosts');
+    expect(mockGetCarve).toHaveBeenCalledTimes(1);
+
+    // The Refresh button (mirrors the query detail page) re-fetches.
+    const refresh = await screen.findByRole('button', { name: 'Refresh carved files' });
+    await user.click(refresh);
+    await waitFor(() => {
+      expect(mockGetCarve).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('does not render a fake completion date for scheduled files', async () => {
     mockGetCarve.mockResolvedValue(makeCarveDetail({ files: [makeFile()] }));
     mockListNodes.mockResolvedValue({

--- a/frontend/src/features/carves/CarveDetailPage.test.tsx
+++ b/frontend/src/features/carves/CarveDetailPage.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRouter,
+  createRoute,
+  createRootRoute,
+  RouterProvider,
+  Outlet,
+} from '@tanstack/react-router';
+import { CarveDetailPage } from './CarveDetailPage';
+import type { CarveDetail, CarveFile, DistributedQuery } from '$/api/types';
+
+const mockGetCarve = vi.fn<() => Promise<CarveDetail>>();
+const mockActOnCarve = vi.fn<() => Promise<{ message: string }>>();
+const mockListNodes = vi.fn<() => Promise<{ items: Array<{ uuid: string; hostname: string; localname: string }> }>>();
+
+vi.mock('$/api/carves', () => ({
+  getCarve: (...args: unknown[]) => mockGetCarve(...(args as [])),
+  actOnCarve: (...args: unknown[]) => mockActOnCarve(...(args as [])),
+  getCarveArchiveUrl: () => '/download.carve',
+}));
+
+vi.mock('$/api/nodes', () => ({
+  listNodes: (...args: unknown[]) => mockListNodes(...(args as [])),
+}));
+
+vi.mock('$/api/client', () => ({
+  isAuthenticated: () => true,
+  getCsrfToken: () => 'test-csrf',
+  setCsrfToken: vi.fn(),
+  AuthError: class AuthError extends Error {
+    readonly status = 401;
+    constructor() {
+      super('Unauthorized');
+    }
+  },
+}));
+
+function makeQuery(overrides: Partial<DistributedQuery> = {}): DistributedQuery {
+  return {
+    id: 99,
+    created_at: new Date(Date.now() - 60_000).toISOString(),
+    updated_at: new Date().toISOString(),
+    name: 'carve_abcdef',
+    creator: 'analyst',
+    query: "SELECT * FROM carves WHERE carve=1 AND path = '/etc/hosts';",
+    expected: 2,
+    executions: 1,
+    errors: 0,
+    active: true,
+    hidden: false,
+    protected: false,
+    completed: false,
+    deleted: false,
+    expired: false,
+    type: 'carve',
+    path: '/etc/hosts',
+    environment_id: 1,
+    extra_data: '',
+    expiration: '0001-01-01T00:00:00Z',
+    target: '',
+    targets: [{ type: 'environment', value: 'test-env' }],
+    ...overrides,
+  };
+}
+
+function makeCarveDetail(overrides: Partial<CarveDetail> = {}): CarveDetail {
+  return {
+    query: makeQuery(),
+    files: [],
+    ...overrides,
+  };
+}
+
+function makeFile(overrides: Partial<CarveFile> = {}): CarveFile {
+  return {
+    carve_id: 'carve-id-1',
+    session_id: 'session-1',
+    uuid: 'node-1',
+    path: '/etc/hosts',
+    status: 'SCHEDULED',
+    carve_size: 0,
+    block_size: 4096,
+    total_blocks: 8,
+    completed_blocks: 0,
+    archived: false,
+    created_at: new Date().toISOString(),
+    completed_at: '0001-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeTestRouter(initialPath = '/_app/env/test-env/carves/carve_abcdef') {
+  const rootRoute = createRootRoute({ component: Outlet });
+  const appRoute = createRoute({ getParentRoute: () => rootRoute, path: '/_app', component: Outlet });
+  const envRoute = createRoute({ getParentRoute: () => appRoute, path: 'env/$env', component: Outlet });
+  const listRoute = createRoute({
+    getParentRoute: () => envRoute,
+    path: 'carves',
+    component: () => <div data-testid="carves-page">carves</div>,
+  });
+  const detailRoute = createRoute({
+    getParentRoute: () => envRoute,
+    path: 'carves/$name',
+    component: CarveDetailPage,
+  });
+  const loginRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/login',
+    component: () => <div data-testid="login">login</div>,
+  });
+  const routeTree = rootRoute.addChildren([
+    appRoute.addChildren([envRoute.addChildren([listRoute, detailRoute])]),
+    loginRoute,
+  ]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('CarveDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCarve.mockResolvedValue(makeCarveDetail());
+    mockListNodes.mockResolvedValue({ items: [] });
+    mockActOnCarve.mockResolvedValue({ message: 'ok' });
+  });
+
+  it('shows a complete button for incomplete carves and triggers the action', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(makeTestRouter());
+
+    const button = await screen.findByRole('button', { name: 'Complete carve' });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockActOnCarve).toHaveBeenCalledWith('test-env', 'carve_abcdef', 'complete');
+    });
+  });
+
+  it('hides the complete button for completed carves', async () => {
+    mockGetCarve.mockResolvedValue(makeCarveDetail({ query: makeQuery({ active: false, completed: true }) }));
+    renderWithProviders(makeTestRouter());
+
+    await screen.findByText('/etc/hosts');
+    expect(screen.queryByRole('button', { name: 'Complete carve' })).not.toBeInTheDocument();
+  });
+
+  it('shows the recorded targets', async () => {
+    renderWithProviders(makeTestRouter());
+
+    await screen.findByText('/etc/hosts');
+    expect(screen.getByText('Targets')).toBeInTheDocument();
+    expect(screen.getByText('environment:')).toBeInTheDocument();
+    expect(screen.getByText('test-env')).toBeInTheDocument();
+  });
+
+  it('does not render a fake completion date for scheduled files', async () => {
+    mockGetCarve.mockResolvedValue(makeCarveDetail({ files: [makeFile()] }));
+    mockListNodes.mockResolvedValue({
+      items: [{ uuid: 'node-1', hostname: 'node-1.example', localname: 'node-1.example' }],
+    });
+    renderWithProviders(makeTestRouter());
+
+    await screen.findByText('node-1.example');
+    expect(screen.queryByText('31 Dec')).not.toBeInTheDocument();
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/carves/CarveDetailPage.tsx
+++ b/frontend/src/features/carves/CarveDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate, Link } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
-import { getCarve, getCarveArchiveUrl } from '$/api/carves';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getCarve, getCarveArchiveUrl, actOnCarve } from '$/api/carves';
 import { listNodes } from '$/api/nodes';
 import { AuthError } from '$/api/client';
 import type { CarveFile } from '$/api/types';
@@ -42,6 +42,10 @@ function formatBytes(n: number): string {
   return `${value.toFixed(value >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
 }
 
+function hasRealTimestamp(value?: string): boolean {
+  return typeof value === 'string' && value.length > 0 && !value.startsWith('0001-01-01');
+}
+
 export function CarveDetailPage() {
   const { env, name } = useParams({ from: '/_app/env/$env/carves/$name' });
   const navigate = useNavigate({ from: '/_app/env/$env/carves/$name' });
@@ -51,6 +55,14 @@ export function CarveDetailPage() {
     queryFn: () => getCarve(env, name),
     staleTime: 15_000,
     refetchInterval: 15_000,
+  });
+  const qc = useQueryClient();
+  const completeMutation = useMutation({
+    mutationFn: () => actOnCarve(env, name, 'complete'),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['carve', env, name] });
+      void qc.invalidateQueries({ queryKey: ['carves', env] });
+    },
   });
 
   // Nodes lookup so the carve file rows can render hostname → link to the
@@ -119,6 +131,55 @@ export function CarveDetailPage() {
             </dl>
           )}
         </div>
+
+        {query && !query.completed && !query.deleted && (
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => completeMutation.mutate()}
+              disabled={completeMutation.isPending}
+              className={cn(
+                'px-3 py-1.5 text-xs font-medium rounded-md',
+                'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
+                'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+              )}
+              aria-label="Complete carve"
+            >
+              {completeMutation.isPending ? 'Completing…' : 'Complete carve'}
+            </button>
+          </div>
+        )}
+
+        {query && query.targets !== undefined && (
+          <div className="mt-3">
+            <div className="text-[10px] uppercase tracking-[0.12em] text-[color:var(--text-3)] mb-1">
+              Targets
+            </div>
+            {query.targets.length === 0 ? (
+              <div className="text-xs text-[color:var(--text-3)] italic">
+                No targets recorded.
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {query.targets.map((t, i) => (
+                  <span
+                    key={`${t.type}-${t.value}-${i}`}
+                    className={cn(
+                      'inline-flex items-center gap-1 px-2 py-0.5 rounded-md',
+                      'text-[11px] font-mono-tabular',
+                      'border border-[color:var(--border)] bg-[color:var(--bg-2)]',
+                      'text-[color:var(--text-2)]',
+                    )}
+                  >
+                    <span className="text-[color:var(--text-3)]">{t.type}:</span>
+                    <span className="text-[color:var(--text-1)] font-semibold">{t.value}</span>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="px-6 py-4 flex-1 min-h-0 overflow-auto">
@@ -232,7 +293,11 @@ export function CarveDetailPage() {
                       {f.completed_blocks}/{f.total_blocks}
                     </td>
                     <td className="px-3 py-2 text-xs tnum text-[color:var(--text-2)] text-right">
-                      <span title={f.completed_at}>{formatRelative(f.completed_at)}</span>
+                      {hasRealTimestamp(f.completed_at) ? (
+                        <span title={f.completed_at}>{formatRelative(f.completed_at)}</span>
+                      ) : (
+                        <span>—</span>
+                      )}
                     </td>
                     <td className="px-3 py-2 text-right whitespace-nowrap">
                       {canDownload ? (

--- a/frontend/src/features/carves/CarveDetailPage.tsx
+++ b/frontend/src/features/carves/CarveDetailPage.tsx
@@ -50,7 +50,7 @@ export function CarveDetailPage() {
   const { env, name } = useParams({ from: '/_app/env/$env/carves/$name' });
   const navigate = useNavigate({ from: '/_app/env/$env/carves/$name' });
 
-  const { data, isLoading, isError, error, refetch } = useQuery({
+  const { data, isLoading, isFetching, isError, error, refetch } = useQuery({
     queryKey: ['carve', env, name],
     queryFn: () => getCarve(env, name),
     staleTime: 15_000,
@@ -183,14 +183,50 @@ export function CarveDetailPage() {
       </div>
 
       <div className="px-6 py-4 flex-1 min-h-0 overflow-auto">
-        <h2 className="text-sm font-semibold text-[color:var(--text-1)] mb-3">
-          Carved files ({files.length})
-          {completedFiles.length > 0 && (
-            <span className="ml-2 text-xs text-[color:var(--text-3)] font-normal">
-              · {completedFiles.length} completed
-            </span>
-          )}
-        </h2>
+        <div className="flex items-center gap-3 mb-3">
+          <h2 className="text-sm font-semibold text-[color:var(--text-1)]">
+            Carved files ({files.length})
+            {completedFiles.length > 0 && (
+              <span className="ml-2 text-xs text-[color:var(--text-3)] font-normal">
+                · {completedFiles.length} completed
+              </span>
+            )}
+          </h2>
+          <div className="ml-auto flex items-center gap-2">
+            {/* Refresh button — mirrors the query detail page. Reloads the
+            carve, its carved files, the carves list, and the node lookup so
+            an operator watching blocks land can pull the latest state now
+            instead of waiting for the 15s poll. */}
+            <button
+              type="button"
+              onClick={() => {
+                void qc.invalidateQueries({ queryKey: ["carve", env, name] });
+                void qc.invalidateQueries({ queryKey: ["carves", env] });
+                void qc.invalidateQueries({ queryKey: ["carve-nodes-lookup", env] });
+              }}
+              disabled={isFetching}
+              className={cn(
+                'px-3 py-1 text-xs font-medium rounded-md',
+                'border border-[color:var(--border)] text-[color:var(--text-2)]',
+                'hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors',
+                'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+              )}
+              aria-label="Refresh carved files"
+              title="Refresh now"
+            >
+              Refresh
+            </button>
+            {isFetching && !isLoading && (
+              <span
+                aria-live="polite"
+                className="text-[10px] text-[color:var(--text-3)] font-mono-tabular"
+              >
+                refreshing…
+              </span>
+            )}
+          </div>
+        </div>
 
         {isLoading && (
           <p className="text-xs text-[color:var(--text-3)]">Loading…</p>

--- a/frontend/src/features/carves/CarvesListPage.test.tsx
+++ b/frontend/src/features/carves/CarvesListPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   createMemoryHistory,
@@ -129,10 +130,10 @@ describe('CarvesListPage', () => {
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByText('carve_abcdef')).toBeInTheDocument();
+      expect(screen.getByText('/etc/hosts')).toBeInTheDocument();
     });
     expect(screen.getByText('analyst')).toBeInTheDocument();
-    expect(screen.getByText('/etc/hosts')).toBeInTheDocument();
+    expect(screen.getAllByText('Active').length).toBeGreaterThan(1);
   });
 
   it('shows the empty state with a "Start first carve" CTA when none exist', async () => {
@@ -170,5 +171,33 @@ describe('CarvesListPage', () => {
     expect(args.target).toBe('active');
     expect(args.sort).toBe('name');
     expect(args.dir).toBe('asc');
+  });
+
+  it('refresh button refetches the carves table', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue(makeResponse());
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('/etc/hosts')).toBeInTheDocument();
+    });
+
+    const callsBeforeRefresh = mockList.mock.calls.length;
+    await user.click(screen.getByRole('button', { name: 'Refresh carves' }));
+
+    await waitFor(() => {
+      expect(mockList.mock.calls.length).toBeGreaterThan(callsBeforeRefresh);
+    });
+  });
+
+  it('renders pending status when a carve has been picked up but not completed', async () => {
+    mockList.mockResolvedValue(
+      makeResponse({ items: [makeCarve({ carve_status: 'PENDING' } as Partial<DistributedQuery>)] }),
+    );
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/features/carves/CarvesListPage.tsx
+++ b/frontend/src/features/carves/CarvesListPage.tsx
@@ -19,6 +19,44 @@ import { Pagination } from '$/components/data/Pagination';
 import { SearchInput } from '$/components/data/SearchInput';
 import { SortableHeader } from '$/components/data/SortableHeader';
 
+function CarveStatusBadge({
+  q,
+}: {
+  q: { active: boolean; completed: boolean; expired: boolean; deleted: boolean; carve_status?: string };
+}) {
+  if (q.carve_status === 'PENDING') return <ListBadge variant="warning" label="Pending" />;
+  if (q.carve_status === 'COMPLETED') return <ListBadge variant="success" label="Completed" />;
+  if (q.carve_status === 'EXPIRED') return <ListBadge variant="warning" label="Expired" />;
+  if (q.carve_status === 'DELETED') return <ListBadge variant="danger" label="Deleted" />;
+  if (q.carve_status === 'ACTIVE') return <ListBadge variant="info" label="Active" />;
+  if (q.deleted) return <ListBadge variant="danger" label="Deleted" />;
+  if (q.expired) return <ListBadge variant="warning" label="Expired" />;
+  if (q.completed) return <ListBadge variant="success" label="Completed" />;
+  if (q.active) return <ListBadge variant="info" label="Active" />;
+  return <ListBadge variant="dim" label="Unknown" />;
+}
+
+function ListBadge({
+  variant,
+  label,
+}: {
+  variant: 'success' | 'warning' | 'danger' | 'info' | 'dim';
+  label: string;
+}) {
+  const cls = {
+    success:
+      'bg-[rgba(var(--success-r),var(--success-g),var(--success-b),0.12)] text-[color:var(--success)]',
+    warning:
+      'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)]',
+    danger:
+      'bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.12)] text-[color:var(--danger)]',
+    info: 'bg-[rgba(var(--info-r),var(--info-g),var(--info-b),0.12)] text-[color:var(--info)]',
+    dim: 'bg-[color:var(--bg-2)] text-[color:var(--text-3)]',
+  }[variant];
+
+  return <span className={cn('px-2 py-0.5 rounded-full text-xs font-medium', cls)}>{label}</span>;
+}
+
 const CARVE_STATUS_TABS: StatusTab<CarveTarget>[] = [
   { value: 'all', label: 'All' },
   { value: 'active', label: 'Active' },
@@ -161,6 +199,22 @@ export function CarvesListPage() {
         </div>
 
         <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            disabled={isFetching}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-md',
+              'border border-[color:var(--border)] text-[color:var(--text-2)]',
+              'hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors',
+              'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+            aria-label="Refresh carves"
+          >
+            Refresh
+          </button>
+
           <Link
             to="/_app/env/$env/carves/new"
             params={{ env }}
@@ -217,7 +271,14 @@ export function CarvesListPage() {
               </th>
               <SortableHeader
                 column={'name' as CarveSortColumn}
-                label="Name"
+                label="Path"
+                currentSort={sort}
+                currentDir={dir}
+                onSortChange={handleSortChange}
+              />
+              <SortableHeader
+                column={'creator' as CarveSortColumn}
+                label="Creator"
                 currentSort={sort}
                 currentDir={dir}
                 onSortChange={handleSortChange}
@@ -226,15 +287,8 @@ export function CarvesListPage() {
                 scope="col"
                 className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide"
               >
-                Path
+                Status
               </th>
-              <SortableHeader
-                column={'creator' as CarveSortColumn}
-                label="Creator"
-                currentSort={sort}
-                currentDir={dir}
-                onSortChange={handleSortChange}
-              />
               <SortableHeader
                 column={'executions' as CarveSortColumn}
                 label="Progress"
@@ -351,20 +405,16 @@ export function CarvesListPage() {
                           'text-sm font-medium font-mono-tabular text-[color:var(--text-link)]',
                           'hover:underline',
                         )}
+                        title={item.path || item.name}
                       >
-                        {item.name}
+                        {item.path || item.name}
                       </Link>
-                    </td>
-                    <td className="px-4 py-3 max-w-md">
-                      <code
-                        className="block truncate font-mono-tabular text-xs text-[color:var(--text-2)]"
-                        title={item.path}
-                      >
-                        {item.path || '—'}
-                      </code>
                     </td>
                     <td className="px-4 py-3 text-[color:var(--text-2)] text-xs">
                       {item.creator}
+                    </td>
+                    <td className="px-4 py-3">
+                      <CarveStatusBadge q={item} />
                     </td>
                     <td className="px-4 py-3 text-xs tnum text-[color:var(--text-2)]">
                       <span title={`${item.executions}/${item.expected} (errors: ${item.errors})`}>

--- a/frontend/src/features/queries/QueryDetailPage.test.tsx
+++ b/frontend/src/features/queries/QueryDetailPage.test.tsx
@@ -138,6 +138,26 @@ describe('QueryDetailPage', () => {
     });
   });
 
+  it('Refresh button reloads the query and its results (refresh everything)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(makeTestRouter());
+
+    // Initial load fires both the query and its results.
+    await screen.findByText('SELECT 1;');
+    const initialQueries = mockGetQuery.mock.calls.length;
+    const initialResults = mockListQueryResults.mock.calls.length;
+    expect(initialQueries).toBeGreaterThanOrEqual(1);
+    expect(initialResults).toBeGreaterThanOrEqual(1);
+
+    // The Refresh button invalidates everything, so both fetch again.
+    const refresh = await screen.findByRole('button', { name: 'Refresh query results' });
+    await user.click(refresh);
+    await waitFor(() => {
+      expect(mockGetQuery.mock.calls.length).toBeGreaterThan(initialQueries);
+      expect(mockListQueryResults.mock.calls.length).toBeGreaterThan(initialResults);
+    });
+  });
+
   it('hides the complete button for completed queries', async () => {
     mockGetQuery.mockResolvedValue(makeQuery({ active: false, completed: true }));
     renderWithProviders(makeTestRouter());

--- a/frontend/src/features/queries/QueryDetailPage.tsx
+++ b/frontend/src/features/queries/QueryDetailPage.tsx
@@ -307,10 +307,11 @@ export function QueryDetailPage() {
               in legacy when watching a long-running distributed query land. */}
           <button
             type="button"
-            onClick={() => {
-              void qc.invalidateQueries({ queryKey: ['query', env, name] });
-              void qc.invalidateQueries({ queryKey: ['query-results', env, name] });
-            }}
+            // Refresh everything: the query, its results, the queries list,
+            // and any other live data on the page (stats, activity) — so an
+            // operator watching a query land gets a fully fresh view, not just
+            // the results table.
+            onClick={() => void qc.invalidateQueries()}
             className={cn(
               'px-3 py-1 text-xs font-medium rounded-md',
               'border border-[color:var(--border)] text-[color:var(--text-2)]',

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -114,6 +114,7 @@ type DistributedQuery struct {
 	ExtraData     string         `json:"extra_data"`
 	Expiration    time.Time      `json:"expiration"`
 	Target        string         `json:"target"`
+	CarveStatus   string         `gorm:"-" json:"carve_status,omitempty"`
 }
 
 // NodeQuery links a node to a query
@@ -567,7 +568,11 @@ func (q *Queries) UpdateQueryStatus(queryName string, nodeID uint, statusCode in
 		Count(&pending).Error; err != nil {
 		return err
 	}
-	if pending == 0 {
+	// Standard distributed queries are complete once every targeted node has
+	// reached a terminal node_query status. Carves use the same delivery
+	// mechanism, but the actual file transfer continues after query delivery, so
+	// they must not be auto-completed here.
+	if pending == 0 && query.Type != CarveQueryType {
 		if err := q.DB.Model(&query).Updates(map[string]interface{}{"completed": true, "active": false}).Error; err != nil {
 			return err
 		}

--- a/pkg/queries/queries_test.go
+++ b/pkg/queries/queries_test.go
@@ -174,6 +174,32 @@ func TestUpdateQueryStatusCompletesParentQueryWhenAllTargetsFinish(t *testing.T)
 	assert.False(t, afterSecond.Active, "query should no longer be active when all targets are terminal")
 }
 
+func TestUpdateQueryStatusDoesNotAutoCompleteCarveWhenAllTargetsFinish(t *testing.T) {
+	db := testDB(t)
+	q, nodes, query := setupTestData(t, db)
+
+	query.Type = queries.CarveQueryType
+	query.Active = true
+	query.Completed = false
+	require.NoError(t, db.Save(&query).Error)
+
+	relations := []queries.NodeQuery{
+		{NodeID: nodes[0].ID, QueryID: query.ID, Status: queries.DistributedQueryStatusPending},
+		{NodeID: nodes[1].ID, QueryID: query.ID, Status: queries.DistributedQueryStatusPending},
+	}
+	for _, relation := range relations {
+		require.NoError(t, db.Create(&relation).Error)
+	}
+
+	require.NoError(t, q.UpdateQueryStatus(query.Name, nodes[0].ID, 0))
+	require.NoError(t, q.UpdateQueryStatus(query.Name, nodes[1].ID, 0))
+
+	var updated queries.DistributedQuery
+	require.NoError(t, db.First(&updated, query.ID).Error)
+	assert.False(t, updated.Completed, "carves should not be auto-completed when node query delivery finishes")
+	assert.True(t, updated.Active, "carves should remain active until the carve flow itself is completed")
+}
+
 func TestCreateNodeQueries(t *testing.T) {
 	db := testDB(t)
 	q, nodes, query := setupTestData(t, db)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -277,12 +277,24 @@ type CarveFileView struct {
 	CompletedAt     time.Time `json:"completed_at"`
 }
 
+// QueryTargetView is the SPA-facing shape for stored distributed-query targets.
+type QueryTargetView struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// DistributedQueryView augments a query row with its recorded targets.
+type DistributedQueryView struct {
+	queries.DistributedQuery
+	Targets []QueryTargetView `json:"targets"`
+}
+
 // CarveDetailResponse is the SPA-canonical response for
 // GET /api/v1/carves/{env}/{name}. It pairs the carve QUERY metadata with
 // the per-node CarvedFile rows produced by the carve.
 type CarveDetailResponse struct {
-	Query queries.DistributedQuery `json:"query"`
-	Files []CarveFileView          `json:"files"`
+	Query DistributedQueryView `json:"query"`
+	Files []CarveFileView      `json:"files"`
 }
 
 // EnvAccessView mirrors users.EnvAccess but lives in the types package so


### PR DESCRIPTION
## Summary

This PR improves carve lifecycle visibility and aligns carve behavior with the actual node-side file transfer flow.

## What changed

### Carve lifecycle and status
- Stop marking parent carve queries as completed as soon as the distributed query delivery finishes
- Keep carves `Active` until a node actually picks them up
- Show carves as `Pending` once one or more targets have scheduled/started the carve
- Mark carves `Completed` only after all expected targets have fully finished their carve uploads

### Carve list UX
- Display the carve path instead of the internal generated carve name
- Add a dedicated status column with clear lifecycle badges
- Add a manual `Refresh` button to refetch the carves table
- Surface the derived carve lifecycle state from the API to the React list

### Carve detail UX
- Add a `Complete carve` action for incomplete carves
- Show recorded carve targets in the detail page
- Avoid rendering zero-value completion timestamps as bogus dates like `31 Dec`

### Carve target handling
- Persist carve target rows when a carve is created
- Return those target rows from the carve detail API response

## Why

This fixes a few operator-facing problems in the carve workflow:
- carves could look completed even though nodes had only scheduled them
- carves could remain active forever even after every target actually finished
- the list showed internal carve names instead of the real file path operators care about
- whole-environment carve targets were not visible in the detail view
- unset completion timestamps rendered like real dates

## Testing

- `GOCACHE=/tmp/osctrl-gocache go test ./pkg/queries ./cmd/tls/handlers`
- `cd frontend && node node_modules/.ignored/vitest/vitest.mjs run src/features/carves/CarvesListPage.test.tsx src/features/carves/CarveDetailPage.test.tsx`
- `cd frontend && node node_modules/.ignored/typescript/bin/tsc -p tsconfig.json --noEmit`

## Notes

- Carve list status now uses a carve-specific derived state from carved-file rows rather than relying only on the parent distributed-query flags.
- The target persistence fix applies to newly created carves; older carves created before target rows were stored may still have incomplete target metadata.