### PR TITLE
Replace pseudo-cache with proper cache in `osctrl-api`

### DIFF
--- a/cmd/api/handlers/env_cache.go
+++ b/cmd/api/handlers/env_cache.go
@@ -1,0 +1,15 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+)
+
+func (h *HandlersApi) invalidateEnvCache(ctx context.Context, uuid string) {
+	if h.EnvCache == nil || uuid == "" {
+		return
+	}
+	h.EnvCache.InvalidateEnv(ctx, uuid)
+	log.Debug().Str("env", uuid).Msg("invalidated environment cache")
+}

--- a/cmd/api/handlers/env_cache_test.go
+++ b/cmd/api/handlers/env_cache_test.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+)
+
+func TestWithEnvCacheWiresEnvironmentCache(t *testing.T) {
+	envCache := &environments.EnvCache{}
+
+	h := CreateHandlersApi(WithEnvCache(envCache))
+
+	if h.EnvCache != envCache {
+		t.Fatalf("EnvCache was not wired")
+	}
+}

--- a/cmd/api/handlers/environments.go
+++ b/cmd/api/handlers/environments.go
@@ -532,6 +532,7 @@ func (h *HandlersApi) EnvEnrollActionsHandler(w http.ResponseWriter, r *http.Req
 		apiErrorResponse(w, "invalid action", http.StatusBadRequest, fmt.Errorf("invalid action %s", actionVar))
 		return
 	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	// Return query name as serialized response
 	log.Debug().Msgf("Returned data for environment %s : %s", env.Name, msgReturn)
 	h.AuditLog.EnvAction(ctx[ctxUser], actionVar+" enrollment for environment "+env.Name, strings.Split(r.RemoteAddr, ":")[0], env.ID)
@@ -626,6 +627,7 @@ func (h *HandlersApi) EnvRemoveActionsHandler(w http.ResponseWriter, r *http.Req
 		apiErrorResponse(w, "invalid action", http.StatusBadRequest, fmt.Errorf("invalid action %s", actionVar))
 		return
 	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	// Return query name as serialized response
 	log.Debug().Msgf("Returned data for environment %s : %s", env.Name, msgReturn)
 	h.AuditLog.EnvAction(ctx[ctxUser], actionVar+" removal for environment "+env.Name, strings.Split(r.RemoteAddr, ":")[0], env.ID)
@@ -739,6 +741,7 @@ func (h *HandlersApi) EnvActionsHandler(w http.ResponseWriter, r *http.Request) 
 				}
 			}
 			msgReturn = "environment created successfully"
+			h.invalidateEnvCache(r.Context(), env.UUID)
 		} else {
 			apiErrorResponse(w, "environment already exists", http.StatusBadRequest, fmt.Errorf("environment %s already exists", e.Name))
 			return
@@ -774,6 +777,7 @@ func (h *HandlersApi) EnvActionsHandler(w http.ResponseWriter, r *http.Request) 
 			apiErrorResponse(w, "error deleting environment", http.StatusInternalServerError, err)
 			return
 		}
+		h.invalidateEnvCache(r.Context(), targetEnv.UUID)
 		msgReturn = "environment deleted successfully"
 	case "edit":
 		// Verify request fields
@@ -790,6 +794,7 @@ func (h *HandlersApi) EnvActionsHandler(w http.ResponseWriter, r *http.Request) 
 				apiErrorResponse(w, "error updating hostname", http.StatusInternalServerError, err)
 				return
 			}
