### PR TITLE
Replace pseudo-cache for environments and settings with proper cache

### DIFF
--- a/cmd/api/handlers/environments_crud.go
+++ b/cmd/api/handlers/environments_crud.go
@@ -510,7 +510,7 @@ func (h *HandlersApi) EnvironmentConfigPatchHandler(w http.ResponseWriter, r *ht
 	// request instead of waiting for the cache TTL to expire.
 	if h.RedisCache != nil {
 		ctx := context.Background()
-		if err := h.RedisCache.Client.Set(ctx, "envcache:invalidate:"+env.UUID, "1", 60*time.Second).Err(); err != nil {
+		if err := h.RedisCache.Client.Set(ctx, environments.RedisEnvInvalidatePrefix+env.UUID, "1", 60*time.Second).Err(); err != nil {
 			log.Warn().Err(err).Str("env", env.UUID).Msg("failed to signal env cache invalidation")
 		}
 	}

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -52,14 +53,13 @@ var validPlatform = map[string]bool{
 // HandlersTLS to keep all handlers for TLS
 type HandlersTLS struct {
 	Envs            *environments.EnvManager
-	EnvsMap         *environments.MapEnvironments
 	EnvCache        *environments.EnvCache
 	Nodes           *nodes.NodeManager
 	Tags            *tags.TagManager
 	Queries         *queries.Queries
 	Carves          *carves.Carves
 	Settings        *settings.Settings
-	SettingsMap     *settings.MapSettings
+	SettingsCache   *settings.RedisSettingsCache
 	Logs            *logging.LoggerTLS
 	WriteHandler    *batchWriter
 	ActivityWriter  *activityWriter
@@ -95,13 +95,6 @@ func WithEnvCache(ec *environments.EnvCache) Option {
 	}
 }
 
-// WithEnvsMap to pass value as option
-func WithEnvsMap(envsmap *environments.MapEnvironments) Option {
-	return func(h *HandlersTLS) {
-		h.EnvsMap = envsmap
-	}
-}
-
 // WithSettings to pass value as option
 func WithSettings(settings *settings.Settings) Option {
 	return func(h *HandlersTLS) {
@@ -109,10 +102,10 @@ func WithSettings(settings *settings.Settings) Option {
 	}
 }
 
-// WithSettingsMap to pass value as option
-func WithSettingsMap(settingsmap *settings.MapSettings) Option {
+// WithSettingsCache to pass Redis-backed TLS settings cache
+func WithSettingsCache(settingsCache *settings.RedisSettingsCache) Option {
 	return func(h *HandlersTLS) {
-		h.SettingsMap = settingsmap
+		h.SettingsCache = settingsCache
 	}
 }
 
@@ -268,6 +261,24 @@ func (h *HandlersTLS) shouldDebugHTTP(uuid string) bool {
 // node has been identified, via shouldDebugHTTP + DebugHTTPDumpWithBody.
 func (h *HandlersTLS) debugHTTPAll() bool {
 	return h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP && h.DebugHTTPConfig.TargetHostIdentifier == ""
+}
+
+func (h *HandlersTLS) acceleratedSeconds(ctx context.Context) int {
+	if h.SettingsCache != nil {
+		values, err := h.SettingsCache.GetMap(ctx)
+		if err == nil {
+			if value, ok := values[settings.AcceleratedSeconds]; ok {
+				return int(value.Integer)
+			}
+		}
+	}
+	if h.Settings != nil {
+		value, err := h.Settings.GetInteger(config.ServiceTLS, settings.AcceleratedSeconds, settings.NoEnvironmentID)
+		if err == nil {
+			return int(value)
+		}
+	}
+	return 0
 }
 
 func (h *HandlersTLS) PrometheusMiddleware(next http.Handler) http.Handler {

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -169,7 +169,7 @@ func (h *HandlersTLS) EnrollHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	response := types.EnrollResponse{NodeKey: nodeKey, NodeInvalid: nodeInvalid}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Response: %+v", response)
 	}
 	// Serialize and send response
@@ -252,7 +252,7 @@ func (h *HandlersTLS) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 		response = types.ConfigResponse{NodeInvalid: true}
 	}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		if x, ok := response.([]byte); ok {
 			log.Debug().Msgf("Configuration: %s", string(x))
 		} else {
@@ -357,7 +357,7 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 		// Process logs and update metadata
 		go func() {
 			start := time.Now()
-			results := h.Logs.ProcessLogs(t.Data, t.LogType, env.Name, utils.GetIP(r), len(body), (*h.EnvsMap)[env.Name].DebugHTTP)
+			results := h.Logs.ProcessLogs(t.Data, t.LogType, env.Name, utils.GetIP(r), len(body), env.DebugHTTP)
 			duration := time.Since(start).Seconds()
 			logProcessDuration.WithLabelValues(string(env.UUID), t.LogType).Observe(duration)
 			// Ingest posture data from result logs (if enabled)
@@ -371,7 +371,7 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 	// Prepare response
 	response = types.LogResponse{NodeInvalid: nodeInvalid}
 	// Debug
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Response: %+v", response)
 	}
 	// Serialize and send response
@@ -464,13 +464,13 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Serialize queries
 	if accelerate {
-		sAccelerate := int((*h.SettingsMap)[settings.AcceleratedSeconds].Integer)
+		sAccelerate := h.acceleratedSeconds(r.Context())
 		response = types.AcceleratedQueryReadResponse{Queries: qs, Accelerate: sAccelerate, NodeInvalid: nodeInvalid}
 	} else {
 		response = types.QueryReadResponse{Queries: qs, NodeInvalid: nodeInvalid}
 	}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Response: %+v", response)
 	}
 	// Serialize and send response
@@ -565,7 +565,7 @@ func (h *HandlersTLS) QueryWriteHandler(w http.ResponseWriter, r *http.Request) 
 		h.recordActivity(env.UUID, node.UUID, activity.EventQueryWrite)
 		go func() {
 			start := time.Now()
-			h.Logs.ProcessLogQueryResult(t, env.ID, (*h.EnvsMap)[env.Name].DebugHTTP)
+			h.Logs.ProcessLogQueryResult(t, env.ID, env.DebugHTTP)
 			duration := time.Since(start).Seconds()
 			distributedQueryProcessingDuration.WithLabelValues(string(env.UUID)).Observe(duration)
 		}()
@@ -575,7 +575,7 @@ func (h *HandlersTLS) QueryWriteHandler(w http.ResponseWriter, r *http.Request) 
 	// Prepare response
 	response = types.QueryWriteResponse{NodeInvalid: nodeInvalid}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Response: %+v", response)
 	}
 	// Send response
@@ -596,7 +596,7 @@ func (h *HandlersTLS) QuickEnrollHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusInternalServerError, TLSResponse{Message: "Invalid"})
@@ -669,7 +669,7 @@ func (h *HandlersTLS) QuickRemoveHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusInternalServerError, TLSResponse{Message: "Invalid"})
@@ -744,7 +744,7 @@ func (h *HandlersTLS) CarveInitHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
@@ -813,7 +813,7 @@ func (h *HandlersTLS) CarveInitHandler(w http.ResponseWriter, r *http.Request) {
 	// Prepare response
 	response = types.CarveInitResponse{Success: initCarve, SessionID: carveSessionID}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Response: %+v", response)
 	}
 	// Send response
@@ -834,7 +834,7 @@ func (h *HandlersTLS) CarveBlockHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
@@ -879,7 +879,7 @@ func (h *HandlersTLS) CarveBlockHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	// Prepare response
 	response := types.CarveBlockResponse{Success: blockCarve}
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Response: %+v", response)
 	}
 	// Send response
@@ -901,7 +901,7 @@ func (h *HandlersTLS) FlagsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
@@ -940,7 +940,7 @@ func (h *HandlersTLS) FlagsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Flags: %s", string(response))
 	}
 	// Send response
