### PR TITLE
Fixed serialization error in `/results` for console

### DIFF
--- a/pkg/console/manager.go
+++ b/pkg/console/manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
 	"gorm.io/gorm"
 )
 
@@ -244,14 +245,27 @@ func (m *Manager) queryResults(queryName string) ([]map[string]any, error) {
 		return rows, nil
 	}
 	err := logging.StreamQueryResults(m.DB, queryName, func(row logging.OsqueryQueryData) error {
-		var decoded []map[string]any
-		if err := json.Unmarshal([]byte(row.Data), &decoded); err != nil {
+		decoded, err := decodeResultRows([]byte(row.Data))
+		if err != nil {
 			return err
 		}
 		rows = append(rows, decoded...)
 		return nil
 	})
 	return rows, err
+}
+
+func decodeResultRows(data []byte) ([]map[string]any, error) {
+	var wrapped types.QueryWriteData
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Result != nil {
+		data = wrapped.Result
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func isTerminalStatus(status string) bool {

--- a/pkg/console/manager_test.go
+++ b/pkg/console/manager_test.go
@@ -156,6 +156,30 @@ func TestRefreshCDUpdatesWorkingDirectoryAfterResult(t *testing.T) {
 	require.Equal(t, "/etc", refreshed.CWD)
 }
 
+func TestCommandResultsDecodeStoredQueryWriteData(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, _, err := manager.SubmitCommand(session.ID, "ps")
+	require.NoError(t, err)
+
+	result, err := json.Marshal([]map[string]string{{"pid": "1", "name": "launchd"}})
+	require.NoError(t, err)
+	wrapped, err := json.Marshal(map[string]any{
+		"name":    command.DistributedQueryName,
+		"result":  json.RawMessage(result),
+		"status":  0,
+		"message": "",
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{Name: command.DistributedQueryName, Data: string(wrapped), Status: 0}).Error)
+	require.NoError(t, markNodeQueryStatus(db, command.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+
+	rows, err := manager.CommandResults(command.ID)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"pid": "1", "name": "launchd"}}, rows)
+}
+
 func markNodeQueryStatus(db *gorm.DB, name, status string) error {
 	var distributed queries.DistributedQuery
 	if err := db.Where("name = ?", name).First(&distributed).Error; err != nil {


### PR DESCRIPTION
The console result decoder was expecting osquery_query_data.data to be the raw result array, but real TLS ingestion stores a types.QueryWriteData wrapper:

```
{ "name": "...", "result": [ ... ], "status": 0, "message": "" }
```

So `/results` hit a JSON unmarshal error and returned the generic error getting command results.