### PR TITLE
Full text area for all components of configuration

### DIFF
--- a/frontend/src/features/enrollment/AssembledConfigCard.tsx
+++ b/frontend/src/features/enrollment/AssembledConfigCard.tsx
@@ -127,7 +127,7 @@ export function AssembledConfigCard({ env }: { env: string }) {
         <CodeEditor
           value={cfgQuery.data?.data ?? ''}
           language="json"
-          height="360px"
+          height="calc(100vh - 260px)"
           readOnly
           aria-label={`Assembled osquery configuration for environment ${env}`}
         />

--- a/frontend/src/features/environments/EnvConfigPage.tsx
+++ b/frontend/src/features/environments/EnvConfigPage.tsx
@@ -468,7 +468,7 @@ export function EnvConfigPage() {
                 onChange={(v) =>
                   setDraft((d) => (d ? { ...d, [key]: v } : d))
                 }
-                height="420px"
+                height="calc(100vh - 220px)"
               />
               {isDirty && diffsOpen[key] && (
                 <div className="p-3 border-t border-[color:var(--border)]">


### PR DESCRIPTION
All the text areas for each component of configuration (options, schedule, packs, etc) did not fill the parent div.