### PR TITLE
Adding interactive console mode to `osctrl-cli`

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -236,6 +236,12 @@ func init() {
 	// Initialize CLI flags commands
 	commands = []*cli.Command{
 		{
+			Name:    "shell",
+			Aliases: []string{"console", "interactive", "repl"},
+			Usage:   "Interactive shell session (Metasploit-style) — access nodes, queries, carves, ...",
+			Action:  cliWrapper(runShell),
+		},
+		{
 			Name:   "audit-logs",
 			Usage:  "Get all audit logs for actions performed in osctrl",
 			Action: cliWrapper(auditLogs),

--- a/cmd/cli/shell.go
+++ b/cmd/cli/shell.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/mattn/go-runewidth"
+	"gorm.io/gorm/logger"
+
+	"github.com/jmpsec/osctrl/pkg/version"
+	"github.com/urfave/cli/v3"
+)
+
+// shell.go — Metasploit-style interactive shell for osctrl-cli.
+//
+// One persistent session holds the backend connection (REST API or local DB)
+// open and exposes the same surface as the CLI subcommands through a
+// context-based REPL: `use nodes`, `list`, `show <id>`, `run <sql>`, etc. No
+// re-invocation of the binary per action.
+
+// shellCmd is one REPL command within a context.
+type shellCmd struct {
+	name    string
+	aliases string // space-separated aliases, matched in dispatch
+	args    string // usage hint, e.g. "<uuid|hostname>"
+	help    string
+	min     int
+	fn      func(s *shellState, args []string)
+}
+
+// shellModule is a context (nodes, queries, ...) with its own command set.
+type shellModule struct {
+	name  string
+	label string
+	desc  string
+	cmds  []shellCmd
+}
+
+// shellState is the live session.
+type shellState struct {
+	store   DataStore
+	rl      *lineEditor
+	env     string // active environment
+	ctx     string // current module name ("" = top level)
+	modules map[string]*shellModule
+	order   []string // module names in display order
+	global  []shellCmd
+	// run options shared by queries/carves
+	opts map[string]string
+	// cached resource names for tab completion (refreshed by list/show)
+	envNames   []string
+	nodeKeys   []string
+	queryNames []string
+	running    bool
+}
+
+// runShell is the action behind the `shell` command.
+func runShell(ctx context.Context, cmd *cli.Command) error {
+	var store DataStore
+	switch {
+	case dbFlag:
+		store = newDBStore()
+	case apiFlag:
+		store = newAPIStore(osctrlAPI)
+	default:
+		return fmt.Errorf("enable --db or --api to use the interactive shell")
+	}
+	if dbFlag {
+		// Silence gorm's logger: it writes carriage returns + SQL traces to
+		// stdout that scramble the REPL. The shell surfaces errors via return
+		// values, so the trace logger is pure noise here.
+		db.Conn.Logger = logger.Discard
+		if err := db.Check(); err != nil {
+			return fmt.Errorf("db check: %w", err)
+		}
+	} else {
+		if err := osctrlAPI.CheckAPI(); err != nil {
+			return fmt.Errorf("api check: %w", err)
+		}
+	}
+	initColors()
+	s := newShellState(store)
+	printBanner(version.OsctrlVersion, store.Mode())
+	// Best-effort: prime env name cache.
+	if names, err := store.EnvNames(); err == nil {
+		s.envNames = names
+		if len(names) > 0 && s.env == "" {
+			s.env = names[0]
+		}
+	}
+	return s.loop()
+}
+
+func newShellState(store DataStore) *shellState {
+	s := &shellState{
+		store:   store,
+		opts:    map[string]string{"expiration": "6"},
+		modules: map[string]*shellModule{},
+	}
+	s.rl = &lineEditor{complete: s.completer}
+	s.buildModules()
+	s.buildGlobal()
+	return s
+}
+
+func (s *shellState) loop() error {
+	s.running = true
+	for s.running {
+		prompt := s.prompt()
+		line, err := s.rl.readline(prompt)
+		if errors.Is(err, io.EOF) {
+			fmt.Println()
+			return nil
+		}
+		if errors.Is(err, errInterrupt) {
+			// Ctrl-C: abort current line, stay in shell
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		args := tokenize(line)
+		if len(args) == 0 {
+			continue
+		}
+		s.dispatch(args)
+	}
+	return nil
+}
+
+func (s *shellState) prompt() string {
+	bracket := paint(cGreen, "> ")
+	if s.ctx == "" {
+		if s.env != "" {
+			return paint(cCyan+cBold, "osctrl") + paint(cYellow, "["+s.env+"]") + bracket
+		}
+		return paint(cCyan+cBold, "osctrl") + bracket
+	}
+	ctx := paint(cMagenta, "("+s.ctx+":"+s.env+")")
+	if s.env == "" {
+		ctx = paint(cMagenta, "("+s.ctx+")")
+	}
+	return paint(cCyan+cBold, "osctrl") + " " + ctx + bracket
+}
+
+// dispatch resolves args[0] to a command in the current module, then global.
+func (s *shellState) dispatch(args []string) {
+	name := args[0]
+	rest := args[1:]
+	if s.ctx != "" {
+		if m, ok := s.modules[s.ctx]; ok {
+			if c, ok := findCmd(m.cmds, name); ok {
+				s.runCmd(c, rest)
+				return
+			}
+		}
+	}
+	if c, ok := findCmd(s.global, name); ok {
+		s.runCmd(c, rest)
+		return
+	}
+	fmt.Printf("❌ unknown command: %s — type 'help'\n", name)
+}
+
+func (s *shellState) runCmd(c shellCmd, args []string) {
+	if c.min > 0 && len(args) < c.min {
+		fmt.Printf("usage: %s %s\n", c.name, c.args)
+		return
+	}
+	c.fn(s, args)
+}
+
+func findCmd(cmds []shellCmd, name string) (shellCmd, bool) {
+	for _, c := range cmds {
+		if c.name == name {
+			return c, true
+		}
+		for _, a := range strings.Fields(c.aliases) {
+			if a == name {
+				return c, true
+			}
+		}
+	}
+	return shellCmd{}, false
+}
+
+// ─────────────────────────────── helpers ───────────────────────────────
+
+func (s *shellState) confirm(prompt string) bool {
+	line, err := s.rl.readline(prompt + " [y/N] ")
+	if err != nil {
+		return false
+	}
+	r := strings.ToLower(strings.TrimSpace(line))
+	return r == "y" || r == "yes"
+}
+
+func (s *shellState) requireEnv() bool {
+	if s.env == "" {
+		fmt.Println("❌ no active environment. Use: set env <name>  (or: use environments)")
+		return false
+	}
+	return true
+}
+
+// printTable renders a header + rows as a clean, borderless ASCII table.
+// Plain ASCII (no box-drawing glyphs, no carriage returns) so it never
+// scrambles the REPL output regardless of terminal UTF-8 support.
+func printTable(headers []string, rows [][]string) {
+	if len(rows) == 0 {
+		fmt.Println("(none)")
+		return
+	}
+	cols := len(headers)
+	width := make([]int, cols)
+	for i, h := range headers {
+		width[i] = visibleWidth(h)
+	}
+	for _, r := range rows {
+		for i := 0; i < cols && i < len(r); i++ {
+			if w := visibleWidth(r[i]); w > width[i] {
+				width[i] = w
+			}
+		}
+	}
+	coloredHeaders := make([]string, cols)
+	for i, h := range headers {
+		coloredHeaders[i] = paint(cCyan+cBold, h)
+	}
+	printRowRaw(coloredHeaders, width)
+	// full-width separator spanning columns + 2-space gutters
+	fmt.Println(paint(cGray, strings.Repeat("─", sumWidth(width)+2*(cols-1))))
+	for _, r := range rows {
+		colored := make([]string, cols)
+		for i := 0; i < cols; i++ {
+			cell := ""
+			if i < len(r) {
+				cell = r[i]
+			}
+			colored[i] = colorCell(cell)
+		}
+		printRowRaw(colored, width)
+	}
+}
+
+// padRight pads s with spaces so its visible (display) width equals dw.
+func padRight(s string, dw int) string {
+	if w := visibleWidth(s); w < dw {
+		return s + strings.Repeat(" ", dw-w)
+	}
+	return s
+}
+
+func sumWidth(w []int) int {
+	n := 0
+	for _, x := range w {
+		n += x
+	}
+	return n
+}
+
+// printRowRaw prints one padded row with two-space column gutters. Padding is
+// computed from the visible rune width, so ANSI color codes don't misalign.
+func printRowRaw(cells []string, width []int) {
+	var b strings.Builder
+	for i := range width {
+		c := ""
+		if i < len(cells) {
+			c = cells[i]
+		}
+		b.WriteString(c)
+		if i < len(width)-1 {
+			b.WriteString(strings.Repeat(" ", width[i]-visibleWidth(c)))
+			b.WriteString("  ")
+		}
+	}
+	fmt.Println(b.String())
+}
+
+// visibleWidth returns the rune count of s after stripping ANSI escape codes,
+// used so colored cells stay aligned.
+func visibleWidth(s string) int {
+	return runewidth.StringWidth(ansiStrip(s))
+}
+
+// ansiStrip removes CSI escape sequences from s.
+func ansiStrip(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			i += 2
+			for i < len(s) && (s[i] < 0x40 || s[i] > 0x7e) {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// tokenize splits a command line on whitespace, honoring double-quoted spans.
+func tokenize(line string) []string {
+	var out []string
+	var cur strings.Builder
+	inQ := false
+	for _, r := range line {
+		switch {
+		case r == '"':
+			inQ = !inQ
+		case (r == ' ' || r == '\t') && !inQ:
+			if cur.Len() > 0 {
+				out = append(out, cur.String())
+				cur.Reset()
+			}
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if cur.Len() > 0 {
+		out = append(out, cur.String())
+	}
+	return out
+}
+
+// kvArgs parses "key=value" tokens into a map.
+func kvArgs(args []string) map[string]string {
+	m := map[string]string{}
+	for _, a := range args {
+		if idx := strings.Index(a, "="); idx > 0 {
+			m[a[:idx]] = a[idx+1:]
+		}
+	}
+	return m
+}
+
+func okf(format string, a ...any) { fmt.Printf("✅ "+format+"\n", a...) }
+func errf(format string, a ...any) {
+	fmt.Printf("%s %s\n", paint(cRed, "❌"), fmt.Sprintf(format, a...))
+}
+
+// ─────────────────────────────── shared formatters ───────────────────────────────
+
+func boolTag(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+func shortTime(t time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+	return t.Format("2006-01-02 15:04")
+}
+
+// parseHidden interprets a "hidden" option value as a boolean.
+func parseHidden(v string) bool {
+	v = strings.ToLower(strings.TrimSpace(v))
+	return v == "yes" || v == "y" || v == "true" || v == "1"
+}

--- a/cmd/cli/shell_commands.go
+++ b/cmd/cli/shell_commands.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// shell_commands.go — global commands, module registry, help, completion.
+
+func (s *shellState) buildGlobal() {
+	s.global = []shellCmd{
+		{name: "help", aliases: "?", args: "", help: "show help for the current context", fn: s.cmdHelp},
+		{name: "use", args: "<module>", help: "enter a module context", min: 1, fn: s.cmdUse},
+		{name: "back", args: "", help: "leave the current module context", fn: s.cmdBack},
+		{name: "set", args: "env <name>  |  <option> <value>", help: "set active env or a run option", fn: s.cmdSet},
+		{name: "show", args: "environments | env", help: "list environments", fn: s.cmdShow},
+		{name: "stats", args: "", help: "dashboard statistics across environments", fn: s.cmdStats},
+		{name: "exit", aliases: "quit", args: "", help: "exit the shell", fn: s.cmdExit},
+	}
+}
+
+func (s *shellState) buildModules() {
+	add := func(m *shellModule) {
+		s.modules[m.name] = m
+		s.order = append(s.order, m.name)
+	}
+	add(&shellModule{name: "nodes", label: "nodes", desc: "enrolled osquery nodes", cmds: nodesCommands()})
+	add(&shellModule{name: "queries", label: "queries", desc: "on-demand distributed queries", cmds: queriesCommands()})
+	add(&shellModule{name: "carves", label: "carves", desc: "file carves", cmds: carvesCommands()})
+	add(&shellModule{name: "environments", label: "env", desc: "TLS environments", cmds: envCommands()})
+	add(&shellModule{name: "tags", label: "tags", desc: "node tags", cmds: tagsCommands()})
+	add(&shellModule{name: "users", label: "users", desc: "users and permissions", cmds: usersCommands()})
+	add(&shellModule{name: "audit", label: "audit", desc: "audit logs", cmds: auditCommands()})
+	add(&shellModule{name: "settings", label: "settings", desc: "configuration values (db mode)", cmds: settingsCommands()})
+}
+
+// ─────────────────────────────── global commands ───────────────────────────────
+
+func (s *shellState) cmdHelp(_ *shellState, _ []string) {
+	if s.ctx != "" {
+		if m, ok := s.modules[s.ctx]; ok {
+			fmt.Printf("%s %s %s\n\n", moduleIcon(m.name), paint(cCyan+cBold, m.name), paint(cGray, "— "+m.desc))
+			printCmdHelp(m.cmds)
+			fmt.Printf("\n%s\n", paint(cGray, "Global: back, help, set, show, stats, exit"))
+			return
+		}
+	}
+	fmt.Printf("%s\n\n", paint(cCyan+cBold, "📚 osctrl-cli interactive shell"))
+	fmt.Printf("%s\n", paint(cYellow, "Modules (use <module>):"))
+	for _, name := range s.order {
+		m := s.modules[name]
+		fmt.Printf("  %s  %s  %s\n",
+			paint(cMagenta, padRight(moduleIcon(name), 2)),
+			paint(cCyan+cBold, padRight(m.name, 13)),
+			paint(cGray, m.desc))
+	}
+	fmt.Println()
+	fmt.Printf("%s\n", paint(cYellow, "Global commands:"))
+	printCmdHelp(s.global)
+}
+
+func printCmdHelp(cmds []shellCmd) {
+	for _, c := range cmds {
+		usage := c.name
+		if c.args != "" {
+			usage += " " + c.args
+		}
+		fmt.Printf("  %s  %s\n", paint(cGreen, padRight(usage, 26)), paint(cGray, c.help))
+	}
+}
+
+func (s *shellState) cmdUse(_ *shellState, args []string) {
+	name := args[0]
+	if _, ok := s.modules[name]; !ok {
+		errf("no such module: %s", name)
+		return
+	}
+	s.ctx = name
+	fmt.Printf("%s %s\n", paint(cCyan, "-> context:"), paint(cMagenta+cBold, name))
+}
+
+func (s *shellState) cmdBack(_ *shellState, _ []string) {
+	if s.ctx == "" {
+		fmt.Println("already at top level")
+		return
+	}
+	fmt.Printf("%s %s\n", paint(cGray, "<- leaving"), paint(cMagenta, s.ctx))
+	s.ctx = ""
+}
+
+func (s *shellState) cmdExit(_ *shellState, _ []string) { s.running = false }
+
+func (s *shellState) cmdSet(_ *shellState, args []string) {
+	if len(args) == 0 {
+		fmt.Println("usage: set env <name>   |   set <option> <value>")
+		fmt.Println("options: uuids hosts platforms tags hidden expiration")
+		return
+	}
+	if args[0] == "env" {
+		if len(args) < 2 {
+			fmt.Println("usage: set env <name>")
+			return
+		}
+		s.env = args[1]
+		okf("active environment: %s", s.env)
+		return
+	}
+	if len(args) < 2 {
+		fmt.Printf("usage: set %s <value>\n", args[0])
+		return
+	}
+	s.opts[args[0]] = args[1]
+	okf("%s = %s", args[0], args[1])
+}
+
+func (s *shellState) cmdShow(_ *shellState, args []string) {
+	if len(args) == 0 || args[0] == "environments" || args[0] == "env" {
+		s.showEnvironments()
+		return
+	}
+	errf("unknown show target: %s", args[0])
+}
+
+func (s *shellState) showEnvironments() {
+	es, err := spinGet("🌐 Fetching environments", func() ([]envRow, error) { return s.store.Environments() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	s.envNames = nil
+	rows := make([][]string, 0, len(es))
+	for _, e := range es {
+		s.envNames = append(s.envNames, e.Name)
+		rows = append(rows, []string{e.Name, e.UUID, e.Hostname, e.Type, boolTag(e.DebugHTTP), boolTag(e.AcceptEnroll)})
+	}
+	printTable([]string{"Name", "UUID", "Hostname", "Type", "Debug", "Accept"}, rows)
+}
+
+func (s *shellState) cmdStats(_ *shellState, _ []string) {
+	st, err := spinGet("📊 Loading stats", func() (tuiStats, error) { return s.store.Stats() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	fmt.Printf("%s %s\n", paint(cCyan, "🖥️  Nodes"), fmt.Sprintf("total %s · active %s · inactive %s (offline after %dh)", paint(cBold, itoa(st.TotalNodes)), paint(cGreen, itoa(st.ActiveNodes)), paint(cRed, itoa(st.InactiveNodes)), st.InactiveHours))
+	fmt.Printf("%s queries %s · carves %s\n", paint(cCyan, "🔍 Active"), paint(cBold, itoa(int64(st.TotalActiveQueries))), paint(cBold, itoa(int64(st.TotalActiveCarves))))
+	fmt.Printf("%s linux %s · darwin %s · windows %s · other %s\n", paint(cCyan, "💻 Platforms"), itoa(st.Platforms.Linux), itoa(st.Platforms.Darwin), itoa(st.Platforms.Windows), itoa(st.Platforms.Other))
+	fmt.Println()
+	rows := make([][]string, 0, len(st.Environments))
+	for _, e := range st.Environments {
+		rows = append(rows, []string{e.Name, itoa(e.Active), itoa(e.Inactive), itoa(e.Total), itoa(int64(e.ActiveQueries)), itoa(int64(e.ActiveCarves))})
+	}
+	printTable([]string{"Env", "Active", "Inactive", "Total", "Queries", "Carves"}, rows)
+}
+
+func itoa(i int64) string {
+	if i == 0 {
+		return "0"
+	}
+	return fmt.Sprintf("%d", i)
+}
+
+// ─────────────────────────────── completion ───────────────────────────────
+
+func (s *shellState) completer(line string, cursor int) ([]string, string) {
+	tokens := strings.Fields(line[:cursor])
+	if len(tokens) == 0 {
+		// starting a word: offer commands + "use"
+		cands := s.commandCandidates()
+		return cands, ""
+	}
+	// completing the first token (a command)
+	if len(tokens) == 1 && !strings.HasSuffix(line[:cursor], " ") {
+		prefix := tokens[0]
+		cands := filterPrefix(s.commandCandidates(), prefix)
+		return cands, longestCommonPrefix(cands)
+	}
+	// completing an argument
+	return s.argCandidates(tokens, line, cursor)
+}
+
+func (s *shellState) commandCandidates() []string {
+	var cands []string
+	if s.ctx != "" {
+		if m, ok := s.modules[s.ctx]; ok {
+			for _, c := range m.cmds {
+				cands = append(cands, c.name)
+			}
+		}
+	}
+	cands = append(cands, globalNames(s.global)...)
+	sort.Strings(cands)
+	return dedup(cands)
+}
+
+func (s *shellState) argCandidates(tokens []string, line string, cursor int) ([]string, string) {
+	cmd := tokens[0]
+	switch cmd {
+	case "use":
+		return dedup(s.order), ""
+	case "set":
+		if len(tokens) == 1 {
+			return []string{"env", "uuids", "hosts", "platforms", "tags", "hidden", "expiration"}, ""
+		}
+		if tokens[1] == "env" && len(tokens) == 2 {
+			return filterPrefix(s.envNames, currentWord(line, cursor)), longestCommonPrefix(s.envNames)
+		}
+	case "show":
+		if len(tokens) == 1 {
+			return []string{"environments", "env"}, ""
+		}
+	}
+	// resource-name completion for the active module's primary key
+	switch s.ctx {
+	case "nodes":
+		if cmd == "show" || cmd == "delete" || cmd == "tag" {
+			c := filterPrefix(s.nodeKeys, currentWord(line, cursor))
+			return c, longestCommonPrefix(c)
+		}
+	case "queries":
+		if cmd == "show" || cmd == "results" || cmd == "complete" || cmd == "expire" || cmd == "delete" {
+			c := filterPrefix(s.queryNames, currentWord(line, cursor))
+			return c, longestCommonPrefix(c)
+		}
+	}
+	return nil, ""
+}
+
+func currentWord(line string, cursor int) string {
+	start := cursor
+	for start > 0 && line[start-1] != ' ' {
+		start--
+	}
+	return line[start:cursor]
+}
+
+func globalNames(cmds []shellCmd) []string {
+	out := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		out = append(out, c.name)
+		if c.aliases != "" {
+			out = append(out, c.aliases)
+		}
+	}
+	return out
+}
+
+func filterPrefix(items []string, p string) []string {
+	var out []string
+	for _, it := range items {
+		if strings.HasPrefix(it, p) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+func longestCommonPrefix(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	p := items[0]
+	for _, it := range items[1:] {
+		for !strings.HasPrefix(it, p) {
+			p = p[:len(p)-1]
+			if p == "" {
+				return ""
+			}
+		}
+	}
+	return p
+}
+
+func dedup(items []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, it := range items {
+		if !seen[it] {
+			seen[it] = true
+			out = append(out, it)
+		}
+	}
+	return out
+}

--- a/cmd/cli/shell_modules.go
+++ b/cmd/cli/shell_modules.go
@@ -1,0 +1,750 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// label prints a right-aligned colored field label for detail views.
+func label(k string) string {
+	return paint(cCyan, fmt.Sprintf("%-15s", k+":"))
+}
+
+// shell_modules.go — per-module command sets and handlers.
+
+// ─────────────────────────────── nodes ───────────────────────────────
+
+func nodesCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "[active|inactive|all]", help: "list nodes in the active env (default: all)", fn: shNodesList},
+		{name: "search", args: "<query>", help: "search nodes by hostname/uuid/ip/user", min: 1, fn: shNodesSearch},
+		{name: "show", args: "<uuid|hostname>", help: "show node detail", min: 1, fn: shNodesShow},
+		{name: "delete", aliases: "rm", args: "<uuid>", help: "delete (archive) a node", min: 1, fn: shNodesDelete},
+		{name: "tag", args: "<uuid> <tag>", help: "apply a tag to a node", min: 2, fn: shNodesTag},
+	}
+}
+
+func shNodesList(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	target := "all"
+	if len(args) > 0 {
+		target = args[0]
+	}
+	nds, err := spinGet("🖥️  Fetching nodes", func() ([]nodeRow, error) { return s.store.Nodes(s.env, target) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	s.cacheNodeKeys(nds)
+	rows := make([][]string, 0, len(nds))
+	for _, n := range nds {
+		st := "active"
+		if !n.Active {
+			st = "inactive"
+		}
+		rows = append(rows, []string{n.Hostname, n.UUID, n.Platform, n.PlatformVersion, n.OsqueryVersion, n.IPAddress, n.LastSeen, st})
+	}
+	fmt.Printf("%d %s nodes in %s\n", len(nds), target, s.env)
+	printTable([]string{"Hostname", "UUID", "Platform", "Version", "Osquery", "IP", "LastSeen", "Status"}, rows)
+}
+
+func shNodesSearch(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	nds, err := spinGet("🖥️  Fetching nodes", func() ([]nodeRow, error) { return s.store.Nodes(s.env, "all") })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	s.cacheNodeKeys(nds)
+	q := strings.ToLower(strings.Join(args, " "))
+	rows := make([][]string, 0)
+	for _, n := range nds {
+		hay := strings.ToLower(n.Hostname + " " + n.UUID + " " + n.IPAddress + " " + n.Localname + " " + n.Username)
+		if strings.Contains(hay, q) {
+			st := "active"
+			if !n.Active {
+				st = "inactive"
+			}
+			rows = append(rows, []string{n.Hostname, n.UUID, n.Platform, n.IPAddress, n.LastSeen, st})
+		}
+	}
+	fmt.Printf("%d matches for %q\n", len(rows), q)
+	printTable([]string{"Hostname", "UUID", "Platform", "IP", "LastSeen", "Status"}, rows)
+}
+
+func shNodesShow(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	n, err := spinGet("🖥️  Fetching node", func() (nodeRow, error) { return s.store.Node(s.env, args[0]) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	status := "active"
+	if !n.Active {
+		status = "inactive"
+	}
+	fmt.Printf("%s %s\n", label("Hostname"), n.Hostname)
+	fmt.Printf("%s %s\n", label("Localname"), n.Localname)
+	fmt.Printf("%s %s\n", label("UUID"), n.UUID)
+	fmt.Printf("%s %s\n", label("Environment"), n.Environment)
+	fmt.Printf("%s %s %s\n", label("Platform"), n.Platform, n.PlatformVersion)
+	fmt.Printf("%s %s\n", label("Osquery"), n.OsqueryVersion)
+	fmt.Printf("%s %s\n", label("IP address"), n.IPAddress)
+	fmt.Printf("%s %s\n", label("Username"), n.Username)
+	fmt.Printf("%s %s / %s\n", label("CPU / Memory"), n.CPU, n.Memory)
+	fmt.Printf("%s %s\n", label("Hardware serial"), n.HardwareSerial)
+	fmt.Printf("%s %d\n", label("Bytes received"), n.BytesReceived)
+	fmt.Printf("%s %s\n", label("Last seen"), n.LastSeen)
+	fmt.Printf("%s %s\n", label("First seen"), n.FirstSeen)
+	fmt.Printf("%s %s\n", label("Status"), colorCell(status))
+}
+
+func shNodesDelete(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	uuid := args[0]
+	if !s.confirm(fmt.Sprintf("Delete node %s?", uuid)) {
+		fmt.Println("aborted")
+		return
+	}
+	if err := spinDo("🗑️  Deleting node", func() error { return s.store.DeleteNode(s.env, uuid) }); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("deleted node %s", uuid)
+}
+
+func shNodesTag(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	if err := spinDo("🏷️  Tagging node", func() error { return s.store.TagNode(s.env, args[0], args[1]) }); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("tagged node %s with %s", args[0], args[1])
+}
+
+func (s *shellState) cacheNodeKeys(nds []nodeRow) {
+	s.nodeKeys = s.nodeKeys[:0]
+	for _, n := range nds {
+		s.nodeKeys = append(s.nodeKeys, n.UUID, n.Hostname)
+	}
+}
+
+// ─────────────────────────────── queries ───────────────────────────────
+
+func queriesCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "[active|completed|expired|deleted|hidden|all]", help: "list on-demand queries", fn: shQueriesList},
+		{name: "show", args: "<name>", help: "show query detail", min: 1, fn: shQueriesShow},
+		{name: "run", args: "<sql>", help: "run a new query (uses set options)", min: 1, fn: shQueriesRun},
+		{name: "results", args: "<name>", help: "show query results", min: 1, fn: shQueriesResults},
+		{name: "complete", args: "<name>", help: "mark query complete", min: 1, fn: shQueriesComplete},
+		{name: "expire", args: "<name>", help: "expire query", min: 1, fn: shQueriesExpire},
+		{name: "delete", aliases: "rm", args: "<name>", help: "delete query", min: 1, fn: shQueriesDelete},
+		{name: "options", args: "", help: "show current run options", fn: shShowOptions},
+	}
+}
+
+func shQueriesList(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	target := "active"
+	if len(args) > 0 {
+		target = args[0]
+	}
+	qs, err := spinGet("🔍 Fetching queries", func() ([]queryRow, error) { return s.store.Queries(s.env, target) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	s.cacheQueryNames(qs)
+	rows := make([][]string, 0, len(qs))
+	for _, q := range qs {
+		rows = append(rows, []string{q.Name, q.Creator, q.Status, strconv.Itoa(q.Expected), strconv.Itoa(q.Executions), strconv.Itoa(q.Errors), q.Query})
+	}
+	fmt.Printf("%d %s queries in %s\n", len(qs), target, s.env)
+	printTable([]string{"Name", "Creator", "Status", "Expected", "Exec", "Err", "Query"}, rows)
+}
+
+func shQueriesShow(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	qs, err := spinGet("🔍 Fetching queries", func() ([]queryRow, error) { return s.store.Queries(s.env, "all") })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	for _, q := range qs {
+		if q.Name == args[0] {
+			printQueryDetail(q)
+			return
+		}
+	}
+	errf("query not found: %s", args[0])
+}
+
+func printQueryDetail(q queryRow) {
+	fmt.Printf("Name:        %s\n", q.Name)
+	fmt.Printf("Creator:     %s\n", q.Creator)
+	fmt.Printf("Type:        %s\n", q.Type)
+	fmt.Printf("Status:      %s\n", q.Status)
+	fmt.Printf("Hidden:      %s\n", boolTag(q.Hidden))
+	fmt.Printf("Expected:    %d\n", q.Expected)
+	fmt.Printf("Executions:  %d\n", q.Executions)
+	fmt.Printf("Errors:      %d\n", q.Errors)
+	fmt.Printf("Target:      %s\n", q.Target)
+	fmt.Printf("Created:     %s\n", q.Created)
+	fmt.Printf("Expiration:  %s\n", q.Expiration)
+	fmt.Printf("Query:\n%s\n", q.Query)
+}
+
+func shQueriesRun(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	req := s.buildRunReq(strings.Join(args, " "))
+	if err := spinDo("🔍 Dispatching query", func() error { return s.store.RunQuery(req) }); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("query dispatched in %s", s.env)
+}
+
+func shQueriesResults(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	body, err := spinGet("🔍 Loading results", func() (string, error) { return s.store.QueryResults(s.env, args[0]) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	fmt.Println(body)
+}
+
+func shQueriesComplete(s *shellState, args []string) { lifecycleQuery(s, args[0], "complete") }
+func shQueriesExpire(s *shellState, args []string)   { lifecycleQuery(s, args[0], "expire") }
+func shQueriesDelete(s *shellState, args []string) {
+	if !s.confirm(fmt.Sprintf("Delete query %s?", args[0])) {
+		fmt.Println("aborted")
+		return
+	}
+	lifecycleQuery(s, args[0], "delete")
+}
+
+func lifecycleQuery(s *shellState, name, action string) {
+	if !s.requireEnv() {
+		return
+	}
+	err := spinDo("🔍 "+action, func() error {
+		switch action {
+		case "complete":
+			return s.store.CompleteQuery(s.env, name)
+		case "expire":
+			return s.store.ExpireQuery(s.env, name)
+		case "delete":
+			return s.store.DeleteQuery(s.env, name)
+		}
+		return nil
+	})
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("%s %s", action, name)
+}
+
+func (s *shellState) cacheQueryNames(qs []queryRow) {
+	s.queryNames = s.queryNames[:0]
+	for _, q := range qs {
+		s.queryNames = append(s.queryNames, q.Name)
+	}
+}
+
+// ─────────────────────────────── carves ───────────────────────────────
+
+func carvesCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "[active|completed|expired|deleted|all]", help: "list carve queries", fn: shCarvesList},
+		{name: "files", args: "", help: "list carved files in the active env", fn: shCarvesFiles},
+		{name: "show", args: "<name>", help: "show carve query detail", min: 1, fn: shCarvesShow},
+		{name: "run", args: "<path>", help: "start a carve (uses set options)", min: 1, fn: shCarvesRun},
+		{name: "complete", args: "<name>", help: "mark carve complete", min: 1, fn: shCarvesComplete},
+		{name: "expire", args: "<name>", help: "expire carve", min: 1, fn: shCarvesExpire},
+		{name: "delete", aliases: "rm", args: "<name>", help: "delete carve", min: 1, fn: shCarvesDelete},
+		{name: "options", args: "", help: "show current run options", fn: shShowOptions},
+	}
+}
+
+func shCarvesList(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	target := "active"
+	if len(args) > 0 {
+		target = args[0]
+	}
+	qs, err := spinGet("📦 Fetching carves", func() ([]queryRow, error) { return s.store.CarveQueries(s.env, target) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(qs))
+	for _, q := range qs {
+		rows = append(rows, []string{q.Name, q.Creator, q.Status, strconv.Itoa(q.Expected), strconv.Itoa(q.Executions), q.Query})
+	}
+	fmt.Printf("%d %s carve queries in %s\n", len(qs), target, s.env)
+	printTable([]string{"Name", "Creator", "Status", "Expected", "Exec", "Query"}, rows)
+}
+
+func shCarvesFiles(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	cs, err := spinGet("📦 Fetching carved files", func() ([]carveRow, error) { return s.store.Carves(s.env) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(cs))
+	for _, c := range cs {
+		rows = append(rows, []string{c.CarveID, c.QueryName, c.UUID, c.Path, c.Status, fmt.Sprintf("%d/%d", c.CompletedBlocks, c.TotalBlocks), c.CompletedAt})
+	}
+	fmt.Printf("%d carved files in %s\n", len(cs), s.env)
+	printTable([]string{"CarveID", "Query", "UUID", "Path", "Status", "Blocks", "Completed"}, rows)
+}
+
+func shCarvesShow(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	qs, err := spinGet("📦 Fetching carves", func() ([]queryRow, error) { return s.store.CarveQueries(s.env, "all") })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	for _, q := range qs {
+		if q.Name == args[0] {
+			printQueryDetail(q)
+			return
+		}
+	}
+	errf("carve query not found: %s", args[0])
+}
+
+func shCarvesRun(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	req := s.buildRunReq(args[0])
+	if err := spinDo("📦 Dispatching carve", func() error { return s.store.RunCarve(req) }); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("carve dispatched in %s", s.env)
+}
+
+func shCarvesComplete(s *shellState, args []string) { lifecycleCarve(s, args[0], "complete") }
+func shCarvesExpire(s *shellState, args []string)   { lifecycleCarve(s, args[0], "expire") }
+func shCarvesDelete(s *shellState, args []string) {
+	if !s.confirm(fmt.Sprintf("Delete carve %s?", args[0])) {
+		fmt.Println("aborted")
+		return
+	}
+	lifecycleCarve(s, args[0], "delete")
+}
+
+func lifecycleCarve(s *shellState, name, action string) {
+	if !s.requireEnv() {
+		return
+	}
+	err := spinDo("📦 "+action, func() error {
+		switch action {
+		case "complete":
+			return s.store.CompleteCarve(s.env, name)
+		case "expire":
+			return s.store.ExpireCarve(s.env, name)
+		case "delete":
+			return s.store.DeleteCarve(s.env, name)
+		}
+		return nil
+	})
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("%s carve %s", action, name)
+}
+
+// buildRunReq assembles a runQueryReq from active env + set options.
+func (s *shellState) buildRunReq(query string) runQueryReq {
+	exp, _ := strconv.Atoi(s.opts["expiration"])
+	return runQueryReq{
+		Env:       s.env,
+		Query:     query,
+		UUIDs:     csvSplit(s.opts["uuids"]),
+		Hosts:     csvSplit(s.opts["hosts"]),
+		Platforms: csvSplit(s.opts["platforms"]),
+		Tags:      csvSplit(s.opts["tags"]),
+		Hidden:    parseHidden(s.opts["hidden"]),
+		ExpHours:  exp,
+	}
+}
+
+func shShowOptions(s *shellState, _ []string) {
+	fmt.Printf("env:        %s\n", s.env)
+	fmt.Printf("uuids:      %s\n", s.opts["uuids"])
+	fmt.Printf("hosts:      %s\n", s.opts["hosts"])
+	fmt.Printf("platforms:  %s\n", s.opts["platforms"])
+	fmt.Printf("tags:       %s\n", s.opts["tags"])
+	fmt.Printf("hidden:     %s\n", s.opts["hidden"])
+	fmt.Printf("expiration: %s (hours)\n", s.opts["expiration"])
+}
+
+// ─────────────────────────────── environments ───────────────────────────────
+
+func envCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "", help: "list environments", fn: shEnvList},
+		{name: "show", args: "<name>", help: "show environment detail", min: 1, fn: shEnvShow},
+		{name: "delete", aliases: "rm", args: "<name>", help: "delete an environment (db)", min: 1, fn: shEnvDelete},
+		{name: "extend-enroll", args: "<name>", help: "extend enroll URL expiry", min: 1, fn: shEnvAction("enroll", "extend")},
+		{name: "rotate-enroll", args: "<name>", help: "rotate enroll URL", min: 1, fn: shEnvAction("enroll", "rotate")},
+		{name: "expire-enroll", args: "<name>", help: "expire enroll URL", min: 1, fn: shEnvAction("enroll", "expire")},
+		{name: "notexpire-enroll", args: "<name>", help: "mark enroll URL non-expiring", min: 1, fn: shEnvAction("enroll", "notexpire")},
+		{name: "extend-remove", args: "<name>", help: "extend remove URL expiry", min: 1, fn: shEnvAction("remove", "extend")},
+		{name: "rotate-remove", args: "<name>", help: "rotate remove URL", min: 1, fn: shEnvAction("remove", "rotate")},
+		{name: "expire-remove", args: "<name>", help: "expire remove URL", min: 1, fn: shEnvAction("remove", "expire")},
+		{name: "notexpire-remove", args: "<name>", help: "mark remove URL non-expiring", min: 1, fn: shEnvAction("remove", "notexpire")},
+	}
+}
+
+func shEnvList(s *shellState, _ []string) { s.showEnvironments() }
+
+func shEnvShow(s *shellState, args []string) {
+	es, err := spinGet("🌐 Fetching environments", func() ([]envRow, error) { return s.store.Environments() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	for _, e := range es {
+		if e.Name == args[0] {
+			fmt.Printf("Name:          %s\n", e.Name)
+			fmt.Printf("UUID:          %s\n", e.UUID)
+			fmt.Printf("Hostname:      %s\n", e.Hostname)
+			fmt.Printf("Type:          %s\n", e.Type)
+			fmt.Printf("Icon:          %s\n", e.Icon)
+			fmt.Printf("Debug HTTP:    %s\n", boolTag(e.DebugHTTP))
+			fmt.Printf("Accept enrolls:%s\n", boolTag(e.AcceptEnroll))
+			fmt.Printf("Enroll expire: %s\n", shortTime(e.EnrollExpire))
+			fmt.Printf("Remove expire: %s\n", shortTime(e.RemoveExpire))
+			fmt.Printf("Created:       %s\n", shortTime(e.CreatedAt))
+			return
+		}
+	}
+	errf("environment not found: %s", args[0])
+}
+
+func shEnvDelete(s *shellState, args []string) {
+	if s.store.Mode() == "api" {
+		errf("environment deletion is not exposed via the REST API; use --db mode")
+		return
+	}
+	if !s.confirm(fmt.Sprintf("Delete environment %s?", args[0])) {
+		fmt.Println("aborted")
+		return
+	}
+	if err := envs.Delete(args[0]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("deleted environment %s", args[0])
+}
+
+func shEnvAction(target, action string) func(*shellState, []string) {
+	return func(s *shellState, args []string) {
+		msg, err := s.store.EnvAction(args[0], target, action)
+		if err != nil {
+			errf("%v", err)
+			return
+		}
+		okf("%s", msg)
+	}
+}
+
+// ─────────────────────────────── tags ───────────────────────────────
+
+func tagsCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "[env]", help: "list tags (active env if omitted)", fn: shTagsList},
+		{name: "show", args: "<name>", help: "show tag (active env)", min: 1, fn: shTagsShow},
+		{name: "add", args: "<name> [color=.. icon=.. desc=.. type=.. custom=..]", help: "add a tag", min: 1, fn: shTagsAdd},
+		{name: "edit", args: "<name> [color=.. icon=.. desc=.. type=.. custom=..]", help: "edit a tag", min: 1, fn: shTagsEdit},
+		{name: "delete", aliases: "rm", args: "<name>", help: "delete a tag", min: 1, fn: shTagsDelete},
+	}
+}
+
+func shTagsList(s *shellState, args []string) {
+	ts, err := spinGet("🏷️  Fetching tags", func() ([]tagRow, error) { return s.store.Tags() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	env := s.env
+	if len(args) > 0 {
+		env = args[0]
+	}
+	rows := make([][]string, 0)
+	for _, t := range ts {
+		rows = append(rows, []string{t.Name, t.TagType, t.CustomTag, t.Description, t.Color, t.CreatedBy, boolTag(t.AutoTag)})
+	}
+	fmt.Printf("%d tags\n", len(rows))
+	printTable([]string{"Name", "Type", "Custom", "Description", "Color", "Creator", "Auto"}, rows)
+	_ = env
+}
+
+func shTagsShow(s *shellState, args []string) {
+	ts, err := spinGet("🏷️  Fetching tags", func() ([]tagRow, error) { return s.store.Tags() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	for _, t := range ts {
+		if t.Name == args[0] {
+			fmt.Printf("Name:        %s\n", t.Name)
+			fmt.Printf("Type:        %s\n", t.TagType)
+			fmt.Printf("Custom:      %s\n", t.CustomTag)
+			fmt.Printf("Description: %s\n", t.Description)
+			fmt.Printf("Color:       %s\n", t.Color)
+			fmt.Printf("Icon:        %s\n", t.Icon)
+			fmt.Printf("Creator:     %s\n", t.CreatedBy)
+			fmt.Printf("Auto:        %s\n", boolTag(t.AutoTag))
+			return
+		}
+	}
+	errf("tag not found: %s", args[0])
+}
+
+func shTagsAdd(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	kv := kvArgs(args[1:])
+	if err := s.store.AddTag(s.env, args[0], kv["color"], kv["icon"], kv["desc"], kv["type"], kv["custom"]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("created tag %s in %s", args[0], s.env)
+}
+
+func shTagsEdit(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	kv := kvArgs(args[1:])
+	if err := s.store.EditTag(s.env, args[0], kv["color"], kv["icon"], kv["desc"], kv["type"], kv["custom"]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("edited tag %s", args[0])
+}
+
+func shTagsDelete(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	if !s.confirm(fmt.Sprintf("Delete tag %s?", args[0])) {
+		fmt.Println("aborted")
+		return
+	}
+	if err := s.store.DeleteTag(s.env, args[0]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("deleted tag %s", args[0])
+}
+
+// ─────────────────────────────── users ───────────────────────────────
+
+func usersCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "", help: "list users", fn: shUsersList},
+		{name: "show", args: "<username>", help: "show user detail", min: 1, fn: shUsersShow},
+		{name: "add", args: "<username> password=<..> [email=.. fullname=.. admin=true service=false]", help: "add a user", min: 1, fn: shUsersAdd},
+		{name: "edit", args: "<username> <password|email|fullname|admin|service>=<value>", help: "edit a user field", min: 2, fn: shUsersEdit},
+		{name: "delete", aliases: "rm", args: "<username>", help: "delete a user", min: 1, fn: shUsersDelete},
+		{name: "permissions", aliases: "perms", args: "<username>", help: "show a user's permissions", min: 1, fn: shUsersPerms},
+	}
+}
+
+func shUsersList(s *shellState, _ []string) {
+	us, err := spinGet("👤 Fetching users", func() ([]userRow, error) { return s.store.Users() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(us))
+	for _, u := range us {
+		rows = append(rows, []string{u.Username, u.Fullname, u.Email, boolTag(u.Admin), boolTag(u.Service), u.LastAccess})
+	}
+	fmt.Printf("%d users\n", len(us))
+	printTable([]string{"Username", "Fullname", "Email", "Admin", "Service", "LastAccess"}, rows)
+}
+
+func shUsersShow(s *shellState, args []string) {
+	us, err := spinGet("👤 Fetching users", func() ([]userRow, error) { return s.store.Users() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	for _, u := range us {
+		if u.Username == args[0] {
+			fmt.Printf("Username:   %s\n", u.Username)
+			fmt.Printf("Fullname:   %s\n", u.Fullname)
+			fmt.Printf("Email:      %s\n", u.Email)
+			fmt.Printf("Admin:      %s\n", boolTag(u.Admin))
+			fmt.Printf("Service:    %s\n", boolTag(u.Service))
+			fmt.Printf("Last access:%s\n", u.LastAccess)
+			return
+		}
+	}
+	errf("user not found: %s", args[0])
+}
+
+func shUsersAdd(s *shellState, args []string) {
+	kv := kvArgs(args[1:])
+	admin := parseBool(kv["admin"])
+	service := parseBool(kv["service"])
+	if err := s.store.CreateUser(args[0], kv["password"], kv["email"], kv["fullname"], admin, service); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("created user %s", args[0])
+}
+
+func shUsersEdit(s *shellState, args []string) {
+	field := args[1]
+	if idx := strings.Index(field, "="); idx > 0 {
+		key := field[:idx]
+		val := field[idx+1:]
+		if err := s.store.EditUserField(args[0], key, val); err != nil {
+			errf("%v", err)
+			return
+		}
+		okf("updated %s.%s", args[0], key)
+		return
+	}
+	errf("usage: edit <username> <field>=<value>")
+}
+
+func shUsersDelete(s *shellState, args []string) {
+	if !s.confirm(fmt.Sprintf("Delete user %s?", args[0])) {
+		fmt.Println("aborted")
+		return
+	}
+	if err := s.store.DeleteUser(args[0]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("deleted user %s", args[0])
+}
+
+func shUsersPerms(s *shellState, args []string) {
+	ps, err := spinGet("👤 Fetching permissions", func() ([]permRow, error) { return s.store.Permissions(args[0]) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(ps))
+	for _, p := range ps {
+		rows = append(rows, []string{p.Username, p.Environment, p.AccessType, boolTag(p.AccessValue), p.GrantedBy})
+	}
+	printTable([]string{"Username", "Environment", "Access", "Granted", "GrantedBy"}, rows)
+}
+
+// ─────────────────────────────── audit ───────────────────────────────
+
+func auditCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "", help: "list audit logs", fn: shAuditList},
+	}
+}
+
+func shAuditList(s *shellState, _ []string) {
+	ls, err := spinGet("📜 Fetching audit logs", func() ([]auditRow, error) { return s.store.AuditLogs() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(ls))
+	for _, a := range ls {
+		rows = append(rows, []string{a.When, a.Username, a.LogType, a.Service, a.SourceIP, a.Line})
+	}
+	fmt.Printf("%d audit entries\n", len(ls))
+	printTable([]string{"When", "User", "Type", "Service", "IP", "Entry"}, rows)
+}
+
+// ─────────────────────────────── settings ───────────────────────────────
+
+func settingsCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "", help: "list configuration values", fn: shSettingsList},
+		{name: "add", args: "<service> <name> <type> <value>", help: "add a setting (db)", min: 4, fn: shSettingsAdd},
+		{name: "update", args: "<service> <name> <type> <value>", help: "update a setting (db)", min: 4, fn: shSettingsUpdate},
+		{name: "delete", aliases: "rm", args: "<service> <name>", help: "delete a setting (db)", min: 2, fn: shSettingsDelete},
+	}
+}
+
+func shSettingsList(s *shellState, _ []string) {
+	vs, err := spinGet("⚙️  Fetching settings", func() ([]settingRow, error) { return s.store.Settings() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(vs))
+	for _, v := range vs {
+		rows = append(rows, []string{v.Service, v.Name, v.Type, v.Value, v.Info})
+	}
+	fmt.Printf("%d settings\n", len(vs))
+	printTable([]string{"Service", "Name", "Type", "Value", "Info"}, rows)
+}
+
+func shSettingsAdd(s *shellState, args []string) {
+	if err := s.store.AddSetting(args[0], args[1], args[2], args[3]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("added setting %s/%s", args[0], args[1])
+}
+
+func shSettingsUpdate(s *shellState, args []string) {
+	if err := s.store.UpdateSetting(args[0], args[1], args[2], args[3]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("updated setting %s/%s", args[0], args[1])
+}
+
+func shSettingsDelete(s *shellState, args []string) {
+	if !s.confirm(fmt.Sprintf("Delete setting %s/%s?", args[0], args[1])) {
+		fmt.Println("aborted")
+		return
+	}
+	if err := s.store.DeleteSetting(args[0], args[1]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("deleted setting %s/%s", args[0], args[1])
+}

--- a/cmd/cli/shell_readline.go
+++ b/cmd/cli/shell_readline.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/term"
+)
+
+// shell_readline.go — a small raw-mode line editor with history and tab
+// completion for the interactive shell. No external readline dependency was
+// available offline, so this is built on golang.org/x/term (already a CLI dep).
+//
+// Editing: ←/→/Home/End, Backspace, Delete, Ctrl-A/E/K/U, ↑/↓ history, Tab
+// completion, Ctrl-C abort, Ctrl-D EOF on an empty line.
+
+type completer func(line string, cursor int) (candidates []string, commonPrefix string)
+
+type lineEditor struct {
+	history  []string
+	histIdx  int
+	complete completer
+	br       *bufio.Reader
+}
+
+type interruptErr struct{}
+
+func (interruptErr) Error() string { return "interrupted" }
+
+var errInterrupt = interruptErr{}
+
+// readline reads one edited line. Returns the line (no newline), io.EOF on
+// Ctrl-D over an empty line, or errInterrupt on Ctrl-C.
+func (le *lineEditor) readline(prompt string) (string, error) {
+	fd := int(os.Stdin.Fd())
+	old, err := term.MakeRaw(fd)
+	if err != nil {
+		return le.readLinePlain(prompt)
+	}
+	defer func() { _ = term.Restore(fd, old) }()
+
+	out := os.Stdout
+	buf := []rune{}
+	cursor := 0
+	le.histIdx = len(le.history)
+
+	redraw := func() {
+		fmt.Fprint(out, "\r"+prompt+string(buf)+"\x1b[K")
+		if back := len(buf) - cursor; back > 0 {
+			fmt.Fprintf(out, "\x1b[%dD", back)
+		}
+	}
+	redraw()
+
+	insert := func(r rune) {
+		buf = append(buf, 0)
+		copy(buf[cursor+1:], buf[cursor:])
+		buf[cursor] = r
+		cursor++
+	}
+	deleteAt := func(pos int) {
+		if pos >= 0 && pos < len(buf) {
+			buf = append(buf[:pos], buf[pos+1:]...)
+		}
+	}
+
+	tmp := make([]byte, 64)
+	for {
+		n, rerr := os.Stdin.Read(tmp)
+		if rerr != nil {
+			return "", rerr
+		}
+		i := 0
+		for i < n {
+			b := tmp[i]
+			switch b {
+			case '\r', '\n':
+				fmt.Fprintln(out)
+				line := string(buf)
+				if strings.TrimSpace(line) != "" {
+					le.history = append(le.history, line)
+				}
+				return line, nil
+			case 0x03: // Ctrl-C
+				fmt.Fprintln(out, "^C")
+				return "", errInterrupt
+			case 0x04: // Ctrl-D
+				if len(buf) == 0 {
+					fmt.Fprintln(out)
+					return "", io.EOF
+				}
+				deleteAt(cursor)
+				redraw()
+			case 0x08, 0x7f: // Backspace
+				if cursor > 0 {
+					deleteAt(cursor - 1)
+					cursor--
+					redraw()
+				}
+			case 0x01: // Ctrl-A
+				cursor = 0
+				redraw()
+			case 0x05: // Ctrl-E
+				cursor = len(buf)
+				redraw()
+			case 0x0b: // Ctrl-K
+				buf = buf[:cursor]
+				redraw()
+			case 0x15: // Ctrl-U
+				buf = buf[cursor:]
+				cursor = 0
+				redraw()
+			case 0x09: // Tab
+				le.doCompletion(out, &buf, &cursor, redraw)
+			case 0x1b:
+				seq, consumed := readEscape(tmp[i:], n-i)
+				i += consumed
+				switch seq {
+				case "A": // up — history back
+					if le.histIdx > 0 {
+						le.histIdx--
+						buf = []rune(le.history[le.histIdx])
+						cursor = len(buf)
+						redraw()
+					}
+				case "B": // down — history forward
+					if le.histIdx < len(le.history)-1 {
+						le.histIdx++
+						buf = []rune(le.history[le.histIdx])
+						cursor = len(buf)
+						redraw()
+					} else {
+						le.histIdx = len(le.history)
+						buf = nil
+						cursor = 0
+						redraw()
+					}
+				case "C": // right
+					if cursor < len(buf) {
+						cursor++
+						redraw()
+					}
+				case "D": // left
+					if cursor > 0 {
+						cursor--
+						redraw()
+					}
+				case "H", "1": // home
+					cursor = 0
+					redraw()
+				case "F", "4": // end
+					cursor = len(buf)
+					redraw()
+				case "3": // delete
+					deleteAt(cursor)
+					redraw()
+				}
+				continue
+			default:
+				r, size := utf8.DecodeRune(tmp[i:n])
+				if r == utf8.RuneError && size == 1 {
+					i++
+					continue
+				}
+				insert(r)
+				redraw()
+				i += size
+				continue
+			}
+			i++
+		}
+	}
+}
+
+// doCompletion mutates buf/cursor using the configured completer.
+func (le *lineEditor) doCompletion(out *os.File, buf *[]rune, cursor *int, redraw func()) {
+	if le.complete == nil {
+		return
+	}
+	cands, common := le.complete(string(*buf), *cursor)
+	if len(cands) == 0 {
+		return
+	}
+	start := tokenStart(*buf, *cursor)
+	if common != "" && common != string((*buf)[start:*cursor]) {
+		newBuf := append([]rune{}, (*buf)[:start]...)
+		newBuf = append(newBuf, []rune(common)...)
+		newBuf = append(newBuf, (*buf)[*cursor:]...)
+		*buf = newBuf
+		*cursor = start + len([]rune(common))
+		if len(cands) == 1 {
+			// add trailing space for a completed word
+			*buf = append(*buf, ' ')
+			*cursor++
+		}
+		redraw()
+		return
+	}
+	if len(cands) > 1 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, strings.Join(cands, "  "))
+		redraw()
+	}
+}
+
+// readEscape reads an ANSI escape sequence starting at src[0]==0x1b; returns
+// the payload (e.g. "A", "3") and bytes consumed.
+func readEscape(src []byte, avail int) (string, int) {
+	if avail < 2 {
+		return "", 1
+	}
+	if src[1] != '[' && src[1] != 'O' {
+		return "", 2
+	}
+	if avail < 3 {
+		return "", 2
+	}
+	if avail >= 4 && src[3] == '~' {
+		return string(src[2:3]), 4
+	}
+	return string(src[2:3]), 3
+}
+
+// tokenStart is where the whitespace-delimited token under cursor begins.
+func tokenStart(buf []rune, cursor int) int {
+	for i := cursor; i > 0; i-- {
+		if buf[i-1] == ' ' {
+			return i
+		}
+	}
+	return 0
+}
+
+// readLinePlain is the non-TTY fallback (piped input / scripts). It reads a
+// full line so multi-word commands work when stdin is not a terminal.
+func (le *lineEditor) readLinePlain(prompt string) (string, error) {
+	fmt.Fprint(os.Stdout, prompt)
+	if le.br == nil {
+		le.br = bufio.NewReader(os.Stdin)
+	}
+	line, err := le.br.ReadString('\n')
+	if err != nil && line == "" {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}

--- a/cmd/cli/shell_store.go
+++ b/cmd/cli/shell_store.go
@@ -1,0 +1,1334 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/carves"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/handlers"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/tags"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+)
+
+// APIStatsPath is the REST path for dashboard stats.
+const APIStatsPath = "/stats"
+
+// tui_store.go — single data-access façade for the interactive TUI.
+//
+// The TUI never branches on dbFlag/apiFlag itself; it talks to a DataStore
+// implementation. apiStore wraps the existing OsctrlAPI client; dbStore wraps
+// the pkg/* managers. DTOs (xxxRow) decouple the views from the underlying
+// model JSON shapes so a view does not care whether data came from REST or GORM.
+
+// ─────────────────────────────── DTOs ───────────────────────────────
+
+type tuiPlatformCounts struct {
+	Linux   int64 `json:"linux"`
+	Darwin  int64 `json:"darwin"`
+	Windows int64 `json:"windows"`
+	Other   int64 `json:"other"`
+}
+
+type tuiEnvStats struct {
+	UUID          string            `json:"uuid"`
+	Name          string            `json:"name"`
+	Active        int64             `json:"active"`
+	Inactive      int64             `json:"inactive"`
+	Total         int64             `json:"total"`
+	ActiveQueries int               `json:"active_queries"`
+	ActiveCarves  int               `json:"active_carves"`
+	Platforms     tuiPlatformCounts `json:"platform_counts"`
+}
+
+type tuiStats struct {
+	TotalNodes         int64             `json:"total_nodes"`
+	ActiveNodes        int64             `json:"active_nodes"`
+	InactiveNodes      int64             `json:"inactive_nodes"`
+	InactiveHours      int64             `json:"inactive_hours"`
+	TotalActiveQueries int               `json:"total_active_queries"`
+	TotalActiveCarves  int               `json:"total_active_carves"`
+	Platforms          tuiPlatformCounts `json:"platform_counts"`
+	Environments       []tuiEnvStats     `json:"environments"`
+}
+
+type envRow struct {
+	Name         string
+	UUID         string
+	Hostname     string
+	Type         string
+	Icon         string
+	DebugHTTP    bool
+	EnrollExpire time.Time
+	RemoveExpire time.Time
+	AcceptEnroll bool
+	CreatedAt    time.Time
+}
+
+type nodeRow struct {
+	UUID            string
+	Hostname        string
+	Localname       string
+	Platform        string
+	PlatformVersion string
+	OsqueryVersion  string
+	IPAddress       string
+	Username        string
+	Environment     string
+	LastSeen        string
+	FirstSeen       string
+	Active          bool
+	CPU             string
+	Memory          string
+	HardwareSerial  string
+	BytesReceived   int
+	Raw             nodes.OsqueryNode // kept for detail rendering (json:"-")
+}
+
+type queryRow struct {
+	Name       string
+	Creator    string
+	Query      string
+	Type       string
+	Expected   int
+	Executions int
+	Errors     int
+	Status     string
+	Hidden     bool
+	Created    string
+	Expiration string
+	Target     string
+}
+
+type carveRow struct {
+	CarveID         string
+	QueryName       string
+	UUID            string
+	Environment     string
+	Path            string
+	Status          string
+	CarveSize       int
+	CompletedBlocks int
+	TotalBlocks     int
+	CompletedAt     string
+}
+
+type tagRow struct {
+	Name        string
+	Description string
+	Color       string
+	Icon        string
+	CreatedBy   string
+	TagType     string
+	CustomTag   string
+	AutoTag     bool
+}
+
+type userRow struct {
+	Username   string
+	Email      string
+	Fullname   string
+	Admin      bool
+	Service    bool
+	LastAccess string
+}
+
+type auditRow struct {
+	When     string
+	Username string
+	Service  string
+	Line     string
+	LogType  string
+	Severity string
+	SourceIP string
+}
+
+type settingRow struct {
+	Name    string
+	Service string
+	Type    string
+	Value   string
+	Info    string
+}
+
+type permRow struct {
+	Username    string
+	Environment string
+	AccessType  string
+	AccessValue bool
+	GrantedBy   string
+}
+
+// runQueryReq captures the shared shape of "run query" and "run carve" forms.
+type runQueryReq struct {
+	Env       string
+	Query     string
+	UUIDs     []string
+	Hosts     []string
+	Platforms []string
+	Tags      []string
+	Hidden    bool
+	ExpHours  int
+}
+
+// ─────────────────────────────── Interface ───────────────────────────────
+
+type DataStore interface {
+	Mode() string // "api" or "db"
+	Stats() (tuiStats, error)
+	Environments() ([]envRow, error)
+	EnvNames() ([]string, error)
+	Nodes(env, target string) ([]nodeRow, error)
+	Node(env, identifier string) (nodeRow, error)
+	Queries(env, target string) ([]queryRow, error)
+	QueryResults(env, name string) (string, error)
+	Carves(env string) ([]carveRow, error)
+	CarveQueries(env, target string) ([]queryRow, error)
+	Tags() ([]tagRow, error)
+	Users() ([]userRow, error)
+	AuditLogs() ([]auditRow, error)
+	Settings() ([]settingRow, error)
+
+	DeleteNode(env, identifier string) error
+	RunQuery(req runQueryReq) error
+	CompleteQuery(env, name string) error
+	ExpireQuery(env, name string) error
+	DeleteQuery(env, name string) error
+	RunCarve(req runQueryReq) error
+	CompleteCarve(env, name string) error
+	ExpireCarve(env, name string) error
+	DeleteCarve(env, name string) error
+
+	// Management actions
+	TagNode(env, uuid, tag string) error
+	AddTag(env, name, color, icon, desc, tagType, custom string) error
+	EditTag(env, name, color, icon, desc, tagType, custom string) error
+	DeleteTag(env, name string) error
+	CreateUser(username, password, email, fullname string, admin, service bool) error
+	EditUserField(username, field, value string) error
+	DeleteUser(username string) error
+	EnvAction(name, target, action string) (string, error)
+	AddSetting(service, name, typ, value string) error
+	UpdateSetting(service, name, typ, value string) error
+	DeleteSetting(service, name string) error
+	Permissions(username string) ([]permRow, error)
+}
+
+// ─────────────────────────────── helpers ───────────────────────────────
+
+func isActive(lastSeen time.Time, hours int64) bool {
+	if hours <= 0 {
+		hours = 24
+	}
+	return time.Since(lastSeen) < time.Duration(hours)*time.Hour
+}
+
+func queryStatus(q queries.DistributedQuery) string {
+	switch {
+	case q.Deleted:
+		return "DELETED"
+	case q.Expired:
+		return "EXPIRED"
+	case q.Completed:
+		return "COMPLETE"
+	case q.Active:
+		return "ACTIVE"
+	default:
+		return "—"
+	}
+}
+
+func csvSplit(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	out := parts[:0]
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func tagTypeName(t uint) string {
+	switch t {
+	case tags.TagTypeEnv:
+		return "env"
+	case tags.TagTypePlatform:
+		return "platform"
+	case tags.TagTypeCustom:
+		return "custom"
+	case tags.TagTypeUnknown:
+		return "unknown"
+	case tags.TagTypeTag:
+		return "tag"
+	default:
+		return strconv.FormatUint(uint64(t), 10)
+	}
+}
+
+// parseTagType maps a friendly tag-type name to its numeric constant.
+func parseTagType(s string) uint {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "env", "environment":
+		return tags.TagTypeEnv
+	case "platform":
+		return tags.TagTypePlatform
+	case "custom":
+		return tags.TagTypeCustom
+	case "tag":
+		return tags.TagTypeTag
+	case "unknown":
+		return tags.TagTypeUnknown
+	default:
+		return tags.TagTypeCustom
+	}
+}
+
+func auditTypeName(t uint) string {
+	switch t {
+	case auditlog.LogTypeLogin:
+		return "login"
+	case auditlog.LogTypeNode:
+		return "node"
+	case auditlog.LogTypeLogout:
+		return "logout"
+	case auditlog.LogTypeTag:
+		return "tag"
+	case auditlog.LogTypeSetting:
+		return "setting"
+	case auditlog.LogTypeVisit:
+		return "visit"
+	case auditlog.LogTypeUser:
+		return "user"
+	case auditlog.LogTypeQuery:
+		return "query"
+	case auditlog.LogTypeCarve:
+		return "carve"
+	case auditlog.LogTypeEnvironment:
+		return "env"
+	default:
+		return strconv.FormatUint(uint64(t), 10)
+	}
+}
+
+func settingValueDisplay(s settings.SettingValue) string {
+	switch s.Type {
+	case settings.TypeBoolean:
+		return strconv.FormatBool(s.Boolean)
+	case settings.TypeInteger:
+		return strconv.FormatInt(s.Integer, 10)
+	default:
+		return s.String
+	}
+}
+
+// nodeToRow maps an OsqueryNode plus inactive threshold to a nodeRow.
+func nodeToRow(n nodes.OsqueryNode, hours int64) nodeRow {
+	return nodeRow{
+		UUID:            n.UUID,
+		Hostname:        n.Hostname,
+		Localname:       n.Localname,
+		Platform:        n.Platform,
+		PlatformVersion: n.PlatformVersion,
+		OsqueryVersion:  n.OsqueryVersion,
+		IPAddress:       n.IPAddress,
+		Username:        n.Username,
+		Environment:     n.Environment,
+		LastSeen:        utils.PastFutureTimes(n.LastSeen),
+		FirstSeen:       utils.PastFutureTimes(n.CreatedAt),
+		Active:          isActive(n.LastSeen, hours),
+		CPU:             n.CPU,
+		Memory:          n.Memory,
+		HardwareSerial:  n.HardwareSerial,
+		BytesReceived:   n.BytesReceived,
+		Raw:             n,
+	}
+}
+
+func queryToRow(q queries.DistributedQuery) queryRow {
+	return queryRow{
+		Name:       q.Name,
+		Creator:    q.Creator,
+		Query:      q.Query,
+		Type:       q.Type,
+		Expected:   q.Expected,
+		Executions: q.Executions,
+		Errors:     q.Errors,
+		Status:     queryStatus(q),
+		Hidden:     q.Hidden,
+		Created:    utils.PastFutureTimes(q.CreatedAt),
+		Expiration: utils.PastFutureTimes(q.Expiration),
+		Target:     q.Target,
+	}
+}
+
+func carveToRow(c carves.CarvedFile) carveRow {
+	completed := "—"
+	if !c.CompletedAt.IsZero() {
+		completed = utils.PastFutureTimes(c.CompletedAt)
+	}
+	return carveRow{
+		CarveID:         c.CarveID,
+		QueryName:       c.QueryName,
+		UUID:            c.UUID,
+		Environment:     c.Environment,
+		Path:            c.Path,
+		Status:          c.Status,
+		CarveSize:       c.CarveSize,
+		CompletedBlocks: c.CompletedBlocks,
+		TotalBlocks:     c.TotalBlocks,
+		CompletedAt:     completed,
+	}
+}
+
+func envToRow(e environments.TLSEnvironment) envRow {
+	return envRow{
+		Name:         e.Name,
+		UUID:         e.UUID,
+		Hostname:     e.Hostname,
+		Type:         e.Type,
+		Icon:         e.Icon,
+		DebugHTTP:    e.DebugHTTP,
+		EnrollExpire: e.EnrollExpire,
+		RemoveExpire: e.RemoveExpire,
+		AcceptEnroll: e.AcceptEnrolls,
+		CreatedAt:    e.CreatedAt,
+	}
+}
+
+func tagToRow(t tags.AdminTag) tagRow {
+	return tagRow{
+		Name:        t.Name,
+		Description: t.Description,
+		Color:       t.Color,
+		Icon:        t.Icon,
+		CreatedBy:   t.CreatedBy,
+		TagType:     tagTypeName(t.TagType),
+		CustomTag:   t.CustomTag,
+		AutoTag:     t.AutoTag,
+	}
+}
+
+func userToRow(u users.AdminUser) userRow {
+	last := "—"
+	if !u.LastAccess.IsZero() {
+		last = utils.PastFutureTimes(u.LastAccess)
+	}
+	return userRow{Username: u.Username, Email: u.Email, Fullname: u.Fullname, Admin: u.Admin, Service: u.Service, LastAccess: last}
+}
+
+func auditToRow(a auditlog.AuditLog) auditRow {
+	return auditRow{
+		When:     utils.PastFutureTimes(a.CreatedAt),
+		Username: a.Username,
+		Service:  a.Service,
+		Line:     a.Line,
+		LogType:  auditTypeName(a.LogType),
+		Severity: strconv.FormatUint(uint64(a.Severity), 10),
+		SourceIP: a.SourceIP,
+	}
+}
+
+// ─────────────────────────────── apiStore ───────────────────────────────
+
+type apiStore struct {
+	api *OsctrlAPI
+}
+
+func newAPIStore(api *OsctrlAPI) DataStore { return &apiStore{api: api} }
+
+func (s *apiStore) Mode() string { return "api" }
+
+func (s *apiStore) Stats() (tuiStats, error) {
+	var st tuiStats
+	reqURL := fmt.Sprintf("%s%s", s.api.Configuration.URL, path.Join(APIPath, APIStatsPath))
+	raw, err := s.api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return st, fmt.Errorf("stats: %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return st, fmt.Errorf("stats parse: %w", err)
+	}
+	return st, nil
+}
+
+func (s *apiStore) Environments() ([]envRow, error) {
+	envs, err := s.api.GetEnvironments()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]envRow, 0, len(envs))
+	for _, e := range envs {
+		out = append(out, envToRow(e))
+	}
+	return out, nil
+}
+
+func (s *apiStore) EnvNames() ([]string, error) {
+	envs, err := s.Environments()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(envs))
+	for _, e := range envs {
+		out = append(out, e.Name)
+	}
+	return out, nil
+}
+
+func (s *apiStore) Nodes(env, target string) ([]nodeRow, error) {
+	nds, err := s.api.GetNodes(env, target)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]nodeRow, 0, len(nds))
+	for _, n := range nds {
+		out = append(out, nodeToRow(n, 24))
+	}
+	return out, nil
+}
+
+func (s *apiStore) Node(env, identifier string) (nodeRow, error) {
+	n, err := s.api.GetNode(env, identifier)
+	if err != nil {
+		return nodeRow{}, err
+	}
+	return nodeToRow(n, 24), nil
+}
+
+func (s *apiStore) Queries(env, target string) ([]queryRow, error) {
+	qs, err := s.api.GetQueries(target, env)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]queryRow, 0, len(qs))
+	for _, q := range qs {
+		out = append(out, queryToRow(q))
+	}
+	return out, nil
+}
+
+func (s *apiStore) QueryResults(env, name string) (string, error) {
+	reqURL := fmt.Sprintf("%s%s", s.api.Configuration.URL, path.Join(APIPath, APIQueries, env, "results", name))
+	raw, err := s.api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("results: %w - %s", err, string(raw))
+	}
+	// Pretty-print if it's JSON, otherwise return raw.
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, raw, "", "  "); err == nil && pretty.Len() > 0 {
+		return pretty.String(), nil
+	}
+	return string(raw), nil
+}
+
+func (s *apiStore) Carves(env string) ([]carveRow, error) {
+	cs, err := s.api.GetCarves(env)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]carveRow, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, carveToRow(c))
+	}
+	return out, nil
+}
+
+func (s *apiStore) CarveQueries(env, target string) ([]queryRow, error) {
+	qs, err := s.api.GetCarveQueries(target, env)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]queryRow, 0, len(qs))
+	for _, q := range qs {
+		out = append(out, queryToRow(q))
+	}
+	return out, nil
+}
+
+func (s *apiStore) Tags() ([]tagRow, error) {
+	ts, err := s.api.GetAllTags()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]tagRow, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, tagToRow(t))
+	}
+	return out, nil
+}
+
+func (s *apiStore) Users() ([]userRow, error) {
+	us, err := s.api.GetUsers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]userRow, 0, len(us))
+	for _, u := range us {
+		out = append(out, userToRow(u))
+	}
+	return out, nil
+}
+
+func (s *apiStore) AuditLogs() ([]auditRow, error) {
+	ls, err := s.api.GetAuditLogs()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]auditRow, 0, len(ls))
+	for _, a := range ls {
+		out = append(out, auditToRow(a))
+	}
+	return out, nil
+}
+
+func (s *apiStore) Settings() ([]settingRow, error) {
+	return nil, fmt.Errorf("settings are not exposed by the REST API; use --db mode")
+}
+
+func (s *apiStore) DeleteNode(env, id string) error { return s.api.DeleteNode(env, id) }
+
+func (s *apiStore) RunQuery(req runQueryReq) error {
+	_, err := s.api.RunQuery(req.Env, req.Query, req.UUIDs, req.Hosts, req.Platforms, req.Tags, req.Hidden, req.ExpHours)
+	return err
+}
+
+func (s *apiStore) CompleteQuery(env, name string) error {
+	_, err := s.api.CompleteQuery(env, name)
+	return err
+}
+func (s *apiStore) ExpireQuery(env, name string) error {
+	_, err := s.api.ExpireQuery(env, name)
+	return err
+}
+func (s *apiStore) DeleteQuery(env, name string) error {
+	_, err := s.api.DeleteQuery(env, name)
+	return err
+}
+
+func (s *apiStore) RunCarve(req runQueryReq) error {
+	_, err := s.api.RunCarve(req.Env, req.Query, req.UUIDs, req.Hosts, req.Platforms, req.Tags, req.Hidden, req.ExpHours)
+	return err
+}
+func (s *apiStore) CompleteCarve(env, name string) error {
+	_, err := s.api.CompleteCarve(env, name)
+	return err
+}
+func (s *apiStore) ExpireCarve(env, name string) error {
+	_, err := s.api.ExpireCarve(env, name)
+	return err
+}
+func (s *apiStore) DeleteCarve(env, name string) error {
+	_, err := s.api.DeleteCarve(env, name)
+	return err
+}
+
+// ─────────────────────────────── dbStore ───────────────────────────────
+
+type dbStore struct{}
+
+func newDBStore() DataStore { return &dbStore{} }
+
+func (s *dbStore) Mode() string { return "db" }
+
+func (s *dbStore) inactiveHours() int64 {
+	if settingsmgr == nil {
+		return 24
+	}
+	h := settingsmgr.InactiveHours(settings.NoEnvironmentID)
+	if h <= 0 {
+		// Missing/unset inactive_hours setting — default to a sane 24h so the
+		// active/inactive filter and status column aren't degenerate.
+		return 24
+	}
+	return h
+}
+
+func (s *dbStore) Stats() (tuiStats, error) {
+	allEnvs, err := envs.All()
+	if err != nil {
+		return tuiStats{}, fmt.Errorf("envs: %w", err)
+	}
+	hours := s.inactiveHours()
+	out := tuiStats{InactiveHours: hours, Environments: make([]tuiEnvStats, 0, len(allEnvs))}
+	for _, e := range allEnvs {
+		ns, err := nodesmgr.GetStatsByEnv(e.Name, hours)
+		if err != nil {
+			continue
+		}
+		pc, _ := nodesmgr.GetPlatformCountsByEnv(e.Name)
+		activeQ, _ := queriesmgr.GetQueries(queries.TargetActive, e.ID)
+		aq, ac := 0, 0
+		for _, q := range activeQ {
+			if q.Type == queries.CarveQueryType {
+				ac++
+			} else {
+				aq++
+			}
+		}
+		row := tuiEnvStats{
+			UUID: e.UUID, Name: e.Name,
+			Active: ns.Active, Inactive: ns.Inactive, Total: ns.Total,
+			ActiveQueries: aq, ActiveCarves: ac,
+			Platforms: tuiPlatformCounts{Linux: pc.Linux, Darwin: pc.Darwin, Windows: pc.Windows, Other: pc.Other},
+		}
+		out.Environments = append(out.Environments, row)
+		out.TotalNodes += ns.Total
+		out.ActiveNodes += ns.Active
+		out.InactiveNodes += ns.Inactive
+		out.TotalActiveQueries += aq
+		out.TotalActiveCarves += ac
+		out.Platforms.Linux += pc.Linux
+		out.Platforms.Darwin += pc.Darwin
+		out.Platforms.Windows += pc.Windows
+		out.Platforms.Other += pc.Other
+	}
+	return out, nil
+}
+
+func (s *dbStore) Environments() ([]envRow, error) {
+	es, err := envs.All()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]envRow, 0, len(es))
+	for _, e := range es {
+		out = append(out, envToRow(e))
+	}
+	return out, nil
+}
+
+func (s *dbStore) EnvNames() ([]string, error) {
+	es, err := envs.Names()
+	if err != nil {
+		return nil, err
+	}
+	return es, nil
+}
+
+func (s *dbStore) Nodes(env, target string) ([]nodeRow, error) {
+	nds, err := nodesmgr.GetByEnv(env, target, s.inactiveHours())
+	if err != nil {
+		return nil, err
+	}
+	out := make([]nodeRow, 0, len(nds))
+	hours := s.inactiveHours()
+	for _, n := range nds {
+		out = append(out, nodeToRow(n, hours))
+	}
+	return out, nil
+}
+
+func (s *dbStore) Node(env, identifier string) (nodeRow, error) {
+	e, err := envs.Get(env)
+	if err != nil {
+		// fall back to name lookup
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return nodeRow{}, fmt.Errorf("env: %w", err)
+		}
+	}
+	n, err := nodesmgr.GetByIdentifierEnv(identifier, e.ID)
+	if err != nil {
+		return nodeRow{}, err
+	}
+	return nodeToRow(n, s.inactiveHours()), nil
+}
+
+func (s *dbStore) Queries(env, target string) ([]queryRow, error) {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return nil, fmt.Errorf("env: %w", err)
+		}
+	}
+	qs, err := queriesmgr.GetQueries(target, e.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]queryRow, 0, len(qs))
+	for _, q := range qs {
+		out = append(out, queryToRow(q))
+	}
+	return out, nil
+}
+
+func (s *dbStore) QueryResults(env, name string) (string, error) {
+	// DB-mode results are not trivially available without the logging layer
+	// wiring; surface a clear message rather than faking it.
+	return "", fmt.Errorf("query results in --db mode require the logging sink; use --api mode")
+}
+
+func (s *dbStore) Carves(env string) ([]carveRow, error) {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return nil, fmt.Errorf("env: %w", err)
+		}
+	}
+	cs, err := filecarves.GetByEnv(e.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]carveRow, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, carveToRow(c))
+	}
+	return out, nil
+}
+
+func (s *dbStore) CarveQueries(env, target string) ([]queryRow, error) {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return nil, fmt.Errorf("env: %w", err)
+		}
+	}
+	qs, err := queriesmgr.GetCarves(target, e.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]queryRow, 0, len(qs))
+	for _, q := range qs {
+		out = append(out, queryToRow(q))
+	}
+	return out, nil
+}
+
+func (s *dbStore) Tags() ([]tagRow, error) {
+	ts, err := tagsmgr.All()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]tagRow, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, tagToRow(t))
+	}
+	return out, nil
+}
+
+func (s *dbStore) Users() ([]userRow, error) {
+	us, err := adminUsers.All()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]userRow, 0, len(us))
+	for _, u := range us {
+		out = append(out, userToRow(u))
+	}
+	return out, nil
+}
+
+func (s *dbStore) AuditLogs() ([]auditRow, error) {
+	ls, err := auditlogsmgr.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]auditRow, 0, len(ls))
+	for _, a := range ls {
+		out = append(out, auditToRow(a))
+	}
+	return out, nil
+}
+
+func (s *dbStore) Settings() ([]settingRow, error) {
+	vs, err := settingsmgr.RetrieveAllValues()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]settingRow, 0, len(vs))
+	for _, v := range vs {
+		out = append(out, settingRow{Name: v.Name, Service: v.Service, Type: v.Type, Value: settingValueDisplay(v), Info: v.Info})
+	}
+	return out, nil
+}
+
+func (s *dbStore) DeleteNode(_, identifier string) error {
+	if err := nodesmgr.ArchiveDeleteByUUID(identifier); err != nil {
+		return err
+	}
+	auditlogsmgr.NodeAction(getShellUsername(), "delete node "+identifier, "CLI", 0)
+	return nil
+}
+
+func (s *dbStore) RunQuery(req runQueryReq) error {
+	_, err := runDistributedQuery(req)
+	return err
+}
+func (s *dbStore) RunCarve(req runQueryReq) error {
+	_, err := runDistributedCarve(req)
+	return err
+}
+
+func (s *dbStore) CompleteQuery(env, name string) error {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return err
+		}
+	}
+	return queriesmgr.Complete(name, e.ID)
+}
+func (s *dbStore) ExpireQuery(env, name string) error {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return err
+		}
+	}
+	return queriesmgr.Expire(name, e.ID)
+}
+func (s *dbStore) DeleteQuery(env, name string) error {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return err
+		}
+	}
+	return queriesmgr.Delete(name, e.ID)
+}
+
+func (s *dbStore) CompleteCarve(env, name string) error { return s.CompleteQuery(env, name) }
+func (s *dbStore) ExpireCarve(env, name string) error   { return s.ExpireQuery(env, name) }
+func (s *dbStore) DeleteCarve(env, name string) error   { return s.DeleteQuery(env, name) }
+
+// runDistributedQuery creates an on-demand query in --db mode, mirroring the
+// `query run` subcommand's create path (pkg/handlers target resolution + node
+// query rows + expected count + audit entry).
+func runDistributedQuery(req runQueryReq) (types.ApiQueriesResponse, error) {
+	e, err := envs.Get(req.Env)
+	if err != nil {
+		e, err = envs.GetByName(req.Env)
+		if err != nil {
+			return types.ApiQueriesResponse{}, fmt.Errorf("env: %w", err)
+		}
+	}
+	queryName := queries.GenQueryName()
+	expTime := queries.QueryExpiration(req.ExpHours)
+	if req.ExpHours == 0 {
+		expTime = time.Time{}
+	}
+	newQuery := queries.DistributedQuery{
+		Query:         req.Query,
+		Name:          queryName,
+		Creator:       appName,
+		Active:        true,
+		Expiration:    expTime,
+		Hidden:        req.Hidden,
+		Type:          queries.StandardQueryType,
+		EnvironmentID: e.ID,
+	}
+	if err := queriesmgr.Create(&newQuery); err != nil {
+		return types.ApiQueriesResponse{}, fmt.Errorf("query create: %w", err)
+	}
+	data := handlers.ProcessingQuery{
+		Envs:          []string{},
+		Platforms:     req.Platforms,
+		UUIDs:         req.UUIDs,
+		Hosts:         req.Hosts,
+		Tags:          req.Tags,
+		EnvID:         e.ID,
+		InactiveHours: settingsmgr.InactiveHours(settings.NoEnvironmentID),
+	}
+	manager := handlers.Managers{Nodes: nodesmgr, Envs: envs, Tags: tagsmgr}
+	targetNodesID, err := handlers.CreateQueryCarve(data, manager, newQuery)
+	if err != nil {
+		return types.ApiQueriesResponse{}, fmt.Errorf("query targets: %w", err)
+	}
+	if len(targetNodesID) != 0 {
+		if err := queriesmgr.CreateNodeQueries(targetNodesID, newQuery.ID); err != nil {
+			return types.ApiQueriesResponse{}, fmt.Errorf("node queries: %w", err)
+		}
+	}
+	if err := queriesmgr.SetExpected(queryName, len(targetNodesID), e.ID); err != nil {
+		return types.ApiQueriesResponse{}, fmt.Errorf("set expected: %w", err)
+	}
+	auditlogsmgr.NewQuery(getShellUsername(), req.Query, "CLI", e.ID)
+	return types.ApiQueriesResponse{Name: queryName}, nil
+}
+
+// runDistributedCarve creates a carve query in --db mode, mirroring `carve run`.
+func runDistributedCarve(req runQueryReq) (types.ApiQueriesResponse, error) {
+	e, err := envs.Get(req.Env)
+	if err != nil {
+		e, err = envs.GetByName(req.Env)
+		if err != nil {
+			return types.ApiQueriesResponse{}, fmt.Errorf("env: %w", err)
+		}
+	}
+	cName := carves.GenCarveName()
+	expTime := queries.QueryExpiration(req.ExpHours)
+	if req.ExpHours == 0 {
+		expTime = time.Time{}
+	}
+	newQuery := queries.DistributedQuery{
+		Query:         carves.GenCarveQuery(req.Query, false),
+		Name:          cName,
+		Creator:       appName,
+		Active:        true,
+		Expiration:    expTime,
+		Hidden:        req.Hidden,
+		Type:          queries.CarveQueryType,
+		Path:          req.Query,
+		EnvironmentID: e.ID,
+	}
+	if err := queriesmgr.Create(&newQuery); err != nil {
+		return types.ApiQueriesResponse{}, fmt.Errorf("carve create: %w", err)
+	}
+	data := handlers.ProcessingQuery{
+		Envs:          []string{},
+		Platforms:     req.Platforms,
+		UUIDs:         req.UUIDs,
+		Hosts:         req.Hosts,
+		Tags:          req.Tags,
+		EnvID:         e.ID,
+		InactiveHours: settingsmgr.InactiveHours(settings.NoEnvironmentID),
+	}
+	manager := handlers.Managers{Nodes: nodesmgr, Envs: envs, Tags: tagsmgr}
+	targetNodesID, err := handlers.CreateQueryCarve(data, manager, newQuery)
+	if err != nil {
+		return types.ApiQueriesResponse{}, fmt.Errorf("carve targets: %w", err)
+	}
+	if len(targetNodesID) != 0 {
+		if err := queriesmgr.CreateNodeQueries(targetNodesID, newQuery.ID); err != nil {
+			return types.ApiQueriesResponse{}, fmt.Errorf("node queries: %w", err)
+		}
+	}
+	if err := queriesmgr.SetExpected(cName, len(targetNodesID), e.ID); err != nil {
+		return types.ApiQueriesResponse{}, fmt.Errorf("set expected: %w", err)
+	}
+	auditlogsmgr.NewCarve(getShellUsername(), req.Query, "CLI", e.ID)
+	return types.ApiQueriesResponse{Name: cName}, nil
+}
+
+// ─────────────────────────────── apiStore: management actions ───────────────────────────────
+
+func (s *apiStore) TagNode(env, uuid, tag string) error {
+	return s.api.TagNode(env, uuid, tag, tags.TagTypeTag, "")
+}
+
+func (s *apiStore) AddTag(env, name, color, icon, desc, tagType, custom string) error {
+	_, err := s.api.AddTag(env, name, color, icon, desc, parseTagType(tagType), custom)
+	return err
+}
+
+func (s *apiStore) EditTag(env, name, color, icon, desc, tagType, custom string) error {
+	_, err := s.api.EditTag(env, name, color, icon, desc, parseTagType(tagType), custom)
+	return err
+}
+
+func (s *apiStore) DeleteTag(env, name string) error {
+	_, err := s.api.DeleteTag(env, name)
+	return err
+}
+
+func (s *apiStore) CreateUser(username, password, email, fullname string, admin, service bool) error {
+	return s.api.CreateUser(username, password, email, fullname, "", admin, service)
+}
+
+func (s *apiStore) EditUserField(username, field, value string) error {
+	cur, err := s.api.GetUser(username)
+	if err != nil {
+		return fmt.Errorf("fetch user: %w", err)
+	}
+	// API expects a plaintext password; when not changing it, send empty and let
+	// the server keep the existing hash.
+	pass, email, fullname := "", cur.Email, cur.Fullname
+	admin, service := cur.Admin, cur.Service
+	switch strings.ToLower(field) {
+	case "password":
+		pass = value
+	case "email":
+		email = value
+	case "fullname":
+		fullname = value
+	case "admin":
+		admin = parseBool(value)
+	case "service":
+		service = parseBool(value)
+	default:
+		return fmt.Errorf("unknown field %q", field)
+	}
+	return s.api.EditUser(username, pass, email, fullname, "", admin, service)
+}
+
+func (s *apiStore) DeleteUser(username string) error { return s.api.DeleteUser(username) }
+
+func (s *apiStore) EnvAction(name, target, action string) (string, error) {
+	switch target {
+	case "enroll":
+		switch action {
+		case "extend":
+			return s.api.ExtendEnrollment(name)
+		case "rotate":
+			return s.api.RotateEnrollment(name)
+		case "expire":
+			return s.api.ExpireEnrollment(name)
+		case "notexpire":
+			return s.api.NotexpireEnrollment(name)
+		}
+	case "remove":
+		switch action {
+		case "extend":
+			return s.api.ExtendRemove(name)
+		case "rotate":
+			return s.api.RotateRemove(name)
+		case "expire":
+			return s.api.ExpireRemove(name)
+		case "notexpire":
+			return s.api.NotexpireRemove(name)
+		}
+	}
+	return "", fmt.Errorf("unknown action %s/%s", target, action)
+}
+
+func (s *apiStore) AddSetting(service, name, typ, value string) error {
+	return fmt.Errorf("settings management is not exposed by the REST API; use --db mode")
+}
+func (s *apiStore) UpdateSetting(service, name, typ, value string) error {
+	return fmt.Errorf("settings management is not exposed by the REST API; use --db mode")
+}
+func (s *apiStore) DeleteSetting(service, name string) error {
+	return fmt.Errorf("settings management is not exposed by the REST API; use --db mode")
+}
+
+func (s *apiStore) Permissions(username string) ([]permRow, error) {
+	return nil, fmt.Errorf("permissions read is not wired for the REST API in this version; use --db mode")
+}
+
+// ─────────────────────────────── dbStore: management actions ───────────────────────────────
+
+func (s *dbStore) TagNode(_, uuid, tag string) error {
+	// Resolve env from the node itself.
+	n, err := nodesmgr.GetByUUID(uuid)
+	if err != nil {
+		return fmt.Errorf("node: %w", err)
+	}
+	return tagsmgr.NewTag(tag, "", "", tags.DefaultTagIcon, getShellUsername(), n.EnvironmentID, false, tags.TagTypeTag, "")
+}
+
+func (s *dbStore) AddTag(env, name, color, icon, desc, tagType, custom string) error {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return fmt.Errorf("env: %w", err)
+		}
+	}
+	_, err = tagsmgr.New(name, desc, color, icon, getShellUsername(), e.ID, false, parseTagType(tagType), custom)
+	return err
+}
+
+func (s *dbStore) EditTag(env, name, color, icon, desc, tagType, custom string) error {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return fmt.Errorf("env: %w", err)
+		}
+	}
+	if desc != "" {
+		if err := tagsmgr.ChangeGetDescription(name, desc, e.ID); err != nil {
+			return err
+		}
+	}
+	if color != "" {
+		if err := tagsmgr.ChangeGetColor(name, color, e.ID); err != nil {
+			return err
+		}
+	}
+	if icon != "" {
+		if err := tagsmgr.ChangeGetIcon(name, icon, e.ID); err != nil {
+			return err
+		}
+	}
+	if tagType != "" {
+		if err := tagsmgr.ChangeGetTagType(name, parseTagType(tagType), e.ID); err != nil {
+			return err
+		}
+	}
+	if custom != "" {
+		if err := tagsmgr.ChangeGetCustom(name, custom, e.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *dbStore) DeleteTag(env, name string) error {
+	e, err := envs.Get(env)
+	if err != nil {
+		e, err = envs.GetByName(env)
+		if err != nil {
+			return fmt.Errorf("env: %w", err)
+		}
+	}
+	return tagsmgr.DeleteGet(name, e.ID)
+}
+
+func (s *dbStore) CreateUser(username, password, email, fullname string, admin, service bool) error {
+	u, err := adminUsers.New(username, password, email, fullname, admin, service)
+	if err != nil {
+		return err
+	}
+	return adminUsers.Create(u)
+}
+
+func (s *dbStore) EditUserField(username, field, value string) error {
+	switch strings.ToLower(field) {
+	case "password":
+		return adminUsers.ChangePassword(username, value)
+	case "email":
+		return adminUsers.ChangeEmail(username, value)
+	case "fullname":
+		return adminUsers.ChangeFullname(username, value)
+	case "admin":
+		return adminUsers.ChangeAdmin(username, parseBool(value))
+	case "service":
+		return adminUsers.ChangeService(username, parseBool(value))
+	default:
+		return fmt.Errorf("unknown field %q", field)
+	}
+}
+
+func (s *dbStore) DeleteUser(username string) error { return adminUsers.Delete(username) }
+
+func (s *dbStore) EnvAction(name, target, action string) (string, error) {
+	e, err := envs.Get(name)
+	if err != nil {
+		e, err = envs.GetByName(name)
+		if err != nil {
+			return "", fmt.Errorf("env: %w", err)
+		}
+	}
+	var aerr error
+	switch target {
+	case "enroll":
+		switch action {
+		case "extend":
+			aerr = envs.ExtendEnroll(e.UUID)
+		case "rotate":
+			aerr = envs.RotateEnroll(e.Name)
+		case "expire":
+			aerr = envs.ExpireEnroll(e.UUID)
+		case "notexpire":
+			aerr = envs.NotExpireEnroll(e.UUID)
+		default:
+			return "", fmt.Errorf("unknown action %s", action)
+		}
+	case "remove":
+		switch action {
+		case "extend":
+			aerr = envs.ExtendRemove(e.UUID)
+		case "rotate":
+			aerr = envs.RotateRemove(e.Name)
+		case "expire":
+			aerr = envs.ExpireRemove(e.UUID)
+		case "notexpire":
+			aerr = envs.NotExpireRemove(e.UUID)
+		default:
+			return "", fmt.Errorf("unknown action %s", action)
+		}
+	default:
+		return "", fmt.Errorf("unknown target %s", target)
+	}
+	if aerr != nil {
+		return "", aerr
+	}
+	return fmt.Sprintf("%s %s %s", target, action, "ok"), nil
+}
+
+func (s *dbStore) AddSetting(service, name, typ, value string) error {
+	switch strings.ToLower(typ) {
+	case "string":
+		return settingsmgr.NewStringValue(service, name, value, settings.NoEnvironmentID)
+	case "boolean", "bool":
+		return settingsmgr.NewBooleanValue(service, name, parseBool(value), settings.NoEnvironmentID)
+	case "integer", "int":
+		iv, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("integer: %w", err)
+		}
+		return settingsmgr.NewIntegerValue(service, name, iv, settings.NoEnvironmentID)
+	default:
+		return fmt.Errorf("unknown type %q (string|boolean|integer)", typ)
+	}
+}
+
+func (s *dbStore) UpdateSetting(service, name, typ, value string) error {
+	// Delete-then-create keeps the value fresh without a generic setter.
+	if err := settingsmgr.DeleteValue(service, name, settings.NoEnvironmentID); err != nil {
+		return err
+	}
+	return s.AddSetting(service, name, typ, value)
+}
+
+func (s *dbStore) DeleteSetting(service, name string) error {
+	return settingsmgr.DeleteValue(service, name, settings.NoEnvironmentID)
+}
+
+func (s *dbStore) Permissions(username string) ([]permRow, error) {
+	ps, err := adminUsers.GetAllPermissions(username)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]permRow, 0, len(ps))
+	for _, pr := range ps {
+		out = append(out, permRow{
+			Username:    pr.Username,
+			Environment: pr.Environment,
+			AccessType:  accessTypeName(pr.AccessType),
+			AccessValue: pr.AccessValue,
+			GrantedBy:   pr.GrantedBy,
+		})
+	}
+	return out, nil
+}
+
+// parseBool tolerates common truthy strings.
+func parseBool(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "yes", "y", "1", "on":
+		return true
+	}
+	return false
+}
+
+// accessTypeName maps a users.AccessType int to a readable label.
+func accessTypeName(t int) string {
+	switch t {
+	case 0:
+		return "admin"
+	case 1:
+		return "user"
+	case 2:
+		return "query"
+	case 3:
+		return "carve"
+	default:
+		return strconv.Itoa(t)
+	}
+}