@@ -962,7 +962,7 @@ func (h *HandlersTLS) CertHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
@@ -995,7 +995,7 @@ func (h *HandlersTLS) CertHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Certificate: %s", string(response))
 	}
 	// Send response
@@ -1017,7 +1017,7 @@ func (h *HandlersTLS) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
@@ -1060,7 +1060,7 @@ func (h *HandlersTLS) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Certificate: %v", response)
 	}
 	// Send response
@@ -1082,7 +1082,7 @@ func (h *HandlersTLS) ScriptHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
@@ -1148,7 +1148,7 @@ func (h *HandlersTLS) ScriptHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Debug HTTP
-	if (*h.EnvsMap)[env.Name].DebugHTTP {
+	if env.DebugHTTP {
 		log.Debug().Msgf("Script: %s", string(response))
 	}
 	// Send response
@@ -1169,7 +1169,7 @@ func (h *HandlersTLS) EnrollPackageHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Get environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))
@@ -1300,7 +1300,7 @@ func (h *HandlersTLS) OsqueryConfigEndpointHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	// If we are here, the secret is confirmed, so we can proceed to get the environment
-	env, err := h.Envs.GetByUUID(envVar)
+	env, err := h.EnvCache.GetByUUID(r.Context(), envVar)
 	if err != nil {
 		log.Err(err).Msg("error getting environment")
 		utils.HTTPResponse(w, "", http.StatusInternalServerError, []byte(""))

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -71,8 +71,6 @@ var (
 	redis                *cache.RedisManager
 	settingsmgr          *settings.Settings
 	envs                 *environments.EnvManager
-	envsmap              environments.MapEnvironments
-	settingsmap          settings.MapSettings
 	nodesmgr             *nodes.NodeManager
 	queriesmgr           *queries.Queries
 	filecarves           *carves.Carves
@@ -214,14 +212,12 @@ func osctrlService() {
 	// (envcache:invalidate:{uuid}) so osctrl-tls picks up the change
 	// on the next /config request instead of serving stale data for
 	// the full TTL.
-	envCache := environments.NewEnvCache(*envs)
-	if redis != nil {
-		envCache.SetInvalidationCheck(func(ctx context.Context, uuid string) bool {
-			n, err := redis.Client.Exists(ctx, "envcache:invalidate:"+uuid).Result()
-			return err == nil && n > 0
-		})
-		log.Info().Msg("EnvCache invalidation wired to Redis")
-	}
+	envCache := environments.NewRedisEnvCache(*envs, redis.Client)
+	envCache.SetInvalidationCheck(func(ctx context.Context, uuid string) bool {
+		n, err := redis.Client.Exists(ctx, environments.RedisEnvInvalidatePrefix+uuid).Result()
+		return err == nil && n > 0
+	})
+	log.Info().Msg("Environment cache wired to Redis")
 	log.Info().Msg("Initialize settings")
 	settingsmgr = settings.NewSettings(db.Conn)
 	log.Info().Msg("Initialize nodes")
@@ -245,6 +241,12 @@ func osctrlService() {
 	if err := loadingSettings(settingsmgr, flagParams); err != nil {
 		log.Fatal().Msgf("Error loading settings - %v", err)
 	}
+	settingsCacheTTL := time.Duration(settingsmgr.RefreshSettings(config.ServiceTLS)) * time.Second
+	if settingsCacheTTL <= 0 {
+		settingsCacheTTL = time.Duration(defaultRefresh) * time.Second
+	}
+	settingsCache := settings.NewRedisSettingsCache(settingsmgr, redis.Client, config.ServiceTLS, settings.NoEnvironmentID, settingsCacheTTL)
+	log.Info().Msg("TLS settings cache wired to Redis")
 	// Initialize batch writer
 	log.Info().Msg("Initializing batch writer")
 	tlsWriter := handlers.NewBatchWriter(
@@ -268,36 +270,6 @@ func osctrlService() {
 	if err != nil {
 		log.Fatal().Msgf("Error loading logger - %s: %v", flagParams.Logger.Type, err)
 	}
-	// Sleep to reload environments
-	// FIXME Implement Redis cache
-	// FIXME splay this?
-	log.Info().Msg("Preparing pseudo-cache for environments")
-	go func() {
-		_t := settingsmgr.RefreshEnvs(config.ServiceTLS)
-		if _t == 0 {
-			_t = int64(defaultRefresh)
-		}
-		for {
-			log.Debug().Msg("Refreshing environments")
-			envsmap = refreshEnvironments()
-			time.Sleep(time.Duration(_t) * time.Second)
-		}
-	}()
-	// Sleep to reload settings
-	// FIXME Implement Redis cache
-	// FIXME splay this?
-	log.Info().Msg("Preparing pseudo-cache for settings")
-	go func() {
-		_t := settingsmgr.RefreshSettings(config.ServiceTLS)
-		if _t == 0 {
-			_t = int64(defaultRefresh)
-		}
-		for {
-			log.Debug().Msg("Refreshing settings")
-			settingsmap = refreshSettings()
-			time.Sleep(time.Duration(_t) * time.Second)
-		}
-	}()
 	if flagParams.Metrics.Enabled {
 		log.Info().Msg("Metrics are enabled")
 		// Register Prometheus metrics
@@ -329,13 +301,12 @@ func osctrlService() {
 	handlersTLS = handlers.CreateHandlersTLS(
 		handlers.WithEnvs(envs),
 		handlers.WithEnvCache(envCache),
-		handlers.WithEnvsMap(&envsmap),
 		handlers.WithNodes(nodesmgr),
 		handlers.WithTags(tagsmgr),
 		handlers.WithQueries(queriesmgr),
 		handlers.WithCarves(filecarves),
 		handlers.WithSettings(settingsmgr),
-		handlers.WithSettingsMap(&settingsmap),
+		handlers.WithSettingsCache(settingsCache),
 		handlers.WithLogs(loggerTLS),
 		handlers.WithWriteHandler(tlsWriter),
 		handlers.WithActivityWriter(activityWriter),

--- a/cmd/tls/utils.go
+++ b/cmd/tls/utils.go
@@ -2,62 +2,7 @@ package main
 
 import (
 	"github.com/jmpsec/osctrl/pkg/config"
-	"github.com/jmpsec/osctrl/pkg/environments"
-	"github.com/jmpsec/osctrl/pkg/settings"
-	"github.com/rs/zerolog/log"
 )
-
-// Helper to determine if an IPv4 is public, based on the following:
-// Class   Starting IPAddress  Ending IPAddress
-// A       		10.0.0.0       	 10.255.255.255
-// B       		172.16.0.0       172.31.255.255
-// C       		192.168.0.0      192.168.255.255
-// Link-local 169.254.0.0      169.254.255.255
-// Local      127.0.0.0        127.255.255.255
-/*
-func isPublicIP(ip net.IP) bool {
-	// Use native functions
-	if ip.IsLoopback() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() {
-		return false
-	}
-	// Check each octet
-	if ip4 := ip.To4(); ip4 != nil {
-		switch {
-		case ip4[0] == 10:
-			return false
-		case ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31:
-			return false
-		case ip4[0] == 192 && ip4[1] == 168:
-			return false
-		default:
-			return true
-		}
-	}
-	return false
-}
-*/
-
-// Helper to refresh the environments map until cache/Redis support is implemented
-func refreshEnvironments() environments.MapEnvironments {
-	log.Debug().Msg("Refreshing environments...")
-	_envsmap, err := envs.GetMap()
-	if err != nil {
-		log.Err(err).Msg("error refreshing environments")
-		return environments.MapEnvironments{}
-	}
-	return _envsmap
-}
-
-// Helper to refresh the settings until cache/Redis support is implemented
-func refreshSettings() settings.MapSettings {
-	log.Debug().Msg("Refreshing settings...")
-	_settingsmap, err := settingsmgr.GetMap(config.ServiceTLS, settings.NoEnvironmentID)
-	if err != nil {
-		log.Err(err).Msg("error refreshing settings")
-		return settings.MapSettings{}
-	}
-	return _settingsmap
-}
 
 // Helper to convert YAML settings loaded from file to settings
 func loadedYAMLToServiceParams(yml config.TLSConfiguration, loadedFile string) *config.ServiceParameters {

--- a/pkg/cache/redis-json.go
+++ b/pkg/cache/redis-json.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+// RedisJSONCache stores typed JSON values in Redis under a fixed key prefix.
+type RedisJSONCache[T any] struct {
+	client *redis.Client
+	prefix string
+}
+
+// NewRedisJSONCache creates a typed Redis-backed JSON cache.
+func NewRedisJSONCache[T any](client *redis.Client, prefix string) *RedisJSONCache[T] {
+	return &RedisJSONCache[T]{
+		client: client,
+		prefix: strings.TrimSuffix(prefix, ":"),
+	}
+}
+
+// Get retrieves and decodes a value. ok=false means Redis had no value.
+func (c *RedisJSONCache[T]) Get(ctx context.Context, key string) (T, bool, error) {
+	var zero T
+	data, err := c.client.Get(ctx, c.cacheKey(key)).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return zero, false, nil
+		}
+		return zero, false, err
+	}
+
+	var value T
+	if err := json.Unmarshal(data, &value); err != nil {
+		return zero, false, err
+	}
+	return value, true, nil
+}
+
+// Set encodes and stores a value. ttl<=0 stores without expiration.
+func (c *RedisJSONCache[T]) Set(ctx context.Context, key string, value T, ttl time.Duration) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return c.client.Set(ctx, c.cacheKey(key), data, ttl).Err()
+}
+
+// Delete removes a cached value.
+func (c *RedisJSONCache[T]) Delete(ctx context.Context, key string) error {
+	return c.client.Del(ctx, c.cacheKey(key)).Err()
+}
+
+func (c *RedisJSONCache[T]) cacheKey(key string) string {
+	if c.prefix == "" {
+		return key
+	}
+	return c.prefix + ":" + key
+}

--- a/pkg/cache/redis-json_test.go
+++ b/pkg/cache/redis-json_test.go
@@ -1,0 +1,229 @@
+package cache
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/require"
+)
+
+type redisJSONTestValue struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+func TestRedisJSONCacheRoundTrip(t *testing.T) {
+	client, store := newRedisJSONTestClient(t)
+	cache := NewRedisJSONCache[redisJSONTestValue](client, "test:json")
+
+	ctx := context.Background()
+	require.NoError(t, cache.Set(ctx, "alpha", redisJSONTestValue{Name: "alpha", Enabled: true}, time.Minute))
+
+	got, ok, err := cache.Get(ctx, "alpha")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, redisJSONTestValue{Name: "alpha", Enabled: true}, got)
+	require.Equal(t, time.Minute, store.expireFor("test:json:alpha"))
+}
+
+func TestRedisJSONCacheDelete(t *testing.T) {
+	client, _ := newRedisJSONTestClient(t)
+	cache := NewRedisJSONCache[redisJSONTestValue](client, "test:json")
+
+	ctx := context.Background()
+	require.NoError(t, cache.Set(ctx, "alpha", redisJSONTestValue{Name: "alpha"}, time.Minute))
+	require.NoError(t, cache.Delete(ctx, "alpha"))
+
+	_, ok, err := cache.Get(ctx, "alpha")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func newRedisJSONTestClient(t *testing.T) (*redis.Client, *redisJSONFakeStore) {
+	t.Helper()
+
+	store := &redisJSONFakeStore{
+		values:  make(map[string][]byte),
+		expires: make(map[string]time.Duration),
+	}
+	client := redis.NewClient(&redis.Options{
+		Addr:     "fake-redis",
+		PoolSize: 1,
+		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			serverConn, clientConn := net.Pipe()
+			go serveRedisJSONFake(serverConn, store)
+			return clientConn, nil
+		},
+	})
+
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	return client, store
+}
+
+type redisJSONFakeStore struct {
+	mu      sync.Mutex
+	values  map[string][]byte
+	expires map[string]time.Duration
+}
+
+func serveRedisJSONFake(conn net.Conn, store *redisJSONFakeStore) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	for {
+		args, err := readRedisJSONRESPArray(reader)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				_, _ = conn.Write([]byte("-ERR read failed\r\n"))
+			}
+			return
+		}
+		if len(args) == 0 {
+			_, _ = conn.Write([]byte("-ERR empty command\r\n"))
+			return
+		}
+
+		if err := handleRedisJSONFakeCommand(conn, store, args); err != nil {
+			_, _ = conn.Write([]byte("-ERR " + err.Error() + "\r\n"))
+			return
+		}
+	}
+}
+
+func handleRedisJSONFakeCommand(conn net.Conn, store *redisJSONFakeStore, args []string) error {
+	switch strings.ToUpper(args[0]) {
+	case "GET":
+		if len(args) != 2 {
+			return fmt.Errorf("unexpected GET args: %v", args)
+		}
+		value, ok := store.get(args[1])
+		if !ok {
+			_, err := conn.Write([]byte("$-1\r\n"))
+			return err
+		}
+		_, err := fmt.Fprintf(conn, "$%d\r\n", len(value))
+		if err != nil {
+			return err
+		}
+		_, err = conn.Write(append(value, []byte("\r\n")...))
+		return err
+
+	case "SET":
+		if len(args) != 3 && len(args) != 5 {
+			return fmt.Errorf("unexpected SET args: %v", args)
+		}
+		var ttl time.Duration
+		if len(args) == 5 {
+			if strings.ToUpper(args[3]) != "EX" {
+				return fmt.Errorf("unexpected SET expiration args: %v", args)
+			}
+			seconds, err := strconv.Atoi(args[4])
+			if err != nil {
+				return err
+			}
+			ttl = time.Duration(seconds) * time.Second
+		}
+		store.set(args[1], []byte(args[2]), ttl)
+		_, err := conn.Write([]byte("+OK\r\n"))
+		return err
+
+	case "DEL":
+		for _, key := range args[1:] {
+			store.delete(key)
+		}
+		_, err := fmt.Fprintf(conn, ":%d\r\n", len(args)-1)
+		return err
+
+	case "PING":
+		_, err := conn.Write([]byte("+PONG\r\n"))
+		return err
+
+	default:
+		return fmt.Errorf("unsupported command %q", args[0])
+	}
+}
+
+func readRedisJSONRESPArray(reader *bufio.Reader) ([]string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+	if !strings.HasPrefix(line, "*") {
+		return nil, fmt.Errorf("expected array, got %q", line)
+	}
+	count, err := strconv.Atoi(strings.TrimPrefix(line, "*"))
+	if err != nil {
+		return nil, err
+	}
+	args := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		header, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		header = strings.TrimSuffix(strings.TrimSuffix(header, "\n"), "\r")
+		if !strings.HasPrefix(header, "$") {
+			return nil, fmt.Errorf("expected bulk string, got %q", header)
+		}
+		size, err := strconv.Atoi(strings.TrimPrefix(header, "$"))
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, size+2)
+		if _, err := io.ReadFull(reader, buf); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf[:size]))
+	}
+	return args, nil
+}
+
+func (s *redisJSONFakeStore) set(key string, value []byte, ttl time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.values[key] = append([]byte(nil), value...)
+	if ttl > 0 {
+		s.expires[key] = ttl
+	}
+}
+
+func (s *redisJSONFakeStore) get(key string) ([]byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	value, ok := s.values[key]
+	if !ok {
+		return nil, false
+	}
+	return append([]byte(nil), value...), true
+}
+
+func (s *redisJSONFakeStore) delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.values, key)
+	delete(s.expires, key)
+}
+
+func (s *redisJSONFakeStore) expireFor(key string) time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.expires[key]
+}

