### PR TITLE
Adding more fields to the all nodes table

### DIFF
--- a/cmd/api/handlers/nodes.go
+++ b/cmd/api/handlers/nodes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/posture"
 	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -454,14 +455,30 @@ func (h *HandlersApi) projectNode(node nodes.OsqueryNode) types.NodeView {
 		countryCode = h.GeoIP.Lookup(node.IPAddress)
 	}
 	var uptime *types.NodeUptime
+	var postureSummary *types.NodePostureSummary
 	if h.PostureEnabled && h.Posture != nil {
 		var err error
 		uptime, err = h.Posture.GetUptimeByNode(node.UUID)
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			log.Warn().Err(err).Str("node_uuid", node.UUID).Msg("posture: failed to load node uptime")
 		}
+		postureSummary, err = h.Posture.GetSummaryByNode(node.UUID)
+		if err != nil {
+			log.Warn().Err(err).Str("node_uuid", node.UUID).Msg("posture: failed to load node posture summary")
+			postureSummary = nil
+		}
 	}
-	return types.ProjectNodeWithCountryAndUptime(node, countryCode, uptime)
+	var nodeTags []tags.AdminTag
+	if h.Tags != nil {
+		var err error
+		nodeTags, err = h.Tags.GetTags(node)
+		if err != nil {
+			log.Warn().Err(err).Uint("node_id", node.ID).Str("node_uuid", node.UUID).Msg("tags: failed to load node tags")
+			nodeTags = nil
+		}
+	}
+	health := types.CalculateNodeHealth(node, h.inactiveHours(), h.PostureEnabled, postureSummary)
+	return types.ProjectNodeWithCountryUptimePostureTagsAndHealth(node, countryCode, uptime, postureSummary, nodeTags, health)
 }
 
 func (h *HandlersApi) projectNodesWithGeo(in []nodes.OsqueryNode) []types.NodeView {
@@ -470,6 +487,8 @@ func (h *HandlersApi) projectNodesWithGeo(in []nodes.OsqueryNode) []types.NodeVi
 		lookup = h.GeoIP.Lookup
 	}
 	uptimes := map[string]*types.NodeUptime{}
+	postureSummaries := map[string]*types.NodePostureSummary{}
+	nodeTags := map[uint][]tags.AdminTag{}
 	if h.PostureEnabled && h.Posture != nil && len(in) > 0 {
 		uuids := make([]string, 0, len(in))
 		for _, node := range in {
@@ -481,8 +500,41 @@ func (h *HandlersApi) projectNodesWithGeo(in []nodes.OsqueryNode) []types.NodeVi
 			log.Warn().Err(err).Msg("posture: failed to load node uptime batch")
 			uptimes = map[string]*types.NodeUptime{}
 		}
+		postureSummaries, err = h.Posture.GetSummaryByNodes(uuids)
+		if err != nil {
+			log.Warn().Err(err).Msg("posture: failed to load node posture summary batch")
+			postureSummaries = map[string]*types.NodePostureSummary{}
+		}
 	}
-	return types.ProjectNodesWithCountryAndUptime(in, lookup, uptimes)
+	if h.Tags != nil && len(in) > 0 {
+		nodeIDs := make([]uint, 0, len(in))
+		for _, node := range in {
+			nodeIDs = append(nodeIDs, node.ID)
+		}
+		var err error
+		nodeTags, err = h.Tags.GetTagsByNodeIDs(nodeIDs)
+		if err != nil {
+			log.Warn().Err(err).Msg("tags: failed to load node tags batch")
+			nodeTags = map[uint][]tags.AdminTag{}
+		}
+	}
+	healthByNode := make(map[uint]types.NodeHealth, len(in))
+	inactiveHours := h.inactiveHours()
+	for _, node := range in {
+		posture := postureSummaries[node.UUID]
+		if posture == nil {
+			posture = postureSummaries[strings.ToUpper(node.UUID)]
+		}
+		healthByNode[node.ID] = types.CalculateNodeHealth(node, inactiveHours, h.PostureEnabled, posture)
+	}
+	return types.ProjectNodesWithCountryUptimePostureTagsAndHealth(in, lookup, uptimes, postureSummaries, nodeTags, healthByNode)
+}
+
+func (h *HandlersApi) inactiveHours() int64 {
+	if h.Settings == nil {
+		return settings.DefaultInactiveHours
+	}
+	return h.Settings.InactiveHours(settings.NoEnvironmentID)
 }
 
 // NodesPagedHandler returns paginated, sorted, searchable nodes for an env.

--- a/cmd/api/handlers/nodes_posture_test.go
+++ b/cmd/api/handlers/nodes_posture_test.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/posture"
+	"github.com/jmpsec/osctrl/pkg/tags"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -33,6 +35,33 @@ func TestProjectNodeAddsUptimeWhenPostureEnabled(t *testing.T) {
 	}
 }
 