--- a/cmd/cli/shell_store_test.go
+++ b/cmd/cli/shell_store_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+)
+
+func TestNodeToRowActiveInactive(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name   string
+		seen   time.Time
+		hours  int64
+		active bool
+	}{
+		{"fresh", now, 24, true},
+		{"just_within", now.Add(-23 * time.Hour), 24, true},
+		{"stale", now.Add(-48 * time.Hour), 24, false},
+		{"zero_hours_defaults_active", now.Add(-1 * time.Hour), 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			n := nodes.OsqueryNode{UUID: "ABC", Hostname: "h", LastSeen: c.seen, Environment: "dev"}
+			row := nodeToRow(n, c.hours)
+			if row.Active != c.active {
+				t.Fatalf("expected active=%v got %v", c.active, row.Active)
+			}
+			if row.UUID != "ABC" {
+				t.Fatalf("uuid not mapped: %q", row.UUID)
+			}
+		})
+	}
+}
+
+func TestQueryStatus(t *testing.T) {
+	cases := []struct {
+		q    queries.DistributedQuery
+		want string
+	}{
+		{queries.DistributedQuery{Active: true}, "ACTIVE"},
+		{queries.DistributedQuery{Completed: true}, "COMPLETE"},
+		{queries.DistributedQuery{Expired: true}, "EXPIRED"},
+		{queries.DistributedQuery{Deleted: true}, "DELETED"},
+		{queries.DistributedQuery{}, "—"},
+	}
+	for _, c := range cases {
+		if got := queryStatus(c.q); got != c.want {
+			t.Fatalf("queryStatus: got %q want %q", got, c.want)
+		}
+	}
+}
+
+func TestCsvSplit(t *testing.T) {
+	got := csvSplit("a, b ,, c")
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len got=%d want=%d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("idx %d got %q want %q", i, got[i], want[i])
+		}
+	}
+	if csvSplit("") != nil {
+		t.Fatalf("empty should be nil")
+	}
+}
+
+func TestParseHidden(t *testing.T) {
+	for _, v := range []string{"yes", "Y", "true", "1"} {
+		if !parseHidden(v) {
+			t.Fatalf("expected hidden for %q", v)
+		}
+	}
+	for _, v := range []string{"", "no", "0", "x"} {
+		if parseHidden(v) {
+			t.Fatalf("expected not hidden for %q", v)
+		}
+	}
+}

