### PR TITLE
Node-scoped read-only console powered by hidden accelerated distributed queries

### DIFF
--- a/cmd/api/handlers/console.go
+++ b/cmd/api/handlers/console.go
@@ -189,7 +189,7 @@ func (h *HandlersApi) consoleSessionContext(w http.ResponseWriter, r *http.Reque
 
 func consolePathUint(w http.ResponseWriter, r *http.Request, name string) (uint, bool) {
 	value := r.PathValue(name)
-	id, err := strconv.ParseUint(value, 10, 64)
+	id, err := strconv.ParseUint(value, 10, strconv.IntSize)
 	if value == "" || err != nil {
 		apiErrorResponse(w, "invalid "+name, http.StatusBadRequest, err)
 		return 0, false

--- a/cmd/api/handlers/console.go
+++ b/cmd/api/handlers/console.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+	"gorm.io/gorm"
+)
+
+type consoleCommandRequest struct {
+	Input string `json:"input"`
+}
+
+type consoleCommandResponse struct {
+	Command console.Command       `json:"command"`
+	Parsed  console.ParsedCommand `json:"parsed"`
+}
+
+func (h *HandlersApi) ConsoleSessionCreateHandler(w http.ResponseWriter, r *http.Request) {
+	env, ctx, ok := h.consoleEnvContext(w, r)
+	if !ok {
+		return
+	}
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
+		apiErrorResponse(w, "missing node uuid", http.StatusBadRequest, nil)
+		return
+	}
+	node, err := h.Nodes.GetByUUIDEnv(uuid, env.ID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErrorResponse(w, "node not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error getting node", http.StatusInternalServerError, err)
+		return
+	}
+	session, err := h.Console.CreateSession(env, node, ctx[ctxUser])
+	if err != nil {
+		apiErrorResponse(w, "error creating console session", http.StatusInternalServerError, err)
+		return
+	}
+	h.auditConsoleVisit(ctx[ctxUser], r, env.ID)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, session)
+}
+
+func (h *HandlersApi) ConsoleSessionShowHandler(w http.ResponseWriter, r *http.Request) {
+	env, ctx, session, ok := h.consoleSessionContext(w, r)
+	if !ok {
+		return
+	}
+	h.auditConsoleVisit(ctx[ctxUser], r, env.ID)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, session)
+}
+
+func (h *HandlersApi) ConsoleSessionDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	_, _, session, ok := h.consoleSessionContext(w, r)
+	if !ok {
+		return
+	}
+	if err := h.Console.CloseSession(session.ID); err != nil {
+		apiErrorResponse(w, "error closing console session", http.StatusInternalServerError, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: "console session closed"})
+}
+
+func (h *HandlersApi) ConsoleCommandCreateHandler(w http.ResponseWriter, r *http.Request) {
+	env, ctx, session, ok := h.consoleSessionContext(w, r)
+	if !ok {
+		return
+	}
+	var body consoleCommandRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing POST body", http.StatusBadRequest, err)
+		return
+	}
+	command, parsed, err := h.Console.SubmitCommand(session.ID, body.Input)
+	if err != nil {
+		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
+		return
+	}
+	if h.AuditLog != nil {
+		h.AuditLog.QueryAction(ctx[ctxUser], "console command "+parsed.Command, strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, consoleCommandResponse{Command: command, Parsed: parsed})
+}
+
+func (h *HandlersApi) ConsoleCommandShowHandler(w http.ResponseWriter, r *http.Request) {
+	_, _, session, ok := h.consoleSessionContext(w, r)
+	if !ok {
+		return
+	}
+	commandID, ok := consolePathUint(w, r, "command_id")
+	if !ok {
+		return
+	}
+	command, err := h.Console.GetCommand(session.ID, commandID)
+	if err != nil {
+		consoleNotFoundOrError(w, "command not found", "error getting command", err)
+		return
+	}
+	command, err = h.Console.RefreshCommandStatus(command.ID)
+	if err != nil {
+		apiErrorResponse(w, "error refreshing command", http.StatusInternalServerError, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, command)
+}
+
+func (h *HandlersApi) ConsoleCommandResultsHandler(w http.ResponseWriter, r *http.Request) {
+	_, _, session, ok := h.consoleSessionContext(w, r)
+	if !ok {
+		return
+	}
+	commandID, ok := consolePathUint(w, r, "command_id")
+	if !ok {
+		return
+	}
+	command, err := h.Console.GetCommand(session.ID, commandID)
+	if err != nil {
+		consoleNotFoundOrError(w, "command not found", "error getting command", err)
+		return
+	}
+	results, err := h.Console.CommandResults(command.ID)
+	if err != nil {
+		apiErrorResponse(w, "error getting command results", http.StatusInternalServerError, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, results)
+}
+
+func (h *HandlersApi) consoleEnvContext(w http.ResponseWriter, r *http.Request) (environments.TLSEnvironment, ContextValue, bool) {
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		apiErrorResponse(w, "missing env", http.StatusBadRequest, nil)
+		return environments.TLSEnvironment{}, nil, false
+	}
+	env, err := h.Envs.Get(envVar)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
+			return environments.TLSEnvironment{}, nil, false
+		}
+		apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, err)
+		return environments.TLSEnvironment{}, nil, false
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.QueryLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return environments.TLSEnvironment{}, nil, false
+	}
+	return env, ctx, true
+}
+
+func (h *HandlersApi) consoleSessionContext(w http.ResponseWriter, r *http.Request) (environments.TLSEnvironment, ContextValue, console.Session, bool) {
+	env, ctx, ok := h.consoleEnvContext(w, r)
+	if !ok {
+		return environments.TLSEnvironment{}, nil, console.Session{}, false
+	}
+	sessionID, ok := consolePathUint(w, r, "session_id")
+	if !ok {
+		return environments.TLSEnvironment{}, nil, console.Session{}, false
+	}
+	session, err := h.Console.GetSession(sessionID)
+	if err != nil {
+		consoleNotFoundOrError(w, "session not found", "error getting session", err)
+		return environments.TLSEnvironment{}, nil, console.Session{}, false
+	}
+	if session.EnvironmentID != env.ID {
+		apiErrorResponse(w, "session not found", http.StatusNotFound, nil)
+		return environments.TLSEnvironment{}, nil, console.Session{}, false
+	}
+	if session.Creator != ctx[ctxUser] {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use console session by user %s", ctx[ctxUser]))
+		return environments.TLSEnvironment{}, nil, console.Session{}, false
+	}
+	return env, ctx, session, true
+}
+
+func consolePathUint(w http.ResponseWriter, r *http.Request, name string) (uint, bool) {
+	value := r.PathValue(name)
+	id, err := strconv.ParseUint(value, 10, 64)
+	if value == "" || err != nil {
+		apiErrorResponse(w, "invalid "+name, http.StatusBadRequest, err)
+		return 0, false
+	}
+	return uint(id), true
+}
+
+func consoleNotFoundOrError(w http.ResponseWriter, notFoundMsg, errorMsg string, err error) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		apiErrorResponse(w, notFoundMsg, http.StatusNotFound, err)
+		return
+	}
+	apiErrorResponse(w, errorMsg, http.StatusInternalServerError, err)
+}
+
+func (h *HandlersApi) auditConsoleVisit(user string, r *http.Request, envID uint) {
+	if h.AuditLog != nil {
+		h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], envID)
+	}
+}