--- a/pkg/environments/env-cache.go
+++ b/pkg/environments/env-cache.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"time"
 
+	redis "github.com/go-redis/redis/v8"
 	"github.com/jmpsec/osctrl/pkg/cache"
 )
 
 const (
-	cacheName = "environments"
+	cacheName                = "environments"
+	redisEnvCacheName        = "osctrl:tls:environment"
+	RedisEnvInvalidatePrefix = "envcache:invalidate:"
 	// envCacheTTL is the maximum time a TLSEnvironment can sit in the
 	// EnvCache before the next request refetches from the database.
 	//
@@ -29,7 +32,9 @@ const (
 // EnvCache provides cached access to TLS environments
 type EnvCache struct {
 	// The cache itself, storing Environment objects
-	cache *cache.MemoryCache[TLSEnvironment]
+	cache       *cache.MemoryCache[TLSEnvironment]
+	redisCache  *cache.RedisJSONCache[TLSEnvironment]
+	redisClient *redis.Client
 
 	// Reference to the environment manager for cache misses
 	envs EnvManager
@@ -54,6 +59,15 @@ func NewEnvCache(envs EnvManager) *EnvCache {
 	}
 }
 
+// NewRedisEnvCache creates a Redis-backed environment cache.
+func NewRedisEnvCache(envs EnvManager, client *redis.Client) *EnvCache {
+	return &EnvCache{
+		redisCache:  cache.NewRedisJSONCache[TLSEnvironment](client, redisEnvCacheName),
+		redisClient: client,
+		envs:        envs,
+	}
+}
+
 // SetInvalidationCheck wires a callback that is called on each
 // GetByUUID. If the callback returns true, the cached entry is
 // considered stale and the env is refetched from the DB. The typical
@@ -68,8 +82,27 @@ func (ec *EnvCache) GetByUUID(ctx context.Context, uuid string) (TLSEnvironment,
 	// Check if a cross-process invalidation signal has been received
 	// (e.g., osctrl-api patched the config and set a Redis key).
 	if ec.invalidationCheck != nil && ec.invalidationCheck(ctx, uuid) {
-		ec.cache.Delete(ctx, uuid)
+		ec.InvalidateEnv(ctx, uuid)
+		if ec.redisClient != nil {
+			_ = ec.redisClient.Del(ctx, RedisEnvInvalidatePrefix+uuid).Err()
+		}
 	}
+
+	if ec.redisCache != nil {
+		if env, found, err := ec.redisCache.Get(ctx, uuid); err == nil && found {
+			return env, nil
+		} else if err != nil {
+			_ = ec.redisCache.Delete(ctx, uuid)
+		}
+
+		env, err := ec.envs.GetByUUID(uuid)
+		if err != nil {
+			return TLSEnvironment{}, err
+		}
+		_ = ec.redisCache.Set(ctx, uuid, env, envCacheTTL)
+		return env, nil
+	}
+
 	// Try to get from cache first
 	if env, found := ec.cache.Get(ctx, uuid); found {
 		return env, nil
@@ -90,17 +123,28 @@ func (ec *EnvCache) GetByUUID(ctx context.Context, uuid string) (TLSEnvironment,
 // that mutate env rows in the same process SHOULD invoke this so the
 // next request refetches the row without waiting for the TTL.
 func (ec *EnvCache) InvalidateEnv(ctx context.Context, uuid string) {
+	if ec.redisCache != nil {
+		_ = ec.redisCache.Delete(ctx, uuid)
+		return
+	}
 	ec.cache.Delete(ctx, uuid)
 }
 
 // InvalidateAll clears the entire cache. Used on bulk operations or
 // after operator-driven secret rotations.
 func (ec *EnvCache) InvalidateAll(ctx context.Context) {
+	if ec.redisCache != nil {
+		return
+	}
 	ec.cache.Clear(ctx)
 }
 
 // UpdateEnvInCache updates an environment in the cache
 func (ec *EnvCache) UpdateEnvInCache(ctx context.Context, env TLSEnvironment) {
+	if ec.redisCache != nil {
+		_ = ec.redisCache.Set(ctx, env.UUID, env, envCacheTTL)
+		return
+	}
 	ec.cache.Set(ctx, env.UUID, env, envCacheTTL)
 }
 

--- a/pkg/settings/redis_cache_test.go
+++ b/pkg/settings/redis_cache_test.go
@@ -1,0 +1,174 @@
+package settings
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+func newSettingsRedisTestClient(t *testing.T) (*redis.Client, *settingsRedisFakeStore) {
+	t.Helper()
+
+	store := &settingsRedisFakeStore{
+		values:  make(map[string][]byte),
+		expires: make(map[string]time.Duration),
+	}
+	client := redis.NewClient(&redis.Options{
+		Addr:     "fake-redis",
+		PoolSize: 1,
+		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			serverConn, clientConn := net.Pipe()
+			go serveSettingsRedisFake(serverConn, store)
+			return clientConn, nil
+		},
+	})
+
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	return client, store
+}
+
+type settingsRedisFakeStore struct {
+	mu      sync.Mutex
+	values  map[string][]byte
+	expires map[string]time.Duration
+}
+
+func serveSettingsRedisFake(conn net.Conn, store *settingsRedisFakeStore) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	for {
+		args, err := readSettingsRESPArray(reader)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				_, _ = conn.Write([]byte("-ERR read failed\r\n"))
+			}
+			return
+		}
+		if len(args) == 0 {
+			_, _ = conn.Write([]byte("-ERR empty command\r\n"))
+			return
+		}
+
+		if err := handleSettingsRedisCommand(conn, store, args); err != nil {
+			_, _ = conn.Write([]byte("-ERR " + err.Error() + "\r\n"))
+			return
+		}
+	}
+}
+
+func handleSettingsRedisCommand(conn net.Conn, store *settingsRedisFakeStore, args []string) error {
+	switch strings.ToUpper(args[0]) {
+	case "GET":
+		value, ok := store.get(args[1])
+		if !ok {
+			_, err := conn.Write([]byte("$-1\r\n"))
+			return err
+		}
+		_, err := fmt.Fprintf(conn, "$%d\r\n", len(value))
+		if err != nil {
+			return err
+		}
+		_, err = conn.Write(append(value, []byte("\r\n")...))
+		return err
+
+	case "SET":
+		var ttl time.Duration
+		if len(args) == 5 {
+			seconds, err := strconv.Atoi(args[4])
+			if err != nil {
+				return err
+			}
+			ttl = time.Duration(seconds) * time.Second
+		}
+		store.set(args[1], []byte(args[2]), ttl)
+		_, err := conn.Write([]byte("+OK\r\n"))
+		return err
+
+	case "DEL":
+		for _, key := range args[1:] {
+			store.delete(key)
+		}
+		_, err := fmt.Fprintf(conn, ":%d\r\n", len(args)-1)
+		return err
+
+	case "PING":
+		_, err := conn.Write([]byte("+PONG\r\n"))
+		return err
+
+	default:
+		return fmt.Errorf("unsupported command %q", args[0])
+	}
+}
+
+func readSettingsRESPArray(reader *bufio.Reader) ([]string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+	count, err := strconv.Atoi(strings.TrimPrefix(line, "*"))
+	if err != nil {
+		return nil, err
+	}
+	args := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		header, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		header = strings.TrimSuffix(strings.TrimSuffix(header, "\n"), "\r")
+		size, err := strconv.Atoi(strings.TrimPrefix(header, "$"))
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, size+2)
+		if _, err := io.ReadFull(reader, buf); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf[:size]))
+	}
+	return args, nil
+}
+
+func (s *settingsRedisFakeStore) set(key string, value []byte, ttl time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.values[key] = append([]byte(nil), value...)
+	if ttl > 0 {
+		s.expires[key] = ttl
+	}
+}
+
+func (s *settingsRedisFakeStore) get(key string) ([]byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	value, ok := s.values[key]
+	if !ok {
+		return nil, false
+	}
+	return append([]byte(nil), value...), true
+}
+
+func (s *settingsRedisFakeStore) delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.values, key)
+	delete(s.expires, key)
+}