--- a/cmd/cli/shell_ui.go
+++ b/cmd/cli/shell_ui.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// shell_ui.go — visual polish for the interactive shell: ANSI colors, a
+// braille spinner for in-flight fetches, and emoji accents. Colors and the
+// spinner are auto-disabled when stdout is not a TTY (piped output stays
+// clean and machine-readable).
+
+// ANSI color codes.
+const (
+	cReset   = "\x1b[0m"
+	cBold    = "\x1b[1m"
+	cDim     = "\x1b[2m"
+	cRed     = "\x1b[31m"
+	cGreen   = "\x1b[32m"
+	cYellow  = "\x1b[33m"
+	cBlue    = "\x1b[34m"
+	cMagenta = "\x1b[35m"
+	cCyan    = "\x1b[36m"
+	cGray    = "\x1b[90m"
+)
+
+// useColor enables ANSI color output; forceColor lets a user opt in even
+// when stdout is piped (e.g. piping into a color-aware pager).
+var useColor bool
+
+// spinnerEnabled gates the animated spinner — only on a real terminal so
+// piped output never gets spinner frames mixed in.
+var spinnerOn bool
+
+func paint(c, s string) string {
+	if !useColor {
+		return s
+	}
+	return c + s + cReset
+}
+
+// colorCell colorizes well-known status/boolean words for table cells.
+func colorCell(s string) string {
+	switch s {
+	case "active", "ACTIVE", "COMPLETE", "yes":
+		return paint(cGreen, s)
+	case "inactive", "INACTIVE", "EXPIRED", "DELETED", "no":
+		return paint(cRed, s)
+	case "—", "-":
+		return paint(cGray, s)
+	default:
+		return s
+	}
+}
+
+// spinnerEnabled reports whether animated spinners should render.
+func spinnerEnabled() bool { return spinnerOn }
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// animate renders a spinner + label until done is closed, then clears the line
+// and signals via stopped. Owns the line clear so there's no write race with
+// the caller.
+func animate(label string, done <-chan struct{}, stopped chan<- struct{}) {
+	i := 0
+	pad := strings.Repeat(" ", 4)
+	t := time.NewTicker(80 * time.Millisecond)
+	defer t.Stop()
+	for {
+		fmt.Printf("\r%s %s%s", paint(cCyan, spinnerFrames[i]), label, pad)
+		i = (i + 1) % len(spinnerFrames)
+		select {
+		case <-t.C:
+		case <-done:
+			fmt.Printf("\r\x1b[K")
+			close(stopped)
+			return
+		}
+	}
+}
+
+// spinGet runs fn with a spinner; returns fn's result. No-op spinner when not
+// a TTY.
+func spinGet[T any](label string, fn func() (T, error)) (T, error) {
+	if !spinnerEnabled() {
+		return fn()
+	}
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go animate(label, done, stopped)
+	res, err := fn()
+	close(done)
+	<-stopped
+	return res, err
+}
+
+// spinDo runs a void action with a spinner.
+func spinDo(label string, fn func() error) error {
+	_, err := spinGet(label, func() (struct{}, error) {
+		return struct{}{}, fn()
+	})
+	return err
+}
+
+// isTTY returns true if stdout is an interactive terminal.
+func isTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// initColors sets up color/spinner flags. Called once at shell startup.
+func initColors() {
+	tty := isTTY()
+	useColor = tty || os.Getenv("OSCTRL_CLI_FORCE_COLOR") != ""
+	spinnerOn = tty
+}
+
+// printBanner prints the welcome banner.
+func printBanner(version, mode string) {
+	line := paint(cCyan+cBold, "🛡️  osctrl-cli interactive shell")
+	fmt.Printf("%s  %s\n", line, paint(cDim, "v"+version))
+	fmt.Printf("📡  %s\n", paint(cBlue, mode+" mode"))
+	fmt.Printf("💡  %s\n", paint(cGray, "Type 'help' or '?' for help · 'exit' to quit"))
+}
+
+// moduleIcon returns an emoji for a module name.
+// moduleIcon returns a bare emoji for a module. All chosen glyphs are
+// East-Asian-Wide (display width 2) so they align in a fixed-width column.
+func moduleIcon(name string) string {
+	switch name {
+	case "nodes":
+		return "🖥️"
+	case "queries":
+		return "🔍"
+	case "carves":
+		return "📦"
+	case "environments":
+		return "🌐"
+	case "tags":
+		return "🏷️"
+	case "users":
+		return "👤"
+	case "audit":
+		return "📜"
+	case "settings":
+		return "🛠️"
+	default:
+		return "•"
+	}
+}

