### PR TITLE
Adding buttons for node operations

### DIFF
--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
 )
 
 // QueryTargets enumerates the target filters accepted by QueryListHandler.
@@ -194,21 +195,6 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 	if q.ExpHours == 0 {
 		expTime = time.Time{}
 	}
-	// Prepare and create new query
-	newQuery := queries.DistributedQuery{
-		Query:         q.Query,
-		Name:          queries.GenQueryName(),
-		Creator:       ctx[ctxUser],
-		Active:        true,
-		Expiration:    expTime,
-		Hidden:        q.Hidden,
-		Type:          queries.StandardQueryType,
-		EnvironmentID: env.ID,
-	}
-	if err := h.Queries.Create(&newQuery); err != nil {
-		apiErrorResponse(w, "error creating query", http.StatusInternalServerError, err)
-		return
-	}
 	// Prepare data for the handler code
 	data := handlers.ProcessingQuery{
 		Envs:          q.Environments,
@@ -224,33 +210,49 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 		Envs:  h.Envs,
 		Tags:  h.Tags,
 	}
-	targetNodesID, err := handlers.CreateQueryCarve(data, manager, newQuery)
+	targetNodesID, err := handlers.CreateQueryCarve(data, manager, queries.DistributedQuery{})
 	if err != nil {
 		apiErrorResponse(w, "error creating query", http.StatusInternalServerError, err)
 		return
-	}
-	// If the list is empty, we don't need to create node queries
-	if len(targetNodesID) != 0 {
-		if err := h.Queries.CreateNodeQueries(targetNodesID, newQuery.ID); err != nil {
-			log.Err(err).Msgf("error creating node queries for query %s", newQuery.Name)
-			apiErrorResponse(w, "error creating node queries", http.StatusInternalServerError, err)
-			return
-		}
 	}
 	targetRows, err := handlers.BuildQueryTargetRecords(data, manager)
 	if err != nil {
 		apiErrorResponse(w, "error creating query targets", http.StatusInternalServerError, err)
 		return
 	}