--- a/cmd/api/handlers/console_test.go
+++ b/cmd/api/handlers/console_test.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupConsoleHandlers(t *testing.T) (*gorm.DB, *HandlersApi, environments.TLSEnvironment, nodes.OsqueryNode) {
+	t.Helper()
+
+	dsn := "file:" + strings.NewReplacer("/", "_", " ", "_").Replace(t.Name()) + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+
+	envs := environments.CreateEnvironment(db)
+	nodesmgr := nodes.CreateNodes(db)
+	queryManager := queries.CreateQueries(db)
+	consoleManager := console.NewManager(db, queryManager)
+	userManager := users.CreateUserManager(db)
+
+	env := environments.TLSEnvironment{UUID: "env-uuid", Name: "env"}
+	require.NoError(t, db.Create(&env).Error)
+	node := nodes.OsqueryNode{UUID: "NODE-UUID", Platform: "linux", EnvironmentID: env.ID, Environment: env.UUID}
+	require.NoError(t, db.Create(&node).Error)
+
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "alice"}))
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "bob"}))
+	require.NoError(t, userManager.CreatePermission(users.UserPermission{
+		Username:      "alice",
+		AccessType:    int(users.QueryLevel),
+		AccessValue:   true,
+		Environment:   env.UUID,
+		EnvironmentID: env.ID,
+	}))
+
+	h := CreateHandlersApi(
+		WithDB(db),
+		WithEnvs(envs),
+		WithUsers(userManager),
+		WithNodes(nodesmgr),
+		WithQueries(queryManager),
+		WithConsole(consoleManager),
+	)
+	return db, h, env, node
+}
+
+func TestConsoleSessionCreateRequiresQueryPermission(t *testing.T) {
+	_, h, env, node := setupConsoleHandlers(t)
+
+	req := consoleRequest(http.MethodPost, "/console", nil, "bob")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("uuid", node.UUID)
+	rr := httptest.NewRecorder()
+
+	h.ConsoleSessionCreateHandler(rr, req)
+	require.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestConsoleSessionCreateRejectsNodeFromOtherEnv(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	otherEnv := environments.TLSEnvironment{UUID: "other-env-uuid", Name: "other-env"}
+	require.NoError(t, db.Create(&otherEnv).Error)
+	require.NoError(t, db.Model(&node).Updates(map[string]any{"environment_id": otherEnv.ID, "environment": otherEnv.UUID}).Error)
+
+	req := consoleRequest(http.MethodPost, "/console", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("uuid", node.UUID)
+	rr := httptest.NewRecorder()
+
+	h.ConsoleSessionCreateHandler(rr, req)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestConsoleCommandRejectsSecondInFlightCommand(t *testing.T) {
+	_, h, env, node := setupConsoleHandlers(t)
+	session, err := h.Console.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	first := consoleRequest(http.MethodPost, "/console", []byte(`{"input":"ps"}`), "alice")
+	first.SetPathValue("env", env.Name)
+	first.SetPathValue("session_id", fmt.Sprint(session.ID))
+	firstRR := httptest.NewRecorder()
+	h.ConsoleCommandCreateHandler(firstRR, first)
+	require.Equal(t, http.StatusCreated, firstRR.Code)
+
+	second := consoleRequest(http.MethodPost, "/console", []byte(`{"input":"ls"}`), "alice")
+	second.SetPathValue("env", env.Name)
+	second.SetPathValue("session_id", fmt.Sprint(session.ID))
+	secondRR := httptest.NewRecorder()
+	h.ConsoleCommandCreateHandler(secondRR, second)
+	require.Equal(t, http.StatusBadRequest, secondRR.Code)
+}
+
+func consoleRequest(method, target string, body []byte, username string) *http.Request {
+	req := httptest.NewRequest(method, target, bytes.NewReader(body))
+	ctx := context.WithValue(req.Context(), ContextKey(contextAPI), ContextValue{ctxUser: username})
+	return req.WithContext(ctx)
+}

--- a/cmd/api/handlers/features.go
+++ b/cmd/api/handlers/features.go
@@ -8,7 +8,8 @@ import (
 
 // FeaturesResponse advertises server-side feature switches consumed by the SPA.
 type FeaturesResponse struct {
-	Posture bool `json:"posture"`
+	Posture     bool `json:"posture"`
+	Accelerated bool `json:"accelerated"`
 }
 
 // FeaturesHandler — GET /api/v1/features.
@@ -17,6 +18,7 @@ func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 		utils.DebugHTTPDump(h.DebugHTTP, r, false)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, FeaturesResponse{
-		Posture: h.PostureEnabled,
+		Posture:     h.PostureEnabled,
+		Accelerated: h.OsqueryValues.Accelerated,
 	})
 }

--- a/cmd/api/handlers/features_test.go
+++ b/cmd/api/handlers/features_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
 )
 
 func TestFeaturesHandlerReportsPostureDisabledByDefault(t *testing.T) {
@@ -23,6 +25,9 @@ func TestFeaturesHandlerReportsPostureDisabledByDefault(t *testing.T) {
 	}
 	if resp.Posture {
 		t.Fatalf("posture feature: got true want false")
+	}
+	if resp.Accelerated {
+		t.Fatalf("accelerated feature: got true want false")
 	}
 }
 
@@ -43,5 +48,25 @@ func TestFeaturesHandlerReportsPostureEnabled(t *testing.T) {
 	}
 	if !resp.Posture {
 		t.Fatalf("posture feature: got false want true")
+	}
+}
+
+func TestFeaturesHandlerReportsAcceleratedEnabled(t *testing.T) {
+	h := &HandlersApi{}
+	WithOsqueryValues(config.YAMLConfigurationOsquery{Accelerated: true})(h)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/features", nil)
+	w := httptest.NewRecorder()
+
+	h.FeaturesHandler(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", w.Code)
+	}
+	var resp FeaturesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Accelerated {
+		t.Fatalf("accelerated feature: got false want true")
 	}
 }

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/geoip"
 	"github.com/jmpsec/osctrl/pkg/logging"
