### PR TITLE
Adding osquery mode to console to run queries directly

### DIFF
--- a/cmd/api/handlers/console.go
+++ b/cmd/api/handlers/console.go
@@ -5,11 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/jmpsec/osctrl/pkg/carves"
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -17,13 +24,30 @@ import (
 )
 
 type consoleCommandRequest struct {
-	Input string `json:"input"`
+	Input       string `json:"input"`
+	OsqueryMode bool   `json:"osquery_mode"`
 }
 
 type consoleCommandResponse struct {
 	Command console.Command       `json:"command"`
 	Parsed  console.ParsedCommand `json:"parsed"`
 }
+
+type consoleNodeInfo struct {
+	IPAddress       string `json:"ip_address"`
+	OsqueryUser     string `json:"osquery_user"`
+	OsqueryVersion  string `json:"osquery_version"`
+	Platform        string `json:"platform"`
+	PlatformVersion string `json:"platform_version"`
+}
+
+type consoleSessionResponse struct {
+	Session  console.Session        `json:"session"`
+	History  []console.HistoryEntry `json:"history"`
+	NodeInfo consoleNodeInfo        `json:"node_info"`
+}
+
+const defaultConsoleQueryReadSeconds = 5
 
 func (h *HandlersApi) ConsoleSessionCreateHandler(w http.ResponseWriter, r *http.Request) {
 	env, ctx, ok := h.consoleEnvContext(w, r)
@@ -44,18 +68,32 @@ func (h *HandlersApi) ConsoleSessionCreateHandler(w http.ResponseWriter, r *http
 		apiErrorResponse(w, "error getting node", http.StatusInternalServerError, err)
 		return
 	}
+	history, err := h.Console.History(env.ID, node.ID, ctx[ctxUser], 100)
+	if err != nil {
+		apiErrorResponse(w, "error getting console history", http.StatusInternalServerError, err)
+		return
+	}
 	session, err := h.Console.CreateSession(env, node, ctx[ctxUser])
 	if err != nil {
 		apiErrorResponse(w, "error creating console session", http.StatusInternalServerError, err)
 		return
 	}
 	h.auditConsoleVisit(ctx[ctxUser], r, env.ID)
-	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, session)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, consoleSessionResponse{
+		Session:  session,
+		History:  history,
+		NodeInfo: consoleNodeInfoFromNode(node),
+	})
 }
 
 func (h *HandlersApi) ConsoleSessionShowHandler(w http.ResponseWriter, r *http.Request) {
 	env, ctx, session, ok := h.consoleSessionContext(w, r)
 	if !ok {
+		return
+	}
+	session, err := h.Console.TouchSession(session.ID)
+	if err != nil {
+		apiErrorResponse(w, "error refreshing console session", http.StatusInternalServerError, err)
 		return
 	}
 	h.auditConsoleVisit(ctx[ctxUser], r, env.ID)
@@ -84,15 +122,128 @@ func (h *HandlersApi) ConsoleCommandCreateHandler(w http.ResponseWriter, r *http
 		apiErrorResponse(w, "error parsing POST body", http.StatusBadRequest, err)
 		return
 	}
-	command, parsed, err := h.Console.SubmitCommand(session.ID, body.Input)
+	preview, err := console.ParseInput(body.Input, session.CWD, session.Platform, body.OsqueryMode)
 	if err != nil {
 		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
 		return
+	}
+	if preview.Kind == console.CommandCarve && !h.Users.CheckPermissions(ctx[ctxUser], users.CarveLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use console get by user %s", ctx[ctxUser]))
+		return
+	}
+
+	command, parsed, err := h.Console.SubmitCommandWithTimeout(session.ID, body.Input, h.consoleCommandTimeout(preview), body.OsqueryMode)
+	if err != nil {
+		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
+		return
+	}
+	if parsed.Kind == console.CommandCarve {
+		carveName, err := h.createConsoleCarve(env, session, ctx[ctxUser], parsed.Path)
+		if err != nil {
+			apiErrorResponse(w, "error creating carve", http.StatusInternalServerError, err)
+			return
+		}
+		parsed.Message = "created carve " + carveName
+	} else if parsed.Kind == console.CommandLocal && parsed.Command == "tables" && parsed.Mode == "osquery" {
+		parsed.Output = h.consoleTablesOutput(session.Platform)
 	}
 	if h.AuditLog != nil {
 		h.AuditLog.QueryAction(ctx[ctxUser], "console command "+parsed.Command, strings.Split(r.RemoteAddr, ":")[0], env.ID)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, consoleCommandResponse{Command: command, Parsed: parsed})
+}
+
+func (h *HandlersApi) createConsoleCarve(env environments.TLSEnvironment, session console.Session, creator, path string) (string, error) {
+	newQuery := queries.DistributedQuery{
+		Query:         carves.GenCarveQuery(path, false),
+		Name:          carves.GenCarveName(),
+		Creator:       "console:" + creator,
+		Active:        true,
+		Type:          queries.CarveQueryType,
+		Path:          path,
+		EnvironmentID: env.ID,
+		Expected:      1,
+	}
+	if err := h.Queries.Create(&newQuery); err != nil {
+		return "", err
+	}
+	if err := h.Queries.CreateNodeQueries([]uint{session.NodeID}, newQuery.ID); err != nil {
+		return "", err
+	}
+	if err := h.Queries.CreateTarget(newQuery.Name, "uuid", session.NodeUUID); err != nil {
+		return "", err
+	}
+	if err := h.Queries.SetExpected(newQuery.Name, 1, env.ID); err != nil {
+		return "", err
+	}
+	if h.AuditLog != nil {
+		h.AuditLog.NewCarve(creator, path, "", env.ID)
+	}
+	return newQuery.Name, nil
+}
+
+func consoleNodeInfoFromNode(node nodes.OsqueryNode) consoleNodeInfo {
+	return consoleNodeInfo{
+		IPAddress:       node.IPAddress,
+		OsqueryUser:     node.OsqueryUser,
+		OsqueryVersion:  node.OsqueryVersion,
+		Platform:        node.Platform,
+		PlatformVersion: node.PlatformVersion,
+	}
+}
+
+func (h *HandlersApi) consoleTablesOutput(platform string) string {
+	names := make([]string, 0, len(h.OsqueryTables))
+	for _, table := range h.OsqueryTables {
+		if osqueryTableSupportsPlatform(table, platform) {
+			names = append(names, table.Name)
+		}
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		if platform == "" {
+			return "no osquery tables loaded"
+		}
+		return "no osquery tables loaded for " + platform
+	}
+	label := platform
+	if label == "" {
+		label = "all platforms"
+	}
+	return fmt.Sprintf("tables for %s (%d)\n%s", label, len(names), strings.Join(names, "\n"))
+}
+
+func (h *HandlersApi) consoleCommandTimeout(parsed console.ParsedCommand) time.Duration {
+	seconds := int64(defaultConsoleQueryReadSeconds)
+	if h.Settings != nil {
+		if configured, err := h.Settings.GetInteger(config.ServiceTLS, settings.AcceleratedSeconds, settings.NoEnvironmentID); err == nil && configured > 0 {
+			seconds = configured
+		}
+	}
+	if parsed.Kind == console.CommandRemote && parsed.Command == "sql" {
+		timeout := time.Duration(seconds*12) * time.Second
+		if timeout < time.Minute {
+			return time.Minute
+		}
+		return timeout
+	}
+	return time.Duration(seconds*2) * time.Second
+}
+
+func osqueryTableSupportsPlatform(table types.OsqueryTable, platform string) bool {
+	if platform == "" {
+		return true
+	}
+	if len(table.Platforms) == 0 {
+		return true
+	}
+	nodeBucket := nodes.NormalizePlatformBucket(platform)
+	for _, supported := range table.Platforms {
+		if strings.EqualFold(supported, platform) || nodes.NormalizePlatformBucket(supported) == nodeBucket {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *HandlersApi) ConsoleCommandShowHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/api/handlers/console_test.go
+++ b/cmd/api/handlers/console_test.go
@@ -3,16 +3,22 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/jmpsec/osctrl/pkg/carves"
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
@@ -29,8 +35,10 @@ func setupConsoleHandlers(t *testing.T) (*gorm.DB, *HandlersApi, environments.TL
 	envs := environments.CreateEnvironment(db)
 	nodesmgr := nodes.CreateNodes(db)
 	queryManager := queries.CreateQueries(db)
+	carveManager := carves.CreateFileCarves(db, config.CarverDB, nil)
 	consoleManager := console.NewManager(db, queryManager)
 	userManager := users.CreateUserManager(db)
+	settingsManager := settings.NewSettings(db)
 
 	env := environments.TLSEnvironment{UUID: "env-uuid", Name: "env"}
 	require.NoError(t, db.Create(&env).Error)
@@ -53,9 +61,67 @@ func setupConsoleHandlers(t *testing.T) (*gorm.DB, *HandlersApi, environments.TL
 		WithUsers(userManager),
 		WithNodes(nodesmgr),
 		WithQueries(queryManager),
+		WithCarves(carveManager),
+		WithSettings(settingsManager),
 		WithConsole(consoleManager),
 	)
 	return db, h, env, node
+}
+
+func TestConsoleSessionCreateReturnsHistory(t *testing.T) {
+	_, h, env, node := setupConsoleHandlers(t)
+	oldSession, err := h.Console.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	_, _, err = h.Console.SubmitCommand(oldSession.ID, "pwd")
+	require.NoError(t, err)
+
+	req := consoleRequest(http.MethodPost, "/console", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("uuid", node.UUID)
+	rr := httptest.NewRecorder()
+
+	h.ConsoleSessionCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var resp consoleSessionResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Session.ID)
+	require.Len(t, resp.History, 1)
+	require.Equal(t, "pwd", resp.History[0].Command.Input)
+}
+
+func TestConsoleSessionCreateReturnsNodeInfo(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	require.NoError(t, db.Model(&node).Updates(map[string]any{
+		"ip_address":       "10.0.0.8",
+		"osquery_user":     "root",
+		"osquery_version":  "5.11.0",
+		"platform":         "darwin",
+		"platform_version": "14.5",
+	}).Error)
+
+	req := consoleRequest(http.MethodPost, "/console", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("uuid", node.UUID)
+	rr := httptest.NewRecorder()
+
+	h.ConsoleSessionCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp struct {
+		NodeInfo struct {
+			IPAddress       string `json:"ip_address"`
+			OsqueryUser     string `json:"osquery_user"`
+			OsqueryVersion  string `json:"osquery_version"`
+			Platform        string `json:"platform"`
+			PlatformVersion string `json:"platform_version"`
+		} `json:"node_info"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, "10.0.0.8", resp.NodeInfo.IPAddress)
+	require.Equal(t, "root", resp.NodeInfo.OsqueryUser)
+	require.Equal(t, "5.11.0", resp.NodeInfo.OsqueryVersion)
+	require.Equal(t, "darwin", resp.NodeInfo.Platform)
+	require.Equal(t, "14.5", resp.NodeInfo.PlatformVersion)
 }
 
 func TestConsoleSessionCreateRequiresQueryPermission(t *testing.T) {
@@ -68,6 +134,27 @@ func TestConsoleSessionCreateRequiresQueryPermission(t *testing.T) {
 
 	h.ConsoleSessionCreateHandler(rr, req)
 	require.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestConsoleSessionShowRefreshesSession(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	session, err := h.Console.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	oldUpdatedAt := time.Now().Add(-time.Hour)
+	require.NoError(t, db.Model(&session).UpdateColumn("updated_at", oldUpdatedAt).Error)
+	before := time.Now()
+
+	req := consoleRequest(http.MethodGet, "/console", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	rr := httptest.NewRecorder()
+
+	h.ConsoleSessionShowHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var refreshed console.Session
+	require.NoError(t, db.First(&refreshed, session.ID).Error)
+	require.False(t, refreshed.UpdatedAt.Before(before))
 }
 
 func TestConsoleSessionCreateRejectsNodeFromOtherEnv(t *testing.T) {
@@ -103,6 +190,176 @@ func TestConsoleCommandRejectsSecondInFlightCommand(t *testing.T) {
 	secondRR := httptest.NewRecorder()
 	h.ConsoleCommandCreateHandler(secondRR, second)
 	require.Equal(t, http.StatusBadRequest, secondRR.Code)
+}
+
+func TestConsoleCommandExpirationUsesDoubleAcceleratedQueryReadInterval(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	require.NoError(t, h.Settings.NewIntegerValue(config.ServiceTLS, settings.AcceleratedSeconds, 7, settings.NoEnvironmentID))
+	session, err := h.Console.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	before := time.Now()
+
+	req := consoleRequest(http.MethodPost, "/console", []byte(`{"input":"ps"}`), "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	rr := httptest.NewRecorder()
+
+	h.ConsoleCommandCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp consoleCommandResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", resp.Command.DistributedQueryName).First(&distributed).Error)
+	require.True(t, distributed.Expiration.After(before.Add(13*time.Second)))
+	require.True(t, distributed.Expiration.Before(before.Add(15*time.Second)))
+}
+
+func TestConsoleOsqueryModeSQLUsesLongerExpiration(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	require.NoError(t, h.Settings.NewIntegerValue(config.ServiceTLS, settings.AcceleratedSeconds, 5, settings.NoEnvironmentID))
+	session, err := h.Console.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	before := time.Now()
+
+	req := consoleRequest(http.MethodPost, "/console", []byte(`{"input":"select * from osquery_info","osquery_mode":true}`), "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	rr := httptest.NewRecorder()
+
+	h.ConsoleCommandCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp consoleCommandResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", resp.Command.DistributedQueryName).First(&distributed).Error)
+	require.True(t, distributed.Expiration.After(before.Add(59*time.Second)))
+	require.True(t, distributed.Expiration.Before(before.Add(61*time.Second)))
+}
+
+func TestConsoleGetRequiresCarvePermission(t *testing.T) {
+	_, h, env, node := setupConsoleHandlers(t)
+	session, err := h.Console.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	req := consoleRequest(http.MethodPost, "/console", []byte(`{"input":"get /etc/passwd"}`), "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	rr := httptest.NewRecorder()
+
+	h.ConsoleCommandCreateHandler(rr, req)
+	require.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestConsoleGetCreatesNodeTargetedCarve(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	require.NoError(t, h.Users.CreatePermission(users.UserPermission{
+		Username:      "alice",
+		AccessType:    int(users.CarveLevel),
+		AccessValue:   true,
+		Environment:   env.UUID,
+		EnvironmentID: env.ID,
+	}))
+	session, err := h.Console.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	req := consoleRequest(http.MethodPost, "/console", []byte(`{"input":"get /etc/passwd"}`), "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	rr := httptest.NewRecorder()
+
+	h.ConsoleCommandCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp consoleCommandResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, console.CommandCarve, resp.Parsed.Kind)
+	require.Equal(t, console.StatusCompleted, resp.Command.Status)
+	require.Contains(t, resp.Parsed.Message, "carve")
+
+	var carveQuery queries.DistributedQuery
+	require.NoError(t, db.Where("type = ?", queries.CarveQueryType).First(&carveQuery).Error)
+	require.Equal(t, "/etc/passwd", carveQuery.Path)
+	require.Equal(t, "console:alice", carveQuery.Creator)
+	require.Equal(t, 1, carveQuery.Expected)
+
+	var nodeQuery queries.NodeQuery
+	require.NoError(t, db.Where("query_id = ?", carveQuery.ID).First(&nodeQuery).Error)
+	require.Equal(t, node.ID, nodeQuery.NodeID)
+
+	targets, err := h.Queries.GetTargets(carveQuery.Name)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, "uuid", targets[0].Type)
+	require.Equal(t, node.UUID, targets[0].Value)
+}
+
+func TestConsoleOsqueryModeTablesUsesLoadedTablesForNodePlatform(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	require.NoError(t, db.Model(&node).Update("platform", "linux").Error)
+	h.OsqueryTables = []types.OsqueryTable{
+		{Name: "apps", Platforms: []string{"darwin"}},
+		{Name: "file", Platforms: []string{}},
+		{Name: "processes", Platforms: []string{"linux", "darwin"}},
+		{Name: "rpm_packages", Platforms: []string{"linux"}},
+	}
+	session, err := h.Console.CreateSession(env, nodes.OsqueryNode{
+		ID:            node.ID,
+		UUID:          node.UUID,
+		Platform:      "linux",
+		EnvironmentID: env.ID,
+		Environment:   env.UUID,
+	}, "alice")
+	require.NoError(t, err)
+
+	req := consoleRequest(http.MethodPost, "/console", []byte(`{"input":".tables","osquery_mode":true}`), "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	rr := httptest.NewRecorder()
+
+	h.ConsoleCommandCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp consoleCommandResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, console.CommandLocal, resp.Parsed.Kind)
+	require.Equal(t, "tables", resp.Parsed.Command)
+	require.Contains(t, resp.Parsed.Output, "file")
+	require.Contains(t, resp.Parsed.Output, "processes")
+	require.Contains(t, resp.Parsed.Output, "rpm_packages")
+	require.NotContains(t, resp.Parsed.Output, "apps")
+}
+
+func TestConsoleOsqueryModeTablesTreatsLinuxDistrosAsLinux(t *testing.T) {
+	_, h, env, node := setupConsoleHandlers(t)
+	h.OsqueryTables = []types.OsqueryTable{
+		{Name: "apps", Platforms: []string{"darwin"}},
+		{Name: "deb_packages", Platforms: []string{"linux"}},
+		{Name: "file", Platforms: []string{}},
+	}
+	session, err := h.Console.CreateSession(env, nodes.OsqueryNode{
+		ID:            node.ID,
+		UUID:          node.UUID,
+		Platform:      "debian",
+		EnvironmentID: env.ID,
+		Environment:   env.UUID,
+	}, "alice")
+	require.NoError(t, err)
+
+	req := consoleRequest(http.MethodPost, "/console", []byte(`{"input":".tables","osquery_mode":true}`), "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	rr := httptest.NewRecorder()
+
+	h.ConsoleCommandCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp consoleCommandResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Contains(t, resp.Parsed.Output, "deb_packages")
+	require.Contains(t, resp.Parsed.Output, "file")
+	require.NotContains(t, resp.Parsed.Output, "apps")
 }
 
 func consoleRequest(method, target string, body []byte, username string) *http.Request {

--- a/cmd/tls/handlers/console_acceleration_test.go
+++ b/cmd/tls/handlers/console_acceleration_test.go
@@ -1,0 +1,162 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestShouldAccelerateQueryReadForActiveConsoleSession(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&console.Session{}))
+	queryManager := queries.CreateQueries(db)
+	handler := &HandlersTLS{Queries: queryManager}
+	node := nodes.OsqueryNode{ID: 7, UUID: "NODE-UUID", EnvironmentID: 1}
+	otherNode := nodes.OsqueryNode{ID: 8, UUID: "OTHER-NODE-UUID", EnvironmentID: 1}
+
+	require.False(t, handler.shouldAccelerateQueryRead(node, false))
+	require.True(t, handler.shouldAccelerateQueryRead(node, true))
+
+	require.NoError(t, db.Model(&console.Session{}).Create(map[string]any{
+		"environment_id": 1,
+		"node_id":        node.ID,
+		"node_uuid":      "NODE-UUID",
+		"creator":        "alice",
+		"cwd":            "/",
+		"platform":       "linux",
+		"active":         false,
+	}).Error)
+	require.False(t, handler.shouldAccelerateQueryRead(node, false))
+
+	require.NoError(t, db.Create(&console.Session{
+		EnvironmentID: 1,
+		NodeID:        otherNode.ID,
+		NodeUUID:      otherNode.UUID,
+		Creator:       "alice",
+		CWD:           "/",
+		Platform:      "linux",
+		Active:        true,
+	}).Error)
+	require.False(t, handler.shouldAccelerateQueryRead(node, false))
+	require.True(t, handler.shouldAccelerateQueryRead(otherNode, false))
+
+	require.NoError(t, db.Create(&console.Session{
+		EnvironmentID: 2,
+		NodeID:        node.ID,
+		NodeUUID:      node.UUID,
+		Creator:       "alice",
+		CWD:           "/",
+		Platform:      "linux",
+		Active:        true,
+	}).Error)
+	require.False(t, handler.shouldAccelerateQueryRead(node, false))
+
+	staleSession := console.Session{
+		EnvironmentID: node.EnvironmentID,
+		NodeID:        node.ID,
+		NodeUUID:      node.UUID,
+		Creator:       "alice",
+		CWD:           "/",
+		Platform:      "linux",
+		Active:        true,
+	}
+	require.NoError(t, db.Create(&staleSession).Error)
+	require.NoError(t, db.Model(&staleSession).UpdateColumn("updated_at", time.Now().Add(-consoleSessionFreshness-time.Minute)).Error)
+	require.False(t, handler.shouldAccelerateQueryRead(node, false))
+
+	require.NoError(t, db.Create(&console.Session{
+		EnvironmentID: node.EnvironmentID,
+		NodeID:        node.ID,
+		NodeUUID:      node.UUID,
+		Creator:       "alice",
+		CWD:           "/",
+		Platform:      "linux",
+		Active:        true,
+	}).Error)
+	require.True(t, handler.shouldAccelerateQueryRead(node, false))
+}
+
+func TestQueryReadAcceleratesOnlyConsoleSessionNode(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	envs := environments.CreateEnvironment(db)
+	nodesMgr := nodes.CreateNodes(db)
+	queryManager := queries.CreateQueries(db)
+	settingsMgr := settings.NewSettings(db)
+	require.NoError(t, db.AutoMigrate(&console.Session{}))
+	require.NoError(t, settingsMgr.NewIntegerValue(config.ServiceTLS, settings.AcceleratedSeconds, 5, settings.NoEnvironmentID))
+
+	env := environments.TLSEnvironment{
+		UUID: "11111111-1111-4111-8111-111111111111",
+		Name: "env",
+	}
+	require.NoError(t, db.Create(&env).Error)
+	consoleNode := nodes.OsqueryNode{
+		NodeKey:       "console-node-key",
+		UUID:          "CONSOLE-NODE-UUID",
+		EnvironmentID: env.ID,
+		Environment:   env.UUID,
+	}
+	otherNode := nodes.OsqueryNode{
+		NodeKey:       "other-node-key",
+		UUID:          "OTHER-NODE-UUID",
+		EnvironmentID: env.ID,
+		Environment:   env.UUID,
+	}
+	require.NoError(t, db.Create(&consoleNode).Error)
+	require.NoError(t, db.Create(&otherNode).Error)
+	require.NoError(t, db.Create(&console.Session{
+		EnvironmentID: env.ID,
+		NodeID:        consoleNode.ID,
+		NodeUUID:      consoleNode.UUID,
+		Creator:       "alice",
+		CWD:           "/",
+		Platform:      "linux",
+		Active:        true,
+	}).Error)
+
+	handler := CreateHandlersTLS(
+		WithEnvs(envs),
+		WithEnvCache(environments.NewEnvCache(*envs)),
+		WithNodes(nodesMgr),
+		WithQueries(queryManager),
+		WithSettings(settingsMgr),
+		WithWriteHandler(NewBatchWriter(100, time.Hour, 10, *nodesMgr)),
+		WithOsqueryValues(&config.YAMLConfigurationOsquery{Accelerated: true}),
+	)
+
+	consoleResp := queryReadResponse(t, handler, env.UUID, consoleNode.NodeKey)
+	require.Equal(t, float64(5), consoleResp["accelerate"])
+
+	otherResp := queryReadResponse(t, handler, env.UUID, otherNode.NodeKey)
+	require.NotContains(t, otherResp, "accelerate")
+}
+
+func queryReadResponse(t *testing.T, handler *HandlersTLS, envUUID, nodeKey string) map[string]any {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"node_key": nodeKey})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/"+envUUID+"/"+environments.DefaultQueryReadPath, bytes.NewReader(body))
+	req.SetPathValue("env", envUUID)
+	rr := httptest.NewRecorder()
+
+	handler.QueryReadHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	return resp
+}

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
@@ -34,6 +35,8 @@ var validAction = map[string]bool{
 	settings.ScriptEnroll: true,
 	settings.ScriptRemove: true,
 }
+
+const consoleSessionFreshness = 30 * time.Second
 
 // Valid values for enroll packages
 var validEnrollPackage = map[string]bool{
@@ -265,6 +268,27 @@ func (h *HandlersTLS) debugHTTPAll() bool {
 
 func (h *HandlersTLS) allowsAcceleratedQueries(queryAccelerated bool) bool {
 	return queryAccelerated && h.OsqueryValues != nil && h.OsqueryValues.Accelerated
+}
+
+func (h *HandlersTLS) shouldAccelerateQueryRead(node nodes.OsqueryNode, queryAccelerated bool) bool {
+	if queryAccelerated {
+		return true
+	}
+	return h.hasActiveConsoleSession(node)
+}
+
+func (h *HandlersTLS) hasActiveConsoleSession(node nodes.OsqueryNode) bool {
+	if node.ID == 0 || node.UUID == "" || node.EnvironmentID == 0 || h.Queries == nil || h.Queries.DB == nil {
+		return false
+	}
+	var count int64
+	if err := h.Queries.DB.Model(&console.Session{}).
+		Where("node_id = ? AND node_uuid = ? AND environment_id = ? AND active = ? AND updated_at >= ?", node.ID, node.UUID, node.EnvironmentID, true, time.Now().Add(-consoleSessionFreshness)).
+		Count(&count).Error; err != nil {
+		log.Debug().Err(err).Msg("error checking active console session for accelerated query read")
+		return false
+	}
+	return count > 0
 }
 
 func (h *HandlersTLS) acceleratedSeconds(ctx context.Context) int {

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -449,6 +449,7 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Err(err).Msg("error getting queries from db")
 		}
+		accelerate = h.shouldAccelerateQueryRead(node, accelerate)
 		// Refresh node last seen
 		ip := utils.GetIP(r)
 		if ip == node.IPAddress {

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -52,7 +52,7 @@ const (
 	// Default refreshing interval in seconds
 	defaultRefresh int = 300
 	// Default accelerate interval in seconds
-	defaultAccelerate int = 60
+	defaultAccelerate int = 5
 	// Default expiration of oneliners for enroll/expire
 	defaultOnelinerExpiration bool = true
 )

--- a/cmd/tls/settings_test.go
+++ b/cmd/tls/settings_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestLoadingSettingsDefaultsAcceleratedSecondsToFive(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	mgr := settings.NewSettings(db)
+
+	require.NoError(t, loadingSettings(mgr, &config.ServiceParameters{
+		Service: &config.YAMLConfigurationService{},
+		Logger:  &config.YAMLConfigurationLogger{},
+		Carver:  &config.YAMLConfigurationCarver{},
+	}))
+
+	got, err := mgr.GetInteger(config.ServiceTLS, settings.AcceleratedSeconds, settings.NoEnvironmentID)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), got)
+}

--- a/frontend/src/api/console.ts
+++ b/frontend/src/api/console.ts
@@ -1,13 +1,15 @@
 import { apiFetch } from './client';
 import type {
   ConsoleCommand,
+  ConsoleHistoryEntry,
   ConsoleResultRow,
   ConsoleSession,
+  ConsoleSessionResponse,
   ParsedConsoleCommand,
 } from './types';
 
-export function createConsoleSession(env: string, uuid: string): Promise<ConsoleSession> {
-  return apiFetch<ConsoleSession>(
+export function createConsoleSession(env: string, uuid: string): Promise<ConsoleSessionResponse> {
+  return apiFetch<ConsoleSessionResponse>(
     `/api/v1/console/${encodeURIComponent(env)}/nodes/${encodeURIComponent(uuid)}/sessions`,
     { method: 'POST' },
   );
@@ -20,17 +22,24 @@ export function closeConsoleSession(env: string, sessionId: number): Promise<{ m
   );
 }
 
+export function getConsoleSession(env: string, sessionId: number): Promise<ConsoleSession> {
+  return apiFetch<ConsoleSession>(
+    `/api/v1/console/${encodeURIComponent(env)}/sessions/${sessionId}`,
+  );
+}
+
 export function submitConsoleCommand(
   env: string,
   sessionId: number,
   input: string,
+  osqueryMode = false,
 ): Promise<{ command: ConsoleCommand; parsed: ParsedConsoleCommand }> {
   return apiFetch<{ command: ConsoleCommand; parsed: ParsedConsoleCommand }>(
     `/api/v1/console/${encodeURIComponent(env)}/sessions/${sessionId}/commands`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ input }),
+      body: JSON.stringify({ input, osquery_mode: osqueryMode }),
     },
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -236,6 +236,14 @@ export interface ConsoleSession {
   closed_at?: string;
 }
 
+export interface ConsoleNodeInfo {
+  ip_address: string;
+  osquery_user: string;
+  osquery_version: string;
+  platform: string;
+  platform_version: string;
+}
+
 export interface ConsoleCommand {
   id: number;
   created_at: string;
@@ -252,14 +260,27 @@ export interface ConsoleCommand {
 }
 
 export interface ParsedConsoleCommand {
-  kind: 'local' | 'remote';
+  kind: 'local' | 'remote' | 'carve' | 'mode' | 'exit-mode';
   command: string;
+  mode?: string;
   path?: string;
   sql?: string;
   output?: string;
+  message?: string;
 }
 
 export type ConsoleResultRow = Record<string, unknown>;
+
+export interface ConsoleHistoryEntry {
+  command: ConsoleCommand;
+  results: ConsoleResultRow[];
+}
+
+export interface ConsoleSessionResponse {
+  session: ConsoleSession;
+  history: ConsoleHistoryEntry[];
+  node_info?: ConsoleNodeInfo;
+}
 
 // ---------------------------------------------------------------------------
 // Saved queries

--- a/frontend/src/features/nodes/NodeConsolePage.test.tsx
+++ b/frontend/src/features/nodes/NodeConsolePage.test.tsx
@@ -1,8 +1,17 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NodeConsolePanel } from './NodeConsolePage';
+
+const consoleApi = vi.hoisted(() => ({
+  createConsoleSession: vi.fn(),
+  closeConsoleSession: vi.fn(),
+  getConsoleSession: vi.fn(),
+  submitConsoleCommand: vi.fn(),
+  getConsoleCommand: vi.fn(),
+  getConsoleCommandResults: vi.fn(),
+}));
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children }: { children: ReactNode }) => <a href="/">{children}</a>,
@@ -10,52 +19,37 @@ vi.mock('@tanstack/react-router', () => ({
 }));
 
 vi.mock('$/api/console', () => ({
-  createConsoleSession: vi.fn(async () => ({
-    id: 1,
-    created_at: '2026-07-21T00:00:00Z',
-    updated_at: '2026-07-21T00:00:00Z',
-    environment_id: 1,
-    node_id: 1,
-    node_uuid: 'NODE',
-    creator: 'alice',
-    cwd: '/',
-    platform: 'linux',
-    active: true,
-  })),
-  closeConsoleSession: vi.fn(async () => ({ message: 'closed' })),
-  submitConsoleCommand: vi.fn(async () => ({
-    command: {
-      id: 10,
-      created_at: '2026-07-21T00:00:00Z',
-      updated_at: '2026-07-21T00:00:00Z',
-      session_id: 1,
-      status: 'queued',
-      input: 'ps',
-    },
-    parsed: { kind: 'remote', command: 'ps' },
-  })),
-  getConsoleCommand: vi.fn(async () => ({
-    id: 10,
-    created_at: '2026-07-21T00:00:00Z',
-    updated_at: '2026-07-21T00:00:00Z',
-    session_id: 1,
-    status: 'queued',
-    input: 'ps',
-  })),
-  getConsoleCommandResults: vi.fn(async () => [{ pid: 1, name: 'launchd' }]),
+  createConsoleSession: consoleApi.createConsoleSession,
+  closeConsoleSession: consoleApi.closeConsoleSession,
+  getConsoleSession: consoleApi.getConsoleSession,
+  submitConsoleCommand: consoleApi.submitConsoleCommand,
+  getConsoleCommand: consoleApi.getConsoleCommand,
+  getConsoleCommandResults: consoleApi.getConsoleCommandResults,
 }));
 
 describe('NodeConsolePanel', () => {
-  it('shows spinner and disables input while command is pending', async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleApi.createConsoleSession.mockResolvedValue({
+      session: makeSession(),
+      history: [],
     });
+    consoleApi.closeConsoleSession.mockResolvedValue({ message: 'closed' });
+    consoleApi.getConsoleSession.mockResolvedValue(makeSession());
+    consoleApi.submitConsoleCommand.mockResolvedValue({
+      command: makeCommand({ status: 'queued', input: 'ps' }),
+      parsed: { kind: 'remote', command: 'ps' },
+    });
+    consoleApi.getConsoleCommand.mockResolvedValue(makeCommand({ status: 'queued', input: 'ps' }));
+    consoleApi.getConsoleCommandResults.mockResolvedValue([{ pid: 1, name: 'launchd' }]);
+  });
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <NodeConsolePanel env="env" uuid="NODE" />
-      </QueryClientProvider>,
-    );
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows spinner and disables input while command is pending', async () => {
+    renderConsole();
 
     const input = await screen.findByLabelText(/console input/i);
     await waitFor(() => expect(input).not.toBeDisabled());
@@ -66,4 +60,222 @@ describe('NodeConsolePanel', () => {
     expect(await screen.findByText(/waiting for node/i)).toBeInTheDocument();
     expect(input).toBeDisabled();
   });
+
+  it('renders prior command history when the console opens', async () => {
+    consoleApi.createConsoleSession.mockResolvedValue({
+      session: makeSession(),
+      history: [
+        {
+          command: makeCommand({ id: 7, status: 'completed', input: 'ps' }),
+          results: [{ pid: 1, name: 'launchd' }],
+        },
+      ],
+    });
+
+    renderConsole();
+
+    expect(await screen.findByText('ps')).toBeInTheDocument();
+    expect(screen.getByText('launchd')).toBeInTheDocument();
+  });
+
+  it('focuses the command input when the console opens', async () => {
+    renderConsole();
+
+    const input = await screen.findByLabelText(/console input/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+    expect(input).toHaveFocus();
+  });
+
+  it('keeps the console session fresh while open', async () => {
+    const intervals: Array<() => void> = [];
+    const originalSetInterval = window.setInterval.bind(window);
+    const originalClearInterval = window.clearInterval.bind(window);
+    const setIntervalSpy = vi.spyOn(window, 'setInterval').mockImplementation((handler, timeout, ...args) => {
+      if (timeout === 10000 && typeof handler === 'function') {
+        intervals.push(() => handler());
+        return 1;
+      }
+      return originalSetInterval(handler as TimerHandler, timeout, ...args);
+    });
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval').mockImplementation((id) => {
+      if (id === 1) return undefined;
+      return originalClearInterval(id);
+    });
+    const rendered = renderConsole();
+
+    const input = await screen.findByLabelText(/console input/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    expect(intervals).toHaveLength(1);
+    intervals[0]();
+
+    await waitFor(() => expect(consoleApi.getConsoleSession).toHaveBeenCalledWith('env', 1));
+    rendered.unmount();
+    expect(clearIntervalSpy).toHaveBeenCalledWith(1);
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('keeps the command bar pinned outside the scrollback pane', async () => {
+    consoleApi.createConsoleSession.mockResolvedValue({
+      session: makeSession(),
+      history: Array.from({ length: 30 }, (_, index) => ({
+        command: makeCommand({ id: index + 1, status: 'completed', input: `ps ${index}` }),
+        results: [{ pid: index + 1, name: `proc-${index}` }],
+      })),
+    });
+
+    renderConsole();
+
+    const input = await screen.findByLabelText(/console input/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+    expect(screen.getByTestId('node-console-page')).toHaveClass('h-[calc(100dvh-3.5rem)]');
+    expect(input.closest('form')).toHaveAttribute('data-console-command-bar', 'true');
+    expect(input.closest('form')).toHaveClass('sticky', 'bottom-0');
+  });
+
+  it('shows node connection and osquery metadata in the console header', async () => {
+    consoleApi.createConsoleSession.mockResolvedValue({
+      session: makeSession(),
+      history: [],
+      node_info: {
+        ip_address: '10.0.0.8',
+        osquery_user: 'root',
+        osquery_version: '5.11.0',
+        platform: 'darwin',
+        platform_version: '14.5',
+      },
+    });
+
+    renderConsole();
+
+    expect(await screen.findByText('10.0.0.8')).toBeInTheDocument();
+    expect(screen.getByText('root')).toBeInTheDocument();
+    expect(screen.getByText('osquery')).toBeInTheDocument();
+    expect(screen.getByText('5.11.0')).toBeInTheDocument();
+    expect(screen.getByText('darwin 14.5')).toBeInTheDocument();
+  });
+
+  it('switches into and out of the osquery prompt', async () => {
+    consoleApi.submitConsoleCommand.mockImplementation(async (_env, _sessionID, input) => {
+      if (input === 'sql') {
+        return { command: makeCommand({ input, status: 'completed' }), parsed: { kind: 'mode', command: 'sql', mode: 'osquery', message: 'entering osquery mode' } };
+      }
+      return { command: makeCommand({ input, status: 'completed' }), parsed: { kind: 'exit-mode', command: '.exit', mode: 'osquery', message: 'leaving osquery mode' } };
+    });
+
+    renderConsole();
+    const input = await screen.findByLabelText(/console input/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    fireEvent.change(input, { target: { value: 'sql' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await screen.findByText('entering osquery mode');
+    expect(screen.getByText('osquery>')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '.exit' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await screen.findByText('leaving osquery mode');
+    expect(screen.queryByText('osquery>')).not.toBeInTheDocument();
+  });
+
+  it('sends osquery mode commands with the osquery_mode flag', async () => {
+    consoleApi.submitConsoleCommand.mockResolvedValueOnce({
+      command: makeCommand({ input: 'sql', status: 'completed' }),
+      parsed: { kind: 'mode', command: 'sql', mode: 'osquery', message: 'entering osquery mode' },
+    });
+
+    renderConsole();
+    const input = await screen.findByLabelText(/console input/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    fireEvent.change(input, { target: { value: 'sql' } });
+    fireEvent.submit(input.closest('form')!);
+    await screen.findByText('entering osquery mode');
+
+    fireEvent.change(input, { target: { value: 'select * from osquery_info' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(consoleApi.submitConsoleCommand).toHaveBeenLastCalledWith('env', 1, 'select * from osquery_info', true);
+    });
+  });
+
+  it('shows carve feedback for get without waiting for query results', async () => {
+    consoleApi.submitConsoleCommand.mockResolvedValue({
+      command: makeCommand({ input: 'get /etc/passwd', status: 'completed' }),
+      parsed: { kind: 'carve', command: 'get', path: '/etc/passwd', message: 'created carve carve_abc' },
+    });
+
+    renderConsole();
+    const input = await screen.findByLabelText(/console input/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    fireEvent.change(input, { target: { value: 'get /etc/passwd' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await screen.findByText('created carve carve_abc');
+    expect(screen.queryByText(/waiting for node/i)).not.toBeInTheDocument();
+  });
+
+  it('returns focus to the command input after Run is clicked', async () => {
+    consoleApi.submitConsoleCommand.mockResolvedValue({
+      command: makeCommand({ input: 'pwd', status: 'completed' }),
+      parsed: { kind: 'local', command: 'pwd', output: '/' },
+    });
+
+    renderConsole();
+    const input = await screen.findByLabelText(/console input/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+    input.focus();
+
+    fireEvent.change(input, { target: { value: 'pwd' } });
+    const runButton = screen.getByRole('button', { name: 'Run' });
+    runButton.focus();
+    fireEvent.submit(input.closest('form')!);
+
+    await screen.findByText('/');
+    expect(input).toHaveFocus();
+  });
 });
+
+function renderConsole() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NodeConsolePanel env="env" uuid="NODE" />
+    </QueryClientProvider>,
+  );
+}
+
+function makeSession() {
+  return {
+    id: 1,
+    created_at: '2026-07-21T00:00:00Z',
+    updated_at: '2026-07-21T00:00:00Z',
+    environment_id: 1,
+    node_id: 1,
+    node_uuid: 'NODE',
+    creator: 'alice',
+    cwd: '/',
+    platform: 'linux',
+    active: true,
+  };
+}
+
+function makeCommand(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    created_at: '2026-07-21T00:00:00Z',
+    updated_at: '2026-07-21T00:00:00Z',
+    session_id: 1,
+    status: 'queued',
+    input: 'ps',
+    ...overrides,
+  };
+}

--- a/frontend/src/features/nodes/NodeConsolePage.tsx
+++ b/frontend/src/features/nodes/NodeConsolePage.tsx
@@ -1,25 +1,35 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { Loader2, Terminal } from 'lucide-react';
+import { ArrowLeft, Loader2, Terminal } from 'lucide-react';
 import {
   closeConsoleSession,
   createConsoleSession,
   getConsoleCommand,
   getConsoleCommandResults,
+  getConsoleSession,
   submitConsoleCommand,
 } from '$/api/console';
 import { ApiError, AuthError } from '$/api/client';
-import type { ConsoleCommand, ConsoleResultRow, ConsoleSession } from '$/api/types';
+import type {
+  ConsoleCommand,
+  ConsoleHistoryEntry,
+  ConsoleNodeInfo,
+  ConsoleResultRow,
+  ConsoleSession,
+} from '$/api/types';
 import { Button } from '$/components/atoms/Button';
 import { cn } from '$/lib/cn';
 
 type Entry =
-  | { id: string; type: 'input'; cwd: string; text: string }
+  | { id: string; type: 'input'; prompt: string; text: string }
   | { id: string; type: 'text'; text: string; tone?: 'error' | 'muted' }
   | { id: string; type: 'table'; rows: ConsoleResultRow[] };
 
+type NodeInfoItem = { label: string; value: string };
+
 const terminalStatuses = new Set(['completed', 'error', 'expired']);
+const consoleHeartbeatMs = 10000;
 type PendingCommand = { command: ConsoleCommand; path?: string };
 
 export function NodeConsolePage() {
@@ -30,22 +40,30 @@ export function NodeConsolePage() {
 export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
   const navigate = useNavigate();
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const sessionRef = useRef<ConsoleSession | null>(null);
   const handledCommandRef = useRef<number | null>(null);
+  const focusedOnOpenRef = useRef(false);
+  const focusAfterCommandRef = useRef(false);
   const [session, setSession] = useState<ConsoleSession | null>(null);
+  const [nodeInfo, setNodeInfo] = useState<ConsoleNodeInfo | null>(null);
   const [entries, setEntries] = useState<Entry[]>([]);
   const [input, setInput] = useState('');
   const [pending, setPending] = useState<PendingCommand | null>(null);
+  const [osqueryMode, setOsqueryMode] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
   const [commandError, setCommandError] = useState<string | null>(null);
+  const sessionID = session?.id;
 
   useEffect(() => {
     let alive = true;
     void createConsoleSession(env, uuid)
       .then((created) => {
         if (!alive) return;
-        sessionRef.current = created;
-        setSession(created);
+        sessionRef.current = created.session;
+        setSession(created.session);
+        setNodeInfo(created.node_info ?? null);
+        setEntries(historyToEntries(created.history));
       })
       .catch((error: unknown) => {
         if (!alive) return;
@@ -68,14 +86,54 @@ export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
     bottomRef.current?.scrollIntoView?.({ block: 'end' });
   }, [entries, pending]);
 
+  useEffect(() => {
+    if (!sessionID) return undefined;
+    const interval = window.setInterval(() => {
+      void getConsoleSession(env, sessionID)
+        .then((fresh) => {
+          sessionRef.current = fresh;
+          setSession(fresh);
+        })
+        .catch((error: unknown) => {
+          if (error instanceof AuthError) {
+            void navigate({ to: '/login' });
+          }
+      });
+    }, consoleHeartbeatMs);
+    return () => window.clearInterval(interval);
+  }, [env, navigate, sessionID]);
+
   const submitMutation = useMutation({
     mutationFn: async (value: string) => {
       if (!session) throw new Error('Console is not ready');
-      return submitConsoleCommand(env, session.id, value);
+      return submitConsoleCommand(env, session.id, value, osqueryMode);
     },
     onSuccess: ({ command, parsed }) => {
       if (!session) return;
       setCommandError(null);
+      if (parsed.kind === 'mode') {
+        setOsqueryMode(true);
+        if (parsed.message) {
+          const message = parsed.message;
+          setEntries((current) => [...current, { id: `mode-${command.id}`, type: 'text', text: message }]);
+        }
+        return;
+      }
+      if (parsed.kind === 'exit-mode') {
+        setOsqueryMode(false);
+        if (parsed.message) {
+          const message = parsed.message;
+          setEntries((current) => [...current, { id: `mode-${command.id}`, type: 'text', text: message }]);
+        }
+        return;
+      }
+      if (parsed.kind === 'carve') {
+        setEntries((current) => [
+          ...current,
+          { id: `carve-${command.id}`, type: 'text', text: parsed.message || 'carve created' },
+        ]);
+        return;
+      }
       if (parsed.kind === 'local') {
         if (parsed.command === 'clear') {
           setEntries([]);
@@ -155,36 +213,75 @@ export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
     if (!value || !session || pending || submitMutation.isPending) return;
     setEntries((current) => [
       ...current,
-      { id: `in-${Date.now()}`, type: 'input', cwd: session.cwd, text: value },
+      { id: `in-${Date.now()}`, type: 'input', prompt, text: value },
     ]);
     setInput('');
+    focusAfterCommandRef.current = true;
     submitMutation.mutate(value);
   }
 
   const disabled = !session || Boolean(pending) || submitMutation.isPending;
-  const prompt = useMemo(() => `${session?.cwd ?? '/'} $`, [session?.cwd]);
+  const prompt = useMemo(() => (osqueryMode ? 'osquery>' : `${session?.cwd ?? '/'} $`), [osqueryMode, session?.cwd]);
+  const nodeInfoItems = useMemo(() => formatNodeInfoItems(nodeInfo), [nodeInfo]);
+
+  function focusCommandInput() {
+    if (disabled) return;
+    inputRef.current?.focus({ preventScroll: true });
+  }
+
+  useEffect(() => {
+    if (session && !disabled && !focusedOnOpenRef.current) {
+      focusCommandInput();
+      focusedOnOpenRef.current = true;
+      return;
+    }
+    if (disabled || !focusAfterCommandRef.current) return;
+    focusCommandInput();
+    focusAfterCommandRef.current = false;
+  }, [commandError, disabled, entries, session]);
 
   return (
-    <div className="flex h-full min-h-0 flex-col px-6 py-4">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 text-[color:var(--text-1)]">
-            <Terminal className="h-4 w-4 text-[color:var(--signal)]" aria-hidden="true" />
-            <h1 className="text-base font-semibold">Console</h1>
+    <div
+      data-testid="node-console-page"
+      className="flex h-[calc(100dvh-3.5rem)] max-h-[calc(100dvh-3.5rem)] min-h-0 flex-col overflow-hidden px-6 py-4"
+    >
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-3 border-b border-[color:var(--border)] pb-3">
+        <div className="min-w-0 space-y-2">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded border border-[color:var(--border)] bg-[color:var(--bg-2)] text-[color:var(--signal)]">
+              <Terminal className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <h1 className="text-base font-semibold leading-5 text-[color:var(--text-1)]">Console</h1>
+              <p className="mt-0.5 truncate font-mono-tabular text-xs text-[color:var(--text-3)]">{uuid}</p>
+            </div>
           </div>
-          <p className="mt-0.5 truncate font-mono-tabular text-xs text-[color:var(--text-3)]">{uuid}</p>
+          {nodeInfoItems.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {nodeInfoItems.map((item) => (
+                <span
+                  key={`${item.label}-${item.value}`}
+                  className="inline-flex max-w-full items-center gap-1.5 rounded border border-[color:var(--border)] bg-[color:var(--bg-2)] px-2 py-1 text-[11px] leading-none text-[color:var(--text-3)]"
+                >
+                  <span className="uppercase tracking-normal text-[color:var(--text-4)]">{item.label}</span>
+                  <span className="truncate font-mono-tabular text-[color:var(--text-2)]">{item.value}</span>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <Link
           to="/_app/env/$env/nodes/$uuid"
           params={{ env, uuid }}
-          className="rounded border border-[color:var(--border)] px-3 py-1.5 text-xs font-medium text-[color:var(--text-2)] transition-colors hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded border border-[color:var(--border)] bg-[color:var(--bg-1)] px-3 py-1.5 text-xs font-medium text-[color:var(--text-2)] transition-colors hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]"
         >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
           Back
         </Link>
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-[color:var(--border)] bg-[#050708] text-[#d7f8df] shadow-inner">
-        <div className="flex-1 overflow-auto px-4 py-3 font-mono text-xs leading-5">
+        <div className="min-h-0 flex-1 overflow-auto px-4 py-3 font-mono text-xs leading-5" onScroll={focusCommandInput}>
           {sessionError && <Line tone="error" text={sessionError} />}
           {!session && !sessionError && <Line tone="muted" text="opening console..." />}
           {entries.map((entry) => (
@@ -200,9 +297,14 @@ export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
           <div ref={bottomRef} />
         </div>
 
-        <form onSubmit={onSubmit} className="flex items-center gap-2 border-t border-white/10 px-4 py-2">
+        <form
+          onSubmit={onSubmit}
+          data-console-command-bar="true"
+          className="sticky bottom-0 z-10 flex shrink-0 items-center gap-2 border-t border-white/10 bg-[#050708] px-4 py-2"
+        >
           <span className="shrink-0 font-mono text-xs text-[#8fe8a4]">{prompt}</span>
           <input
+            ref={inputRef}
             aria-label="Console input"
             value={input}
             onChange={(event) => setInput(event.target.value)}
@@ -224,7 +326,7 @@ function ConsoleEntry({ entry }: { entry: Entry }) {
   if (entry.type === 'input') {
     return (
       <div className="whitespace-pre-wrap">
-        <span className="text-[#8fe8a4]">{entry.cwd} $ </span>
+        <span className="text-[#8fe8a4]">{entry.prompt} </span>
         <span>{entry.text}</span>
       </div>
     );
@@ -233,6 +335,45 @@ function ConsoleEntry({ entry }: { entry: Entry }) {
     return <ResultTable rows={entry.rows} />;
   }
   return <Line text={entry.text} tone={entry.tone} />;
+}
+
+function historyToEntries(history: ConsoleHistoryEntry[]): Entry[] {
+  const entries: Entry[] = [];
+  for (const item of history) {
+    entries.push({
+      id: `history-in-${item.command.id}`,
+      type: 'input',
+      prompt: '$',
+      text: item.command.input,
+    });
+    if (item.command.error) {
+      entries.push({
+        id: `history-err-${item.command.id}`,
+        type: 'text',
+        tone: 'error',
+        text: item.command.error,
+      });
+    }
+    if (item.results.length > 0) {
+      entries.push({
+        id: `history-rows-${item.command.id}`,
+        type: 'table',
+        rows: item.results,
+      });
+    }
+  }
+  return entries;
+}
+
+function formatNodeInfoItems(info: ConsoleNodeInfo | null): NodeInfoItem[] {
+  if (!info) return [];
+  const items: NodeInfoItem[] = [];
+  if (info.ip_address) items.push({ label: 'ip', value: info.ip_address });
+  if (info.osquery_user) items.push({ label: 'user', value: info.osquery_user });
+  if (info.osquery_version) items.push({ label: 'osquery', value: info.osquery_version });
+  const platform = [info.platform, info.platform_version].filter(Boolean).join(' ');
+  if (platform) items.push({ label: 'platform', value: platform });
+  return items;
 }
 
 function Line({ text, tone }: { text: string; tone?: 'error' | 'muted' }) {

--- a/pkg/console/manager.go
+++ b/pkg/console/manager.go
@@ -3,6 +3,7 @@ package console
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/environments"
@@ -13,7 +14,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const commandExpiration = 5 * time.Minute
+const defaultCommandTimeout = 10 * time.Second
 
 type Manager struct {
 	DB      *gorm.DB
@@ -51,7 +52,23 @@ func (m *Manager) GetSession(sessionID uint) (Session, error) {
 	return session, nil
 }
 
-func (m *Manager) SubmitCommand(sessionID uint, input string) (Command, ParsedCommand, error) {
+func (m *Manager) TouchSession(sessionID uint) (Session, error) {
+	if err := m.DB.Model(&Session{}).
+		Where("id = ? AND active = ?", sessionID, true).
+		UpdateColumn("updated_at", time.Now()).Error; err != nil {
+		return Session{}, err
+	}
+	return m.GetSession(sessionID)
+}
+
+func (m *Manager) SubmitCommand(sessionID uint, input string, osqueryModeOpt ...bool) (Command, ParsedCommand, error) {
+	return m.SubmitCommandWithTimeout(sessionID, input, defaultCommandTimeout, osqueryModeOpt...)
+}
+
+func (m *Manager) SubmitCommandWithTimeout(sessionID uint, input string, timeout time.Duration, osqueryModeOpt ...bool) (Command, ParsedCommand, error) {
+	if timeout <= 0 {
+		timeout = defaultCommandTimeout
+	}
 	var session Session
 	if err := m.DB.First(&session, sessionID).Error; err != nil {
 		return Command{}, ParsedCommand{}, err
@@ -69,7 +86,11 @@ func (m *Manager) SubmitCommand(sessionID uint, input string) (Command, ParsedCo
 		return Command{}, ParsedCommand{}, fmt.Errorf("another command is still pending")
 	}
 
-	parsed, err := Parse(input, session.CWD, session.Platform)
+	osqueryMode := false
+	if len(osqueryModeOpt) > 0 {
+		osqueryMode = osqueryModeOpt[0]
+	}
+	parsed, err := ParseInput(input, session.CWD, session.Platform, osqueryMode)
 	if err != nil {
 		return Command{}, ParsedCommand{}, err
 	}
@@ -104,7 +125,7 @@ func (m *Manager) SubmitCommand(sessionID uint, input string) (Command, ParsedCo
 			Hidden:        true,
 			Type:          queries.ConsoleQueryType,
 			EnvironmentID: session.EnvironmentID,
-			Expiration:    time.Now().Add(commandExpiration),
+			Expiration:    time.Now().Add(timeout),
 			Expected:      1,
 			ExtraData:     string(extra),
 		}
@@ -175,6 +196,9 @@ func (m *Manager) RefreshCommandStatus(commandID uint) (Command, error) {
 		if distributed.Expiration.Before(now) {
 			updates["status"] = StatusExpired
 			updates["expired_at"] = &now
+			if err := m.expireDistributedQuery(distributed.ID); err != nil {
+				return Command{}, err
+			}
 		}
 	case queries.DistributedQueryStatusCompleted:
 		status, errText, err := m.completedStatusForCommand(command)
@@ -205,6 +229,19 @@ func (m *Manager) RefreshCommandStatus(commandID uint) (Command, error) {
 	return command, nil
 }
 
+func (m *Manager) expireDistributedQuery(queryID uint) error {
+	return m.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&queries.DistributedQuery{}).
+			Where("id = ?", queryID).
+			Updates(map[string]any{"expired": true, "active": false}).Error; err != nil {
+			return err
+		}
+		return tx.Model(&queries.NodeQuery{}).
+			Where("query_id = ? AND status = ?", queryID, queries.DistributedQueryStatusPending).
+			Update("status", queries.DistributedQueryStatusExpired).Error
+	})
+}
+
 func (m *Manager) CommandResults(commandID uint) ([]map[string]any, error) {
 	command, err := m.RefreshCommandStatus(commandID)
 	if err != nil {
@@ -213,7 +250,41 @@ func (m *Manager) CommandResults(commandID uint) ([]map[string]any, error) {
 	return m.queryResults(command.DistributedQueryName)
 }
 
+func (m *Manager) History(envID, nodeID uint, creator string, limit int) ([]HistoryEntry, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	var commands []Command
+	err := m.DB.Model(&Command{}).
+		Joins("JOIN console_sessions ON console_sessions.id = console_commands.session_id").
+		Where("console_sessions.environment_id = ? AND console_sessions.node_id = ? AND console_sessions.creator = ?", envID, nodeID, creator).
+		Order("console_commands.created_at DESC").
+		Limit(limit).
+		Find(&commands).Error
+	if err != nil {
+		return nil, err
+	}
+
+	history := make([]HistoryEntry, 0, len(commands))
+	for i := len(commands) - 1; i >= 0; i-- {
+		command := commands[i]
+		results, err := m.queryResults(command.DistributedQueryName)
+		if err != nil {
+			results = []map[string]any{}
+		}
+		history = append(history, HistoryEntry{Command: command, Results: results})
+	}
+	return history, nil
+}
+
 func (m *Manager) completedStatusForCommand(command Command) (string, string, error) {
+	if !isCDCommand(command.Input) {
+		return StatusCompleted, "", nil
+	}
+
 	var session Session
 	if err := m.DB.First(&session, command.SessionID).Error; err != nil {
 		return StatusError, "", err
@@ -237,6 +308,11 @@ func (m *Manager) completedStatusForCommand(command Command) (string, string, er
 		return StatusError, "", err
 	}
 	return StatusCompleted, "", nil
+}
+
+func isCDCommand(input string) bool {
+	fields := strings.Fields(input)
+	return len(fields) > 0 && strings.EqualFold(fields[0], "cd")
 }
 
 func (m *Manager) queryResults(queryName string) ([]map[string]any, error) {

--- a/pkg/console/manager_test.go
+++ b/pkg/console/manager_test.go
@@ -3,12 +3,14 @@ package console_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -120,6 +122,80 @@ func TestRefreshCommandStatusFromNodeQuery(t *testing.T) {
 	require.NotNil(t, got.CompletedAt)
 }
 
+func TestRefreshCommandStatusExpiresDistributedQueryAndNodeQuery(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, _, err := manager.SubmitCommandWithTimeout(session.ID, "select * from osquery_info", time.Nanosecond, true)
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond)
+
+	got, err := manager.RefreshCommandStatus(command.ID)
+	require.NoError(t, err)
+	require.Equal(t, console.StatusExpired, got.Status)
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", command.DistributedQueryName).First(&distributed).Error)
+	require.True(t, distributed.Expired)
+	require.False(t, distributed.Active)
+
+	var nodeQuery queries.NodeQuery
+	require.NoError(t, db.Where("query_id = ?", distributed.ID).First(&nodeQuery).Error)
+	require.Equal(t, queries.DistributedQueryStatusExpired, nodeQuery.Status)
+}
+
+func TestRefreshOsqueryModeSQLCompletesFromNodeQuery(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, _, err := manager.SubmitCommand(session.ID, "select * from osquery_info", true)
+	require.NoError(t, err)
+
+	require.NoError(t, markNodeQueryStatus(db, command.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+	got, err := manager.RefreshCommandStatus(command.ID)
+	require.NoError(t, err)
+	require.Equal(t, console.StatusCompleted, got.Status)
+	require.Empty(t, got.Error)
+	require.NotNil(t, got.CompletedAt)
+}
+
+func TestOsqueryModeSQLIsDeliveredAndCompletesFromQueryWrite(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, _, err := manager.SubmitCommand(session.ID, "select * from osquery_info", true)
+	require.NoError(t, err)
+
+	delivered, accelerate, err := manager.Queries.NodeQueries(node)
+	require.NoError(t, err)
+	require.True(t, accelerate)
+	require.Equal(t, "select * from osquery_info", delivered[command.DistributedQueryName])
+
+	result, err := json.Marshal([]map[string]string{{"version": "5.13.1"}})
+	require.NoError(t, err)
+	wrapped, err := json.Marshal(types.QueryWriteData{
+		Name:   command.DistributedQueryName,
+		Result: result,
+		Status: 0,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{
+		UUID:        node.UUID,
+		Environment: env.UUID,
+		Name:        command.DistributedQueryName,
+		Data:        string(wrapped),
+		Status:      0,
+	}).Error)
+	require.NoError(t, manager.Queries.UpdateQueryStatus(command.DistributedQueryName, node.ID, 0))
+
+	got, err := manager.RefreshCommandStatus(command.ID)
+	require.NoError(t, err)
+	require.Equal(t, console.StatusCompleted, got.Status)
+	rows, err := manager.CommandResults(command.ID)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"version": "5.13.1"}}, rows)
+}
+
 func TestRefreshCommandStatusMarksError(t *testing.T) {
 	db, manager, env, node := setupConsoleManager(t)
 	session, err := manager.CreateSession(env, node, "alice")
@@ -178,6 +254,41 @@ func TestCommandResultsDecodeStoredQueryWriteData(t *testing.T) {
 	rows, err := manager.CommandResults(command.ID)
 	require.NoError(t, err)
 	require.Equal(t, []map[string]any{{"pid": "1", "name": "launchd"}}, rows)
+}
+
+func TestHistoryReturnsCommandsForSameNodeUserAndEnvironment(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	command, _, err := manager.SubmitCommand(session.ID, "ps")
+	require.NoError(t, err)
+
+	result, err := json.Marshal([]map[string]string{{"pid": "1", "name": "launchd"}})
+	require.NoError(t, err)
+	wrapped, err := json.Marshal(map[string]any{
+		"name":   command.DistributedQueryName,
+		"result": json.RawMessage(result),
+		"status": 0,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{Name: command.DistributedQueryName, Data: string(wrapped), Status: 0}).Error)
+
+	otherNode := nodes.OsqueryNode{UUID: "OTHER-NODE", Platform: "linux", EnvironmentID: env.ID, Environment: env.UUID}
+	require.NoError(t, db.Create(&otherNode).Error)
+	otherSession, err := manager.CreateSession(env, otherNode, "alice")
+	require.NoError(t, err)
+	_, _, err = manager.SubmitCommand(otherSession.ID, "pwd")
+	require.NoError(t, err)
+	bobSession, err := manager.CreateSession(env, node, "bob")
+	require.NoError(t, err)
+	_, _, err = manager.SubmitCommand(bobSession.ID, "pwd")
+	require.NoError(t, err)
+
+	history, err := manager.History(env.ID, node.ID, "alice", 25)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	require.Equal(t, command.ID, history[0].Command.ID)
+	require.Equal(t, []map[string]any{{"pid": "1", "name": "launchd"}}, history[0].Results)
 }
 
 func markNodeQueryStatus(db *gorm.DB, name, status string) error {

--- a/pkg/console/models.go
+++ b/pkg/console/models.go
@@ -7,8 +7,11 @@ import (
 )
 
 const (
-	CommandLocal  = "local"
-	CommandRemote = "remote"
+	CommandLocal    = "local"
+	CommandRemote   = "remote"
+	CommandCarve    = "carve"
+	CommandMode     = "mode"
+	CommandExitMode = "exit-mode"
 
 	StatusQueued    = "queued"
 	StatusDelivered = "delivered"
@@ -32,6 +35,10 @@ type Session struct {
 	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
 }
 
+func (Session) TableName() string {
+	return "console_sessions"
+}
+
 type Command struct {
 	ID                   uint           `gorm:"primarykey" json:"id"`
 	CreatedAt            time.Time      `json:"created_at"`
@@ -48,10 +55,21 @@ type Command struct {
 	ExpiredAt            *time.Time     `json:"expired_at,omitempty"`
 }
 
+func (Command) TableName() string {
+	return "console_commands"
+}
+
 type ParsedCommand struct {
 	Kind    string `json:"kind"`
 	Command string `json:"command"`
+	Mode    string `json:"mode,omitempty"`
 	Path    string `json:"path,omitempty"`
 	SQL     string `json:"sql,omitempty"`
 	Output  string `json:"output,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type HistoryEntry struct {
+	Command Command          `json:"command"`
+	Results []map[string]any `json:"results"`
 }

--- a/pkg/console/parser.go
+++ b/pkg/console/parser.go
@@ -17,9 +17,26 @@ func DefaultCWD(platform string) string {
 }
 
 func Parse(input, cwd, platform string) (ParsedCommand, error) {
+	return ParseInput(input, cwd, platform, false)
+}
+
+func ParseInput(input, cwd, platform string, osqueryMode bool) (ParsedCommand, error) {
 	input = strings.TrimSpace(input)
 	if input == "" {
 		return ParsedCommand{}, fmt.Errorf("command can not be empty")
+	}
+
+	if osqueryMode {
+		switch strings.ToLower(input) {
+		case "exit", "quit", ".exit":
+			return ParsedCommand{Kind: CommandExitMode, Command: strings.ToLower(input), Mode: "osquery", Message: "leaving osquery mode"}, nil
+		case ".tables":
+			return ParsedCommand{Kind: CommandLocal, Command: "tables", Mode: "osquery"}, nil
+		}
+		if err := validateSelect(input); err != nil {
+			return ParsedCommand{}, err
+		}
+		return ParsedCommand{Kind: CommandRemote, Command: "sql", Mode: "osquery", SQL: input}, nil
 	}
 
 	fields := strings.Fields(input)
@@ -33,6 +50,15 @@ func Parse(input, cwd, platform string) (ParsedCommand, error) {
 		return ParsedCommand{Kind: CommandLocal, Command: "help", Output: helpText()}, nil
 	case "clear":
 		return ParsedCommand{Kind: CommandLocal, Command: "clear"}, nil
+	case "get":
+		if args == "" {
+			return ParsedCommand{}, fmt.Errorf("get requires a path")
+		}
+		if forbiddenShellSyntax.MatchString(args) {
+			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
+		}
+		target := resolvePath(args, cwd, platform)
+		return ParsedCommand{Kind: CommandCarve, Command: "get", Path: target}, nil
 	case "ls":
 		if forbiddenShellSyntax.MatchString(args) {
 			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
@@ -67,10 +93,18 @@ func Parse(input, cwd, platform string) (ParsedCommand, error) {
 		return ParsedCommand{Kind: CommandRemote, Command: "cd", Path: target, SQL: sql}, nil
 	case "sql":
 		sql := strings.TrimSpace(args)
+		if sql == "" {
+			return ParsedCommand{Kind: CommandMode, Command: "sql", Mode: "osquery", Message: "entering osquery mode"}, nil
+		}
 		if err := validateSelect(sql); err != nil {
 			return ParsedCommand{}, err
 		}
 		return ParsedCommand{Kind: CommandRemote, Command: "sql", SQL: sql}, nil
+	case "osquery":
+		if args != "" {
+			return ParsedCommand{}, fmt.Errorf("osquery does not accept arguments")
+		}
+		return ParsedCommand{Kind: CommandMode, Command: "osquery", Mode: "osquery", Message: "entering osquery mode"}, nil
 	default:
 		return ParsedCommand{}, fmt.Errorf("unsupported command %q", cmd)
 	}
@@ -148,5 +182,5 @@ func quoteSQL(value string) string {
 }
 
 func helpText() string {
-	return "Supported commands: pwd, cd <path>, ls [path], stat <path>, ps, sql <select ...>, help, clear"
+	return "Supported commands: pwd, cd <path>, ls [path], stat <path>, ps, sql [select ...], osquery, get <path>, help, clear. In osquery mode: .tables, .exit"
 }

--- a/pkg/console/parser_test.go
+++ b/pkg/console/parser_test.go
@@ -56,6 +56,60 @@ func TestParseRawSQLRequiresSelect(t *testing.T) {
 	require.Contains(t, err.Error(), "single")
 }
 
+func TestParseEntersOsqueryMode(t *testing.T) {
+	for _, input := range []string{"sql", "osquery"} {
+		got, err := console.Parse(input, "/", "linux")
+		require.NoError(t, err)
+		require.Equal(t, console.CommandMode, got.Kind)
+		require.Equal(t, input, got.Command)
+		require.Equal(t, "osquery", got.Mode)
+	}
+}
+
+func TestParseOsqueryModeTreatsInputAsSQL(t *testing.T) {
+	got, err := console.ParseInput("select * from osquery_info", "/", "linux", true)
+	require.NoError(t, err)
+	require.Equal(t, console.CommandRemote, got.Kind)
+	require.Equal(t, "sql", got.Command)
+	require.Equal(t, "select * from osquery_info", got.SQL)
+
+	_, err = console.ParseInput("delete from processes", "/", "linux", true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SELECT")
+}
+
+func TestParseOsqueryModeExit(t *testing.T) {
+	for _, input := range []string{"exit", "quit", ".exit"} {
+		got, err := console.ParseInput(input, "/", "linux", true)
+		require.NoError(t, err)
+		require.Equal(t, console.CommandExitMode, got.Kind)
+		require.Equal(t, "osquery", got.Mode)
+	}
+}
+
+func TestParseOsqueryModeTables(t *testing.T) {
+	got, err := console.ParseInput(".tables", "/", "linux", true)
+	require.NoError(t, err)
+	require.Equal(t, console.CommandLocal, got.Kind)
+	require.Equal(t, "tables", got.Command)
+	require.Equal(t, "osquery", got.Mode)
+
+	_, err = console.Parse(".tables", "/", "linux")
+	require.Error(t, err)
+}
+
+func TestParseGetCreatesCarveCommand(t *testing.T) {
+	got, err := console.Parse("get ssh/sshd_config", "/etc", "linux")
+	require.NoError(t, err)
+	require.Equal(t, console.CommandCarve, got.Kind)
+	require.Equal(t, "get", got.Command)
+	require.Equal(t, "/etc/ssh/sshd_config", got.Path)
+
+	_, err = console.Parse("get", "/", "linux")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "path")
+}
+
 func TestParseRejectsShellSyntax(t *testing.T) {
 	for _, input := range []string{"ls /tmp | head", "ls > out", "ls && ps", "cat /etc/passwd"} {
 		_, err := console.Parse(input, "/", "linux")

--- a/pkg/logging/process.go
+++ b/pkg/logging/process.go
@@ -91,20 +91,31 @@ func (l *LoggerTLS) ProcessLogQueryResult(queriesWrite types.QueryWriteRequest, 
 		log.Error().Msgf("ProcessLogQueryResult: EnvID[%d] does not match Node.EnvironmentID[%d] — dropping results", envid, node.EnvironmentID)
 		return
 	}
-	// Tap into results so we can update internal metrics
-	for q, r := range queriesWrite.Queries {
-		// Dispatch query name, result and status
-		d := types.QueryWriteData{
-			Name:    q,
-			Result:  r,
-			Status:  queriesWrite.Statuses[q],
-			Message: queriesWrite.Messages[q],
+	// Tap into results/statuses so we can update internal metrics. Failed
+	// osquery queries may report only status/message without a result payload.
+	queryNames := make(map[string]struct{}, len(queriesWrite.Queries)+len(queriesWrite.Statuses))
+	for q := range queriesWrite.Queries {
+		queryNames[q] = struct{}{}
+	}
+	for q := range queriesWrite.Statuses {
+		queryNames[q] = struct{}{}
+	}
+	for q := range queryNames {
+		status := queriesWrite.Statuses[q]
+		if r, ok := queriesWrite.Queries[q]; ok {
+			// Dispatch query name, result and status
+			d := types.QueryWriteData{
+				Name:    q,
+				Result:  r,
+				Status:  status,
+				Message: queriesWrite.Messages[q],
+			}
+			go l.DispatchQueries(d, node, debug)
 		}
-		go l.DispatchQueries(d, node, debug)
 		// TODO: need be refactored
 		// Update internal metrics per query
 		var err error
-		if queriesWrite.Statuses[q] != 0 {
+		if status != 0 {
 			err = l.Queries.IncError(q, envid)
 		} else {
 			err = l.Queries.IncExecution(q, envid)
@@ -113,7 +124,7 @@ func (l *LoggerTLS) ProcessLogQueryResult(queriesWrite types.QueryWriteRequest, 
 			log.Err(err).Msg("error updating query")
 		}
 		// Update query status
-		if err := l.Queries.UpdateQueryStatus(q, node.ID, queriesWrite.Statuses[q]); err != nil {
+		if err := l.Queries.UpdateQueryStatus(q, node.ID, status); err != nil {
 			log.Err(err).Msg("error updating query status")
 		}
 	}

--- a/pkg/logging/process_test.go
+++ b/pkg/logging/process_test.go
@@ -3,6 +3,13 @@ package logging
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestParseResultLogsPreservesPostureColumns(t *testing.T) {
@@ -32,5 +39,46 @@ func TestParseResultLogsUsesSnapshotAsColumnsForSnapshotResults(t *testing.T) {
 	}
 	if string(logs[0].Columns) != `[{"address":"127.0.0.11","port":"35279"}]` {
 		t.Fatalf("snapshot data was not normalized into columns: %+v", logs[0])
+	}
+}
+
+func TestProcessLogQueryResultUpdatesStatusOnlyError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	nodeMgr := nodes.CreateNodes(db)
+	queryMgr := queries.CreateQueries(db)
+	logger := &LoggerTLS{
+		Logging: config.LoggingNone,
+		Logger:  &LoggerNone{Enabled: false},
+		Nodes:   nodeMgr,
+		Queries: queryMgr,
+	}
+	node := nodes.OsqueryNode{NodeKey: "node-key", UUID: "NODE-A", EnvironmentID: 1, Environment: "env"}
+	if err := db.Create(&node).Error; err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	query := queries.DistributedQuery{Name: "console-query", Query: "select * from missing_table", Active: true, EnvironmentID: 1, Type: queries.ConsoleQueryType}
+	if err := queryMgr.Create(&query); err != nil {
+		t.Fatalf("create query: %v", err)
+	}
+	if err := queryMgr.CreateNodeQueries([]uint{node.ID}, query.ID); err != nil {
+		t.Fatalf("create node query: %v", err)
+	}
+
+	logger.ProcessLogQueryResult(types.QueryWriteRequest{
+		NodeKey:  "node-key",
+		Queries:  types.QueryWriteQueries{},
+		Statuses: types.QueryWriteStatuses{"console-query": 1},
+		Messages: types.QueryWriteMessages{"console-query": "no such table: missing_table"},
+	}, 1, false)
+
+	var nodeQuery queries.NodeQuery
+	if err := db.Where("node_id = ? AND query_id = ?", node.ID, query.ID).First(&nodeQuery).Error; err != nil {
+		t.Fatalf("find node query: %v", err)
+	}
+	if nodeQuery.Status != queries.DistributedQueryStatusError {
+		t.Fatalf("expected status-only query write to mark node query error, got %q", nodeQuery.Status)
 	}
 }

--- a/pkg/nodes/utils.go
+++ b/pkg/nodes/utils.go
@@ -186,10 +186,10 @@ func applyPlatformBucket(q *gorm.DB, bucket string) *gorm.DB {
 	return q
 }
 
-// normalizePlatformBucket folds the osquery-reported platform string into the
+// NormalizePlatformBucket folds the osquery-reported platform string into the
 // SPA-facing buckets. Reads from platformsByBucket so we only maintain one
 // list of recognised distros. Anything not in any bucket lands in "other".
-func normalizePlatformBucket(p string) string {
+func NormalizePlatformBucket(p string) string {
 	for bucket, vals := range platformsByBucket {
 		for _, v := range vals {
 			if v == p {
@@ -198,4 +198,8 @@ func normalizePlatformBucket(p string) string {
 		}
 	}
 	return "other"
+}
+
+func normalizePlatformBucket(p string) string {
+	return NormalizePlatformBucket(p)
 }

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -179,6 +179,8 @@ func (q *Queries) NodeQueries(node nodes.OsqueryNode) (QueryReadQueries, bool, e
 		Select("dq.name, dq.query, dq.type").
 		Joins("JOIN node_queries nq ON dq.id = nq.query_id").
 		Where("nq.node_id = ? AND nq.status = ?", node.ID, DistributedQueryStatusPending).
+		Where("dq.active = ? AND dq.completed = ? AND dq.deleted = ? AND dq.expired = ?", true, false, false, false).
+		Where("dq.expiration > ?", time.Now()).
 		Scan(&results)
 
 	if len(results) == 0 {

--- a/pkg/queries/queries_test.go
+++ b/pkg/queries/queries_test.go
@@ -107,6 +107,7 @@ func TestNodeQueriesAcceleratesConsoleQueries(t *testing.T) {
 		Hidden:        true,
 		Active:        true,
 		EnvironmentID: 1,
+		Expiration:    time.Now().Add(time.Hour),
 	}
 	require.NoError(t, q.Create(&consoleQuery))
 	require.NoError(t, q.CreateNodeQueries([]uint{testNodes[0].ID}, consoleQuery.ID))
@@ -115,6 +116,33 @@ func TestNodeQueriesAcceleratesConsoleQueries(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, accelerate)
 	require.Equal(t, "SELECT * FROM processes;", result["console-query"])
+
+	otherResult, otherAccelerate, err := q.NodeQueries(testNodes[1])
+	require.NoError(t, err)
+	require.False(t, otherAccelerate)
+	require.NotContains(t, otherResult, "console-query")
+}
+
+func TestNodeQueriesSkipsExpiredPendingQueries(t *testing.T) {
+	db := testDB(t)
+	q, testNodes, _ := setupTestData(t, db)
+
+	expiredQuery := queries.DistributedQuery{
+		Name:          "expired-console-query",
+		Query:         "SELECT * FROM osquery_info;",
+		Type:          queries.ConsoleQueryType,
+		Hidden:        true,
+		Active:        true,
+		EnvironmentID: 1,
+		Expiration:    time.Now().Add(-time.Minute),
+	}
+	require.NoError(t, q.Create(&expiredQuery))
+	require.NoError(t, q.CreateNodeQueries([]uint{testNodes[0].ID}, expiredQuery.ID))
+
+	result, accelerate, err := q.NodeQueries(testNodes[0])
+	require.NoError(t, err)
+	require.False(t, accelerate)
+	require.NotContains(t, result, "expired-console-query")
 }
 
 func TestUpdateQueryStatus(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the SQL mode, command history, file carve support, node-scoped acceleration safeguards, and UI/handler fixes for more reliable quasi real-time behavior.

## Changes

- Added console session metadata and command lifecycle handling:
  - Per-session working directory.
  - Per-node/per-user command history.
  - Active session heartbeat via `GET /console/{env}/sessions/{session_id}`.
  - Session freshness guard so stale active sessions stop accelerating nodes.

- Added osquery SQL mode:
  - `sql` or `osquery` enters an `osquery>` prompt.
  - Queries issued in SQL mode are sent as raw read-only osquery SQL.
  - `.exit`, `exit`, or `quit` leaves SQL mode.
  - `.tables` lists loaded osquery tables supported by the node platform.
  - Linux distro platform values, such as Debian, are normalized to Linux table support.

- Added console file carve support:
  - `get <path>` creates a targeted file carve.
  - Requires carve permission.
  - Carves are attributed as issued from console by the user and target the console node.

- Tightened accelerated query behavior:
  - Default accelerated read interval is now 5 seconds.
  - Console distributed queries use `type = console`.
  - Console queries are hidden from normal query lists.
  - Query reads only return `accelerate` for the node with a pending console query or a fresh active console session.
  - Stale sessions no longer keep nodes accelerated.
  - Expired console commands expire their backing distributed query and node query rows.

- Fixed console result handling:
  - Status-only osquery errors are processed even when no result payload is returned.
  - Query result decoding supports wrapped osquery query-write payloads.
  - Expired/deleted/completed distributed queries are filtered out of node query reads.

- Improved console UI:
  - Shows a spinner while waiting for the node.
  - Keeps focus on the command input after commands run.
  - Pins the command input outside the scrollback pane.
  - Focuses the input when the console opens.
  - Shows node context in the header, including IP, osquery user, osquery version, and platform.
  - Adds session heartbeat while the console is open.

## Validation

- `GOCACHE=/tmp/osctrl-gocache go test ./pkg/console ./pkg/queries ./cmd/api/handlers ./cmd/tls/handlers`
- `npm test -- NodeConsolePage.test.tsx`
- `npm run check`
- `git diff --check`