-	for _, target := range targetRows {
-		if err := h.Queries.CreateTarget(newQuery.Name, target.Type, target.Value); err != nil {
-			apiErrorResponse(w, "error creating query targets", http.StatusInternalServerError, err)
-			return
-		}
+
+	// Prepare and create new query. Target rows and node-query rows are
+	// committed atomically so TLS never sees a half-built query with Expected=0.
+	newQuery := queries.DistributedQuery{
+		Query:         q.Query,
+		Name:          queries.GenQueryName(),
+		Creator:       ctx[ctxUser],
+		Expected:      len(targetNodesID),
+		Active:        true,
+		Expiration:    expTime,
+		Hidden:        q.Hidden,
+		Type:          queries.StandardQueryType,
+		EnvironmentID: env.ID,
 	}
-	// Update value for expected
-	if err := h.Queries.SetExpected(newQuery.Name, len(targetNodesID), env.ID); err != nil {
-		apiErrorResponse(w, "error setting expected", http.StatusInternalServerError, err)
+	if err := h.DB.Transaction(func(tx *gorm.DB) error {
+		queryStore := &queries.Queries{DB: tx}
+		if err := queryStore.Create(&newQuery); err != nil {
+			return err
+		}
+		if len(targetNodesID) != 0 {
+			if err := queryStore.CreateNodeQueries(targetNodesID, newQuery.ID); err != nil {
+				log.Err(err).Msgf("error creating node queries for query %s", newQuery.Name)
+				return err
+			}
+		}
+		for _, target := range targetRows {
+			if err := queryStore.CreateTarget(newQuery.Name, target.Type, target.Value); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		apiErrorResponse(w, "error creating query", http.StatusInternalServerError, err)
 		return
 	}
 	// Return query name as serialized response

--- a/cmd/api/handlers/queries_test.go
+++ b/cmd/api/handlers/queries_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueriesRunHandlerCreatesPendingNodeQueryForUUIDTarget(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	h.DebugHTTPConfig = &config.YAMLConfigurationDebug{}
+	auditLog, err := auditlog.CreateAuditLogManager(db, "api", false)
+	require.NoError(t, err)
+	h.AuditLog = auditLog
+
+	body, err := json.Marshal(types.ApiDistributedQueryRequest{
+		Query:    "select * from os_version;",
+		UUIDs:    []string{node.UUID},
+		ExpHours: 24,
+	})
+	require.NoError(t, err)
+
+	req := consoleRequest(http.MethodPost, "/queries", body, "alice")
+	req.SetPathValue("env", env.Name)
+	rr := httptest.NewRecorder()
+
+	h.QueriesRunHandler(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var resp types.ApiQueriesResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", resp.Name).First(&distributed).Error)
+	require.Equal(t, 1, distributed.Expected)
+	require.True(t, distributed.Expiration.After(time.Now().Add(23*time.Hour)))
+
+	var nodeQuery queries.NodeQuery
+	require.NoError(t, db.Where("node_id = ? AND query_id = ?", node.ID, distributed.ID).First(&nodeQuery).Error)
+	require.Equal(t, queries.DistributedQueryStatusPending, nodeQuery.Status)
+}

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
@@ -11,7 +11,7 @@ import {
   Outlet,
 } from '@tanstack/react-router';
 import { NodeDetailPage } from './NodeDetailPage';
-import type { NodePosture, OsqueryNode } from '$/api/types';
+import type { NodePosture, OsqueryNode, SavedQueriesPagedResponse, AdminTag } from '$/api/types';
 import type { NodeActivityBucket, NodeTileSeries } from '$/api/stats';
 import type { SettingValue } from '$/api/settings';
 import type { Features } from '$/api/features';
@@ -26,6 +26,11 @@ const mockGetNodeActivity = vi.fn<() => Promise<NodeActivityBucket[]>>();
 const mockGetNodeActivityTiles = vi.fn<() => Promise<NodeTileSeries>>();
 const mockListServiceSettings = vi.fn<() => Promise<SettingValue[]>>();
 const mockGetFeatures = vi.fn<() => Promise<Features>>();
+const mockListSavedQueries = vi.fn<() => Promise<SavedQueriesPagedResponse>>();
+const mockRunQuery = vi.fn<() => Promise<{ query_name: string }>>();
+const mockRunCarve = vi.fn<() => Promise<{ query_name: string }>>();
+const mockListEnvTags = vi.fn<() => Promise<AdminTag[]>>();
+const mockTagNode = vi.fn<() => Promise<{ message: string }>>();
 
 vi.mock('$/api/nodes', () => ({
   getNode: (...args: unknown[]) => mockGetNode(...(args as [])),
@@ -57,6 +62,23 @@ vi.mock('$/api/settings', () => ({
 
 vi.mock('$/api/features', () => ({
   getFeatures: (...args: unknown[]) => mockGetFeatures(...(args as [])),
+}));
+
+vi.mock('$/api/saved-queries', () => ({
+  listSavedQueries: (...args: unknown[]) => mockListSavedQueries(...(args as [])),
+}));
+
+vi.mock('$/api/queries', () => ({
+  runQuery: (...args: unknown[]) => mockRunQuery(...(args as [])),
+}));
+
+vi.mock('$/api/carves', () => ({
+  runCarve: (...args: unknown[]) => mockRunCarve(...(args as [])),
+}));
+
+vi.mock('$/api/tags', () => ({
+  listEnvTags: (...args: unknown[]) => mockListEnvTags(...(args as [])),
+  tagNode: (...args: unknown[]) => mockTagNode(...(args as [])),
 }));
 
 vi.mock('$/api/client', () => ({
@@ -131,6 +153,46 @@ function makeActivityBuckets(): NodeActivityBucket[] {
   ];
 }
 
+function makeSavedQueries(): SavedQueriesPagedResponse {
+  return {
+    items: [
+      {
+        id: 1,
+        created_at: '2026-07-26T10:00:00Z',
+        updated_at: '2026-07-26T10:00:00Z',
+        name: 'process inventory',
+        creator: 'alice',
+        query: 'select * from processes;',
+        environment_id: 1,
+      },
+    ],
+    page: 1,
+    page_size: 50,
+    total_items: 1,
+    total_pages: 1,
+  };
+}
+
+function makeTags(): AdminTag[] {
+  return [
+    {
+      id: 1,
+      created_at: '2026-07-26T10:00:00Z',
+      updated_at: '2026-07-26T10:00:00Z',
+      name: 'prod',
+      description: 'Production',
+      color: '#2ecc71',
+      icon: 'fas fa-tag',
+      created_by: 'alice',
+      custom_tag: 'tag',
+      auto_tag: false,
+      environment_id: 1,
+      tag_type: 6,
+      cohort: true,
+    },
+  ];
+}
+
 function makeTestRouter(initialPath = '/_app/env/test-env/nodes/abc12345-0000-0000-0000-000000000001') {
   const rootRoute = createRootRoute({ component: Outlet });
 
@@ -164,9 +226,21 @@ function makeTestRouter(initialPath = '/_app/env/test-env/nodes/abc12345-0000-00
     component: () => <div data-testid="query-new-page">query new</div>,
   });
 
+  const queryDetailRoute = createRoute({
+    getParentRoute: () => envRoute,
+    path: 'queries/$name',
+    component: () => <div data-testid="query-detail-page">query detail</div>,
+  });
+
+  const carveDetailRoute = createRoute({
+    getParentRoute: () => envRoute,
+    path: 'carves/$name',
+    component: () => <div data-testid="carve-detail-page">carve detail</div>,
+  });
+
   const routeTree = rootRoute.addChildren([
     appRoute.addChildren([
-      envRoute.addChildren([nodesRoute, nodeDetailRoute, queryNewRoute]),
+      envRoute.addChildren([nodesRoute, nodeDetailRoute, queryNewRoute, queryDetailRoute, carveDetailRoute]),
     ]),
   ]);
 
@@ -214,6 +288,11 @@ describe('NodeDetailPage', () => {
     });
     mockListServiceSettings.mockResolvedValue([]);
     mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockListSavedQueries.mockResolvedValue(makeSavedQueries());
+    mockRunQuery.mockResolvedValue({ query_name: 'query-123' });
+    mockRunCarve.mockResolvedValue({ query_name: 'carve-123' });
+    mockListEnvTags.mockResolvedValue(makeTags());
+    mockTagNode.mockResolvedValue({ message: 'ok' });
   });
 
   it('shows node activity in the default details view and removes the separate activity tab', async () => {
@@ -485,5 +564,150 @@ describe('NodeDetailPage', () => {
     });
 
     expect(screen.queryByRole('link', { name: /console/i })).not.toBeInTheDocument();
+  });
+
+  it('wraps single-node actions away from the hostname block', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    const toolbar = screen.getByLabelText('Node actions');
+    expect(toolbar).toHaveClass('grid');
+    expect(toolbar).toHaveClass('grid-cols-2');
+    expect(toolbar).toHaveClass('xl:flex');
+  });
+
+  it('runs a saved query against the current node from a modal', async () => {
+    const user = userEvent.setup();
+    mockGetMe.mockResolvedValue({
+      admin: false,
+      permissions: {
+        'env-uuid-1': { user: true, query: true, carve: false, admin: false },
+      },
+    });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /run query/i }));
+    await user.selectOptions(screen.getByLabelText('Saved query'), 'process inventory');
+    await user.click(screen.getByRole('button', { name: /run on node/i }));
+
+    await waitFor(() => {
+      expect(mockRunQuery).toHaveBeenCalledWith('test-env', {
+        query: 'select * from processes;',
+        uuid_list: ['abc12345-0000-0000-0000-000000000001'],
+        exp_hours: 24,
+      });
+    });
+  });
+
+  it('runs an ad-hoc query against the current node from a modal', async () => {
+    const user = userEvent.setup();
+    mockGetMe.mockResolvedValue({
+      admin: false,
+      permissions: {
+        'env-uuid-1': { user: true, query: true, carve: false, admin: false },
+      },
+    });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /run query/i }));
+    await user.type(screen.getByLabelText('SQL query'), 'select * from os_version;');
+    await user.click(screen.getByRole('button', { name: /run on node/i }));
+
+    await waitFor(() => {
+      expect(mockRunQuery).toHaveBeenCalledWith('test-env', {
+        query: 'select * from os_version;',
+        uuid_list: ['abc12345-0000-0000-0000-000000000001'],
+        exp_hours: 24,
+      });
+    });
+  });
+
+  it('starts a file carve against the current node from a modal', async () => {
+    const user = userEvent.setup();
+    mockGetMe.mockResolvedValue({
+      admin: false,
+      permissions: {
+        'env-uuid-1': { user: true, query: false, carve: true, admin: false },
+      },
+    });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /carve file/i }));
+    await user.type(screen.getByLabelText('File path'), '/etc/hosts');
+    await user.click(screen.getByRole('button', { name: /start carve/i }));
+
+    await waitFor(() => {
+      expect(mockRunCarve).toHaveBeenCalledWith('test-env', {
+        path: '/etc/hosts',
+        uuid_list: ['abc12345-0000-0000-0000-000000000001'],
+      });
+    });
+  });
+
+  it('tags the current node from a modal', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /^tag$/i }));
+    const dialog = screen.getByRole('dialog', { name: /tag web-server-01/i });
+    await user.selectOptions(within(dialog).getByLabelText('Tag'), 'prod');
+    await user.click(within(dialog).getByRole('button', { name: /apply tag/i }));
+
+    await waitFor(() => {
+      expect(mockTagNode).toHaveBeenCalledWith('test-env', {
+        uuid: 'abc12345-0000-0000-0000-000000000001',
+        tag: 'prod',
+        type: 6,
+      });
+    });
+  });
+
+  it('creates and applies a custom tag from the node modal', async () => {
+    const user = userEvent.setup();
+    mockListEnvTags.mockResolvedValue([]);
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /^tag$/i }));
+    const dialog = screen.getByRole('dialog', { name: /tag web-server-01/i });
+    await user.type(within(dialog).getByLabelText('Custom tag'), 'incident-response');
+    await user.click(within(dialog).getByRole('button', { name: /apply tag/i }));
+
+    await waitFor(() => {
+      expect(mockTagNode).toHaveBeenCalledWith('test-env', {
+        uuid: 'abc12345-0000-0000-0000-000000000001',
+        tag: 'incident-response',
+        type: 6,
+      });
+    });
   });
 });

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -2,8 +2,12 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import { usePageTitle } from '$/lib/usePageTitle';
 import { useParams, Link, useNavigate } from '@tanstack/react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Terminal } from 'lucide-react';