@@ -30,6 +31,7 @@ type HandlersApi struct {
 	EnvCache        *environments.EnvCache
 	Nodes           *nodes.NodeManager
 	Queries         *queries.Queries
+	Console         *console.Manager
 	Carves          *carves.Carves
 	Settings        *settings.Settings
 	Activity        activityReader
@@ -106,6 +108,12 @@ func WithNodes(nodes *nodes.NodeManager) HandlersOption {
 func WithQueries(queries *queries.Queries) HandlersOption {
 	return func(h *HandlersApi) {
 		h.Queries = queries
+	}
+}
+
+func WithConsole(consoleManager *console.Manager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.Console = consoleManager
 	}
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/cache"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/geoip"
 	"github.com/jmpsec/osctrl/pkg/logging"
@@ -123,6 +124,7 @@ var (
 	envs                 *environments.EnvManager
 	nodesmgr             *nodes.NodeManager
 	queriesmgr           *queries.Queries
+	consolemgr           *console.Manager
 	filecarves           *carves.Carves
 	handlersApi          *handlers.HandlersApi
 	app                  *cli.Command
@@ -316,6 +318,8 @@ func osctrlAPIService() {
 	nodesmgr = nodes.CreateNodes(db.Conn)
 	log.Info().Msg("Initialize queries")
 	queriesmgr = queries.CreateQueries(db.Conn)
+	log.Info().Msg("Initialize console")
+	consolemgr = console.NewManager(db.Conn, queriesmgr)
 	log.Info().Msg("Initialize carves")
 	filecarves = carves.CreateFileCarves(db.Conn, flagParams.Carver.Type, nil)
 	log.Info().Msg("Loading service settings")
@@ -375,6 +379,7 @@ func osctrlAPIService() {
 		handlers.WithTags(tagsmgr),
 		handlers.WithNodes(nodesmgr),
 		handlers.WithQueries(queriesmgr),
+		handlers.WithConsole(consolemgr),
 		handlers.WithCarves(filecarves),
 		handlers.WithSettings(settingsmgr),
 		handlers.WithActivityReader(activity.NewRedisStore(redis.Client, activity.DefaultPrefix, activity.DefaultRetentionDays, 8*24*time.Hour)),
@@ -589,6 +594,25 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"POST "+_apiPath(apiQueriesPath)+"/{env}/{action}/{name}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.QueriesActionHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		// API: accelerated per-node console
+		muxAPI.Handle(
+			"POST "+_apiPath("/console")+"/{env}/nodes/{uuid}/sessions",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.ConsoleSessionCreateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath("/console")+"/{env}/sessions/{session_id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.ConsoleSessionShowHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"DELETE "+_apiPath("/console")+"/{env}/sessions/{session_id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.ConsoleSessionDeleteHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath("/console")+"/{env}/sessions/{session_id}/commands",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.ConsoleCommandCreateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath("/console")+"/{env}/sessions/{session_id}/commands/{command_id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.ConsoleCommandShowHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath("/console")+"/{env}/sessions/{session_id}/commands/{command_id}/results",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.ConsoleCommandResultsHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		// API: saved queries (Track 4)
 		muxAPI.Handle(
 			"GET "+_apiPath(apiSavedQueriesPath)+"/{env}",

--- a/frontend/src/api/console.ts
+++ b/frontend/src/api/console.ts
@@ -1,0 +1,56 @@
+import { apiFetch } from './client';
+import type {
+  ConsoleCommand,
+  ConsoleResultRow,
+  ConsoleSession,
+  ParsedConsoleCommand,
+} from './types';
+
+export function createConsoleSession(env: string, uuid: string): Promise<ConsoleSession> {
+  return apiFetch<ConsoleSession>(
+    `/api/v1/console/${encodeURIComponent(env)}/nodes/${encodeURIComponent(uuid)}/sessions`,
+    { method: 'POST' },
+  );
+}
+
+export function closeConsoleSession(env: string, sessionId: number): Promise<{ message: string }> {
+  return apiFetch<{ message: string }>(
+    `/api/v1/console/${encodeURIComponent(env)}/sessions/${sessionId}`,
+    { method: 'DELETE' },
+  );
+}
+
+export function submitConsoleCommand(
+  env: string,
+  sessionId: number,
+  input: string,
+): Promise<{ command: ConsoleCommand; parsed: ParsedConsoleCommand }> {
+  return apiFetch<{ command: ConsoleCommand; parsed: ParsedConsoleCommand }>(
+    `/api/v1/console/${encodeURIComponent(env)}/sessions/${sessionId}/commands`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input }),
+    },
+  );
+}
+
+export function getConsoleCommand(
+  env: string,
+  sessionId: number,
+  commandId: number,
+): Promise<ConsoleCommand> {
+  return apiFetch<ConsoleCommand>(
+    `/api/v1/console/${encodeURIComponent(env)}/sessions/${sessionId}/commands/${commandId}`,
+  );
+}
+
+export function getConsoleCommandResults(
+  env: string,
+  sessionId: number,
+  commandId: number,
+): Promise<ConsoleResultRow[]> {
+  return apiFetch<ConsoleResultRow[]>(
+    `/api/v1/console/${encodeURIComponent(env)}/sessions/${sessionId}/commands/${commandId}/results`,
+  );
+}

--- a/frontend/src/api/features.ts
+++ b/frontend/src/api/features.ts
@@ -2,6 +2,7 @@ import { apiFetch } from './client';
 
 export interface Features {
   posture: boolean;
+  accelerated: boolean;
 }
 
 export function getFeatures(): Promise<Features> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -217,6 +217,51 @@ export type QuerySortColumn =
   | 'errors';
 
 // ---------------------------------------------------------------------------
+// Console types
+// ---------------------------------------------------------------------------
+
+export type ConsoleCommandStatus = 'queued' | 'delivered' | 'completed' | 'error' | 'expired';
+
+export interface ConsoleSession {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  environment_id: number;
+  node_id: number;
+  node_uuid: string;
+  creator: string;
+  cwd: string;
+  platform: string;
+  active: boolean;
+  closed_at?: string;
+}
+
+export interface ConsoleCommand {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  session_id: number;
+  input: string;
+  translated_sql?: string;
+  distributed_query_name?: string;
+  status: ConsoleCommandStatus;
+  error?: string;
+  delivered_at?: string;
+  completed_at?: string;
+  expired_at?: string;
+}
+
+export interface ParsedConsoleCommand {
+  kind: 'local' | 'remote';
+  command: string;
+  path?: string;
+  sql?: string;
+  output?: string;
+}
+
+export type ConsoleResultRow = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
 // Saved queries
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/features/environments/EnvConfigPage.test.tsx
+++ b/frontend/src/features/environments/EnvConfigPage.test.tsx
@@ -180,7 +180,7 @@ describe('EnvConfigPage', () => {
       data: '{"options":{"logger_plugin":"tls"}}',
     });
     mockGetPostureProfiles.mockResolvedValue([]);
-    mockGetFeatures.mockResolvedValue({ posture: false });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
   });
 
   it('loads the fully rendered tab from the assembled config endpoint', async () => {
@@ -224,7 +224,7 @@ describe('EnvConfigPage', () => {
 
   it('loads posture profiles only after opening the picker', async () => {
     const user = userEvent.setup();
-    mockGetFeatures.mockResolvedValue({ posture: true });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
 
     renderWithProviders();
 
@@ -243,7 +243,7 @@ describe('EnvConfigPage', () => {
 
   it('distinguishes a profile load failure from an empty profile list', async () => {
     const user = userEvent.setup();
-    mockGetFeatures.mockResolvedValue({ posture: true });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
     mockGetPostureProfiles.mockRejectedValue(new Error('profiles unavailable'));
 
     renderWithProviders();

--- a/frontend/src/features/nodes/NodeConsolePage.test.tsx
+++ b/frontend/src/features/nodes/NodeConsolePage.test.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { NodeConsolePanel } from './NodeConsolePage';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children: ReactNode }) => <a href="/">{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('$/api/console', () => ({
+  createConsoleSession: vi.fn(async () => ({
+    id: 1,
+    created_at: '2026-07-21T00:00:00Z',
+    updated_at: '2026-07-21T00:00:00Z',
+    environment_id: 1,
+    node_id: 1,
+    node_uuid: 'NODE',
+    creator: 'alice',
+    cwd: '/',
+    platform: 'linux',
+    active: true,
+  })),
+  closeConsoleSession: vi.fn(async () => ({ message: 'closed' })),
+  submitConsoleCommand: vi.fn(async () => ({
+    command: {
+      id: 10,
+      created_at: '2026-07-21T00:00:00Z',
+      updated_at: '2026-07-21T00:00:00Z',
+      session_id: 1,
+      status: 'queued',
+      input: 'ps',
+    },
+    parsed: { kind: 'remote', command: 'ps' },
+  })),
+  getConsoleCommand: vi.fn(async () => ({
+    id: 10,
+    created_at: '2026-07-21T00:00:00Z',
+    updated_at: '2026-07-21T00:00:00Z',
+    session_id: 1,
+    status: 'queued',
+    input: 'ps',
+  })),
+  getConsoleCommandResults: vi.fn(async () => [{ pid: 1, name: 'launchd' }]),
+}));
+
+describe('NodeConsolePanel', () => {
+  it('shows spinner and disables input while command is pending', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <NodeConsolePanel env="env" uuid="NODE" />
+      </QueryClientProvider>,
+    );
+
+    const input = await screen.findByLabelText(/console input/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    fireEvent.change(input, { target: { value: 'ps' } });
+    fireEvent.submit(input.closest('form')!);
+
+    expect(await screen.findByText(/waiting for node/i)).toBeInTheDocument();
+    expect(input).toBeDisabled();
+  });
+});

--- a/frontend/src/features/nodes/NodeConsolePage.tsx
+++ b/frontend/src/features/nodes/NodeConsolePage.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from '@tanstack/react-router';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Loader2, Terminal } from 'lucide-react';
+import {
+  closeConsoleSession,
+  createConsoleSession,
+  getConsoleCommand,
+  getConsoleCommandResults,
+  submitConsoleCommand,
+} from '$/api/console';
+import { ApiError, AuthError } from '$/api/client';
+import type { ConsoleCommand, ConsoleResultRow, ConsoleSession } from '$/api/types';
+import { Button } from '$/components/atoms/Button';
+import { cn } from '$/lib/cn';
+
+type Entry =
+  | { id: string; type: 'input'; cwd: string; text: string }
+  | { id: string; type: 'text'; text: string; tone?: 'error' | 'muted' }
+  | { id: string; type: 'table'; rows: ConsoleResultRow[] };
+
+const terminalStatuses = new Set(['completed', 'error', 'expired']);
+type PendingCommand = { command: ConsoleCommand; path?: string };
+
+export function NodeConsolePage() {
+  const { env, uuid } = useParams({ from: '/_app/env/$env/nodes/$uuid/console' });
+  return <NodeConsolePanel env={env} uuid={uuid} />;
+}
+
+export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
+  const navigate = useNavigate();
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const sessionRef = useRef<ConsoleSession | null>(null);
+  const handledCommandRef = useRef<number | null>(null);
+  const [session, setSession] = useState<ConsoleSession | null>(null);
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [input, setInput] = useState('');
+  const [pending, setPending] = useState<PendingCommand | null>(null);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+  const [commandError, setCommandError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void createConsoleSession(env, uuid)
+      .then((created) => {
+        if (!alive) return;
+        sessionRef.current = created;
+        setSession(created);
+      })
+      .catch((error: unknown) => {
+        if (!alive) return;
+        if (error instanceof AuthError) {
+          void navigate({ to: '/login' });
+          return;
+        }
+        setSessionError(error instanceof Error ? error.message : 'Could not open console');
+      });
+    return () => {
+      alive = false;
+      const current = sessionRef.current;
+      if (current?.active) {
+        void closeConsoleSession(env, current.id).catch(() => undefined);
+      }
+    };
+  }, [env, navigate, uuid]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView?.({ block: 'end' });
+  }, [entries, pending]);
+
+  const submitMutation = useMutation({
+    mutationFn: async (value: string) => {
+      if (!session) throw new Error('Console is not ready');
+      return submitConsoleCommand(env, session.id, value);
+    },
+    onSuccess: ({ command, parsed }) => {
+      if (!session) return;
+      setCommandError(null);
+      if (parsed.kind === 'local') {
+        if (parsed.command === 'clear') {
+          setEntries([]);
+          return;
+        }
+        if (parsed.output) {
+          setEntries((current) => [
+            ...current,
+            { id: `out-${command.id}`, type: 'text', text: parsed.output ?? '' },
+          ]);
+        }
+        return;
+      }
+      handledCommandRef.current = null;
+      setPending({ command, path: parsed.path });
+    },
+    onError: (error: unknown) => {
+      if (error instanceof AuthError) {
+        void navigate({ to: '/login' });
+        return;
+      }
+      setCommandError(error instanceof Error ? error.message : 'Command failed');
+    },
+  });
+
+  const commandQuery = useQuery({
+    queryKey: ['console-command', env, session?.id, pending?.command.id],
+    queryFn: () => getConsoleCommand(env, session!.id, pending!.command.id),
+    enabled: Boolean(session && pending),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && terminalStatuses.has(status) ? false : 1000;
+    },
+    refetchIntervalInBackground: false,
+  });
+
+  useEffect(() => {
+    const command = commandQuery.data;
+    if (!session || !pending || !command || !terminalStatuses.has(command.status)) return;
+    if (handledCommandRef.current === command.id) return;
+    handledCommandRef.current = command.id;
+
+    void getConsoleCommandResults(env, session.id, command.id)
+      .then((rows) => {
+        setEntries((current) => [
+          ...current,
+          command.status === 'completed'
+            ? { id: `rows-${command.id}`, type: 'table', rows }
+            : {
+                id: `err-${command.id}`,
+                type: 'text',
+                tone: 'error',
+                text: command.error || `Command ${command.status}`,
+              },
+        ]);
+        if (command.status === 'completed' && command.input.trim().toLowerCase().startsWith('cd ') && pending.path) {
+          setSession((current) => (current ? { ...current, cwd: pending.path ?? current.cwd } : current));
+        }
+      })
+      .catch((error: unknown) => {
+        setEntries((current) => [
+          ...current,
+          {
+            id: `err-${command.id}`,
+            type: 'text',
+            tone: 'error',
+            text: error instanceof Error ? error.message : 'Could not load results',
+          },
+        ]);
+      })
+      .finally(() => setPending(null));
+  }, [commandQuery.data, env, pending, session]);
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const value = input.trim();
+    if (!value || !session || pending || submitMutation.isPending) return;
+    setEntries((current) => [
+      ...current,
+      { id: `in-${Date.now()}`, type: 'input', cwd: session.cwd, text: value },
+    ]);
+    setInput('');
+    submitMutation.mutate(value);
+  }
+
+  const disabled = !session || Boolean(pending) || submitMutation.isPending;
+  const prompt = useMemo(() => `${session?.cwd ?? '/'} $`, [session?.cwd]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col px-6 py-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-[color:var(--text-1)]">
+            <Terminal className="h-4 w-4 text-[color:var(--signal)]" aria-hidden="true" />
+            <h1 className="text-base font-semibold">Console</h1>
+          </div>
+          <p className="mt-0.5 truncate font-mono-tabular text-xs text-[color:var(--text-3)]">{uuid}</p>
+        </div>
+        <Link
+          to="/_app/env/$env/nodes/$uuid"
+          params={{ env, uuid }}
+          className="rounded border border-[color:var(--border)] px-3 py-1.5 text-xs font-medium text-[color:var(--text-2)] transition-colors hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]"
+        >
+          Back
+        </Link>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-[color:var(--border)] bg-[#050708] text-[#d7f8df] shadow-inner">
+        <div className="flex-1 overflow-auto px-4 py-3 font-mono text-xs leading-5">
+          {sessionError && <Line tone="error" text={sessionError} />}
+          {!session && !sessionError && <Line tone="muted" text="opening console..." />}
+          {entries.map((entry) => (
+            <ConsoleEntry key={entry.id} entry={entry} />
+          ))}
+          {pending && (
+            <div className="flex items-center gap-2 text-[#8fe8a4]" aria-live="polite">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              <span>waiting for node</span>
+            </div>
+          )}
+          {commandError && <Line tone="error" text={commandError} />}
+          <div ref={bottomRef} />
+        </div>
+
+        <form onSubmit={onSubmit} className="flex items-center gap-2 border-t border-white/10 px-4 py-2">
+          <span className="shrink-0 font-mono text-xs text-[#8fe8a4]">{prompt}</span>
+          <input
+            aria-label="Console input"
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            disabled={disabled}
+            className="min-w-0 flex-1 bg-transparent font-mono text-xs text-[#d7f8df] outline-none placeholder:text-[#5a705f] disabled:cursor-not-allowed disabled:opacity-60"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <Button type="submit" size="sm" variant="ghost" disabled={disabled || input.trim() === ''}>
+            Run
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function ConsoleEntry({ entry }: { entry: Entry }) {
+  if (entry.type === 'input') {
+    return (
+      <div className="whitespace-pre-wrap">
+        <span className="text-[#8fe8a4]">{entry.cwd} $ </span>
+        <span>{entry.text}</span>
+      </div>
+    );
+  }
+  if (entry.type === 'table') {
+    return <ResultTable rows={entry.rows} />;
+  }
+  return <Line text={entry.text} tone={entry.tone} />;
+}
+
+function Line({ text, tone }: { text: string; tone?: 'error' | 'muted' }) {
+  return (
+    <div
+      className={cn(
+        'whitespace-pre-wrap',
+        tone === 'error' && 'text-[#ff8a8a]',
+        tone === 'muted' && 'text-[#7d8b80]',
+      )}
+    >
+      {text}
+    </div>
+  );
+}
+
+function ResultTable({ rows }: { rows: ConsoleResultRow[] }) {
+  if (rows.length === 0) {
+    return <Line tone="muted" text="no rows" />;
+  }
+  const columns = Array.from(rows.reduce((set, row) => {
+    Object.keys(row).forEach((key) => set.add(key));
+    return set;
+  }, new Set<string>()));
+
+  return (
+    <div className="my-1 overflow-x-auto">
+      <table className="min-w-full border-collapse text-left">
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th key={column} className="border-b border-white/15 pr-4 py-1 font-medium text-[#8fe8a4]">
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index}>
+              {columns.map((column) => (
+                <td key={column} className="max-w-[28rem] truncate pr-4 py-1 text-[#d7f8df]">
+                  {String(row[column] ?? '')}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -213,7 +213,7 @@ describe('NodeDetailPage', () => {
       total: [],
     });
     mockListServiceSettings.mockResolvedValue([]);
-    mockGetFeatures.mockResolvedValue({ posture: false });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
   });
 
   it('shows node activity in the default details view and removes the separate activity tab', async () => {
@@ -282,7 +282,7 @@ describe('NodeDetailPage', () => {
 
   it('shows posture data for the selected node', async () => {
     const user = userEvent.setup();
-    mockGetFeatures.mockResolvedValue({ posture: true });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
     mockGetNodePosture.mockResolvedValue([
       {
         id: 10,
@@ -333,5 +333,30 @@ describe('NodeDetailPage', () => {
 
     expect(screen.queryByRole('tab', { name: 'Posture' })).not.toBeInTheDocument();
     expect(mockGetNodePosture).not.toHaveBeenCalled();
+  });
+
+  it('shows the console action only when accelerated queries are enabled', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true });
+    const router = makeTestRouter();
+
+    renderWithProviders(router);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('link', { name: /console/i })).toBeInTheDocument();
+  });
+
+  it('hides the console action when accelerated queries are disabled', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('link', { name: /console/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import { usePageTitle } from '$/lib/usePageTitle';
 import { useParams, Link, useNavigate } from '@tanstack/react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Terminal } from 'lucide-react';
 import { getNode, listNodeLogs, deleteNode, getNodePosture, getNodePostureScore } from '$/api/nodes';
 import type { NodePosture, PostureScore } from '$/api/types';
 import { getMe } from '$/api/users';
@@ -581,6 +582,7 @@ export function NodeDetailPage() {
     staleTime: 5 * 60_000,
   });
   const postureEnabled = features?.posture === true;
+  const acceleratedEnabled = features?.accelerated === true;
   const visibleTabs = useMemo(
     () => TABS.filter((tab) => tab.id !== 'posture' || postureEnabled),
     [postureEnabled],
@@ -788,6 +790,22 @@ export function NodeDetailPage() {
                 archive=true, which the server gates on env-admin —
                 so the button hides for non-admins same as Delete. */}
             <div className="flex items-center gap-2 flex-shrink-0">
+              {acceleratedEnabled && (
+                <Link
+                  to="/_app/env/$env/nodes/$uuid/console"
+                  params={{ env, uuid }}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
+                    'border border-[color:var(--border)] text-[color:var(--text-2)]',
+                    'hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
+                    'transition-colors',
+                    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+                  )}
+                >
+                  <Terminal className="h-3.5 w-3.5" aria-hidden="true" />
+                  Console
+                </Link>
+              )}
               {node.node_key && (
                 <button
                   type="button"

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,6 +8,7 @@ import { envRoute } from './routes/_app/env/$env/route'
 import { envIndexRoute } from './routes/_app/env/$env/index'
 import { envNodesRoute } from './routes/_app/env/$env/nodes'
 import { envNodeDetailRoute } from './routes/_app/env/$env/nodes.$uuid'
+import { envNodeConsoleRoute } from './routes/_app/env/$env/nodes.$uuid.console'
 import { envQueriesRoute } from './routes/_app/env/$env/queries'
 import { envQueryNewRoute } from './routes/_app/env/$env/queries.new'
 import { envQueryDetailRoute } from './routes/_app/env/$env/queries.$name'
@@ -40,6 +41,7 @@ const routeTree = rootRoute.addChildren([
       envIndexRoute,
       envNodesRoute,
       envNodeDetailRoute,
+      envNodeConsoleRoute,
       envQueriesRoute,
       envQueryNewRoute,
       envQueryDetailRoute,

--- a/frontend/src/routes/_app/env/$env/nodes.$uuid.console.tsx
+++ b/frontend/src/routes/_app/env/$env/nodes.$uuid.console.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { envRoute } from './route';
+import { NodeConsolePage } from '$/features/nodes/NodeConsolePage';
+
+export const envNodeConsoleRoute = createRoute({
+  getParentRoute: () => envRoute,
+  path: 'nodes/$uuid/console',
+  component: NodeConsolePage,
+});

--- a/pkg/console/manager.go
+++ b/pkg/console/manager.go
@@ -1,0 +1,264 @@
+package console
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"gorm.io/gorm"
+)
+
+const commandExpiration = 5 * time.Minute
+
+type Manager struct {
+	DB      *gorm.DB
+	Queries *queries.Queries
+}
+
+func NewManager(db *gorm.DB, queryManager *queries.Queries) *Manager {
+	if err := db.AutoMigrate(&Session{}, &Command{}); err != nil {
+		panic(fmt.Sprintf("failed to migrate console tables: %v", err))
+	}
+	return &Manager{DB: db, Queries: queryManager}
+}
+
+func (m *Manager) CreateSession(env environments.TLSEnvironment, node nodes.OsqueryNode, creator string) (Session, error) {
+	session := Session{
+		EnvironmentID: env.ID,
+		NodeID:        node.ID,
+		NodeUUID:      node.UUID,
+		Creator:       creator,
+		CWD:           DefaultCWD(node.Platform),
+		Platform:      node.Platform,
+		Active:        true,
+	}
+	if err := m.DB.Create(&session).Error; err != nil {
+		return Session{}, err
+	}
+	return session, nil
+}
+
+func (m *Manager) GetSession(sessionID uint) (Session, error) {
+	var session Session
+	if err := m.DB.First(&session, sessionID).Error; err != nil {
+		return Session{}, err
+	}
+	return session, nil
+}
+
+func (m *Manager) SubmitCommand(sessionID uint, input string) (Command, ParsedCommand, error) {
+	var session Session
+	if err := m.DB.First(&session, sessionID).Error; err != nil {
+		return Command{}, ParsedCommand{}, err
+	}
+	if !session.Active {
+		return Command{}, ParsedCommand{}, fmt.Errorf("console session is closed")
+	}
+	var pending int64
+	if err := m.DB.Model(&Command{}).
+		Where("session_id = ? AND status IN ?", sessionID, []string{StatusQueued, StatusDelivered}).
+		Count(&pending).Error; err != nil {
+		return Command{}, ParsedCommand{}, err
+	}
+	if pending > 0 {
+		return Command{}, ParsedCommand{}, fmt.Errorf("another command is still pending")
+	}
+
+	parsed, err := Parse(input, session.CWD, session.Platform)
+	if err != nil {
+		return Command{}, ParsedCommand{}, err
+	}
+
+	command := Command{
+		SessionID:     sessionID,
+		Input:         input,
+		TranslatedSQL: parsed.SQL,
+		Status:        StatusCompleted,
+	}
+	if parsed.Kind == CommandRemote {
+		command.Status = StatusQueued
+	}
+
+	err = m.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&command).Error; err != nil {
+			return err
+		}
+		if parsed.Kind == CommandLocal {
+			return nil
+		}
+
+		extra, err := json.Marshal(map[string]uint{"session_id": session.ID, "command_id": command.ID})
+		if err != nil {
+			return err
+		}
+		distributed := queries.DistributedQuery{
+			Name:          queries.GenQueryName(),
+			Query:         parsed.SQL,
+			Creator:       session.Creator,
+			Active:        true,
+			Hidden:        true,
+			Type:          queries.ConsoleQueryType,
+			EnvironmentID: session.EnvironmentID,
+			Expiration:    time.Now().Add(commandExpiration),
+			Expected:      1,
+			ExtraData:     string(extra),
+		}
+		if err := tx.Create(&distributed).Error; err != nil {
+			return err
+		}
+		nodeQuery := queries.NodeQuery{
+			NodeID:  session.NodeID,
+			QueryID: distributed.ID,
+			Status:  queries.DistributedQueryStatusPending,
+		}
+		if err := tx.Create(&nodeQuery).Error; err != nil {
+			return err
+		}
+		command.DistributedQueryName = distributed.Name
+		return tx.Model(&command).Update("distributed_query_name", distributed.Name).Error
+	})
+	if err != nil {
+		return Command{}, ParsedCommand{}, err
+	}
+
+	return command, parsed, nil
+}
+
+func (m *Manager) CloseSession(sessionID uint) error {
+	now := time.Now()
+	return m.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&Session{}).Where("id = ?", sessionID).
+			Updates(map[string]any{"active": false, "closed_at": &now}).Error; err != nil {
+			return err
+		}
+		return tx.Model(&Command{}).
+			Where("session_id = ? AND status IN ?", sessionID, []string{StatusQueued, StatusDelivered}).
+			Updates(map[string]any{"status": StatusExpired, "expired_at": &now}).Error
+	})
+}
+
+func (m *Manager) GetCommand(sessionID, commandID uint) (Command, error) {
+	var command Command
+	if err := m.DB.Where("session_id = ?", sessionID).First(&command, commandID).Error; err != nil {
+		return Command{}, err
+	}
+	return command, nil
+}
+
+func (m *Manager) RefreshCommandStatus(commandID uint) (Command, error) {
+	var command Command
+	if err := m.DB.First(&command, commandID).Error; err != nil {
+		return Command{}, err
+	}
+	if command.DistributedQueryName == "" || isTerminalStatus(command.Status) {
+		return command, nil
+	}
+
+	var distributed queries.DistributedQuery
+	if err := m.DB.Where("name = ?", command.DistributedQueryName).First(&distributed).Error; err != nil {
+		return Command{}, err
+	}
+	var nodeQuery queries.NodeQuery
+	if err := m.DB.Where("query_id = ?", distributed.ID).First(&nodeQuery).Error; err != nil {
+		return Command{}, err
+	}
+
+	now := time.Now()
+	updates := map[string]any{}
+	switch nodeQuery.Status {
+	case queries.DistributedQueryStatusPending:
+		if distributed.Expiration.Before(now) {
+			updates["status"] = StatusExpired
+			updates["expired_at"] = &now
+		}
+	case queries.DistributedQueryStatusCompleted:
+		status, errText, err := m.completedStatusForCommand(command)
+		if err != nil {
+			return Command{}, err
+		}
+		updates["status"] = status
+		updates["completed_at"] = &now
+		if errText != "" {
+			updates["error"] = errText
+		}
+	case queries.DistributedQueryStatusError:
+		updates["status"] = StatusError
+		updates["error"] = "osquery returned an error for this command"
+		updates["completed_at"] = &now
+	case queries.DistributedQueryStatusExpired:
+		updates["status"] = StatusExpired
+		updates["expired_at"] = &now
+	}
+	if len(updates) > 0 {
+		if err := m.DB.Model(&command).Updates(updates).Error; err != nil {
+			return Command{}, err
+		}
+		if err := m.DB.First(&command, commandID).Error; err != nil {
+			return Command{}, err
+		}
+	}
+	return command, nil
+}
+
+func (m *Manager) CommandResults(commandID uint) ([]map[string]any, error) {
+	command, err := m.RefreshCommandStatus(commandID)
+	if err != nil {
+		return nil, err
+	}
+	return m.queryResults(command.DistributedQueryName)
+}
+
+func (m *Manager) completedStatusForCommand(command Command) (string, string, error) {
+	var session Session
+	if err := m.DB.First(&session, command.SessionID).Error; err != nil {
+		return StatusError, "", err
+	}
+	parsed, err := Parse(command.Input, session.CWD, session.Platform)
+	if err != nil {
+		return StatusError, err.Error(), nil
+	}
+	if parsed.Command != "cd" {
+		return StatusCompleted, "", nil
+	}
+
+	rows, err := m.queryResults(command.DistributedQueryName)
+	if err != nil {
+		return StatusError, "", err
+	}
+	if len(rows) == 0 {
+		return StatusError, fmt.Sprintf("directory not found: %s", parsed.Path), nil
+	}
+	if err := m.DB.Model(&session).Update("cwd", parsed.Path).Error; err != nil {
+		return StatusError, "", err
+	}
+	return StatusCompleted, "", nil
+}
+
+func (m *Manager) queryResults(queryName string) ([]map[string]any, error) {
+	rows := []map[string]any{}
+	if queryName == "" {
+		return rows, nil
+	}
+	err := logging.StreamQueryResults(m.DB, queryName, func(row logging.OsqueryQueryData) error {
+		var decoded []map[string]any
+		if err := json.Unmarshal([]byte(row.Data), &decoded); err != nil {
+			return err
+		}
+		rows = append(rows, decoded...)
+		return nil
+	})
+	return rows, err
+}
+
+func isTerminalStatus(status string) bool {
+	switch status {
+	case StatusCompleted, StatusError, StatusExpired:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/console/manager_test.go
+++ b/pkg/console/manager_test.go
@@ -1,0 +1,165 @@
+package console_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupConsoleManager(t *testing.T) (*gorm.DB, *console.Manager, environments.TLSEnvironment, nodes.OsqueryNode) {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&environments.TLSEnvironment{}, &nodes.OsqueryNode{}, &logging.OsqueryQueryData{}))
+
+	env := environments.TLSEnvironment{UUID: "env-uuid", Name: "env"}
+	require.NoError(t, db.Create(&env).Error)
+	node := nodes.OsqueryNode{UUID: "NODE-UUID", Platform: "linux", EnvironmentID: env.ID, Environment: env.UUID}
+	require.NoError(t, db.Create(&node).Error)
+
+	queryManager := queries.CreateQueries(db)
+	return db, console.NewManager(db, queryManager), env, node
+}
+
+func TestCreateSessionDefaultsCWDByPlatform(t *testing.T) {
+	_, manager, env, node := setupConsoleManager(t)
+	node.Platform = "windows"
+
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	require.Equal(t, `C:\`, session.CWD)
+	require.True(t, session.Active)
+	require.Equal(t, node.UUID, session.NodeUUID)
+}
+
+func TestSubmitLocalCommandDoesNotCreateDistributedQuery(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	command, parsed, err := manager.SubmitCommand(session.ID, "pwd")
+	require.NoError(t, err)
+	require.Equal(t, console.StatusCompleted, command.Status)
+	require.Equal(t, console.CommandLocal, parsed.Kind)
+
+	var count int64
+	require.NoError(t, db.Model(&queries.DistributedQuery{}).Count(&count).Error)
+	require.Equal(t, int64(0), count)
+}
+
+func TestSubmitRemoteCommandCreatesHiddenConsoleQuery(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	command, parsed, err := manager.SubmitCommand(session.ID, "ps")
+	require.NoError(t, err)
+	require.Equal(t, console.StatusQueued, command.Status)
+	require.Equal(t, console.CommandRemote, parsed.Kind)
+	require.NotEmpty(t, command.DistributedQueryName)
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", command.DistributedQueryName).First(&distributed).Error)
+	require.Equal(t, queries.ConsoleQueryType, distributed.Type)
+	require.True(t, distributed.Hidden)
+	require.True(t, distributed.Active)
+	require.Equal(t, uint(1), uint(distributed.Expected))
+
+	var nodeQuery queries.NodeQuery
+	require.NoError(t, db.Where("query_id = ?", distributed.ID).First(&nodeQuery).Error)
+	require.Equal(t, node.ID, nodeQuery.NodeID)
+}
+
+func TestSubmitRejectsWhenCommandInFlight(t *testing.T) {
+	_, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	_, _, err = manager.SubmitCommand(session.ID, "ps")
+	require.NoError(t, err)
+	_, _, err = manager.SubmitCommand(session.ID, "ls")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pending")
+}
+
+func TestCloseSessionExpiresPendingCommands(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, _, err := manager.SubmitCommand(session.ID, "ps")
+	require.NoError(t, err)
+
+	require.NoError(t, manager.CloseSession(session.ID))
+
+	var refreshed console.Command
+	require.NoError(t, db.First(&refreshed, command.ID).Error)
+	require.Equal(t, console.StatusExpired, refreshed.Status)
+	require.NotNil(t, refreshed.ExpiredAt)
+}
+
+func TestRefreshCommandStatusFromNodeQuery(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, _, err := manager.SubmitCommand(session.ID, "ps")
+	require.NoError(t, err)
+
+	require.NoError(t, markNodeQueryStatus(db, command.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+	got, err := manager.RefreshCommandStatus(command.ID)
+	require.NoError(t, err)
+	require.Equal(t, console.StatusCompleted, got.Status)
+	require.NotNil(t, got.CompletedAt)
+}
+
+func TestRefreshCommandStatusMarksError(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, _, err := manager.SubmitCommand(session.ID, "ps")
+	require.NoError(t, err)
+
+	require.NoError(t, markNodeQueryStatus(db, command.DistributedQueryName, queries.DistributedQueryStatusError))
+	got, err := manager.RefreshCommandStatus(command.ID)
+	require.NoError(t, err)
+	require.Equal(t, console.StatusError, got.Status)
+	require.NotNil(t, got.CompletedAt)
+}
+
+func TestRefreshCDUpdatesWorkingDirectoryAfterResult(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, parsed, err := manager.SubmitCommand(session.ID, "cd /etc")
+	require.NoError(t, err)
+
+	data, err := json.Marshal([]map[string]string{{"path": "/etc", "type": "directory"}})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{Name: command.DistributedQueryName, Data: string(data), Status: 0}).Error)
+	require.NoError(t, markNodeQueryStatus(db, command.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+
+	got, err := manager.RefreshCommandStatus(command.ID)
+	require.NoError(t, err)
+	require.Equal(t, console.StatusCompleted, got.Status)
+	require.Equal(t, "/etc", parsed.Path)
+
+	var refreshed console.Session
+	require.NoError(t, db.First(&refreshed, session.ID).Error)
+	require.Equal(t, "/etc", refreshed.CWD)
+}
+
+func markNodeQueryStatus(db *gorm.DB, name, status string) error {
+	var distributed queries.DistributedQuery
+	if err := db.Where("name = ?", name).First(&distributed).Error; err != nil {
+		return err
+	}
+	return db.Model(&queries.NodeQuery{}).Where("query_id = ?", distributed.ID).Update("status", status).Error
+}

--- a/pkg/console/models.go
+++ b/pkg/console/models.go
@@ -1,0 +1,57 @@
+package console
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	CommandLocal  = "local"
+	CommandRemote = "remote"
+
+	StatusQueued    = "queued"
+	StatusDelivered = "delivered"
+	StatusCompleted = "completed"
+	StatusError     = "error"
+	StatusExpired   = "expired"
+)
+
+type Session struct {
+	ID            uint           `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+	EnvironmentID uint           `gorm:"not null;index" json:"environment_id"`
+	NodeID        uint           `gorm:"not null;index" json:"node_id"`
+	NodeUUID      string         `gorm:"not null;index" json:"node_uuid"`
+	Creator       string         `gorm:"not null;index" json:"creator"`
+	CWD           string         `gorm:"not null" json:"cwd"`
+	Platform      string         `json:"platform"`
+	Active        bool           `gorm:"not null;default:true" json:"active"`
+	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
+}
+
+type Command struct {
+	ID                   uint           `gorm:"primarykey" json:"id"`
+	CreatedAt            time.Time      `json:"created_at"`
+	UpdatedAt            time.Time      `json:"updated_at"`
+	DeletedAt            gorm.DeletedAt `gorm:"index" json:"-"`
+	SessionID            uint           `gorm:"not null;index" json:"session_id"`
+	Input                string         `gorm:"not null" json:"input"`
+	TranslatedSQL        string         `json:"translated_sql"`
+	DistributedQueryName string         `gorm:"index" json:"distributed_query_name,omitempty"`
+	Status               string         `gorm:"not null;index" json:"status"`
+	Error                string         `json:"error,omitempty"`
+	DeliveredAt          *time.Time     `json:"delivered_at,omitempty"`
+	CompletedAt          *time.Time     `json:"completed_at,omitempty"`
+	ExpiredAt            *time.Time     `json:"expired_at,omitempty"`
+}
+
+type ParsedCommand struct {
+	Kind    string `json:"kind"`
+	Command string `json:"command"`
+	Path    string `json:"path,omitempty"`
+	SQL     string `json:"sql,omitempty"`
+	Output  string `json:"output,omitempty"`
+}

--- a/pkg/console/parser.go
+++ b/pkg/console/parser.go
@@ -1,0 +1,152 @@
+package console
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+)
+
+var forbiddenShellSyntax = regexp.MustCompile(`[|&;<>]`)
+
+func DefaultCWD(platform string) string {
+	if strings.EqualFold(platform, "windows") {
+		return `C:\`
+	}
+	return "/"
+}
+
+func Parse(input, cwd, platform string) (ParsedCommand, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ParsedCommand{}, fmt.Errorf("command can not be empty")
+	}
+
+	fields := strings.Fields(input)
+	cmd := strings.ToLower(fields[0])
+	args := strings.TrimSpace(strings.TrimPrefix(input, fields[0]))
+
+	switch cmd {
+	case "pwd":
+		return ParsedCommand{Kind: CommandLocal, Command: "pwd", Output: cwd}, nil
+	case "help":
+		return ParsedCommand{Kind: CommandLocal, Command: "help", Output: helpText()}, nil
+	case "clear":
+		return ParsedCommand{Kind: CommandLocal, Command: "clear"}, nil
+	case "ls":
+		if forbiddenShellSyntax.MatchString(args) {
+			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
+		}
+		target := resolvePath(args, cwd, platform)
+		sql := fmt.Sprintf("select path, filename, directory, type, size, mode, uid, gid, mtime from file where directory = %s", quoteSQL(target))
+		return ParsedCommand{Kind: CommandRemote, Command: "ls", Path: target, SQL: sql}, nil
+	case "stat":
+		if args == "" {
+			return ParsedCommand{}, fmt.Errorf("stat requires a path")
+		}
+		if forbiddenShellSyntax.MatchString(args) {
+			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
+		}
+		target := resolvePath(args, cwd, platform)
+		sql := fmt.Sprintf("select path, filename, directory, type, size, mode, uid, gid, mtime, atime, ctime from file where path = %s", quoteSQL(target))
+		return ParsedCommand{Kind: CommandRemote, Command: "stat", Path: target, SQL: sql}, nil
+	case "ps":
+		if args != "" {
+			return ParsedCommand{}, fmt.Errorf("ps does not accept arguments")
+		}
+		return ParsedCommand{Kind: CommandRemote, Command: "ps", SQL: "select pid, parent, name, path, cmdline, state, uid, gid, start_time from processes order by pid"}, nil
+	case "cd":
+		if args == "" {
+			return ParsedCommand{}, fmt.Errorf("cd requires a path")
+		}
+		if forbiddenShellSyntax.MatchString(args) {
+			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
+		}
+		target := resolvePath(args, cwd, platform)
+		sql := fmt.Sprintf("select path, type from file where path = %s and type = 'directory'", quoteSQL(target))
+		return ParsedCommand{Kind: CommandRemote, Command: "cd", Path: target, SQL: sql}, nil
+	case "sql":
+		sql := strings.TrimSpace(args)
+		if err := validateSelect(sql); err != nil {
+			return ParsedCommand{}, err
+		}
+		return ParsedCommand{Kind: CommandRemote, Command: "sql", SQL: sql}, nil
+	default:
+		return ParsedCommand{}, fmt.Errorf("unsupported command %q", cmd)
+	}
+}
+
+func validateSelect(sql string) error {
+	lower := strings.ToLower(strings.TrimSpace(sql))
+	if !strings.HasPrefix(lower, "select ") {
+		return fmt.Errorf("raw SQL must be a SELECT statement")
+	}
+	if strings.Count(sql, ";") > 0 {
+		return fmt.Errorf("raw SQL must be a single statement without semicolons")
+	}
+	for _, verb := range []string{" insert ", " update ", " delete ", " drop ", " alter ", " attach ", " detach ", " pragma "} {
+		if strings.Contains(" "+lower+" ", verb) {
+			return fmt.Errorf("raw SQL must be read-only SELECT")
+		}
+	}
+	return nil
+}
+
+func resolvePath(arg, cwd, platform string) string {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		arg = cwd
+	}
+	if strings.EqualFold(platform, "windows") {
+		return resolveWindowsPath(arg, cwd)
+	}
+	if strings.HasPrefix(arg, "/") {
+		return path.Clean(arg)
+	}
+	return path.Clean(path.Join(cwd, arg))
+}
+
+func resolveWindowsPath(arg, cwd string) string {
+	arg = strings.ReplaceAll(arg, "/", `\`)
+	cwd = strings.ReplaceAll(cwd, "/", `\`)
+	if isWindowsAbs(arg) {
+		return cleanWindowsPath(arg)
+	}
+	return cleanWindowsPath(strings.TrimRight(cwd, `\`) + `\` + arg)
+}
+
+func isWindowsAbs(p string) bool {
+	return len(p) >= 3 && p[1] == ':' && p[2] == '\\'
+}
+
+func cleanWindowsPath(p string) string {
+	p = strings.ReplaceAll(p, `/`, `\`)
+	parts := []string{}
+	for _, part := range strings.Split(p, `\`) {
+		if part == "" || part == "." {
+			continue
+		}
+		if part == ".." {
+			if len(parts) > 1 {
+				parts = parts[:len(parts)-1]
+			}
+			continue
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) == 0 {
+		return `C:\`
+	}
+	if len(parts) == 1 && strings.HasSuffix(parts[0], ":") {
+		return parts[0] + `\`
+	}
+	return strings.Join(parts, `\`)
+}
+
+func quoteSQL(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func helpText() string {
+	return "Supported commands: pwd, cd <path>, ls [path], stat <path>, ps, sql <select ...>, help, clear"
+}

--- a/pkg/console/parser_test.go
+++ b/pkg/console/parser_test.go
@@ -1,0 +1,64 @@
+package console_test
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultCWD(t *testing.T) {
+	require.Equal(t, `C:\`, console.DefaultCWD("windows"))
+	require.Equal(t, "/", console.DefaultCWD("darwin"))
+	require.Equal(t, "/", console.DefaultCWD("linux"))
+	require.Equal(t, "/", console.DefaultCWD(""))
+}
+
+func TestParseLocalCommands(t *testing.T) {
+	for _, input := range []string{"pwd", "help", "clear"} {
+		got, err := console.Parse(input, "/etc", "linux")
+		require.NoError(t, err)
+		require.Equal(t, console.CommandLocal, got.Kind)
+		require.Equal(t, input, got.Command)
+	}
+}
+
+func TestParseLSResolvesPOSIXPath(t *testing.T) {
+	got, err := console.Parse("ls ssh", "/etc", "linux")
+	require.NoError(t, err)
+	require.Equal(t, console.CommandRemote, got.Kind)
+	require.Equal(t, "ls", got.Command)
+	require.Equal(t, "/etc/ssh", got.Path)
+	require.Contains(t, got.SQL, "from file")
+	require.Contains(t, got.SQL, "directory = '/etc/ssh'")
+}
+
+func TestParseStatResolvesWindowsPath(t *testing.T) {
+	got, err := console.Parse(`stat Windows\System32`, `C:\`, "windows")
+	require.NoError(t, err)
+	require.Equal(t, `C:\Windows\System32`, got.Path)
+	require.Contains(t, got.SQL, "from file")
+	require.Contains(t, got.SQL, `path = 'C:\Windows\System32'`)
+}
+
+func TestParseRawSQLRequiresSelect(t *testing.T) {
+	got, err := console.Parse("sql select * from osquery_info", "/", "linux")
+	require.NoError(t, err)
+	require.Equal(t, "sql", got.Command)
+	require.Equal(t, "select * from osquery_info", got.SQL)
+
+	_, err = console.Parse("sql delete from processes", "/", "linux")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SELECT")
+
+	_, err = console.Parse("sql select 1; select 2", "/", "linux")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "single")
+}
+
+func TestParseRejectsShellSyntax(t *testing.T) {
+	for _, input := range []string{"ls /tmp | head", "ls > out", "ls && ps", "cat /etc/passwd"} {
+		_, err := console.Parse(input, "/", "linux")
+		require.Error(t, err, input)
+	}
+}

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -43,6 +43,8 @@ const (
 	CarveQueryType string = "carve"
 	// MetadataQueryType defines a regular query
 	MetadataQueryType string = "metadata"
+	// ConsoleQueryType defines a hidden accelerated query used by node consoles
+	ConsoleQueryType string = "console"
 )
 
 const (
@@ -170,10 +172,11 @@ func (q *Queries) NodeQueries(node nodes.OsqueryNode) (QueryReadQueries, bool, e
 	var results []struct {
 		Name  string
 		Query string
+		Type  string
 	}
 
 	q.DB.Table("distributed_queries dq").
-		Select("dq.name, dq.query").
+		Select("dq.name, dq.query, dq.type").
 		Joins("JOIN node_queries nq ON dq.id = nq.query_id").
 		Where("nq.node_id = ? AND nq.status = ?", node.ID, DistributedQueryStatusPending).
 		Scan(&results)
@@ -183,16 +186,23 @@ func (q *Queries) NodeQueries(node nodes.OsqueryNode) (QueryReadQueries, bool, e
 	}
 
 	qs := make(QueryReadQueries)
+	accelerate := false
 	for _, _q := range results {
 		qs[_q.Name] = _q.Query
+		if _q.Type == ConsoleQueryType {
+			accelerate = true
+		}
 	}
 
-	return qs, false, nil
+	return qs, accelerate, nil
 }
 
 // Gets all queries by target (active/completed/all/all-full/deleted/hidden/expired)
 func (q *Queries) Gets(target, qtype string, envid uint) ([]DistributedQuery, error) {
 	var queries []DistributedQuery
+	if qtype == ConsoleQueryType {
+		return queries, nil
+	}
 	switch target {
 	case TargetActive:
 		if err := q.DB.Where(
@@ -598,6 +608,9 @@ func (q *Queries) SetNodeQueriesAsExpired(queryID uint) error {
 //
 // page is 1-indexed. pageSize is clamped to [1, 500] with default 50.
 func (q *Queries) GetByEnvTargetPaged(envID uint, target, qtype, search string, page, pageSize int, sortColumn string, desc bool) (QueryListPage, error) {
+	if qtype == ConsoleQueryType {
+		return QueryListPage{Items: []DistributedQuery{}}, nil
+	}
 	if pageSize <= 0 {
 		pageSize = 50
 	}

--- a/pkg/queries/queries_test.go
+++ b/pkg/queries/queries_test.go
@@ -96,6 +96,27 @@ func TestNodeQueries(t *testing.T) {
 	})
 }
 
+func TestNodeQueriesAcceleratesConsoleQueries(t *testing.T) {
+	db := testDB(t)
+	q, testNodes, _ := setupTestData(t, db)
+
+	consoleQuery := queries.DistributedQuery{
+		Name:          "console-query",
+		Query:         "SELECT * FROM processes;",
+		Type:          queries.ConsoleQueryType,
+		Hidden:        true,
+		Active:        true,
+		EnvironmentID: 1,
+	}
+	require.NoError(t, q.Create(&consoleQuery))
+	require.NoError(t, q.CreateNodeQueries([]uint{testNodes[0].ID}, consoleQuery.ID))
+
+	result, accelerate, err := q.NodeQueries(testNodes[0])
+	require.NoError(t, err)
+	require.True(t, accelerate)
+	require.Equal(t, "SELECT * FROM processes;", result["console-query"])
+}
+
 func TestUpdateQueryStatus(t *testing.T) {
 	db := testDB(t)
 	q, nodes, query := setupTestData(t, db)
@@ -244,6 +265,45 @@ func TestQuerySortableColumnsAllowlist(t *testing.T) {
 	if queries.QuerySortableColumns["created"] != "created_at" {
 		t.Error("created → created_at")
 	}
+}
+
+func TestConsoleQueriesAreExcludedFromNormalLists(t *testing.T) {
+	db := testDB(t)
+	q := queries.CreateQueries(db)
+
+	envID := uint(1)
+	normal := queries.DistributedQuery{
+		Name:          "normal-query",
+		Query:         "SELECT 1;",
+		Type:          queries.StandardQueryType,
+		EnvironmentID: envID,
+		Active:        true,
+	}
+	consoleQuery := queries.DistributedQuery{
+		Name:          "console-query",
+		Query:         "SELECT * FROM file;",
+		Type:          queries.ConsoleQueryType,
+		EnvironmentID: envID,
+		Active:        true,
+		Hidden:        true,
+	}
+	require.NoError(t, q.Create(&normal))
+	require.NoError(t, q.Create(&consoleQuery))
+
+	items, err := q.GetQueries(queries.TargetAllFull, envID)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "normal-query", items[0].Name)
+
+	hidden, err := q.GetQueries(queries.TargetHidden, envID)
+	require.NoError(t, err)
+	require.Empty(t, hidden)
+
+	page, err := q.GetByEnvTargetPaged(envID, queries.TargetAllFull, queries.StandardQueryType, "", 1, 50, "created", true)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), page.TotalItems)
+	require.Len(t, page.Items, 1)
+	require.Equal(t, "normal-query", page.Items[0].Name)
 }
 
 func TestSetNodeQueriesAsExpired(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a node-scoped read-only console powered by hidden accelerated osquery distributed queries.

## Changes

- Added `console` distributed query type for internal console commands.
- Console queries are hidden from normal query lists and hidden-query tabs.
- Pending console queries request accelerated delivery when returned to osquery.
- Added console sessions with per-session working directory.
- Added read-only shell-like commands:
  - `pwd`
  - `help`
  - `clear`
  - `ls [path]`
  - `stat <path>`
  - `ps`
  - `cd <path>`
  - `sql <select ...>`
- Enforced one in-flight command per console session.
- Added console API routes gated by `QueryLevel` permissions.
- Added session ownership checks so users cannot drive another user's console session.
- Added React console UI with pending spinner, result rendering, and polling.
- Added Console button on node detail pages only when accelerated mode is enabled.
- Exposed `accelerated` through `/api/v1/features`.

## Validation

- `go test ./pkg/queries ./pkg/console ./cmd/api ./cmd/tls/handlers ./cmd/tls`
- `go test ./cmd/api/handlers -run Console`
- `go test ./cmd/api/handlers -run Features`
- `npm test -- NodeConsolePage.test.tsx`
- `npm test -- NodeDetailPage.test.tsx EnvConfigPage.test.tsx`
- `npm run check`
- `npm run build`

## Notes

- V1 is read-only.
- `cat` is intentionally unsupported because osquery does not expose arbitrary file contents.
- The Console UI is hidden unless `osquery.accelerated` is enabled.
- Vite build passes with the existing large chunk-size warning.