### PR TITLE
Flag to enable accelerated mode in osquery distributed queries

### DIFF
--- a/cmd/tls/handlers/debug_http_filter_test.go
+++ b/cmd/tls/handlers/debug_http_filter_test.go
@@ -61,3 +61,10 @@ func TestShouldDebugHTTPNilConfig(t *testing.T) {
 	assert.False(t, h.shouldDebugHTTP("DEADBEEF-1234"))
 	assert.False(t, h.debugHTTPAll())
 }
+
+func TestAllowsAcceleratedQueriesRequiresConfigAndQuerySignal(t *testing.T) {
+	assert.False(t, (&HandlersTLS{}).allowsAcceleratedQueries(true))
+	assert.False(t, (&HandlersTLS{OsqueryValues: &config.YAMLConfigurationOsquery{Accelerated: false}}).allowsAcceleratedQueries(true))
+	assert.False(t, (&HandlersTLS{OsqueryValues: &config.YAMLConfigurationOsquery{Accelerated: true}}).allowsAcceleratedQueries(false))
+	assert.True(t, (&HandlersTLS{OsqueryValues: &config.YAMLConfigurationOsquery{Accelerated: true}}).allowsAcceleratedQueries(true))
+}

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -263,6 +263,10 @@ func (h *HandlersTLS) debugHTTPAll() bool {
 	return h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP && h.DebugHTTPConfig.TargetHostIdentifier == ""
 }
 
+func (h *HandlersTLS) allowsAcceleratedQueries(queryAccelerated bool) bool {
+	return queryAccelerated && h.OsqueryValues != nil && h.OsqueryValues.Accelerated
+}
+
 func (h *HandlersTLS) acceleratedSeconds(ctx context.Context) int {
 	if h.SettingsCache != nil {
 		values, err := h.SettingsCache.GetMap(ctx)

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -463,7 +463,7 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 		accelerate = false
 	}
 	// Serialize queries
-	if accelerate {
+	if h.allowsAcceleratedQueries(accelerate) {
 		sAccelerate := h.acceleratedSeconds(r.Context())
 		response = types.AcceleratedQueryReadResponse{Queries: qs, Accelerate: sAccelerate, NodeInvalid: nodeInvalid}
 	} else {

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -70,6 +70,7 @@ osquery:
   config: true
   query: true
   carve: true
+  accelerated: false
 
 # Osctrl daemon configuration
 osctrld:

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -895,6 +895,13 @@ func initOsqueryFlags(params *ServiceParameters) []cli.Flag {
 			Destination: &params.Osquery.Carve,
 		},
 		&cli.BoolFlag{
+			Name:        "osquery-accelerated",
+			Value:       false,
+			Usage:       "Enable accelerated mode when returning distributed queries to osquery",
+			Sources:     cli.EnvVars("OSQUERY_ACCELERATED"),
+			Destination: &params.Osquery.Accelerated,
+		},
+		&cli.BoolFlag{
 			Name:        "read-only-configuration",
 			Value:       false,
 			Usage:       "Disable configuration changes via admin or api services",

--- a/pkg/config/flags_test.go
+++ b/pkg/config/flags_test.go
@@ -31,3 +31,29 @@ func TestServicePostureEnabledFlagDefaultsOff(t *testing.T) {
 		t.Fatalf("posture-enabled flag destination does not wire Service.PostureEnabled")
 	}
 }
+
+func TestOsqueryAcceleratedFlagDefaultsOff(t *testing.T) {
+	params := &ServiceParameters{Osquery: &YAMLConfigurationOsquery{}}
+	flags := initOsqueryFlags(params)
+
+	if params.Osquery.Accelerated {
+		t.Fatalf("accelerated osquery default: got true want false")
+	}
+
+	var acceleratedFlag *cli.BoolFlag
+	for _, flag := range flags {
+		if f, ok := flag.(*cli.BoolFlag); ok && f.Name == "osquery-accelerated" {
+			acceleratedFlag = f
+			break
+		}
+	}
+	if acceleratedFlag == nil {
+		t.Fatalf("missing osquery-accelerated flag")
+	}
+	if acceleratedFlag.Value {
+		t.Fatalf("osquery-accelerated flag default: got true want false")
+	}
+	if acceleratedFlag.Destination != &params.Osquery.Accelerated {
+		t.Fatalf("osquery-accelerated flag destination does not wire Osquery.Accelerated")
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -168,13 +168,14 @@ type YAMLConfigurationRedis struct {
 
 // YAMLConfigurationOsquery to hold the osquery configuration values
 type YAMLConfigurationOsquery struct {
-	Version    string `yaml:"version"`
-	TablesFile string `yaml:"tablesFile"`
-	Logger     bool   `yaml:"logger"`
-	Config     bool   `yaml:"config"`
-	Query      bool   `yaml:"query"`
-	Carve      bool   `yaml:"carve"`
-	ReadOnly   bool   `yaml:"readOnly"`
+	Version     string `yaml:"version"`
+	TablesFile  string `yaml:"tablesFile"`
+	Logger      bool   `yaml:"logger"`
+	Config      bool   `yaml:"config"`
+	Query       bool   `yaml:"query"`
+	Carve       bool   `yaml:"carve"`
+	Accelerated bool   `yaml:"accelerated"`
+	ReadOnly    bool   `yaml:"readOnly"`
 }
 
 // YAMLConfigurationEndpoints to hold the configuration endpoints that will receive osquery configuration updates


### PR DESCRIPTION
Adding osquery specific param/flag to enable osquery accelerated mode: `--osquery-accelerated` or env variable `OSQUERY_ACCELERATED`