--- a/pkg/settings/settings-cache.go
+++ b/pkg/settings/settings-cache.go
@@ -1,0 +1,61 @@
+package settings
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/jmpsec/osctrl/pkg/cache"
+)
+
+const redisSettingsCacheName = "osctrl:tls:settings"
+
+// RedisSettingsCache caches a service/env settings map in Redis.
+type RedisSettingsCache struct {
+	settings *Settings
+	cache    *cache.RedisJSONCache[MapSettings]
+	service  string
+	envID    uint
+	ttl      time.Duration
+}
+
+// NewRedisSettingsCache creates a Redis-backed cache for settings.GetMap.
+func NewRedisSettingsCache(settings *Settings, client *redis.Client, service string, envID uint, ttl time.Duration) *RedisSettingsCache {
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	return &RedisSettingsCache{
+		settings: settings,
+		cache:    cache.NewRedisJSONCache[MapSettings](client, redisSettingsCacheName),
+		service:  service,
+		envID:    envID,
+		ttl:      ttl,
+	}
+}
+
+// GetMap returns the cached settings map, refetching from DB on Redis miss/error.
+func (c *RedisSettingsCache) GetMap(ctx context.Context) (MapSettings, error) {
+	key := c.key()
+	if cached, found, err := c.cache.Get(ctx, key); err == nil && found {
+		return cached, nil
+	} else if err != nil {
+		_ = c.cache.Delete(ctx, key)
+	}
+
+	values, err := c.settings.GetMap(c.service, c.envID)
+	if err != nil {
+		return MapSettings{}, err
+	}
+	_ = c.cache.Set(ctx, key, values, c.ttl)
+	return values, nil
+}
+
+// Invalidate removes the cached settings map.
+func (c *RedisSettingsCache) Invalidate(ctx context.Context) error {
+	return c.cache.Delete(ctx, c.key())
+}
+
+func (c *RedisSettingsCache) key() string {
+	return fmt.Sprintf("%s:%d", c.service, c.envID)
+}