--- a/cmd/cli/shell_ui_test.go
+++ b/cmd/cli/shell_ui_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestAnsiStrip(t *testing.T) {
+	cases := map[string]string{
+		"\x1b[36mhello\x1b[0m":         "hello",
+		"\x1b[1m\x1b[31mactive\x1b[0m": "active",
+		"plain":                        "plain",
+		"\x1b[90m─\x1b[0m":             "─",
+	}
+	for in, want := range cases {
+		if got := ansiStrip(in); got != want {
+			t.Fatalf("ansiStrip(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestVisibleWidth(t *testing.T) {
+	if w := visibleWidth(paint(cGreen, "active")); w != 6 {
+		t.Fatalf("visibleWidth colored active = %d want 6", w)
+	}
+	if w := visibleWidth("inactive"); w != 8 {
+		t.Fatalf("visibleWidth inactive = %d want 8", w)
+	}
+}
+
+func TestPaintNoColor(t *testing.T) {
+	prev := useColor
+	useColor = false
+	defer func() { useColor = prev }()
+	if got := paint(cRed, "x"); got != "x" {
+		t.Fatalf("paint with color off should be plain, got %q", got)
+	}
+}
+
+func TestColorCell(t *testing.T) {
+	prev := useColor
+	useColor = true
+	defer func() { useColor = prev }()
+	if colorCell("active") != cGreen+"active"+cReset {
+		t.Fatal("active should be green")
+	}
+	if colorCell("inactive") != cRed+"inactive"+cReset {
+		t.Fatal("inactive should be red")
+	}
+	if colorCell("foobar") != "foobar" {
+		t.Fatal("unknown cell should be plain")
+	}
+}
+
+func TestSpinGetNonTty(t *testing.T) {
+	// spinnerEnabled() is false in tests (spinnerOn defaults to false), so
+	// spinGet should just invoke fn directly.
+	v, err := spinGet("test", func() (int, error) { return 7, nil })
+	if err != nil || v != 7 {
+		t.Fatalf("spinGet returned (%d,%v) want (7,nil)", v, err)
+	}
+}


### PR DESCRIPTION
# feat(cli): add Metasploit-style interactive shell to osctrl-cli

## Problem

`osctrl-cli` is one-shot: every action re-invokes the binary, re-parses flags, and re-establishes the API/DB connection. There is no way to open a persistent operator session and explore the fleet the way the admin web UI allows from the terminal.

## Change

Adds an `osctrl-cli shell` command (aliases `console`, `interactive`, `repl`) that opens one persistent session — keeping the `--api` or `--db` backend open — and exposes the full CLI surface through a context-based, Metasploit-style REPL. No re-invocation per action.

```
$ osctrl-cli --api-file osctrl-api.json shell
🛡️  osctrl-cli interactive shell  v0.5.4
📡  api mode
osctrl[dev]> use nodes
osctrl (nodes:dev)> list
Hostname  UUID         Platform  Version  Osquery  IP        LastSeen    Status
─────────────────────────────────────────────────────────────────────────────────
host01    NODE-UUID-1  linux     5.15.0   5.12.1   10.0.0.5  1 hour ago  active
mac01     NODE-UUID-2  darwin    23.0     5.12.1   10.0.0.6  2 days ago  inactive
osctrl (nodes:dev)> back
osctrl> use queries
osctrl (queries:dev)> set uuids NODE-UUID-1
osctrl (queries:dev)> run SELECT * FROM osquery_info
✅ query dispatched in dev
osctrl> exit
```

### Architecture
- **`DataStore` façade** (`shell_store.go`) branches `--api`/`--db` once and returns plain DTOs (`nodeRow`, `queryRow`, …), so command handlers stay mode-agnostic and decoupled from model JSON shapes.
- **REPL core** (`shell.go`) + **command registry/help/completion** (`shell_commands.go`) + **per-module handlers** (`shell_modules.go`).
- **Custom readline** (`shell_readline.go`) built on the already-vendored `golang.org/x/term` (no offline readline lib was available): line editing, ↑/↓ history, Tab completion, Ctrl-C/Ctrl-D, plus a non-TTY fallback so commands can be piped in for scripting.

### Surface
- **Modules:** `nodes`, `queries`, `carves`, `environments`, `tags`, `users`, `audit`, `settings`.
- **Global:** `help`/`?` (context-aware), `use <module>`, `back`, `set env <name>` / `set <option> <value>`, `show environments`, `stats`, `exit`.
- **Actions:** run query/carve (with `set` options), complete/expire/delete, delete node, tag node, add/edit/delete tags, add/edit/delete users, permissions, environment enroll/remove actions (extend/rotate/expire/notexpire), settings add/update/delete — destructive ops prompt for confirmation.

### UX polish (`shell_ui.go`)
- ANSI **colors** (cyan headers, green/red status, magenta contexts), auto-disabled when stdout isn't a TTY; `OSCTRL_CLI_FORCE_COLOR=1` forces them for piping into a color-aware pager.
- Braille **spinner** animates during in-flight fetches (TTY only; never pollutes piped output).
- **Emoji** accents for modules/banner/stats.
- Display-width math via `github.com/mattn/go-runewidth` so colored cells and emoji align correctly.

### Bug fixes rolled in
- `nodes list` showed nothing on under-configured DBs: `inactive_hours` defaulted to `0`, making the active filter match nothing — now falls back to 24h; `list` also defaults to `all` so nodes are always visible.
- Scrambled output: gorm's trace logger was writing `\r` + SQL lines to stdout, overwriting the prompt — the shell now silences that logger (`logger.Discard`).
- Misaligned `help` module list: emoji glyphs had inconsistent display widths — icons normalized to width-2 glyphs and padded via `runewidth`; table separator now spans the full table width.

## Validation
- `go build ./...`, `go test ./cmd/cli`, `go vet`, `golangci-lint run ./cmd/cli/...` — all clean (0 lint issues).
- New unit tests: store mapping (`nodeToRow` active/inactive, `queryStatus`, `csvSplit`, `parseHidden`) and UI helpers (`ansiStrip`, `visibleWidth`, `paint`, `colorCell`, `spinGet` non-TTY path).
- Smoke-tested in both piped (scripted commands) and PTY (interactive) modes against a seeded SQLite backend.

## Files
- `cmd/cli/main.go` — register `shell` command.
- `cmd/cli/shell.go` — REPL loop, dispatch, prompt, ASCII table renderer, gorm silencing.
- `cmd/cli/shell_commands.go` — global commands, module registry, help, Tab completion.
- `cmd/cli/shell_modules.go` — per-module command handlers.
- `cmd/cli/shell_readline.go` — raw-mode line editor with history/completion.
- `cmd/cli/shell_store.go` — `DataStore` interface + `apiStore`/`dbStore` implementations + DTOs.
- `cmd/cli/shell_store_test.go`, `cmd/cli/shell_ui_test.go` — tests.
- `cmd/cli/shell_ui.go` — colors, spinner, emoji, runewidth widths.

No new external dependencies (`term`, `tablewriter`, `runewidth` were already in `go.mod`).

## Known limitations
- Settings management and permission reads are `--db` only (the REST API does not expose them).
- Full environment add/update/flags/secret/quick-add still route through the `environment` CLI subcommand; the shell covers env list/show/delete and all enroll/remove URL actions.
- Query results in `--db` mode require the logging sink to be wired; `--api` mode works.

## Security notes
- Destructive actions (delete node/query/carve/tag/user/env, settings delete) require an explicit yes/no confirmation.
- The shell reuses the existing `cliWrapper` backend init and the existing API client / GORM manager methods verbatim — no new privileged code paths, no new secret handling.