+			h.invalidateEnvCache(r.Context(), e.UUID)
 			msgReturn = "environment updated successfully"
 		} else {
 			apiErrorResponse(w, "environment not found", http.StatusNotFound, fmt.Errorf("environment %s not found", e.UUID))
@@ -914,6 +919,7 @@ func (h *HandlersApi) EnvCertUploadHandler(w http.ResponseWriter, r *http.Reques
 		apiErrorResponse(w, "error saving certificate", http.StatusInternalServerError, err)
 		return
 	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	log.Debug().Msgf("Certificate updated for environment %s", env.Name)
 	h.AuditLog.EnvAction(ctx[ctxUser], "upload certificate for environment "+env.Name, strings.Split(r.RemoteAddr, ":")[0], env.ID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: "certificate uploaded successfully"})

--- a/cmd/api/handlers/environments_crud.go
+++ b/cmd/api/handlers/environments_crud.go
@@ -1,13 +1,11 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/environments"
@@ -96,6 +94,7 @@ func (h *HandlersApi) EnvironmentCreateHandler(w http.ResponseWriter, r *http.Re
 		apiErrorResponse(w, "error creating environment", http.StatusInternalServerError, err)
 		return
 	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	// Grant the creating user full access to the new environment so it shows up
 	// in their env list immediately (matches the legacy admin behaviour).
 	access := h.Users.GenEnvUserAccess([]string{env.UUID}, true, true, true, true)
@@ -254,6 +253,7 @@ func (h *HandlersApi) EnvironmentUpdateHandler(w http.ResponseWriter, r *http.Re
 		apiErrorResponse(w, "error updating environment", http.StatusInternalServerError, err)
 		return
 	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	updated, _ := h.Envs.Get(envVar)
 	h.AuditLog.EnvAction(ctx[ctxUser], "update env "+env.Name, strings.Split(r.RemoteAddr, ":")[0], env.ID)
 	log.Debug().Msgf("Updated environment %s", env.Name)
@@ -306,6 +306,7 @@ func (h *HandlersApi) EnvironmentDeleteHandler(w http.ResponseWriter, r *http.Re
 		apiErrorResponse(w, "error deleting environment", http.StatusInternalServerError, err)
 		return
 	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	h.AuditLog.EnvAction(ctx[ctxUser], "delete env "+env.Name, strings.Split(r.RemoteAddr, ":")[0], env.ID)
 	log.Debug().Msgf("Deleted environment %s", env.Name)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: fmt.Sprintf("environment %s deleted", env.Name)})
@@ -505,15 +506,7 @@ func (h *HandlersApi) EnvironmentConfigPatchHandler(w http.ResponseWriter, r *ht
 			return
 		}
 	}
-	// Signal osctrl-tls to invalidate its EnvCache for this env so
-	// agents receive the updated configuration on their next /config
-	// request instead of waiting for the cache TTL to expire.
-	if h.RedisCache != nil {
-		ctx := context.Background()
-		if err := h.RedisCache.Client.Set(ctx, environments.RedisEnvInvalidatePrefix+env.UUID, "1", 60*time.Second).Err(); err != nil {
-			log.Warn().Err(err).Str("env", env.UUID).Msg("failed to signal env cache invalidation")
-		}
-	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	h.AuditLog.ConfAction(ctx[ctxUser], "config patch on env "+env.Name, strings.Split(r.RemoteAddr, ":")[0], env.ID)
 	updated, _ := h.Envs.Get(envVar)
 	resp := types.EnvConfigResponse{
@@ -605,6 +598,7 @@ func (h *HandlersApi) EnvironmentIntervalsPatchHandler(w http.ResponseWriter, r 
 		apiErrorResponse(w, "error updating intervals", http.StatusInternalServerError, err)
 		return
 	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	h.AuditLog.ConfAction(ctx[ctxUser],
 		fmt.Sprintf("intervals patch on env %s: config=%d log=%d query=%d", env.Name, cfg, lg, qr),
 		strings.Split(r.RemoteAddr, ":")[0], env.ID)
@@ -689,6 +683,7 @@ func (h *HandlersApi) EnvironmentExpirationPatchHandler(w http.ResponseWriter, r
 		apiErrorResponse(w, "action must be one of: extend, expire, rotate, not-expire", http.StatusBadRequest, nil)
 		return
 	}
+	h.invalidateEnvCache(r.Context(), env.UUID)
 	h.AuditLog.EnvAction(ctx[ctxUser], body.Action+" enrollment for env "+env.Name, strings.Split(r.RemoteAddr, ":")[0], env.ID)
 	updated, _ := h.Envs.Get(envVar)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, updated)

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"github.com/jmpsec/osctrl/pkg/auditlog"
-	"github.com/jmpsec/osctrl/pkg/cache"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
@@ -28,11 +27,11 @@ type HandlersApi struct {
 	Users           *users.UserManager
 	Tags            *tags.TagManager
 	Envs            *environments.EnvManager
+	EnvCache        *environments.EnvCache
 	Nodes           *nodes.NodeManager
 	Queries         *queries.Queries
 	Carves          *carves.Carves
 	Settings        *settings.Settings
-	RedisCache      *cache.RedisManager
 	Activity        activityReader
 	GeoIP           *geoip.GeoIPResolver
 	Posture         *posture.PostureManager
@@ -92,6 +91,12 @@ func WithEnvs(envs *environments.EnvManager) HandlersOption {
 	}
 }
 
+func WithEnvCache(envCache *environments.EnvCache) HandlersOption {
+	return func(h *HandlersApi) {
+		h.EnvCache = envCache
+	}
+}
+
 func WithNodes(nodes *nodes.NodeManager) HandlersOption {
 	return func(h *HandlersApi) {
 		h.Nodes = nodes
@@ -113,12 +118,6 @@ func WithCarves(carves *carves.Carves) HandlersOption {
 func WithSettings(settings *settings.Settings) HandlersOption {
 	return func(h *HandlersApi) {
 		h.Settings = settings
-	}
-}
-
-func WithCache(rds *cache.RedisManager) HandlersOption {
-	return func(h *HandlersApi) {
-		h.RedisCache = rds
 	}
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -299,6 +299,8 @@ func osctrlAPIService() {
 
 	log.Info().Msg("Initialize environment")
 	envs = environments.CreateEnvironment(db.Conn)
+	envCache := environments.NewRedisEnvCache(*envs, redis.Client)
+	log.Info().Msg("Environment cache wired to Redis")
 	// Security & compliance posture system (disabled by default)
 	var posturemgr *posture.PostureManager
 	if flagParams.Service.PostureEnabled {
@@ -368,13 +370,13 @@ func osctrlAPIService() {
 	handlersApi = handlers.CreateHandlersApi(
 		handlers.WithDB(db.Conn),
 		handlers.WithEnvs(envs),
+		handlers.WithEnvCache(envCache),
 		handlers.WithUsers(apiUsers),
 		handlers.WithTags(tagsmgr),
 		handlers.WithNodes(nodesmgr),
 		handlers.WithQueries(queriesmgr),
 		handlers.WithCarves(filecarves),
 		handlers.WithSettings(settingsmgr),
-		handlers.WithCache(redis),
 		handlers.WithActivityReader(activity.NewRedisStore(redis.Client, activity.DefaultPrefix, activity.DefaultRetentionDays, 8*24*time.Hour)),
 		handlers.WithGeoIP(geoIPResolver),
 		handlers.WithPosture(posturemgr),

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -208,10 +208,9 @@ func osctrlService() {
 	envs = environments.CreateEnvironment(db.Conn)
 
 	// Build EnvCache with Redis-backed cross-process invalidation.
-	// When osctrl-api patches an env config, it sets a Redis key
-	// (envcache:invalidate:{uuid}) so osctrl-tls picks up the change
-	// on the next /config request instead of serving stale data for
-	// the full TTL.
+	// osctrl-api now invalidates the same Redis-backed EnvCache directly
+	// after env mutations so osctrl-tls picks up changes on the next
+	// request instead of serving stale data for the full TTL.
 	envCache := environments.NewRedisEnvCache(*envs, redis.Client)
 	envCache.SetInvalidationCheck(func(ctx context.Context, uuid string) bool {
 		n, err := redis.Client.Exists(ctx, environments.RedisEnvInvalidatePrefix+uuid).Result()

--- a/pkg/environments/env-cache.go
+++ b/pkg/environments/env-cache.go
@@ -15,17 +15,15 @@ const (
 	// envCacheTTL is the maximum time a TLSEnvironment can sit in the
 	// EnvCache before the next request refetches from the database.
 	//
-	// osctrl-tls holds this cache; osctrl-api mutates env rows in the
-	// same DB from a different process. There is no IPC channel between
-	// the two, so envCache invalidation is TTL-based — the TTL bounds
-	// the window during which enroll-secret rotations, env deletions,
-	// or config-PATCH changes can be served stale by osctrl-tls.
+	// osctrl-tls and osctrl-api share this Redis-backed cache across
+	// processes. The TTL bounds the window during which enroll-secret
+	// rotations, env deletions, or config-PATCH changes can be served
+	// stale if Redis invalidation is unavailable.
 	//
 	// 5 minutes: the fallback window if no invalidation signal is
-	// received. With Redis-based invalidation wired in (see
-	// SetInvalidationCheck), config PATCHes are picked up immediately;
-	// this TTL only bounds the worst case (Redis down, API and TLS
-	// can't communicate). 5m keeps DB load low while limiting staleness.
+	// received. With Redis-backed EnvCache invalidation wired in, config
+	// PATCHes are picked up immediately; this TTL only bounds the worst
+	// case. 5m keeps DB load low while limiting staleness.
 	envCacheTTL = 5 * time.Minute
 )
 
@@ -41,8 +39,8 @@ type EnvCache struct {
 
 	// invalidationCheck is called on each GetByUUID. If it returns
 	// true, the cached entry is stale and the env is refetched from
-	// the DB. Set via SetInvalidationCheck — typically a function
-	// that checks a Redis key set by osctrl-api after a config PATCH.
+	// the DB. Set via SetInvalidationCheck for compatibility with
+	// external invalidation signals.
 	invalidationCheck func(ctx context.Context, uuid string) bool
 }
 
@@ -70,9 +68,7 @@ func NewRedisEnvCache(envs EnvManager, client *redis.Client) *EnvCache {
 
 // SetInvalidationCheck wires a callback that is called on each
 // GetByUUID. If the callback returns true, the cached entry is
-// considered stale and the env is refetched from the DB. The typical
-// implementation checks a Redis key that osctrl-api sets after
-// mutating an env row (config PATCH, secret rotation, etc.).
+// considered stale and the env is refetched from the DB.
 func (ec *EnvCache) SetInvalidationCheck(fn func(ctx context.Context, uuid string) bool) {
 	ec.invalidationCheck = fn
 }


### PR DESCRIPTION
## Summary

Remove `osctrl-api`’s direct Redis invalidation marker usage and wire it into the shared Redis-backed environment cache used by `osctrl-tls`.

### Changes

- Added `EnvCache` support to `HandlersApi`.
- Created `invalidateEnvCache(...)` helper for API handlers.
- Initialized `NewRedisEnvCache` in `osctrl-api` startup and passed it into handlers.
- Removed the old `RedisCache` handler dependency used only to set `envcache:invalidate:{uuid}` keys.
- Invalidated the shared environment cache after API environment mutations:
  - create/update/delete
  - config patch
  - interval changes
  - enrollment/removal actions
  - package URL updates
  - certificate uploads
- Updated cache-related comments to reflect direct Redis-backed cache invalidation.

### Validation

```sh
GOCACHE=/tmp/osctrl-gocache go test ./pkg/cache ./pkg/settings ./pkg/environments ./cmd/api/handlers ./cmd/api ./cmd/tls/handlers ./cmd/tls