+import { Archive, Copy, FileArchive, PlayCircle, RefreshCw, Tag, Terminal } from 'lucide-react';
 import { getNode, listNodeLogs, deleteNode, getNodePosture, getNodePostureScore } from '$/api/nodes';
+import { runCarve } from '$/api/carves';
+import { runQuery } from '$/api/queries';
+import { listSavedQueries } from '$/api/saved-queries';
+import { listEnvTags, tagNode } from '$/api/tags';
 import type { NodePosture, NodeUptime, PostureScore } from '$/api/types';
 import { getMe } from '$/api/users';
 import { listEnvironments } from '$/api/environments';
@@ -30,6 +34,7 @@ import { StatusPip } from '$/components/data/StatusPip';
 import { Skeleton } from '$/components/data/Skeleton';
 import { EmptyState } from '$/components/data/EmptyState';
 import { SearchInput } from '$/components/data/SearchInput';
+import { ModalShell } from '$/components/feedback/ModalShell';
 import { HealthBadge, TagChips } from './nodeSignals';
 
 // NodeHeatmapBucket is the merged per-node activity grid the heatmap renders.
@@ -50,6 +55,8 @@ interface NodeHeatmapBucket {
 // ---------------------------------------------------------------------------
 
 type Tab = 'details' | 'status-logs' | 'result-logs' | 'posture';
+type NodeActionModal = 'query' | 'carve' | 'tag' | null;
+const TAG_TYPE_REGULAR = 6;
 
 // ---------------------------------------------------------------------------
 // Detail field groups
@@ -586,6 +593,7 @@ export function NodeDetailPage() {
   const [activityInterval, setActivityInterval] = useState<ActivityInterval>('6h');
   const [copiedNodeKey, setCopiedNodeKey] = useState(false);
   const [copyNodeKeyError, setCopyNodeKeyError] = useState<string | null>(null);
+  const [actionModal, setActionModal] = useState<NodeActionModal>(null);
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const { data: features } = useQuery({
     queryKey: ['features'],
@@ -641,6 +649,9 @@ export function NodeDetailPage() {
   const canAdminNode =
     me?.admin === true ||
     (envUuid !== undefined && me?.permissions?.[envUuid]?.admin === true);
+  const envAccess = envUuid !== undefined ? me?.permissions?.[envUuid] : undefined;
+  const canQueryNode = canAdminNode || envAccess?.query === true;
+  const canCarveNode = canAdminNode || envAccess?.carve === true;
 
   // Archive the current node. The backend's POST /nodes/{env}/delete
   // handler maps to ArchiveDeleteByUUID — it always snapshots into the
@@ -780,7 +791,7 @@ export function NodeDetailPage() {
       </div>
 
       {/* ── Header ── */}
-      <div className="mb-6 flex items-start gap-3">
+      <div className="mb-6 flex flex-col gap-3 xl:flex-row xl:items-start">
         {isLoading ? (
           <div className="flex-1 space-y-2">
             <Skeleton className="h-8 w-64" />
@@ -788,7 +799,7 @@ export function NodeDetailPage() {
           </div>
         ) : node ? (
           <>
-            <div className="flex-1 min-w-0">
+            <div className="min-w-0 xl:flex-1">
               <h1 className="font-display text-2xl font-bold text-[color:var(--text-1)] leading-tight">
                 {node.hostname}
               </h1>
@@ -800,13 +811,67 @@ export function NodeDetailPage() {
                 Archive routes through the same DELETE endpoint with
                 archive=true, which the server gates on env-admin —
                 so the button hides for non-admins same as Delete. */}
-            <div className="flex items-center gap-2 flex-shrink-0">
+            <div
+              aria-label="Node actions"
+              className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:flex xl:flex-wrap xl:items-center xl:justify-end xl:flex-shrink-0"
+            >
+              {canQueryNode && (
+                <button
+                  type="button"
+                  aria-label="Run query"
+                  onClick={() => setActionModal('query')}
+                  className={cn(
+                    'inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
+                    'border border-[color:var(--border)] text-[color:var(--text-2)]',
+                    'hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
+                    'transition-colors',
+                    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+                  )}
+                >
+                  <PlayCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                  Run Query
+                </button>
+              )}
+              {canCarveNode && (
+                <button
+                  type="button"
+                  aria-label="Carve file"
+                  onClick={() => setActionModal('carve')}
+                  className={cn(
+                    'inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
+                    'border border-[color:var(--border)] text-[color:var(--text-2)]',
+                    'hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
+                    'transition-colors',
+                    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+                  )}
+                >
+                  <FileArchive className="h-3.5 w-3.5" aria-hidden="true" />
+                  Carve File
+                </button>
+              )}
+              {canAdminNode && (
+                <button
+                  type="button"
+                  aria-label="Tag"
+                  onClick={() => setActionModal('tag')}
+                  className={cn(
+                    'inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
+                    'border border-[color:var(--border)] text-[color:var(--text-2)]',
+                    'hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
+                    'transition-colors',
+                    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+                  )}
+                >
+                  <Tag className="h-3.5 w-3.5" aria-hidden="true" />
+                  Tag
+                </button>
+              )}
               {acceleratedEnabled && canAdminNode && (
                 <Link
                   to="/_app/env/$env/nodes/$uuid/console"
                   params={{ env, uuid }}
                   className={cn(
-                    'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
+                    'inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
                     'border border-[color:var(--border)] text-[color:var(--text-2)]',
                     'hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
                     'transition-colors',
@@ -823,13 +888,14 @@ export function NodeDetailPage() {
                   aria-label="Copy node key"
                   onClick={handleCopyNodeKey}
                   className={cn(
-                    'px-3 py-1.5 text-xs font-medium rounded',
+                    'inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
                     'border border-[color:var(--border)] text-[color:var(--text-2)]',
                     'hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
                     'transition-colors',
                     'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
                   )}
                 >
+                  <Copy className="h-3.5 w-3.5" aria-hidden="true" />
                   {copiedNodeKey ? 'Copied node key' : 'Copy node key'}
                 </button>
               )}
@@ -838,13 +904,14 @@ export function NodeDetailPage() {
                 aria-label="Refresh node"
                 onClick={handleRefresh}
                 className={cn(
-                  'px-3 py-1.5 text-xs font-medium rounded',
+                  'inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
                   'border border-[color:var(--border)] text-[color:var(--text-2)]',
                   'hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
                   'transition-colors',
                   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
                 )}
               >
+                <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
                 Refresh
               </button>
               {/* Single archive action — no separate hard-delete button.
@@ -863,7 +930,7 @@ export function NodeDetailPage() {
                   onClick={handleArchive}
                   disabled={archiveMut.isPending}
                   className={cn(
-                    'px-3 py-1.5 text-xs font-medium rounded',
+                    'inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded',
                     'border border-[color:var(--danger)] text-[color:var(--danger)]',
                     'hover:bg-[color:var(--danger)] hover:text-white',
                     'transition-colors',
@@ -871,6 +938,7 @@ export function NodeDetailPage() {
                     'disabled:opacity-50 disabled:cursor-not-allowed',
                   )}
                 >
+                  <Archive className="h-3.5 w-3.5" aria-hidden="true" />
                   {archiveMut.isPending ? 'Archiving…' : 'Archive'}
                 </button>
               )}
@@ -1209,7 +1277,361 @@ export function NodeDetailPage() {
           />
         )}
       </div>
+
+      {node && actionModal === 'query' && (
+        <RunNodeQueryModal
+          env={env}
+          uuid={node.uuid}
+          hostname={node.hostname}
+          onClose={() => setActionModal(null)}
+          onStarted={(name) => {
+            setActionModal(null);
+            void navigate({ to: '/_app/env/$env/queries/$name', params: { env, name } });
+          }}
+        />
+      )}
+
+      {node && actionModal === 'carve' && (
+        <CarveNodeFileModal
+          env={env}
+          uuid={node.uuid}
+          hostname={node.hostname}
+          onClose={() => setActionModal(null)}
+          onStarted={(name) => {
+            setActionModal(null);
+            void navigate({ to: '/_app/env/$env/carves/$name', params: { env, name } });
+          }}
+        />
+      )}
+
+      {node && actionModal === 'tag' && (
+        <TagNodeModal
+          env={env}
+          uuid={node.uuid}
+          hostname={node.hostname}
+          onClose={() => setActionModal(null)}
+          onTagged={() => {
+            setActionModal(null);
+            void qc.invalidateQueries({ queryKey: ['node', env, uuid] });
+            void qc.invalidateQueries({ queryKey: ['nodes', env] });
+          }}
+        />
+      )}
     </div>
+  );
+}
+
+function RunNodeQueryModal({
+  env,
+  uuid,
+  hostname,
+  onClose,
+  onStarted,
+}: {
+  env: string;
+  uuid: string;
+  hostname: string;
+  onClose: () => void;
+  onStarted: (name: string) => void;
+}) {
+  const [chosen, setChosen] = useState('');
+  const [sql, setSql] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+  const { data, isLoading } = useQuery({
+    queryKey: ['saved-queries', env, 'node-action'],
+    queryFn: () => listSavedQueries({ env, sort: 'name', dir: 'asc', pageSize: 200 }),
+    staleTime: 60_000,
+  });
+  const list = data?.items ?? [];
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const trimmed = sql.trim();
+      if (!trimmed) throw new Error('Query is required.');
+      return runQuery(env, { query: trimmed, uuid_list: [uuid], exp_hours: 24 });
+    },
+    onSuccess: (res) => onStarted(res.query_name),
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        window.location.href = '/login';
+        return;
+      }
+      setErr(e instanceof Error ? e.message : 'Query failed');
+    },
+  });
+
+  return (
+    <ModalShell title={`Run query on ${hostname}`} titleId="node-run-query-modal-title" onClose={onClose}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutation.mutate();
+        }}
+        className="space-y-4"
+      >
+        <div>
+          <label htmlFor="node-query-select" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            Saved query
+          </label>
+          <select
+            id="node-query-select"
+            value={chosen}
+            onChange={(e) => {
+              const name = e.target.value;
+              setChosen(name);
+              const next = list.find((query) => query.name === name);
+              if (next) setSql(next.query);
+            }}
+            disabled={isLoading || list.length === 0}
+            className={cn(
+              'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+              'bg-[color:var(--bg-2)] text-[color:var(--text-1)]',
+              'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            <option value="">
+              {isLoading ? 'Loading saved queries…' : list.length === 0 ? 'No saved queries in this environment' : 'Pick a saved query…'}
+            </option>
+            {list.map((query) => (
+              <option key={query.id} value={query.name}>
+                {query.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="node-query-sql" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            SQL query
+          </label>
+          <textarea
+            id="node-query-sql"
+            value={sql}
+            onChange={(e) => {
+              setSql(e.target.value);
+              setChosen('');
+            }}
+            rows={5}
+            placeholder="select * from os_version;"
+            className={cn(
+              'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+              'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular',
+              'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+            )}
+          />
+        </div>
+
+        {err && <p role="alert" className="text-xs text-[color:var(--danger)]">{err}</p>}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mutation.isPending || sql.trim().length === 0}
+            className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {mutation.isPending ? 'Running…' : 'Run on node'}
+          </button>
+        </div>
+      </form>
+    </ModalShell>
+  );
+}
+
+function CarveNodeFileModal({
+  env,
+  uuid,
+  hostname,
+  onClose,
+  onStarted,
+}: {
+  env: string;
+  uuid: string;
+  hostname: string;
+  onClose: () => void;
+  onStarted: (name: string) => void;
+}) {
+  const [path, setPath] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const trimmed = path.trim();
+      if (!trimmed) throw new Error('File path is required.');
+      return runCarve(env, { path: trimmed, uuid_list: [uuid] });
+    },
+    onSuccess: (res) => onStarted(res.query_name),
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        window.location.href = '/login';
+        return;
+      }
+      setErr(e instanceof Error ? e.message : 'Carve failed');
+    },
+  });
+
+  return (
+    <ModalShell title={`Carve file from ${hostname}`} titleId="node-carve-file-modal-title" onClose={onClose}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutation.mutate();
+        }}
+        className="space-y-4"
+      >
+        <div>
+          <label htmlFor="node-carve-path" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            File path
+          </label>
+          <input
+            id="node-carve-path"
+            type="text"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            placeholder="/etc/hosts"
+            className={cn(
+              'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+              'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular',
+              'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+            )}
+          />
+        </div>
+
+        {err && <p role="alert" className="text-xs text-[color:var(--danger)]">{err}</p>}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {mutation.isPending ? 'Starting…' : 'Start carve'}
+          </button>
+        </div>
+      </form>
+    </ModalShell>
+  );
+}
+
+function TagNodeModal({
+  env,
+  uuid,
+  hostname,
+  onClose,
+  onTagged,
+}: {
+  env: string;
+  uuid: string;
+  hostname: string;
+  onClose: () => void;
+  onTagged: () => void;
+}) {
+  const [chosen, setChosen] = useState('');
+  const [customTag, setCustomTag] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+  const { data: tags, isLoading } = useQuery({
+    queryKey: ['tags', env],
+    queryFn: () => listEnvTags(env),
+    staleTime: 60_000,
+  });
+  const list = tags ?? [];
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const tag = (customTag.trim() || chosen).trim();
+      if (!tag) throw new Error('Pick a tag to assign.');
+      return tagNode(env, { uuid, tag, type: TAG_TYPE_REGULAR });
+    },
+    onSuccess: () => onTagged(),
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        window.location.href = '/login';
+        return;
+      }
+      setErr(e instanceof Error ? e.message : 'Tagging failed');
+    },
+  });
+
+  return (
+    <ModalShell title={`Tag ${hostname}`} titleId="node-tag-modal-title" onClose={onClose}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutation.mutate();
+        }}
+        className="space-y-4"
+      >
+        <div>
+          <label htmlFor="node-tag-select" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            Tag
+          </label>
+          <select
+            id="node-tag-select"
+            value={chosen}
+            onChange={(e) => {
+              setChosen(e.target.value);
+              setCustomTag('');
+            }}
+            disabled={isLoading || list.length === 0}
+            className={cn(
+              'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+              'bg-[color:var(--bg-2)] text-[color:var(--text-1)]',
+              'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            <option value="">
+              {isLoading ? 'Loading tags…' : list.length === 0 ? 'No tags in this environment' : 'Pick a tag…'}
+            </option>
+            {list.map((tag) => (
+              <option key={tag.id} value={tag.name}>
+                {tag.name}
+                {tag.description ? ` — ${tag.description}` : ''}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="node-custom-tag" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            Custom tag
+          </label>
+          <input
+            id="node-custom-tag"
+            type="text"
+            value={customTag}
+            onChange={(e) => {
+              setCustomTag(e.target.value);
+              if (e.target.value.trim()) setChosen('');
+            }}
+            placeholder="incident-response"
+            className={cn(
+              'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+              'bg-[color:var(--bg-2)] text-[color:var(--text-1)]',
+              'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+            )}
+          />
+        </div>
+
+        {err && <p role="alert" className="text-xs text-[color:var(--danger)]">{err}</p>}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mutation.isPending || (!chosen && customTag.trim().length === 0)}
+            className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {mutation.isPending ? 'Tagging…' : 'Apply tag'}
+          </button>
+        </div>
+      </form>
+    </ModalShell>
   );
 }
 

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -175,12 +175,13 @@ func (q *Queries) NodeQueries(node nodes.OsqueryNode) (QueryReadQueries, bool, e
 		Type  string
 	}
 
+	now := time.Now()
 	q.DB.Table("distributed_queries dq").
 		Select("dq.name, dq.query, dq.type").
 		Joins("JOIN node_queries nq ON dq.id = nq.query_id").
 		Where("nq.node_id = ? AND nq.status = ?", node.ID, DistributedQueryStatusPending).
 		Where("dq.active = ? AND dq.completed = ? AND dq.deleted = ? AND dq.expired = ?", true, false, false, false).
-		Where("dq.expiration > ?", time.Now()).
+		Where("(dq.expiration = ? OR dq.expiration > ?)", time.Time{}, now).
 		Scan(&results)
 
 	if len(results) == 0 {
@@ -434,6 +435,9 @@ func (q *Queries) CleanupExpiredQueries(envid uint) error {
 		return err
 	}
 	for _, query := range qs {
+		if query.Expiration.IsZero() {
+			continue
+		}
 		if query.Expiration.Before(time.Now()) {
 			if err := q.Expire(query.Name, envid); err != nil {
 				return err
@@ -450,6 +454,9 @@ func (q *Queries) CleanupExpiredCarves(envid uint) error {
 		return err
 	}
 	for _, query := range qs {
+		if query.Expiration.IsZero() {
+			continue
+		}
 		if query.Expiration.Before(time.Now()) {
 			if err := q.Expire(query.Name, envid); err != nil {
 				return err

--- a/pkg/queries/queries_test.go
+++ b/pkg/queries/queries_test.go
@@ -145,6 +145,49 @@ func TestNodeQueriesSkipsExpiredPendingQueries(t *testing.T) {
 	require.NotContains(t, result, "expired-console-query")
 }
 
+func TestNodeQueriesReturnsNonExpiringPendingQueries(t *testing.T) {
+	db := testDB(t)
+	q, testNodes, _ := setupTestData(t, db)
+
+	neverExpiresQuery := queries.DistributedQuery{
+		Name:          "never-expires-query",
+		Query:         "SELECT * FROM osquery_info;",
+		Type:          queries.StandardQueryType,
+		Active:        true,
+		EnvironmentID: 1,
+		Expiration:    time.Time{},
+	}
+	require.NoError(t, q.Create(&neverExpiresQuery))
+	require.NoError(t, q.CreateNodeQueries([]uint{testNodes[0].ID}, neverExpiresQuery.ID))
+
+	result, accelerate, err := q.NodeQueries(testNodes[0])
+	require.NoError(t, err)
+	require.False(t, accelerate)
+	require.Equal(t, neverExpiresQuery.Query, result["never-expires-query"])
+}
+
+func TestCleanupExpiredQueriesKeepsNonExpiringQueriesActive(t *testing.T) {
+	db := testDB(t)
+	q, _, _ := setupTestData(t, db)
+
+	neverExpiresQuery := queries.DistributedQuery{
+		Name:          "never-expires-cleanup-query",
+		Query:         "SELECT * FROM osquery_info;",
+		Type:          queries.StandardQueryType,
+		Active:        true,
+		EnvironmentID: 1,
+		Expiration:    time.Time{},
+	}
+	require.NoError(t, q.Create(&neverExpiresQuery))
+
+	require.NoError(t, q.CleanupExpiredQueries(1))
+
+	var reloaded queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", neverExpiresQuery.Name).First(&reloaded).Error)
+	require.True(t, reloaded.Active)
+	require.False(t, reloaded.Expired)
+}
+
 func TestUpdateQueryStatus(t *testing.T) {
 	db := testDB(t)
 	q, nodes, query := setupTestData(t, db)


### PR DESCRIPTION
## Summary

- Added single-node actions to the node detail page:
  - Run an osquery query against the current node
  - Start a file carve for the current node
  - Apply an existing tag or create/apply a custom tag
- Updated the single-node query modal to support both saved-query selection and ad-hoc SQL input.
- Made single-node queries expire after 24 hours.
- Improved node detail header actions for smaller windows:
  - Actions now wrap into multiple rows instead of overlapping hostname/UUID
  - Added icons for copy node key, refresh, archive, query, carve, tag, and console actions
- Fixed distributed query delivery for non-expiring queries by treating zero-time expiration as “never expires.”
- Made API query creation atomic so node-target rows and expected counts are committed together, preventing queries from being marked completed before nodes can pick them up.

## Validation

- `go test ./pkg/queries`
- `go test ./cmd/api/handlers`
- `npm test -- NodeDetailPage.test.tsx`
- `npm run check`
- `git diff --check`