--- a/pkg/settings/settings-cache_test.go
+++ b/pkg/settings/settings-cache_test.go
@@ -1,0 +1,49 @@
+package settings
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisSettingsCacheReturnsCachedMapAfterDatabaseChanges(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	conf := &Settings{DB: db}
+	require.NoError(t, conf.NewIntegerValue(config.ServiceTLS, AcceleratedSeconds, 60, NoEnvironmentID))
+
+	client, _ := newSettingsRedisTestClient(t)
+	cache := NewRedisSettingsCache(conf, client, config.ServiceTLS, NoEnvironmentID, time.Minute)
+
+	ctx := context.Background()
+	first, err := cache.GetMap(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(60), first[AcceleratedSeconds].Integer)
+
+	require.NoError(t, conf.SetInteger(10, config.ServiceTLS, AcceleratedSeconds, NoEnvironmentID))
+
+	second, err := cache.GetMap(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(60), second[AcceleratedSeconds].Integer)
+}
+
+func TestRedisSettingsCacheRefreshesAfterInvalidation(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	conf := &Settings{DB: db}
+	require.NoError(t, conf.NewIntegerValue(config.ServiceTLS, AcceleratedSeconds, 60, NoEnvironmentID))
+
+	client, _ := newSettingsRedisTestClient(t)
+	cache := NewRedisSettingsCache(conf, client, config.ServiceTLS, NoEnvironmentID, time.Minute)
+
+	ctx := context.Background()
+	_, err := cache.GetMap(ctx)
+	require.NoError(t, err)
+	require.NoError(t, conf.SetInteger(10, config.ServiceTLS, AcceleratedSeconds, NoEnvironmentID))
+	require.NoError(t, cache.Invalidate(ctx))
+
+	got, err := cache.GetMap(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), got[AcceleratedSeconds].Integer)
+}