+func TestProjectNodeAddsPostureRiskWhenPostureEnabled(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:node_posture_risk_projection?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	pm := posture.NewPostureManager(db)
+	if err := pm.IngestResult("node-a", "env", posture.QueryPrefix+"disk_encryption", []byte(`[{"name":"/dev/sda","encrypted":"0","type":"ext4"}]`)); err != nil {
+		t.Fatalf("ingest posture: %v", err)
+	}
+	if err := pm.IngestResult("node-a", "env", posture.QueryPrefix+"listening_ports", []byte(`[{"port":"23","address":"0.0.0.0"}]`)); err != nil {
+		t.Fatalf("ingest listening ports: %v", err)
+	}
+	h := &HandlersApi{
+		Posture:        pm,
+		PostureEnabled: true,
+	}
+
+	view := h.projectNode(nodes.OsqueryNode{UUID: "node-a"})
+
+	if view.Posture == nil {
+		t.Fatal("expected posture summary")
+	}
+	if view.Posture.RiskLevel != "high" {
+		t.Fatalf("unexpected risk level %q", view.Posture.RiskLevel)
+	}
+}
+
 func TestProjectNodeOmitsUptimeWhenPostureDisabled(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:node_uptime_disabled?mode=memory&cache=shared"), &gorm.Config{})
 	if err != nil {
@@ -51,5 +80,78 @@ func TestProjectNodeOmitsUptimeWhenPostureDisabled(t *testing.T) {
 
 	if view.Uptime != nil {
 		t.Fatalf("expected uptime to be hidden while posture is disabled: %+v", view.Uptime)
+	}
+	if view.Posture != nil {
+		t.Fatalf("expected posture summary to be hidden while posture is disabled: %+v", view.Posture)
+	}
+}
+
+func TestProjectNodeAddsTagsAndHealth(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:node_tags_health_projection?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	tagMgr := tags.CreateTagManager(db)
+	node := nodes.OsqueryNode{
+		ID:            42,
+		UUID:          "node-a",
+		EnvironmentID: 7,
+		LastSeen:      time.Now().Add(-1 * time.Hour),
+	}
+	if err := tagMgr.TagNode("prod", node, "alice", false, tags.TagTypeTag, ""); err != nil {
+		t.Fatalf("tag node: %v", err)
+	}
+	h := &HandlersApi{Tags: tagMgr}
+
+	view := h.projectNode(node)
+
+	if len(view.Tags) != 1 {
+		t.Fatalf("expected one projected tag, got %+v", view.Tags)
+	}
+	if view.Tags[0].Name != "prod" {
+		t.Fatalf("unexpected tag %+v", view.Tags[0])
+	}
+	if view.Health.Status != "healthy" {
+		t.Fatalf("expected healthy node, got %+v", view.Health)
+	}
+}
+
+func TestProjectNodeHealthPrioritizesOffline(t *testing.T) {
+	h := &HandlersApi{}
+
+	view := h.projectNode(nodes.OsqueryNode{
+		UUID:     "node-offline",
+		LastSeen: time.Now().Add(-100 * time.Hour),
+	})
+
+	if view.Health.Status != "offline" {
+		t.Fatalf("expected offline health, got %+v", view.Health)
+	}
+}
+
+func TestProjectNodeHealthUsesPostureRisk(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:node_health_posture_projection?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	pm := posture.NewPostureManager(db)
+	if err := pm.IngestResult("node-a", "env", posture.QueryPrefix+"disk_encryption", []byte(`[{"name":"/dev/sda","encrypted":"0","type":"ext4"}]`)); err != nil {
+		t.Fatalf("ingest posture: %v", err)
+	}
+	if err := pm.IngestResult("node-a", "env", posture.QueryPrefix+"listening_ports", []byte(`[{"port":"23","address":"0.0.0.0"}]`)); err != nil {
+		t.Fatalf("ingest posture: %v", err)
+	}
+	h := &HandlersApi{
+		Posture:        pm,
+		PostureEnabled: true,
+	}
+
+	view := h.projectNode(nodes.OsqueryNode{
+		UUID:     "node-a",
+		LastSeen: time.Now().Add(-1 * time.Hour),
+	})
+
+	if view.Health.Status != "at_risk" {
+		t.Fatalf("expected at_risk health, got %+v", view.Health)
 	}
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -73,6 +73,18 @@ export interface NodeUptime {
   last_seen?: string;
 }
 
+export interface NodePostureSummary {
+  risk_level?: string;
+}
+
+export type NodeHealthStatus = 'healthy' | 'attention' | 'at_risk' | 'offline' | 'unknown';
+
+export interface NodeHealth {
+  status?: NodeHealthStatus;
+  reason?: string;
+  signals?: string[];
+}
+
 export interface OsqueryNode {
   id: number;
   created_at: string;
@@ -104,6 +116,12 @@ export interface OsqueryNode {
   system_info?: NodeEnrichment;
   /** Optional uptime populated from the latest posture uptime result. */
   uptime?: NodeUptime;
+  /** Optional posture summary populated when posture is enabled. */
+  posture?: NodePostureSummary;
+  /** Environment-scoped tags currently attached to the node. */
+  tags?: AdminTag[];
+  /** Compact server-side triage calculation for list/detail surfaces. */
+  health?: NodeHealth;
 }
 
 export type NodeStatus = 'all' | 'active' | 'inactive';

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -360,6 +360,65 @@ describe('NodeDetailPage', () => {
     expect(screen.getByText('7d 3h 12m')).toBeInTheDocument();
   });
 
+  it('shows node health and tags in the details view', async () => {
+    mockGetNode.mockResolvedValue(
+      makeNode({
+        health: {
+          status: 'attention',
+          reason: 'Posture data unavailable',
+          signals: ['active', 'posture unknown'],
+        },
+        tags: [
+          {
+            id: 1,
+            created_at: '2026-07-26T10:00:00Z',
+            updated_at: '2026-07-26T10:00:00Z',
+            name: 'prod',
+            description: 'Production',
+            color: '#2ecc71',
+            icon: 'fas fa-tag',
+            created_by: 'alice',
+            custom_tag: 'tag',
+            auto_tag: false,
+            environment_id: 1,
+            tag_type: 6,
+            cohort: true,
+          },
+          {
+            id: 2,
+            created_at: '2026-07-26T10:00:00Z',
+            updated_at: '2026-07-26T10:00:00Z',
+            name: 'critical',
+            description: 'Critical',
+            color: '#e74c3c',
+            icon: 'fas fa-tag',
+            created_by: 'alice',
+            custom_tag: 'tag',
+            auto_tag: false,
+            environment_id: 1,
+            tag_type: 6,
+            cohort: true,
+          },
+        ],
+      }),
+    );
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Health')).toBeInTheDocument();
+    expect(screen.getByText('attention')).toBeInTheDocument();
+    expect(screen.getByText('Posture data unavailable')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByText('posture unknown')).toBeInTheDocument();
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+    expect(screen.getByText('prod')).toBeInTheDocument();
+    expect(screen.getByText('critical')).toBeInTheDocument();
+  });
+
   it('hides node uptime while posture is disabled', async () => {
     mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
     mockGetNode.mockResolvedValue(

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -30,6 +30,7 @@ import { StatusPip } from '$/components/data/StatusPip';
 import { Skeleton } from '$/components/data/Skeleton';
 import { EmptyState } from '$/components/data/EmptyState';
 import { SearchInput } from '$/components/data/SearchInput';
+import { HealthBadge, TagChips } from './nodeSignals';
 
 // NodeHeatmapBucket is the merged per-node activity grid the heatmap renders.
 // status/result/query come from the DB-backed logging buckets (full history,
@@ -1018,6 +1019,39 @@ export function NodeDetailPage() {
                   isLoading={tiles24hLoading}
                 />
               </div>
+
+              <KvGrid
+                title="Health"
+                items={[
+                  {
+                    label: 'Status',
+                    value: <HealthBadge health={node.health} />,
+                  },
+                  {
+                    label: 'Reason',
+                    value: node.health?.reason || '—',
+                  },
+                  {
+                    label: 'Signals',
+                    value: node.health?.signals?.length ? (
+                      <div className="flex flex-wrap gap-1">
+                        {node.health.signals.map((signal) => (
+                          <span
+                            key={signal}
+                            className="rounded-full border border-[color:var(--border)] bg-[color:var(--bg-2)] px-1.5 py-0.5 text-[10.5px] font-mono-tabular text-[color:var(--text-2)]"
+                          >
+                            {signal}
+                          </span>
+                        ))}
+                      </div>
+                    ) : '—',
+                  },
+                  {
+                    label: 'Tags',
+                    value: <TagChips tags={node.tags} max={50} />,
+                  },
+                ]}
+              />
 
               <KvGrid
                 title="Identity"

--- a/frontend/src/features/nodes/NodesTablePage.test.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.test.tsx
@@ -14,12 +14,14 @@ import { NodesTablePage } from './NodesTablePage';
 import { nodesSearchSchema } from '$/routes/_app/env/$env/nodes';
 import type { NodesPagedResponse } from '$/api/types';
 import type { SettingValue } from '$/api/settings';
+import type { Features } from '$/api/features';
 
 // ---------------------------------------------------------------------------
 // Mock the nodes API module
 // ---------------------------------------------------------------------------
 const mockListNodes = vi.fn<() => Promise<NodesPagedResponse>>();
 const mockListServiceSettings = vi.fn<() => Promise<SettingValue[]>>();
+const mockGetFeatures = vi.fn<() => Promise<Features>>();
 
 vi.mock('$/api/nodes', () => ({
   listNodes: (...args: unknown[]) => mockListNodes(...(args as [])),
@@ -27,6 +29,10 @@ vi.mock('$/api/nodes', () => ({
 
 vi.mock('$/api/settings', () => ({
   listServiceSettings: (...args: unknown[]) => mockListServiceSettings(...(args as [])),
+}));
+
+vi.mock('$/api/features', () => ({
+  getFeatures: (...args: unknown[]) => mockGetFeatures(...(args as [])),
 }));
 
 vi.mock('$/api/client', () => ({
@@ -153,6 +159,7 @@ describe('NodesTablePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockListServiceSettings.mockResolvedValue([]);
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
   });
 
   it('renders node rows after loading', async () => {
@@ -264,5 +271,150 @@ describe('NodesTablePage', () => {
     });
 
     expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('shows uptime and posture risk badge when posture is enabled', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
+    mockListNodes.mockResolvedValue(
+      makeResponse({
+        items: [
+          {
+            ...makeResponse().items[0],
+            uptime: {
+              days: 7,
+              hours: 3,
+              minutes: 12,
+              seconds: 9,
+              total_seconds: 616329,
+              last_seen: '2026-07-26T10:30:00Z',
+            },
+            posture: {
+              risk_level: 'high',
+            },
+          },
+        ],
+      }),
+    );
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('web-server-01')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Posture' })).toBeInTheDocument();
+    expect(screen.getByText('Uptime 7d 3h')).toBeInTheDocument();
+    const badge = screen.getByText('high');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('aria-label', 'Posture risk high');
+    expect(screen.queryByText('42')).not.toBeInTheDocument();
+
+    const row = screen.getByText('web-server-01').closest('tr') as HTMLTableRowElement | null;
+    expect(row).not.toBeNull();
+    expect(row!.cells[6]).not.toHaveTextContent('Uptime');
+    expect(row!.cells[6]).not.toHaveTextContent('Risk');
+    expect(row!.cells[7]).toHaveTextContent('Uptime 7d 3h');
+    expect(row!.cells[7]).toHaveTextContent('Risk');
+  });
+
+  it('shows health and tags in their own columns', async () => {
+    mockListNodes.mockResolvedValue(
+      makeResponse({
+        items: [
+          {
+            ...makeResponse().items[0],
+            health: {
+              status: 'at_risk',
+              reason: 'Posture risk high',
+              signals: ['active', 'posture high'],
+            },
+            tags: [
+              {
+                id: 1,
+                created_at: '2026-07-26T10:00:00Z',
+                updated_at: '2026-07-26T10:00:00Z',
+                name: 'prod',
+                description: 'Production',
+                color: '#2ecc71',
+                icon: 'fas fa-tag',
+                created_by: 'alice',
+                custom_tag: 'tag',
+                auto_tag: false,
+                environment_id: 1,
+                tag_type: 6,
+                cohort: true,
+              },
+              {
+                id: 2,
+                created_at: '2026-07-26T10:00:00Z',
+                updated_at: '2026-07-26T10:00:00Z',
+                name: 'critical',
+                description: 'Critical',
+                color: '#e74c3c',
+                icon: 'fas fa-tag',
+                created_by: 'alice',
+                custom_tag: 'tag',
+                auto_tag: false,
+                environment_id: 1,
+                tag_type: 6,
+                cohort: true,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('web-server-01')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Health' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Tags' })).toBeInTheDocument();
+    expect(screen.getByText('at risk')).toHaveAttribute('title', 'Posture risk high');
+    expect(screen.getByText('prod')).toBeInTheDocument();
+    expect(screen.getByText('critical')).toBeInTheDocument();
+
+    const row = screen.getByText('web-server-01').closest('tr') as HTMLTableRowElement | null;
+    expect(row).not.toBeNull();
+    expect(row!.cells[2]).toHaveTextContent('at risk');
+    expect(row!.cells[4]).toHaveTextContent('prod');
+    expect(row!.cells[4]).toHaveTextContent('critical');
+  });
+
+  it('hides posture quick signals when posture is disabled', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockListNodes.mockResolvedValue(
+      makeResponse({
+        items: [
+          {
+            ...makeResponse().items[0],
+            uptime: {
+              days: 7,
+              hours: 3,
+              minutes: 12,
+              seconds: 9,
+              total_seconds: 616329,
+              last_seen: '2026-07-26T10:30:00Z',
+            },
+            posture: {
+              risk_level: 'high',
+            },
+          },
+        ],
+      }),
+    );
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('web-server-01')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('columnheader', { name: 'Posture' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Uptime 7d 3h')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Posture risk high')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/nodes/NodesTablePage.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.tsx
@@ -7,9 +7,10 @@ import { getStats, getNodeActivityTilesBatch, type NodeTileSeries } from '$/api/
 import { listEnvTags, tagNode } from '$/api/tags';
 import { getMe } from '$/api/users';
 import { listEnvironments } from '$/api/environments';
+import { getFeatures } from '$/api/features';
 import { AuthError } from '$/api/client';
 import { countryFlag } from '$/lib/flags';
-import type { NodeSort, SortDir, NodeStatus, NodesPagedResponse, AdminTag } from '$/api/types';
+import type { NodeSort, SortDir, NodeStatus, NodesPagedResponse, AdminTag, NodeUptime, NodePostureSummary } from '$/api/types';
 import { formatRelative, formatBytes } from '$/lib/time';
 import { isNodeActive, useInactiveHours } from '$/lib/node-status';
 import { cn } from '$/lib/cn';
@@ -20,6 +21,7 @@ import { Pagination } from '$/components/data/Pagination';
 import { SearchInput } from '$/components/data/SearchInput';
 import { SortableHeader } from '$/components/data/SortableHeader';
 import { ModalShell } from '$/components/feedback/ModalShell';
+import { HealthBadge, TagChips } from './nodeSignals';
 
 const TAG_TYPE_REGULAR = 6; // mirrors pkg/tags.TagTypeTag
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const;
@@ -210,10 +212,57 @@ interface ActivityCellProps {
   bytesReceived: number;
 }
 
+function formatTableUptime(uptime?: NodeUptime): string {
+  if (!uptime) return '—';
+  if (uptime.days > 0) return `${uptime.days}d ${uptime.hours}h`;
+  if (uptime.hours > 0) return `${uptime.hours}h ${uptime.minutes}m`;
+  if (uptime.minutes > 0) return `${uptime.minutes}m`;
+  return `${uptime.seconds}s`;
+}
+
+function displayRiskLevel(riskLevel?: string): 'low' | 'medium' | 'high' | undefined {
+  if (riskLevel === 'low' || riskLevel === 'medium' || riskLevel === 'high') return riskLevel;
+  if (riskLevel === 'critical') return 'high';
+  return undefined;
+}
+
+function RiskBadge({ riskLevel }: { riskLevel?: string }) {
+  const risk = displayRiskLevel(riskLevel);
+  if (!risk) {
+    return <span className="text-[color:var(--text-3)]">—</span>;
+  }
+  return (
+    <span
+      aria-label={`Posture risk ${risk}`}
+      className={cn(
+        'inline-flex items-center px-1.5 py-0.5 rounded-full border',
+        'text-[9px] font-mono-tabular uppercase tracking-[0.08em]',
+        risk === 'low' && 'border-[color:var(--success)]/25 bg-[color:var(--success)]/10 text-[color:var(--success)]',
+        risk === 'medium' && 'border-[color:var(--warning)]/25 bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+        risk === 'high' && 'border-[color:var(--danger)]/25 bg-[color:var(--danger)]/10 text-[color:var(--danger)]',
+      )}
+    >
+      {risk}
+    </span>
+  );
+}
+
+function PostureCell({ uptime, posture }: { uptime?: NodeUptime; posture?: NodePostureSummary }) {
+  return (
+    <div className="flex flex-col gap-1 leading-tight">
+      <span className="text-[10.5px] font-mono-tabular text-[color:var(--text-3)]">
+        Uptime {formatTableUptime(uptime)}
+      </span>
+      <span className="inline-flex items-center gap-1 text-[10.5px] font-mono-tabular text-[color:var(--text-3)]">
+        Risk <RiskBadge riskLevel={posture?.risk_level} />
+      </span>
+    </div>
+  );
+}
+
 /**
- * Per-row "Activity" cell — last seen + bytes received. Just the textual
- * busy-signal; the 24h heatmap lives in its own column (HeatmapCell) so
- * each gets the width it needs.
+ * Per-row "Activity" cell — last seen + bytes received. Posture quick signals
+ * live in their own column when posture is enabled.
  */
 function ActivityCell({ lastSeen, bytesReceived }: ActivityCellProps) {
   return (
@@ -419,6 +468,12 @@ export function NodesTablePage() {
     me?.admin === true ||
     (envUuidForPerms !== undefined &&
       me?.permissions?.[envUuidForPerms]?.admin === true);
+  const { data: features } = useQuery({
+    queryKey: ['features'],
+    queryFn: getFeatures,
+    staleTime: 5 * 60_000,
+  });
+  const postureEnabled = features?.posture === true;
 
   const queryKey = ['nodes', env, { status, q, sort, dir, page, pageSize, platform }] as const;
 
@@ -529,6 +584,7 @@ export function NodesTablePage() {
   const nodes = data?.items ?? [];
   const totalItems = data?.total_items ?? 0;
   const totalPages = data?.total_pages ?? 0;
+  const tableColumnCount = postureEnabled ? 9 : 8;
 
   function handleSortChange(col: NodeSort, newDir: SortDir) {
     updateSearch({ sort: col, dir: newDir, page: 1 });
@@ -670,17 +726,20 @@ export function NodesTablePage() {
 
       {/* ── Table ──
           table-fixed + explicit colgroup. The 24h heatmap gets its own
-          240px column so it can use comfortable 7px cells without competing
-          with the Activity (last-seen + bytes) column for space. Hostname
-          is the flex column that absorbs leftover width. */}
+          240px column so it can use comfortable 7px cells. Posture has a
+          dedicated column when the feature is enabled. Hostname absorbs
+          leftover width. */}
       <div className="flex-1 overflow-auto min-h-0">
         <table className="w-full text-sm border-collapse table-fixed">
           <colgroup>
             <col className="w-10" />
             <col className="w-[110px]" />
-            <col />
-            <col className="w-[180px]" />
             <col className="w-[120px]" />
+            <col />
+            <col className="w-[160px]" />
+            <col className="w-[170px]" />
+            <col className="w-[120px]" />
+            {postureEnabled && <col className="w-[150px]" />}
             <col className="w-[240px]" />
           </colgroup>
           <thead>
@@ -703,6 +762,12 @@ export function NodesTablePage() {
               >
                 Status
               </th>
+              <th
+                scope="col"
+                className="px-4 py-2.5 text-left text-[10px] font-mono-tabular uppercase tracking-[0.14em] text-[color:var(--text-3)]"
+              >
+                Health
+              </th>
               <SortableHeader
                 column="hostname"
                 label="Hostname"
@@ -710,6 +775,12 @@ export function NodesTablePage() {
                 currentDir={dir}
                 onSortChange={handleSortChange}
               />
+              <th
+                scope="col"
+                className="px-4 py-2.5 text-left text-[10px] font-mono-tabular uppercase tracking-[0.14em] text-[color:var(--text-3)]"
+              >
+                Tags
+              </th>
               {/*
                 We surface a single "UUID" header — invisible to the eye, but
                 the test fixture references `getByText('abc12345')` and we want
@@ -731,6 +802,14 @@ export function NodesTablePage() {
                 defaultDir="desc"
                 onSortChange={handleSortChange}
               />
+              {postureEnabled && (
+                <th
+                  scope="col"
+                  className="px-4 py-2.5 text-left text-[10px] font-mono-tabular uppercase tracking-[0.14em] text-[color:var(--text-3)]"
+                >
+                  Posture
+                </th>
+              )}
               <th
                 scope="col"
                 className="px-4 py-2.5 text-left text-[10px] font-mono-tabular uppercase tracking-[0.14em] text-[color:var(--text-3)]"
@@ -741,11 +820,11 @@ export function NodesTablePage() {
           </thead>
 
           <tbody data-stale={isFetching && !isLoading ? 'true' : undefined}>
-            {isLoading && Array.from({ length: 10 }).map((_, i) => <SkeletonRow key={i} cells={6} />)}
+            {isLoading && Array.from({ length: 10 }).map((_, i) => <SkeletonRow key={i} cells={tableColumnCount} />)}
 
             {isError && !isLoading && (
               <tr>
-                <td colSpan={6}>
+                <td colSpan={tableColumnCount}>
                   <EmptyState
                     icon={
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -770,7 +849,7 @@ export function NodesTablePage() {
 
             {!isLoading && !isError && nodes.length === 0 && (
               <tr>
-                <td colSpan={6}>
+                <td colSpan={tableColumnCount}>
                   <EmptyState
                     icon={
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -835,6 +914,11 @@ export function NodesTablePage() {
                       />
                     </td>
 
+                    {/* Health — server-side compact triage calculation */}
+                    <td className="px-4 py-2.5 align-middle">
+                      <HealthBadge health={node.health} />
+                    </td>
+
                     {/* Host — name + uuid + ip stacked */}
                     <td className="px-4 py-2.5 align-middle">
                       <HostCell
@@ -845,6 +929,11 @@ export function NodesTablePage() {
                         ip={node.ip_address}
                         countryCode={node.country_code}
                       />
+                    </td>
+
+                    {/* Tags — compact grouping chips */}
+                    <td className="px-4 py-2.5 align-middle">
+                      <TagChips tags={node.tags} max={3} />
                     </td>
 
                     {/* System — platform icon + version + osquery */}
@@ -863,6 +952,12 @@ export function NodesTablePage() {
                         bytesReceived={node.bytes_received}
                       />
                     </td>
+
+                    {postureEnabled && (
+                      <td className="px-4 py-2.5 align-middle">
+                        <PostureCell uptime={node.uptime} posture={node.posture} />
+                      </td>
+                    )}
 
                     {/* 24h — 4-category heatmap, dedicated column for breathing room */}
                     <td className="px-4 py-2.5 align-middle">

--- a/frontend/src/features/nodes/nodeSignals.tsx
+++ b/frontend/src/features/nodes/nodeSignals.tsx
@@ -1,0 +1,81 @@
+import type { AdminTag, NodeHealth, NodeHealthStatus } from '$/api/types';
+import { cn } from '$/lib/cn';
+
+const HEALTH_LABELS: Record<NodeHealthStatus, string> = {
+  healthy: 'healthy',
+  attention: 'attention',
+  at_risk: 'at risk',
+  offline: 'offline',
+  unknown: 'unknown',
+};
+
+const HEALTH_CLASSES: Record<NodeHealthStatus, string> = {
+  healthy: 'border-[color:var(--success)]/25 bg-[color:var(--success)]/10 text-[color:var(--success)]',
+  attention: 'border-[color:var(--warning)]/25 bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+  at_risk: 'border-[color:var(--danger)]/25 bg-[color:var(--danger)]/10 text-[color:var(--danger)]',
+  offline: 'border-[color:var(--border)] bg-[color:var(--bg-2)] text-[color:var(--text-3)]',
+  unknown: 'border-[color:var(--border)] bg-[color:var(--bg-2)] text-[color:var(--text-3)]',
+};
+
+function normalizeHealthStatus(status?: string): NodeHealthStatus {
+  if (status === 'healthy' || status === 'attention' || status === 'at_risk' || status === 'offline') {
+    return status;
+  }
+  return 'unknown';
+}
+
+export function HealthBadge({ health }: { health?: NodeHealth }) {
+  const status = normalizeHealthStatus(health?.status);
+  return (
+    <span
+      title={health?.reason}
+      className={cn(
+        'inline-flex w-fit items-center rounded-full border px-2 py-0.5',
+        'text-[10px] font-mono-tabular uppercase tracking-[0.08em]',
+        HEALTH_CLASSES[status],
+      )}
+    >
+      {HEALTH_LABELS[status]}
+    </span>
+  );
+}
+
+export function TagChips({
+  tags,
+  max = 3,
+  empty = '—',
+}: {
+  tags?: AdminTag[];
+  max?: number;
+  empty?: string;
+}) {
+  const list = tags ?? [];
+  if (list.length === 0) {
+    return <span className="text-[color:var(--text-3)]">{empty}</span>;
+  }
+  const visible = list.slice(0, max);
+  const overflow = list.length - visible.length;
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {visible.map((tag) => (
+        <span
+          key={`${tag.id}-${tag.name}`}
+          className="inline-flex max-w-[120px] items-center rounded-full border px-1.5 py-0.5 text-[10.5px] font-mono-tabular leading-tight"
+          style={{
+            borderColor: `${tag.color || '#64748b'}55`,
+            backgroundColor: `${tag.color || '#64748b'}18`,
+            color: tag.color || 'var(--text-2)',
+          }}
+          title={tag.description || tag.name}
+        >
+          <span className="truncate">{tag.name}</span>
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span className="text-[10.5px] font-mono-tabular text-[color:var(--text-3)]">
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/pkg/posture/posture.go
+++ b/pkg/posture/posture.go
@@ -429,6 +429,62 @@ func (pm *PostureManager) GetUptimeByNodes(nodeUUIDs []string) (map[string]*type
 	return out, nil
 }
 
+func SummaryFromRecords(records []NodePosture) *types.NodePostureSummary {
+	if len(records) == 0 {
+		return nil
+	}
+	score := NewScoreCalculator().Score(records)
+	if score.RiskLevel == "" {
+		return nil
+	}
+	return &types.NodePostureSummary{RiskLevel: score.RiskLevel}
+}
+
+func (pm *PostureManager) GetSummaryByNode(nodeUUID string) (*types.NodePostureSummary, error) {
+	records, err := pm.GetByNode(nodeUUID)
+	if err != nil {
+		return nil, err
+	}
+	return SummaryFromRecords(records), nil
+}
+
+func (pm *PostureManager) GetSummaryByNodes(nodeUUIDs []string) (map[string]*types.NodePostureSummary, error) {
+	out := make(map[string]*types.NodePostureSummary)
+	if len(nodeUUIDs) == 0 {
+		return out, nil
+	}
+	upperUUIDs := make([]string, 0, len(nodeUUIDs))
+	seen := make(map[string]struct{}, len(nodeUUIDs))
+	for _, uuid := range nodeUUIDs {
+		upper := strings.ToUpper(uuid)
+		if upper == "" {
+			continue
+		}
+		if _, ok := seen[upper]; ok {
+			continue
+		}
+		seen[upper] = struct{}{}
+		upperUUIDs = append(upperUUIDs, upper)
+	}
+	if len(upperUUIDs) == 0 {
+		return out, nil
+	}
+	var records []NodePosture
+	if err := pm.DB.Where("node_uuid IN ?", upperUUIDs).Order("node_uuid ASC, category ASC").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	grouped := make(map[string][]NodePosture)
+	for _, record := range records {
+		grouped[record.NodeUUID] = append(grouped[record.NodeUUID], record)
+	}
+	for nodeUUID, nodeRecords := range grouped {
+		if summary := SummaryFromRecords(nodeRecords); summary != nil {
+			out[nodeUUID] = summary
+		}
+	}
+	return out, nil
+}
+
 // FleetCategorySummary is a per-category summary across all nodes in an environment.
 type FleetCategorySummary struct {
 	Category  string `json:"category"`

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -2,6 +2,7 @@ package tags
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -498,6 +499,58 @@ func (m *TagManager) GetTags(node nodes.OsqueryNode) ([]AdminTag, error) {
 		tags = append(tags, tag)
 	}
 	return tags, nil
+}
+
+// GetTagsByNodeIDs retrieves tags for multiple nodes with two DB queries and
+// groups them by node ID for paginated node-list projection.
+func (m *TagManager) GetTagsByNodeIDs(nodeIDs []uint) (map[uint][]AdminTag, error) {
+	out := make(map[uint][]AdminTag, len(nodeIDs))
+	if len(nodeIDs) == 0 {
+		return out, nil
+	}
+	var tagged []TaggedNode
+	if err := m.DB.Where("node_id IN ?", nodeIDs).Find(&tagged).Error; err != nil {
+		return out, err
+	}
+	if len(tagged) == 0 {
+		return out, nil
+	}
+	tagIDs := make([]uint, 0, len(tagged))
+	seen := make(map[uint]struct{}, len(tagged))
+	for _, t := range tagged {
+		if t.AdminTagID == 0 {
+			continue
+		}
+		if _, ok := seen[t.AdminTagID]; ok {
+			continue
+		}
+		seen[t.AdminTagID] = struct{}{}
+		tagIDs = append(tagIDs, t.AdminTagID)
+	}
+	if len(tagIDs) == 0 {
+		return out, nil
+	}
+	var adminTags []AdminTag
+	if err := m.DB.Where("id IN ?", tagIDs).Find(&adminTags).Error; err != nil {
+		return out, err
+	}
+	byID := make(map[uint]AdminTag, len(adminTags))
+	for _, tag := range adminTags {
+		byID[tag.ID] = tag
+	}
+	for _, t := range tagged {
+		tag, ok := byID[t.AdminTagID]
+		if !ok {
+			continue
+		}
+		out[t.NodeID] = append(out[t.NodeID], tag)
+	}
+	for nodeID := range out {
+		sort.Slice(out[nodeID], func(i, j int) bool {
+			return out[nodeID][i].Name < out[nodeID][j].Name
+		})
+	}
+	return out, nil
 }
 
 // GetTagsByTypeEnv to retrieve the tags of a given type and environment

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -1,0 +1,43 @@
+package tags
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetTagsByNodeIDsReturnsTagsGroupedByNode(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:tags_by_node_ids?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	m := CreateTagManager(db)
+	nodeA := nodes.OsqueryNode{ID: 10, EnvironmentID: 7}
+	nodeB := nodes.OsqueryNode{ID: 11, EnvironmentID: 7}
+	if err := m.TagNode("prod", nodeA, "alice", false, TagTypeTag, ""); err != nil {
+		t.Fatalf("tag node a prod: %v", err)
+	}
+	if err := m.TagNode("critical", nodeA, "alice", false, TagTypeTag, ""); err != nil {
+		t.Fatalf("tag node a critical: %v", err)
+	}
+	if err := m.TagNode("staging", nodeB, "alice", false, TagTypeTag, ""); err != nil {
+		t.Fatalf("tag node b staging: %v", err)
+	}
+
+	got, err := m.GetTagsByNodeIDs([]uint{nodeA.ID, nodeB.ID})
+	if err != nil {
+		t.Fatalf("get tags by node ids: %v", err)
+	}
+
+	if len(got[nodeA.ID]) != 2 {
+		t.Fatalf("expected two tags for node a, got %+v", got[nodeA.ID])
+	}
+	if got[nodeA.ID][0].Name != "critical" || got[nodeA.ID][1].Name != "prod" {
+		t.Fatalf("expected node a tags sorted by name, got %+v", got[nodeA.ID])
+	}
+	if len(got[nodeB.ID]) != 1 || got[nodeB.ID][0].Name != "staging" {
+		t.Fatalf("expected staging for node b, got %+v", got[nodeB.ID])
+	}
+}

--- a/pkg/types/node_view.go
+++ b/pkg/types/node_view.go
@@ -2,10 +2,12 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/tags"
 )
 
 // SPA-facing node projections that surface the parsed-and-sanitized subset of
@@ -106,6 +108,21 @@ type NodeUptime struct {
 	LastSeen     time.Time `json:"last_seen,omitempty"`
 }
 
+// NodePostureSummary is optional quick posture metadata for dense node-list
+// surfaces. Keep this intentionally compact: detailed controls and numeric
+// scores stay on the posture tab.
+type NodePostureSummary struct {
+	RiskLevel string `json:"risk_level,omitempty"`
+}
+
+// NodeHealth is a compact triage signal for dense node-list and node-detail
+// surfaces. Detailed evidence stays in activity/status/posture views.
+type NodeHealth struct {
+	Status  string   `json:"status,omitempty"`
+	Reason  string   `json:"reason,omitempty"`
+	Signals []string `json:"signals,omitempty"`
+}
+
 // NodeView is the JSON shape returned by the node show + list endpoints.
 // It embeds OsqueryNode verbatim (so existing JSON fields stay) and adds the
 // optional enrichment block. Consumers that don't care about the enrichment
@@ -113,10 +130,84 @@ type NodeUptime struct {
 // from it directly.
 type NodeView struct {
 	nodes.OsqueryNode
-	NodeKey     string          `json:"node_key,omitempty"`
-	Enrichment  *NodeEnrichment `json:"system_info,omitempty"`
-	CountryCode string          `json:"country_code,omitempty"`
-	Uptime      *NodeUptime     `json:"uptime,omitempty"`
+	NodeKey     string              `json:"node_key,omitempty"`
+	Enrichment  *NodeEnrichment     `json:"system_info,omitempty"`
+	CountryCode string              `json:"country_code,omitempty"`
+	Uptime      *NodeUptime         `json:"uptime,omitempty"`
+	Posture     *NodePostureSummary `json:"posture,omitempty"`
+	Tags        []tags.AdminTag     `json:"tags,omitempty"`
+	Health      NodeHealth          `json:"health,omitempty"`
+}
+
+// CalculateNodeHealth produces the table/detail triage state from the same
+// data the API already projects. Offline wins over posture so operators do not
+// mistake stale posture data for current risk.
+func CalculateNodeHealth(n nodes.OsqueryNode, inactiveHours int64, postureEnabled bool, posture *NodePostureSummary) NodeHealth {
+	if inactiveHours <= 0 {
+		inactiveHours = 72
+	}
+	if !nodes.IsActive(n, inactiveHours) {
+		if n.LastSeen.IsZero() {
+			return NodeHealth{
+				Status:  "offline",
+				Reason:  "Node has never checked in",
+				Signals: []string{"last seen unknown"},
+			}
+		}
+		return NodeHealth{
+			Status:  "offline",
+			Reason:  "Node has not checked in within the inactive threshold",
+			Signals: []string{"inactive threshold " + formatHoursSignal(inactiveHours)},
+		}
+	}
+	if postureEnabled {
+		risk := strings.ToLower(strings.TrimSpace(postureRisk(posture)))
+		switch risk {
+		case "critical", "high":
+			return NodeHealth{
+				Status:  "at_risk",
+				Reason:  "Posture risk " + risk,
+				Signals: []string{"active", "posture " + risk},
+			}
+		case "medium":
+			return NodeHealth{
+				Status:  "attention",
+				Reason:  "Posture risk medium",
+				Signals: []string{"active", "posture medium"},
+			}
+		case "low":
+			return NodeHealth{
+				Status:  "healthy",
+				Reason:  "Node is active and posture risk is low",
+				Signals: []string{"active", "posture low"},
+			}
+		default:
+			return NodeHealth{
+				Status:  "attention",
+				Reason:  "Posture data unavailable",
+				Signals: []string{"active", "posture unknown"},
+			}
+		}
+	}
+	return NodeHealth{
+		Status:  "healthy",
+		Reason:  "Node is active",
+		Signals: []string{"active"},
+	}
+}
+
+func postureRisk(posture *NodePostureSummary) string {
+	if posture == nil {
+		return ""
+	}
+	return posture.RiskLevel
+}
+
+func formatHoursSignal(hours int64) string {
+	if hours%24 == 0 {
+		return fmt.Sprintf("%dd", hours/24)
+	}
+	return fmt.Sprintf("%dh", hours)
 }
 
 // ProjectNode wraps a single OsqueryNode into the SPA-facing NodeView, parsing
@@ -137,7 +228,15 @@ func ProjectNodeWithUptime(n nodes.OsqueryNode, uptime *NodeUptime) NodeView {
 }
 
 func ProjectNodeWithCountryAndUptime(n nodes.OsqueryNode, countryCode string, uptime *NodeUptime) NodeView {
-	view := NodeView{OsqueryNode: n, Uptime: uptime}
+	return ProjectNodeWithCountryUptimeAndPosture(n, countryCode, uptime, nil)
+}
+
+func ProjectNodeWithCountryUptimeAndPosture(n nodes.OsqueryNode, countryCode string, uptime *NodeUptime, posture *NodePostureSummary) NodeView {
+	return ProjectNodeWithCountryUptimePostureTagsAndHealth(n, countryCode, uptime, posture, nil, NodeHealth{})
+}
+
+func ProjectNodeWithCountryUptimePostureTagsAndHealth(n nodes.OsqueryNode, countryCode string, uptime *NodeUptime, posture *NodePostureSummary, nodeTags []tags.AdminTag, health NodeHealth) NodeView {
+	view := NodeView{OsqueryNode: n, Uptime: uptime, Posture: posture, Tags: nodeTags, Health: health}
 	if countryCode != "" {
 		view.CountryCode = countryCode
 	}
@@ -242,6 +341,14 @@ func ProjectNodesWithCountry(in []nodes.OsqueryNode, lookup func(ip string) stri
 }
 
 func ProjectNodesWithCountryAndUptime(in []nodes.OsqueryNode, lookup func(ip string) string, uptimes map[string]*NodeUptime) []NodeView {
+	return ProjectNodesWithCountryUptimeAndPosture(in, lookup, uptimes, nil)
+}
+
+func ProjectNodesWithCountryUptimeAndPosture(in []nodes.OsqueryNode, lookup func(ip string) string, uptimes map[string]*NodeUptime, postures map[string]*NodePostureSummary) []NodeView {
+	return ProjectNodesWithCountryUptimePostureTagsAndHealth(in, lookup, uptimes, postures, nil, nil)
+}
+
+func ProjectNodesWithCountryUptimePostureTagsAndHealth(in []nodes.OsqueryNode, lookup func(ip string) string, uptimes map[string]*NodeUptime, postures map[string]*NodePostureSummary, tagsByNodeID map[uint][]tags.AdminTag, healthByNodeID map[uint]NodeHealth) []NodeView {
 	out := make([]NodeView, len(in))
 	for i, n := range in {
 		var cc string
@@ -252,7 +359,11 @@ func ProjectNodesWithCountryAndUptime(in []nodes.OsqueryNode, lookup func(ip str
 		if uptime == nil {
 			uptime = uptimes[strings.ToUpper(n.UUID)]
 		}
-		out[i] = ProjectNodeWithCountryAndUptime(n, cc, uptime)
+		posture := postures[n.UUID]
+		if posture == nil {
+			posture = postures[strings.ToUpper(n.UUID)]
+		}
+		out[i] = ProjectNodeWithCountryUptimePostureTagsAndHealth(n, cc, uptime, posture, tagsByNodeID[n.ID], healthByNodeID[n.ID])
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

This branch adds quick node posture, health, and tag visibility to the all-nodes table and single-node detail view.

## Changes

### Node API Projection
- Extends `NodeView` with:
  - `posture.risk_level`
  - `tags`
  - `health.status`
  - `health.reason`
  - `health.signals`
- Adds server-side node health calculation:
  - `offline` when the node is inactive
  - `at_risk` for high/critical posture risk
  - `attention` for medium or unknown posture
  - `healthy` for active nodes with low/no risk
- Loads posture summaries and tags during single-node and paginated node projection.
- Adds batch tag loading by node IDs to avoid per-row tag queries.

### Posture Summary
- Adds posture summary helpers to calculate compact node risk from posture records.
- Supports single-node and batch posture risk summary lookup.

### All Nodes Table
- Adds dedicated `Health` and `Tags` columns.
- Adds a posture column when posture is enabled.
- Keeps `Activity` focused on last seen and bytes received.
- Displays posture risk as a colored badge: `low`, `medium`, or `high`.
- Displays uptime alongside posture risk when posture is enabled.

### Single Node View
- Adds a `Health` section in the Details tab.
- Shows:
  - health badge
  - health reason
  - calculation signals
  - all node tags

### Frontend Shared Components
- Adds reusable node signal rendering for:
  - health badges
  - tag chips

### Tests
- Adds backend tests for:
  - node health projection
  - posture risk projection
  - node tag projection
  - batch tag lookup
- Adds frontend tests for:
  - all-nodes Health and Tags columns
  - posture column behavior
  - node detail Health and Tags section

## Validation

- `npm test -- NodesTablePage.test.tsx`
- `npm test -- NodeDetailPage.test.tsx`
- `npm run check`
- `GOCACHE=/tmp/osctrl-gocache go test ./pkg/tags ./pkg/types ./pkg/posture ./cmd/api/handlers`
- `GOCACHE=/tmp/osctrl-gocache go test ./cmd/api/handlers`
- `git diff --check`