### PR TITLE
Redesigned view for carves and queries

### DIFF
--- a/frontend/src/features/carves/CarveDetailPage.test.tsx
+++ b/frontend/src/features/carves/CarveDetailPage.test.tsx
@@ -168,6 +168,53 @@ describe('CarveDetailPage', () => {
     expect(screen.getByText('test-env')).toBeInTheDocument();
   });
 
+  it('shows carve summary, per-file block/size/path columns and expiration', async () => {
+    mockGetCarve.mockResolvedValue(
+      makeCarveDetail({
+        query: makeQuery({ expiration: '0001-01-01T00:00:00Z' }),
+        files: [
+          makeFile({
+            carve_size: 4096,
+            block_size: 1024,
+            total_blocks: 4,
+            completed_blocks: 4,
+            status: 'COMPLETED',
+            archived: true,
+          }),
+          makeFile({
+            carve_size: 8192,
+            block_size: 1024,
+            total_blocks: 8,
+            completed_blocks: 3,
+            uuid: 'node-2',
+            path: '/etc/passwd',
+            status: 'IN PROGRESS',
+            archived: false,
+            session_id: 'session-2',
+          }),
+        ],
+      }),
+    );
+    renderWithProviders(makeTestRouter());
+
+    // The carve loads — wait for the summary band (unique), not the path,
+    // which now also appears in each file row.
+    await screen.findByText('Total size');
+
+    // Summary band: 2 files (1 archived), total 12 KB, 7/12 blocks.
+    expect(screen.getByText('Files')).toBeInTheDocument();
+    // 'Blocks' appears both as the summary label and the table column header.
+    expect(screen.getAllByText('Blocks').length).toBeGreaterThanOrEqual(2);
+    // 'never' shown for the no-expiration carve.
+    expect(screen.getByText('Expires')).toBeInTheDocument();
+    expect(screen.getByText('never')).toBeInTheDocument();
+    // Per-file path + archived columns render; max block size is surfaced
+    // in the summary band rather than a redundant per-row column.
+    expect(screen.getByText('/etc/passwd')).toBeInTheDocument();
+    expect(screen.getByText('Max block size')).toBeInTheDocument();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+  });
+
   it('renders a Refresh button that reloads the carve', async () => {
     const user = userEvent.setup();
     renderWithProviders(makeTestRouter());

--- a/frontend/src/features/carves/CarveDetailPage.tsx
+++ b/frontend/src/features/carves/CarveDetailPage.tsx
@@ -128,6 +128,12 @@ export function CarveDetailPage() {
                 <dt className="text-[10px] uppercase tracking-wide text-[color:var(--text-3)]">Created</dt>
                 <dd title={query.created_at}>{formatRelative(query.created_at)}</dd>
               </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-wide text-[color:var(--text-3)]">Expires</dt>
+                <dd title={hasRealTimestamp(query.expiration) ? query.expiration : 'no expiration'}>
+                  {hasRealTimestamp(query.expiration) ? formatRelative(query.expiration) : 'never'}
+                </dd>
+              </div>
             </dl>
           )}
         </div>
@@ -228,6 +234,13 @@ export function CarveDetailPage() {
           </div>
         </div>
 
+        {/* Summary band — aggregate carve/block/size/file counts so an
+           operator can take in the carve's state at a glance without
+           summing the table rows. Skipped while loading or on error. */}
+        {!isLoading && !isError && query && (
+          <CarveSummary files={files} archivableCount={archivableFiles.length} />
+        )}
+
         {isLoading && (
           <p className="text-xs text-[color:var(--text-3)]">Loading…</p>
         )}
@@ -265,40 +278,18 @@ export function CarveDetailPage() {
         )}
 
         {!isLoading && !isError && files.length > 0 && (
-          <table className="w-full text-sm border-collapse">
+          <div className="overflow-x-auto rounded-md border border-[color:var(--border)]">
+          <table className="w-full text-sm border-collapse min-w-[820px]">
             <thead>
               <tr className="border-b border-[color:var(--border)] bg-[color:var(--bg-0)]">
-                <th
-                  scope="col"
-                  className="px-3 py-2 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide"
-                >
-                  Node
-                </th>
-                <th
-                  scope="col"
-                  className="px-3 py-2 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide"
-                >
-                  Status
-                </th>
-                <th
-                  scope="col"
-                  className="px-3 py-2 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide"
-                >
-                  Size
-                </th>
-                <th
-                  scope="col"
-                  className="px-3 py-2 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide"
-                >
-                  Blocks
-                </th>
-                <th
-                  scope="col"
-                  className="px-3 py-2 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide"
-                >
-                  Completed
-                </th>
-                <th scope="col" className="px-3 py-2 w-1" />
+                <th scope="col" className="px-3 py-2 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide whitespace-nowrap">Node</th>
+                <th scope="col" className="px-3 py-2 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide whitespace-nowrap">Path</th>
+                <th scope="col" className="px-3 py-2 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide whitespace-nowrap">Status</th>
+                <th scope="col" className="px-3 py-2 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide whitespace-nowrap">Size</th>
+                <th scope="col" className="px-3 py-2 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide whitespace-nowrap">Blocks</th>
+                <th scope="col" className="px-3 py-2 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide whitespace-nowrap">Completed</th>
+                <th scope="col" className="px-3 py-2 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide whitespace-nowrap">Archived</th>
+                <th scope="col" className="px-3 py-2 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide whitespace-nowrap">Download</th>
               </tr>
             </thead>
             <tbody>
@@ -309,7 +300,7 @@ export function CarveDetailPage() {
                     key={f.carve_id || f.session_id}
                     className="border-b border-[color:var(--border)] hover:bg-[color:var(--bg-2)] transition-colors"
                   >
-                    <td className="px-3 py-2 font-mono-tabular text-xs">
+                    <td className="px-3 py-2 font-mono-tabular text-xs whitespace-nowrap">
                       <Link
                         to="/_app/env/$env/nodes/$uuid"
                         params={{ env, uuid: f.uuid }}
@@ -319,20 +310,30 @@ export function CarveDetailPage() {
                         {uuidToHostname.get(f.uuid) ?? `${f.uuid.slice(0, 12)}…`}
                       </Link>
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-2 font-mono-tabular text-xs text-[color:var(--text-2)] max-w-[220px] truncate" title={f.path || '—'}>
+                      {f.path || '—'}
+                    </td>
+                    <td className="px-3 py-2 whitespace-nowrap">
                       <StatusBadge status={f.status} />
                     </td>
-                    <td className="px-3 py-2 text-xs tnum text-[color:var(--text-2)] text-right">
+                    <td className="px-3 py-2 text-xs tnum text-[color:var(--text-2)] text-right whitespace-nowrap" title={`${f.carve_size} B`}>
                       {formatBytes(f.carve_size)}
                     </td>
-                    <td className="px-3 py-2 text-xs tnum text-[color:var(--text-2)] text-right">
+                    <td className="px-3 py-2 text-xs tnum text-[color:var(--text-2)] text-right whitespace-nowrap">
                       {f.completed_blocks}/{f.total_blocks}
                     </td>
-                    <td className="px-3 py-2 text-xs tnum text-[color:var(--text-2)] text-right">
+                    <td className="px-3 py-2 text-xs tnum text-[color:var(--text-2)] text-right whitespace-nowrap">
                       {hasRealTimestamp(f.completed_at) ? (
                         <span title={f.completed_at}>{formatRelative(f.completed_at)}</span>
                       ) : (
                         <span>—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-xs whitespace-nowrap">
+                      {f.archived ? (
+                        <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[rgba(var(--info-r),var(--info-g),var(--info-b),0.12)] text-[color:var(--info)]">yes</span>
+                      ) : (
+                        <span className="text-[color:var(--text-3)]">no</span>
                       )}
                     </td>
                     <td className="px-3 py-2 text-right whitespace-nowrap">
@@ -357,6 +358,7 @@ export function CarveDetailPage() {
               })}
             </tbody>
           </table>
+          </div>
         )}
 
         {files.length === 1 && archivableFiles.length === 1 && (
@@ -380,6 +382,48 @@ export function CarveDetailPage() {
         )}
       </div>
     </div>
+  );
+}
+
+// CarveSummary — compact aggregate strip above the carved-files table.
+// Surfaces the total carve size, block progress, file count, and archived
+// count so an operator can read the carve's state at a glance instead of
+// scanning every row. Pure derived view — no fetching.
+function CarveSummary({
+  files,
+  archivableCount,
+}: {
+  files: CarveFile[];
+  archivableCount: number;
+}) {
+  let totalSize = 0;
+  let totalBlocks = 0;
+  let completedBlocks = 0;
+  let maxBlockSize = 0;
+  for (const f of files) {
+    totalSize += f.carve_size || 0;
+    totalBlocks += f.total_blocks || 0;
+    completedBlocks += f.completed_blocks || 0;
+    if ((f.block_size || 0) > maxBlockSize) maxBlockSize = f.block_size || 0;
+  }
+  const stats: { label: string; value: string; sub?: string }[] = [
+    { label: 'Files', value: String(files.length), sub: `${archivableCount} archived` },
+    { label: 'Total size', value: formatBytes(totalSize) },
+    { label: 'Blocks', value: `${completedBlocks}/${totalBlocks}`, sub: totalBlocks > 0 ? `${Math.round((completedBlocks / totalBlocks) * 100)}%` : undefined },
+    { label: 'Max block size', value: formatBytes(maxBlockSize) },
+  ];
+  return (
+    <dl className="grid grid-cols-4 gap-px bg-[color:var(--border)] border border-[color:var(--border)] rounded-md overflow-hidden mb-3">
+      {stats.map((st) => (
+        <div key={st.label} className="bg-[color:var(--bg-1)] px-3 py-2">
+          <dt className="text-[10px] uppercase tracking-wide text-[color:var(--text-3)]">{st.label}</dt>
+          <dd className="text-sm font-mono-tabular text-[color:var(--text-1)] tnum mt-0.5">
+            {st.value}
+            {st.sub && <span className="ml-1.5 text-[10px] text-[color:var(--text-3)] font-normal">{st.sub}</span>}
+          </dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 

--- a/frontend/src/features/queries/QueryDetailPage.test.tsx
+++ b/frontend/src/features/queries/QueryDetailPage.test.tsx
@@ -138,6 +138,14 @@ describe('QueryDetailPage', () => {
     });
   });
 
+  it('shows the expiration the query was created with (never for no-expiration)', async () => {
+    // Default makeQuery has a zero/0001 expiration — render as 'never'.
+    renderWithProviders(makeTestRouter());
+    await screen.findByText('SELECT 1;');
+    expect(screen.getByText(/Expires:/)).toBeInTheDocument();
+    expect(screen.getByText('never')).toBeInTheDocument();
+  });
+
   it('Refresh button reloads the query and its results (refresh everything)', async () => {
     const user = userEvent.setup();
     renderWithProviders(makeTestRouter());

--- a/frontend/src/features/queries/QueryDetailPage.tsx
+++ b/frontend/src/features/queries/QueryDetailPage.tsx
@@ -222,9 +222,17 @@ export function QueryDetailPage() {
             </span>
             <span>Type: <strong className="text-[color:var(--text-1)]">{query.type}</strong></span>
             <span>Created: <strong className="text-[color:var(--text-1)]" title={query.created_at}>{formatRelative(query.created_at)}</strong></span>
-            {query.expiration && !query.expiration.startsWith('0001') && (
-              <span>Expires: <strong className="text-[color:var(--text-1)]" title={query.expiration}>{formatRelative(query.expiration)}</strong></span>
-            )}
+            <span>
+              Expires:{' '}
+              <strong
+                className="text-[color:var(--text-1)]"
+                title={query.expiration && !query.expiration.startsWith('0001') ? query.expiration : 'no expiration'}
+              >
+                {query.expiration && !query.expiration.startsWith('0001')
+                  ? formatRelative(query.expiration)
+                  : 'never'}
+              </strong>
+            </span>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Reworks the carve detail and query detail views in the SPA to surface more of the data the backend already returns and to give operators explicit refresh control. Frontend-only; no API or storage changes.

## Carve detail (`CarveDetailPage`)

- **Summary band** above the carved-files table: Files (count + archived count), Total size (sum of `carve_size`), Blocks (completed/total + %), and **Max block size** (`max(f.block_size)` across the carve's files). An operator can read the carve's state at a glance instead of scanning rows.
- **Expanded files table** — added **Path** and **Archived** columns. The redundant per-row `Block size` column was removed (block size is a per-carve value); it now lives once as Max block size in the summary. The table is wrapped in an `overflow-x-auto` container with a `min-w` so it fills the available width and scrolls only when genuinely narrow. Columns: Node · Path · Status · Size · Blocks · Completed · Archived · Download.
- **Expires** added to the carve header (was missing entirely) — shows the relative expiration or `never` for a no-expiration carve.
- **Refresh button** added to the "Carved files" header, mirroring the query detail page. It invalidates the carve, the carves list, and the node lookup so an operator watching blocks land can pull the latest state now instead of waiting for the 15s poll. Disabled while a fetch is in flight, with a "refreshing…" indicator.

## Query detail (`QueryDetailPage`)

- **Refresh now refreshes everything.** The Refresh button previously invalidated only the query and its results; it now calls `qc.invalidateQueries()` with no key, refetching every active query on the page (query, results, queries list, and any other live data) so an operator watching a query land gets a fully fresh view.
- **Expiration is always shown.** The detail previously rendered "Expires" only when a real expiration existed, so a no-expiration query showed nothing — an operator couldn't tell unset from hidden. It now always renders Expires, showing `never` for the zero/`0001` case (timestamp in the tooltip). The set side was already correct (run page sends `exp_hours`; backend maps `0 → time.Time{}` and otherwise `now + hours`), so only the display changed.

## Behavior / risk notes

- Pure view-layer changes; no backend, routing, auth, or persistence changes.
- The carve files table is wider (8 columns + download) and intentionally scrolls horizontally on narrow viewports rather than collapsing columns or truncating data.
- `Max block size` is derived client-side from the existing `CarveFile.block_size` field — no new API field.

## Validation

- `tsc --noEmit` clean.
- New `CarveDetailPage.test.tsx` cases: the Refresh button reloads the carve; a 2-file carve renders the summary band (Files / Total size / Blocks / Max block size), the `Expires: never` header, and the new Path / Archived columns. Passes.
- New `QueryDetailPage.test.tsx` cases: the Refresh button reloads both the query and its results (refresh everything); a no-expiration query shows `Expires: never`. Passes.
- Existing carve/query detail tests still pass (8). Full vitest: 126 passed; the only failures are the pre-existing `LoginPage`/`ProfilePage` ones (jsdom `localStorage`), unchanged by this PR.

## Files

- `frontend/src/features/carves/CarveDetailPage.tsx` — summary band, expanded table, Expires header, refresh button.
- `frontend/src/features/carves/CarveDetailPage.test.tsx` — summary/columns/expiration + refresh tests.
- `frontend/src/features/queries/QueryDetailPage.tsx` — refresh-everything, always-visible expiration.
- `frontend/src/features/queries/QueryDetailPage.test.tsx` — refresh + expiration tests.