### PR DESCRIPTION
## Summary

Replaced the TLS service pseudo-cache for environments/settings with Redis-backed cache wiring.

## Changes

- Added a typed Redis JSON cache helper for reusable `GET`/`SET`/`DEL` storage of structured values.
- Updated `EnvCache` to support Redis-backed environment caching with DB fallback on miss/error.
- Kept API-to-TLS environment invalidation, now using a shared invalidation key prefix constant.
- Added a Redis-backed TLS settings cache for settings such as `accelerated_seconds`.
- Removed the TLS process-local `envsmap` / `settingsmap` globals and their periodic refresh goroutines.
- Updated TLS handlers to use `EnvCache.GetByUUID(...)` consistently across osquery, osctrld, quick enroll, package download, and config endpoint paths.
- Replaced handler debug checks from stale map lookups to the already-loaded cached environment.

## Validation

- `GOCACHE=/tmp/osctrl-gocache go test ./pkg/cache ./pkg/settings ./pkg/environments ./cmd/tls/handlers ./cmd/tls ./cmd/api/handlers`
- `GOCACHE=/tmp/osctrl-gocache go test ./...`

## Security Notes

- Redis cache failures fall back to database reads rather than changing request authorization or validation behavior.
- No cached payloads, enroll secrets, tokens, or Redis values are logged by the new cache helpers.
- Existing TLS input validation and API/admin permission checks were left unchanged.