### PR TITLE
Security posture adjusments for risk calculation

### DIFF
--- a/cmd/api/handlers/nodes_posture_test.go
+++ b/cmd/api/handlers/nodes_posture_test.go
@@ -57,7 +57,9 @@ func TestProjectNodeAddsPostureRiskWhenPostureEnabled(t *testing.T) {
 	if view.Posture == nil {
 		t.Fatal("expected posture summary")
 	}
-	if view.Posture.RiskLevel != "high" {
+	// An unencrypted disk is a failing critical control, which escalates
+	// the risk level to critical regardless of the numeric score.
+	if view.Posture.RiskLevel != "critical" {
 		t.Fatalf("unexpected risk level %q", view.Posture.RiskLevel)
 	}
 }

--- a/pkg/posture/scoring.go
+++ b/pkg/posture/scoring.go
@@ -3,6 +3,8 @@ package posture
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"sort"
 	"strings"
 	"time"
 )
@@ -10,6 +12,27 @@ import (
 // ---------------------------------------------------------------------------
 // Control framework — maps posture data to SOC2 / ISO 27001 controls and
 // evaluates each against a policy to produce a quantified risk score.
+//
+// Scoring model:
+//
+//   - A control may draw evidence from several posture categories (e.g.
+//     software inventory accepts deb, rpm, Windows programs, Homebrew or
+//     macOS apps). A category that is empty because it does not apply to
+//     the platform (rpm on a Debian host) is NOT a finding — the control
+//     passes as long as one applicable source has data.
+//   - Controls whose categories were never collected are not evaluated at
+//     all: they do not count as pass, warn or fail ("not applicable" rather
+//     than "unknown risk").
+//   - The total score is normalized: earned risk points divided by the
+//     maximum possible points of the controls that were actually evaluated,
+//     scaled to 0-100. This keeps scores comparable between platforms that
+//     collect a different number of categories, and means a well-monitored
+//     node is not penalized for having more checks.
+//   - The risk level is exception-driven, the way an auditor reads a
+//     report: any failing critical control (e.g. no disk encryption) makes
+//     the node "critical" regardless of how many other controls pass; any
+//     failing high control raises it to at least "high". Otherwise the
+//     normalized score thresholds decide.
 // ---------------------------------------------------------------------------
 
 // Framework is the compliance framework a control belongs to.
@@ -32,14 +55,14 @@ const (
 
 // ControlResult is the evaluation outcome for a single control.
 type ControlResult struct {
-	Category    string    `json:"category"`   // posture category (e.g. "disk_encryption")
-	ControlID   string    `json:"control_id"` // e.g. "A.8.5" or "CC6.6"
+	Category    string    `json:"category"`   // posture category the evidence came from
+	ControlID   string    `json:"control_id"` // e.g. "A.8.24" or "CC6.6"
 	Framework   Framework `json:"framework"`
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
 	Status      string    `json:"status"` // "pass", "warn", "fail"
 	Severity    Severity  `json:"severity"`
-	Score       int       `json:"score"`  // 0 = pass, 1-100 = risk points
+	Score       int       `json:"score"`  // 0 = pass, otherwise earned risk points
 	Detail      string    `json:"detail"` // human-readable explanation
 }
 
@@ -47,7 +70,7 @@ type ControlResult struct {
 type PostureScore struct {
 	NodeUUID   string          `json:"node_uuid"`
 	Timestamp  time.Time       `json:"timestamp"`
-	TotalScore int             `json:"total_score"` // 0-100, lower is better
+	TotalScore int             `json:"total_score"` // 0-100 normalized, lower is better
 	RiskLevel  string          `json:"risk_level"`  // "low", "medium", "high", "critical"
 	Controls   []ControlResult `json:"controls"`
 	PassCount  int             `json:"pass_count"`
@@ -55,7 +78,7 @@ type PostureScore struct {
 	FailCount  int             `json:"fail_count"`
 }
 
-// RiskLevelFromScore converts a numeric score to a risk level.
+// RiskLevelFromScore converts a normalized score to a risk level.
 func RiskLevelFromScore(score int) string {
 	switch {
 	case score >= 70:
@@ -77,6 +100,11 @@ var SeverityWeight = map[Severity]int{
 	SeverityLow:      5,
 }
 
+// warnDivisor: a warning earns a quarter of the control's weight. Warnings
+// are "needs review" items, not confirmed exposures — pricing them at half
+// weight (as before) let a handful of review items outrank a real failure.
+const warnDivisor = 4
+
 // ---------------------------------------------------------------------------
 // ScoreCalculator — takes posture records and evaluates them against
 // policy rules to produce a PostureScore.
@@ -87,17 +115,22 @@ type ScoreCalculator struct {
 	rules []ScoringRule
 }
 
-// ScoringRule defines how to evaluate a posture category.
+// ScoringRule defines how to evaluate one control from posture data.
 type ScoringRule struct {
-	Category    string    `json:"category"`
+	// Categories lists every posture category that can provide evidence
+	// for this control. The rule is evaluated when at least one of them
+	// has been collected; mutually exclusive sources (deb vs rpm) belong
+	// in the same rule so an empty inapplicable source is not a finding.
+	Categories  []string  `json:"categories"`
 	ControlID   string    `json:"control_id"`
 	Framework   Framework `json:"framework"`
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
 	Severity    Severity  `json:"severity"`
-	// Evaluate receives the parsed rows from the posture summary and
-	// returns (status, detail). status is "pass", "warn", or "fail".
-	Evaluate func(rows []map[string]interface{}) (status, detail string)
+	// Evaluate receives the collected categories (only those present for
+	// the node) with their parsed rows and returns (status, detail).
+	// status is "pass", "warn", or "fail".
+	Evaluate func(data map[string][]map[string]interface{}) (status, detail string)
 }
 
 // NewScoreCalculator returns a calculator with all built-in rules.
@@ -111,7 +144,9 @@ func (sc *ScoreCalculator) Score(records []NodePosture) PostureScore {
 		Timestamp: time.Now(),
 	}
 
-	// Build a lookup: category → parsed rows
+	// Build a lookup: category → parsed rows. A collected category with an
+	// empty result is kept as an empty (non-nil) slice — "the query ran and
+	// found nothing" is different from "never collected".
 	categoryData := make(map[string][]map[string]interface{})
 	for _, r := range records {
 		var rows []map[string]interface{}
@@ -124,25 +159,43 @@ func (sc *ScoreCalculator) Score(records []NodePosture) PostureScore {
 				_ = json.Unmarshal([]byte(r.Snapshot), &rows)
 			}
 		}
+		if rows == nil {
+			rows = []map[string]interface{}{}
+		}
 		categoryData[r.Category] = rows
 		if score.NodeUUID == "" {
 			score.NodeUUID = r.NodeUUID
 		}
 	}
 
-	totalScore := 0
+	earned := 0
+	possible := 0
 	for _, rule := range sc.rules {
-		rows, exists := categoryData[rule.Category]
-		if !exists {
-			// Category not collected — skip (can't evaluate what we don't have)
+		// Collect the evidence categories present for this node.
+		data := make(map[string][]map[string]interface{})
+		resultCategory := ""
+		for _, cat := range rule.Categories {
+			rows, exists := categoryData[cat]
+			if !exists {
+				continue
+			}
+			data[cat] = rows
+			// Attribute the result to the first collected category with
+			// data so UI drill-downs land on actual evidence.
+			if resultCategory == "" || (len(categoryData[resultCategory]) == 0 && len(rows) > 0) {
+				resultCategory = cat
+			}
+		}
+		if len(data) == 0 {
+			// Nothing collected for this control — not applicable, skip.
 			continue
 		}
 
-		status, detail := rule.Evaluate(rows)
+		status, detail := rule.Evaluate(data)
 		weight := SeverityWeight[rule.Severity]
 
 		result := ControlResult{
-			Category:    rule.Category,
+			Category:    resultCategory,
 			ControlID:   rule.ControlID,
 			Framework:   rule.Framework,
 			Title:       rule.Title,
@@ -157,87 +210,148 @@ func (sc *ScoreCalculator) Score(records []NodePosture) PostureScore {
 			result.Score = 0
 			score.PassCount++
 		case "warn":
-			result.Score = weight / 2
+			result.Score = weight / warnDivisor
 			score.WarnCount++
 		case "fail":
 			result.Score = weight
 			score.FailCount++
 		}
 
-		totalScore += result.Score
+		earned += result.Score
+		possible += weight
 		score.Controls = append(score.Controls, result)
 	}
 
-	if totalScore > 100 {
-		totalScore = 100
+	if possible > 0 {
+		score.TotalScore = int(math.Round(100 * float64(earned) / float64(possible)))
 	}
-	score.TotalScore = totalScore
-	score.RiskLevel = RiskLevelFromScore(totalScore)
+	score.RiskLevel = riskLevel(score.TotalScore, score.Controls)
 	return score
 }
 
+// riskLevel derives the risk level from the normalized score, escalated by
+// the worst failing control: auditors reason in exceptions, and a single
+// failed critical control (unencrypted disk) is a major nonconformity no
+// matter how many low-weight controls pass around it.
+func riskLevel(score int, controls []ControlResult) string {
+	level := RiskLevelFromScore(score)
+	for _, c := range controls {
+		if c.Status != "fail" {
+			continue
+		}
+		switch c.Severity {
+		case SeverityCritical:
+			return "critical"
+		case SeverityHigh:
+			if level == "low" || level == "medium" {
+				level = "high"
+			}
+		}
+	}
+	return level
+}
+
 // ---------------------------------------------------------------------------
-// Default scoring rules — mapped to SOC2 TSC and ISO 27001 Annex A controls.
-// Each rule evaluates the posture data and returns pass/warn/fail.
+// Default scoring rules — mapped to ISO 27001:2022 Annex A and SOC2 TSC
+// controls. Each rule evaluates the posture evidence and returns
+// pass/warn/fail.
 // ---------------------------------------------------------------------------
 
 func defaultRules() []ScoringRule {
 	return []ScoringRule{
-		// --- Disk Encryption (A.8.5 / CC6.6) ---
+		// --- Disk encryption at rest (A.8.24 / CC6.6) ---
+		// Evidence arrives either as generic disk_encryption rows (Linux and
+		// macOS: "encrypted" flag) or BitLocker rows ("protection_status"),
+		// which Windows profiles store under the disk_encryption category.
 		{
-			Category: "disk_encryption", ControlID: "A.8.5", Framework: FrameworkISO27001,
+			Categories: []string{"disk_encryption", "bitlocker_info"},
+			ControlID:  "A.8.24", Framework: FrameworkISO27001,
 			Title:       "Disk encryption at rest",
-			Description: "All disks must be encrypted. Unencrypted disks expose data at rest.",
+			Description: "Data volumes must be encrypted at rest. Boot and recovery partitions are commonly unencrypted by design.",
 			Severity:    SeverityCritical,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
-					return "warn", "No disk encryption data collected — cannot verify"
+					return "warn", "No disk encryption data collected — cannot verify encryption at rest"
 				}
-				unencrypted := 0
+				total := 0
+				protected := 0
+				osDriveUnprotected := false
 				for _, row := range rows {
+					total++
+					if _, isBitlocker := row["protection_status"]; isBitlocker {
+						// osquery bitlocker_info: protection_status 1 = on
+						status := getStr(row, "protection_status")
+						if status == "1" || strings.EqualFold(status, "On") || strings.EqualFold(status, "Protected") {
+							protected++
+						} else if strings.EqualFold(strings.TrimSuffix(getStr(row, "drive_letter"), ":"), "c") {
+							osDriveUnprotected = true
+						}
+						continue
+					}
 					enc := getStr(row, "encrypted")
-					if enc == "0" || strings.EqualFold(enc, "false") || enc == "" {
-						unencrypted++
+					if enc == "1" || strings.EqualFold(enc, "true") {
+						protected++
 					}
 				}
-				if unencrypted > 0 {
-					return "fail", fmt.Sprintf("%d of %d disk(s) are not encrypted", unencrypted, len(rows))
+				switch {
+				case osDriveUnprotected:
+					return "fail", "OS drive (C:) is not BitLocker-protected"
+				case protected == 0:
+					return "fail", fmt.Sprintf("None of %d disk(s) are encrypted", total)
+				case protected < total:
+					return "warn", fmt.Sprintf("%d of %d disk(s)/volume(s) are not encrypted — verify they hold no data (boot, swap and recovery partitions are commonly unencrypted)", total-protected, total)
+				default:
+					return "pass", fmt.Sprintf("All %d disk(s) are encrypted", total)
 				}
-				return "pass", fmt.Sprintf("All %d disk(s) are encrypted", len(rows))
 			},
 		},
 
-		// --- Disk Encryption Windows (bitlocker_info) ---
+		// --- Software inventory (A.5.9 / CC6.1) ---
+		// One control fed by every package source. Sources are mutually
+		// exclusive per platform (deb vs rpm, Homebrew is optional on
+		// macOS), so an empty inapplicable source is not a finding: the
+		// control passes when any source has data.
 		{
-			Category: "bitlocker_info", ControlID: "A.8.5", Framework: FrameworkISO27001,
-			Title:       "BitLocker disk encryption",
-			Description: "BitLocker protection must be active on all drives.",
-			Severity:    SeverityCritical,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
-				if len(rows) == 0 {
-					return "warn", "No BitLocker data collected"
+			Categories: []string{"packages_deb", "packages_rpm", "packages_windows", "packages_apps", "packages_brew"},
+			ControlID:  "A.5.9", Framework: FrameworkISO27001,
+			Title:       "Software inventory",
+			Description: "An inventory of installed software must be available for asset management and vulnerability assessment.",
+			Severity:    SeverityLow,
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				sourceLabels := map[string]string{
+					"packages_deb":     "deb",
+					"packages_rpm":     "rpm",
+					"packages_windows": "programs",
+					"packages_apps":    "apps",
+					"packages_brew":    "brew",
 				}
-				unprotected := 0
-				for _, row := range rows {
-					status := getStr(row, "protection_status")
-					if status != "On" && !strings.EqualFold(status, "Protected") {
-						unprotected++
+				parts := []string{}
+				totalRows := 0
+				for cat, rows := range data {
+					if len(rows) == 0 {
+						continue
 					}
+					totalRows += len(rows)
+					parts = append(parts, fmt.Sprintf("%d %s", len(rows), sourceLabels[cat]))
 				}
-				if unprotected > 0 {
-					return "fail", fmt.Sprintf("%d of %d drive(s) lack BitLocker protection", unprotected, len(rows))
+				if totalRows == 0 {
+					return "warn", fmt.Sprintf("Package inventory collected from %d source(s) but empty — verify osquery table access", len(data))
 				}
-				return "pass", fmt.Sprintf("All %d drive(s) have BitLocker protection", len(rows))
+				sort.Strings(parts)
+				return "pass", fmt.Sprintf("%d packages inventoried (%s)", totalRows, strings.Join(parts, ", "))
 			},
 		},
 
-		// --- Users with real shells (A.5.15 / CC6.1) ---
+		// --- Users with real shells (A.8.2 / CC6.1) ---
 		{
-			Category: "users", ControlID: "A.5.15", Framework: FrameworkISO27001,
+			Categories: []string{"users"},
+			ControlID:  "A.8.2", Framework: FrameworkISO27001,
 			Title:       "Interactive user accounts",
-			Description: "Review users with login shells. Excessive interactive accounts increase attack surface.",
+			Description: "Review users with login shells. Multiple UID-0 accounts or excessive interactive accounts increase attack surface.",
 			Severity:    SeverityMedium,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "warn", "No user data collected"
 				}
@@ -258,13 +372,15 @@ func defaultRules() []ScoringRule {
 			},
 		},
 
-		// --- SSH authorized keys (A.5.37 / CC6.7) ---
+		// --- SSH authorized keys (A.5.17 / CC6.1) ---
 		{
-			Category: "ssh_keys", ControlID: "A.5.37", Framework: FrameworkISO27001,
+			Categories: []string{"ssh_keys"},
+			ControlID:  "A.5.17", Framework: FrameworkISO27001,
 			Title:       "SSH authorized keys",
 			Description: "Review SSH key access. Keys for root or excessive keys increase unauthorized access risk.",
 			Severity:    SeverityHigh,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "pass", "No SSH authorized keys found"
 				}
@@ -282,48 +398,65 @@ func defaultRules() []ScoringRule {
 			},
 		},
 
-		// --- Listening ports (A.5.15 / CC6.1) ---
+		// --- Listening ports (A.8.20 / CC6.6) ---
+		// Plaintext-authentication services are always a failure. Services
+		// that are legitimate on many servers but dangerous when exposed
+		// (RDP, SMB, SNMP, VNC) are a warning to review exposure, not a
+		// failure: RDP/SMB listen on effectively every Windows server.
 		{
-			Category: "listening_ports", ControlID: "A.5.15", Framework: FrameworkISO27001,
+			Categories: []string{"listening_ports"},
+			ControlID:  "A.8.20", Framework: FrameworkISO27001,
 			Title:       "Open listening ports",
-			Description: "Minimize open ports. Unexpected services increase attack surface.",
+			Description: "Minimize open ports. Plaintext services must not run; remote-access services must not be exposed beyond trusted networks.",
 			Severity:    SeverityMedium,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "pass", "No listening ports"
 				}
-				// Flag well-known dangerous ports
-				dangerousPorts := map[string]bool{
-					"23":   true, // telnet
-					"21":   true, // ftp
-					"3389": true, // rdp (only dangerous if exposed)
-					"445":  true, // smb
-					"161":  true, // snmp
+				plaintextPorts := map[string]string{
+					"23": "telnet",
+					"21": "ftp",
 				}
-				dangerCount := 0
+				reviewPorts := map[string]string{
+					"3389": "rdp",
+					"445":  "smb",
+					"161":  "snmp",
+					"5900": "vnc",
+				}
+				plaintext := []string{}
+				review := []string{}
 				for _, row := range rows {
 					port := getStr(row, "port")
-					if dangerousPorts[port] {
-						dangerCount++
+					if svc, ok := plaintextPorts[port]; ok {
+						plaintext = append(plaintext, svc)
+					}
+					if svc, ok := reviewPorts[port]; ok {
+						review = append(review, svc)
 					}
 				}
-				if dangerCount > 0 {
-					return "fail", fmt.Sprintf("%d listening port(s) on dangerous services (telnet/ftp/rdp/smb/snmp)", dangerCount)
+				if len(plaintext) > 0 {
+					return "fail", fmt.Sprintf("Plaintext service(s) listening: %s", strings.Join(dedupe(plaintext), ", "))
+				}
+				if len(review) > 0 {
+					return "warn", fmt.Sprintf("Remote-access service(s) listening: %s — verify they are not exposed beyond trusted networks", strings.Join(dedupe(review), ", "))
 				}
 				if len(rows) > 50 {
 					return "warn", fmt.Sprintf("%d listening ports — review if all are necessary", len(rows))
 				}
-				return "pass", fmt.Sprintf("%d listening ports, none on dangerous services", len(rows))
+				return "pass", fmt.Sprintf("%d listening ports, none on risky services", len(rows))
 			},
 		},
 
 		// --- Patches / hotfixes (A.8.8 / CC7.1) ---
 		{
-			Category: "patches", ControlID: "A.8.8", Framework: FrameworkISO27001,
+			Categories: []string{"patches"},
+			ControlID:  "A.8.8", Framework: FrameworkISO27001,
 			Title:       "Security patches installed",
 			Description: "Verify security patches are installed. Missing patches are exploitable vulnerabilities.",
 			Severity:    SeverityHigh,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "warn", "No patch data collected — cannot verify patch status"
 				}
@@ -333,11 +466,13 @@ func defaultRules() []ScoringRule {
 
 		// --- SUID binaries (A.8.9 / CC7.4) ---
 		{
-			Category: "suid_binaries", ControlID: "A.8.9", Framework: FrameworkISO27001,
+			Categories: []string{"suid_binaries"},
+			ControlID:  "A.8.9", Framework: FrameworkISO27001,
 			Title:       "SUID binaries",
 			Description: "SUID binaries are privilege escalation vectors. Non-standard SUID binaries are high risk.",
 			Severity:    SeverityMedium,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "pass", "No SUID binaries found"
 				}
@@ -364,11 +499,13 @@ func defaultRules() []ScoringRule {
 
 		// --- Startup items (A.8.9 / CC8.1) ---
 		{
-			Category: "startup_items", ControlID: "A.8.9", Framework: FrameworkISO27001,
+			Categories: []string{"startup_items"},
+			ControlID:  "A.8.9", Framework: FrameworkISO27001,
 			Title:       "Startup items / autostart",
 			Description: "Review programs that run at startup. Unexpected startup items may indicate persistence.",
 			Severity:    SeverityLow,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "pass", "No startup items found"
 				}
@@ -379,13 +516,15 @@ func defaultRules() []ScoringRule {
 			},
 		},
 
-		// --- Browser extensions (A.8.9 / CC6.6) ---
+		// --- Browser extensions (A.8.19 / CC6.6) ---
 		{
-			Category: "browser_extensions_chrome", ControlID: "A.8.9", Framework: FrameworkISO27001,
+			Categories: []string{"browser_extensions_chrome"},
+			ControlID:  "A.8.19", Framework: FrameworkISO27001,
 			Title:       "Chrome browser extensions",
 			Description: "Browser extensions can access sensitive data. Review for unknown or malicious extensions.",
 			Severity:    SeverityMedium,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "pass", "No Chrome extensions found"
 				}
@@ -396,11 +535,13 @@ func defaultRules() []ScoringRule {
 			},
 		},
 		{
-			Category: "browser_extensions_firefox", ControlID: "A.8.9", Framework: FrameworkISO27001,
+			Categories: []string{"browser_extensions_firefox"},
+			ControlID:  "A.8.19", Framework: FrameworkISO27001,
 			Title:       "Firefox browser add-ons",
 			Description: "Firefox add-ons can access sensitive data. Review for unknown or malicious add-ons.",
 			Severity:    SeverityMedium,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "pass", "No Firefox add-ons found"
 				}
@@ -411,13 +552,15 @@ func defaultRules() []ScoringRule {
 			},
 		},
 
-		// --- WiFi networks (A.8.9 / CC6.1) ---
+		// --- WiFi networks (A.8.21 / CC6.1) ---
 		{
-			Category: "wifi_networks", ControlID: "A.8.9", Framework: FrameworkISO27001,
+			Categories: []string{"wifi_networks"},
+			ControlID:  "A.8.21", Framework: FrameworkISO27001,
 			Title:       "Known WiFi networks",
 			Description: "Review saved WiFi networks. Open or unsecured networks pose data interception risk.",
 			Severity:    SeverityLow,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "pass", "No saved WiFi networks"
 				}
@@ -437,29 +580,25 @@ func defaultRules() []ScoringRule {
 
 		// --- macOS sharing preferences (A.8.9 / CC6.1) ---
 		{
-			Category: "file_sharing", ControlID: "A.8.9", Framework: FrameworkISO27001,
+			Categories: []string{"file_sharing"},
+			ControlID:  "A.8.9", Framework: FrameworkISO27001,
 			Title:       "macOS sharing services",
 			Description: "File sharing, screen sharing, and remote login should be disabled unless explicitly required.",
 			Severity:    SeverityMedium,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "warn", "No sharing preference data collected"
 				}
-				if len(rows) == 0 {
-					return "pass", "No sharing data"
-				}
 				row := rows[0]
 				enabled := []string{}
-				for _, svc := range []string{"file_sharing", "screen_sharing", "remote_management", "internet_sharing", "printer_sharing"} {
+				for _, svc := range []string{"file_sharing", "screen_sharing", "remote_login", "remote_management", "internet_sharing", "printer_sharing"} {
 					if getStr(row, svc) == "1" || strings.EqualFold(getStr(row, svc), "true") || strings.EqualFold(getStr(row, svc), "on") {
 						enabled = append(enabled, svc)
 					}
 				}
-				if len(enabled) > 2 {
-					return "warn", fmt.Sprintf("Multiple sharing services enabled: %s", strings.Join(enabled, ", "))
-				}
 				if len(enabled) > 0 {
-					return "pass", fmt.Sprintf("Sharing services enabled: %s", strings.Join(enabled, ", "))
+					return "warn", fmt.Sprintf("Sharing service(s) enabled: %s — disable unless explicitly required", strings.Join(enabled, ", "))
 				}
 				return "pass", "No sharing services enabled"
 			},
@@ -467,77 +606,17 @@ func defaultRules() []ScoringRule {
 
 		// --- Kernel modules (A.8.9 / CC7.4) — Linux servers ---
 		{
-			Category: "kernel_modules", ControlID: "A.8.9", Framework: FrameworkISO27001,
+			Categories: []string{"kernel_modules"},
+			ControlID:  "A.8.9", Framework: FrameworkISO27001,
 			Title:       "Loaded kernel modules",
 			Description: "Review loaded kernel modules. Non-standard modules may indicate rootkits or unnecessary drivers.",
 			Severity:    SeverityLow,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
+			Evaluate: func(data map[string][]map[string]interface{}) (string, string) {
+				rows := mergeRows(data)
 				if len(rows) == 0 {
 					return "pass", "No kernel modules loaded"
 				}
 				return "pass", fmt.Sprintf("%d kernel modules loaded", len(rows))
-			},
-		},
-
-		// --- Installed packages (A.8.7 / CC7.1) ---
-		{
-			Category: "packages_deb", ControlID: "A.8.7", Framework: FrameworkISO27001,
-			Title:       "Installed packages (DEB)",
-			Description: "Track installed packages for inventory and vulnerability assessment.",
-			Severity:    SeverityLow,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
-				if len(rows) == 0 {
-					return "warn", "No package data collected"
-				}
-				return "pass", fmt.Sprintf("%d packages installed", len(rows))
-			},
-		},
-		{
-			Category: "packages_rpm", ControlID: "A.8.7", Framework: FrameworkISO27001,
-			Title:       "Installed packages (RPM)",
-			Description: "Track installed packages for inventory and vulnerability assessment.",
-			Severity:    SeverityLow,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
-				if len(rows) == 0 {
-					return "warn", "No package data collected"
-				}
-				return "pass", fmt.Sprintf("%d packages installed", len(rows))
-			},
-		},
-		{
-			Category: "packages_windows", ControlID: "A.8.7", Framework: FrameworkISO27001,
-			Title:       "Installed programs (Windows)",
-			Description: "Track installed programs for inventory and vulnerability assessment.",
-			Severity:    SeverityLow,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
-				if len(rows) == 0 {
-					return "warn", "No program data collected"
-				}
-				return "pass", fmt.Sprintf("%d programs installed", len(rows))
-			},
-		},
-		{
-			Category: "packages_brew", ControlID: "A.8.7", Framework: FrameworkISO27001,
-			Title:       "Homebrew packages",
-			Description: "Track Homebrew packages for inventory and vulnerability assessment.",
-			Severity:    SeverityLow,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
-				if len(rows) == 0 {
-					return "warn", "No Homebrew package data collected"
-				}
-				return "pass", fmt.Sprintf("%d Homebrew packages installed", len(rows))
-			},
-		},
-		{
-			Category: "packages_apps", ControlID: "A.8.7", Framework: FrameworkISO27001,
-			Title:       "Installed applications (macOS)",
-			Description: "Track installed macOS applications for inventory and vulnerability assessment.",
-			Severity:    SeverityLow,
-			Evaluate: func(rows []map[string]interface{}) (string, string) {
-				if len(rows) == 0 {
-					return "warn", "No application data collected"
-				}
-				return "pass", fmt.Sprintf("%d applications installed", len(rows))
 			},
 		},
 	}
@@ -546,6 +625,34 @@ func defaultRules() []ScoringRule {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// mergeRows flattens the rows of every collected category, in stable
+// category order.
+func mergeRows(data map[string][]map[string]interface{}) []map[string]interface{} {
+	cats := make([]string, 0, len(data))
+	for cat := range data {
+		cats = append(cats, cat)
+	}
+	sort.Strings(cats)
+	var out []map[string]interface{}
+	for _, cat := range cats {
+		out = append(out, data[cat]...)
+	}
+	return out
+}
+
+func dedupe(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
 
 func getStr(row map[string]interface{}, key string) string {
 	v, ok := row[key]

--- a/pkg/posture/scoring_test.go
+++ b/pkg/posture/scoring_test.go
@@ -1,0 +1,311 @@
+package posture
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func postureRecord(t *testing.T, category string, rows []map[string]interface{}) NodePosture {
+	t.Helper()
+	summary, err := json.Marshal(rows)
+	if err != nil {
+		t.Fatalf("marshal rows: %v", err)
+	}
+	return NodePosture{
+		NodeUUID: "TEST-UUID",
+		Category: category,
+		RowCount: len(rows),
+		Summary:  string(summary),
+	}
+}
+
+func findControl(t *testing.T, score PostureScore, title string) ControlResult {
+	t.Helper()
+	for _, c := range score.Controls {
+		if c.Title == title {
+			return c
+		}
+	}
+	t.Fatalf("control %q not found in %+v", title, score.Controls)
+	return ControlResult{}
+}
+
+func hasControl(score PostureScore, title string) bool {
+	for _, c := range score.Controls {
+		if c.Title == title {
+			return true
+		}
+	}
+	return false
+}
+
+func debRows(n int) []map[string]interface{} {
+	rows := make([]map[string]interface{}, n)
+	for i := range rows {
+		rows[i] = map[string]interface{}{"name": "pkg", "version": "1.0"}
+	}
+	return rows
+}
+
+// A Debian/Ubuntu node collects both packages_deb and packages_rpm; the rpm
+// result is legitimately empty and must not produce a warning.
+func TestSoftwareInventoryEmptyRPMOnDebianIsNotAFinding(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "packages_deb", debRows(3)),
+		postureRecord(t, "packages_rpm", nil),
+	})
+	ctrl := findControl(t, score, "Software inventory")
+	if ctrl.Status != "pass" {
+		t.Errorf("expected pass, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if score.WarnCount != 0 {
+		t.Errorf("expected no warnings, got %d: %+v", score.WarnCount, score.Controls)
+	}
+	if len(score.Controls) != 1 {
+		t.Errorf("expected a single inventory control, got %d", len(score.Controls))
+	}
+	if ctrl.Category != "packages_deb" {
+		t.Errorf("expected evidence attributed to packages_deb, got %s", ctrl.Category)
+	}
+}
+
+// The inverse: RHEL-family node with rpm data and an empty deb result.
+func TestSoftwareInventoryEmptyDebOnRHELIsNotAFinding(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "packages_deb", nil),
+		postureRecord(t, "packages_rpm", debRows(5)),
+	})
+	ctrl := findControl(t, score, "Software inventory")
+	if ctrl.Status != "pass" {
+		t.Errorf("expected pass, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if score.WarnCount != 0 {
+		t.Errorf("expected no warnings, got %d", score.WarnCount)
+	}
+}
+
+// macOS without Homebrew: apps inventory present, brew empty — no warning.
+func TestSoftwareInventoryMacWithoutHomebrewIsNotAFinding(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "packages_apps", debRows(40)),
+		postureRecord(t, "packages_brew", nil),
+	})
+	ctrl := findControl(t, score, "Software inventory")
+	if ctrl.Status != "pass" {
+		t.Errorf("expected pass, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if score.WarnCount != 0 {
+		t.Errorf("expected no warnings, got %d", score.WarnCount)
+	}
+}
+
+// All collected inventory sources empty → the control warns (once).
+func TestSoftwareInventoryWarnsWhenAllSourcesEmpty(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "packages_deb", nil),
+		postureRecord(t, "packages_rpm", nil),
+	})
+	ctrl := findControl(t, score, "Software inventory")
+	if ctrl.Status != "warn" {
+		t.Errorf("expected warn, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if score.WarnCount != 1 {
+		t.Errorf("expected exactly one warning, got %d", score.WarnCount)
+	}
+}
+
+// Controls whose categories were never collected must not appear at all.
+func TestUncollectedControlsAreNotEvaluated(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "packages_deb", debRows(3)),
+	})
+	for _, c := range score.Controls {
+		if c.Title != "Software inventory" {
+			t.Errorf("unexpected control evaluated: %s", c.Title)
+		}
+	}
+}
+
+// Windows profiles store BitLocker rows under the disk_encryption category;
+// protection_status must be understood there (osquery reports 1 = on).
+func TestBitLockerRowsUnderDiskEncryptionCategoryPass(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "disk_encryption", []map[string]interface{}{
+			{"drive_letter": "C:", "protection_status": "1"},
+		}),
+	})
+	ctrl := findControl(t, score, "Disk encryption at rest")
+	if ctrl.Status != "pass" {
+		t.Errorf("expected pass for BitLocker-protected drive, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+}
+
+func TestBitLockerUnprotectedOSDriveFailsAndEscalates(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "disk_encryption", []map[string]interface{}{
+			{"drive_letter": "C:", "protection_status": "0"},
+			{"drive_letter": "D:", "protection_status": "1"},
+		}),
+	})
+	ctrl := findControl(t, score, "Disk encryption at rest")
+	if ctrl.Status != "fail" {
+		t.Errorf("expected fail for unprotected OS drive, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if score.RiskLevel != "critical" {
+		t.Errorf("failing critical control must escalate risk level to critical, got %s", score.RiskLevel)
+	}
+}
+
+// Linux with LUKS: root volume encrypted, boot/swap not — a review item,
+// not a failure.
+func TestLinuxPartialDiskEncryptionWarns(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "disk_encryption", []map[string]interface{}{
+			{"name": "/dev/mapper/root", "encrypted": "1"},
+			{"name": "/dev/sda1", "encrypted": "0"},
+		}),
+	})
+	ctrl := findControl(t, score, "Disk encryption at rest")
+	if ctrl.Status != "warn" {
+		t.Errorf("expected warn for partial encryption, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if score.RiskLevel == "critical" {
+		t.Errorf("partial encryption must not be critical, got %s", score.RiskLevel)
+	}
+}
+
+func TestLinuxNoDiskEncryptionFailsAndEscalates(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "disk_encryption", []map[string]interface{}{
+			{"name": "/dev/sda1", "encrypted": "0"},
+		}),
+		postureRecord(t, "packages_deb", debRows(100)),
+		postureRecord(t, "users", []map[string]interface{}{{"username": "root", "uid": "0"}}),
+	})
+	ctrl := findControl(t, score, "Disk encryption at rest")
+	if ctrl.Status != "fail" {
+		t.Errorf("expected fail, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if score.RiskLevel != "critical" {
+		t.Errorf("expected critical risk level from failing critical control, got %s (score %d)", score.RiskLevel, score.TotalScore)
+	}
+}
+
+// RDP/SMB on a Windows server is normal operations: review, not failure.
+func TestRemoteAccessPortsWarnInsteadOfFail(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "listening_ports", []map[string]interface{}{
+			{"port": "3389"},
+			{"port": "445"},
+		}),
+	})
+	ctrl := findControl(t, score, "Open listening ports")
+	if ctrl.Status != "warn" {
+		t.Errorf("expected warn for rdp/smb, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if !strings.Contains(ctrl.Detail, "rdp") || !strings.Contains(ctrl.Detail, "smb") {
+		t.Errorf("detail should name the services: %s", ctrl.Detail)
+	}
+}
+
+func TestPlaintextPortsFail(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "listening_ports", []map[string]interface{}{
+			{"port": "23"},
+		}),
+	})
+	ctrl := findControl(t, score, "Open listening ports")
+	if ctrl.Status != "fail" {
+		t.Errorf("expected fail for telnet, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+}
+
+// A fully healthy node scores 0 / low regardless of how many controls ran.
+func TestHealthyNodeScoresZero(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "packages_deb", debRows(500)),
+		postureRecord(t, "packages_rpm", nil),
+		postureRecord(t, "users", []map[string]interface{}{{"username": "root", "uid": "0"}}),
+		postureRecord(t, "disk_encryption", []map[string]interface{}{{"name": "/dev/sda", "encrypted": "1"}}),
+		postureRecord(t, "listening_ports", []map[string]interface{}{{"port": "22"}}),
+		postureRecord(t, "ssh_keys", nil),
+		postureRecord(t, "kernel_modules", debRows(80)),
+		postureRecord(t, "suid_binaries", []map[string]interface{}{{"path": "/usr/bin/sudo"}}),
+	})
+	if score.TotalScore != 0 {
+		t.Errorf("expected score 0, got %d: %+v", score.TotalScore, score.Controls)
+	}
+	if score.RiskLevel != "low" {
+		t.Errorf("expected low risk, got %s", score.RiskLevel)
+	}
+	if score.FailCount != 0 || score.WarnCount != 0 {
+		t.Errorf("expected clean counts, got warn=%d fail=%d", score.WarnCount, score.FailCount)
+	}
+}
+
+// The normalized score is the earned share of the evaluated controls'
+// weight: a single failing high control out of high+medium+low = 20/35.
+func TestScoreIsNormalizedToEvaluatedControls(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		// patches (high, 20) warns when collected but empty → 5 earned
+		postureRecord(t, "patches", nil),
+		// listening_ports (medium, 10) passes
+		postureRecord(t, "listening_ports", []map[string]interface{}{{"port": "22"}}),
+		// software inventory (low, 5) passes
+		postureRecord(t, "packages_windows", debRows(10)),
+	})
+	// earned = 5 (warn on high), possible = 20+10+5 = 35 → 14
+	if score.TotalScore != 14 {
+		t.Errorf("expected normalized score 14, got %d", score.TotalScore)
+	}
+	if score.RiskLevel != "low" {
+		t.Errorf("expected low risk, got %s", score.RiskLevel)
+	}
+}
+
+func TestFailingHighControlRaisesLevelToHigh(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		// users (medium) fails: two UID-0 accounts
+		postureRecord(t, "users", []map[string]interface{}{
+			{"username": "root", "uid": "0"},
+			{"username": "toor", "uid": "0"},
+		}),
+		// ssh_keys (high) — root key only warns; use a synthetic failing
+		// high control via plaintext port + patches? patches never fails.
+		// Instead verify medium fail alone does not escalate:
+		postureRecord(t, "packages_deb", debRows(10)),
+	})
+	if score.RiskLevel == "critical" {
+		t.Errorf("medium fail must not be critical, got %s", score.RiskLevel)
+	}
+	ctrl := findControl(t, score, "Interactive user accounts")
+	if ctrl.Status != "fail" {
+		t.Errorf("expected fail for duplicate UID-0, got %s", ctrl.Status)
+	}
+}
+
+func TestMacSharingServicesEnabledWarns(t *testing.T) {
+	score := NewScoreCalculator().Score([]NodePosture{
+		postureRecord(t, "file_sharing", []map[string]interface{}{
+			{"file_sharing": "0", "screen_sharing": "1", "remote_login": "1"},
+		}),
+	})
+	ctrl := findControl(t, score, "macOS sharing services")
+	if ctrl.Status != "warn" {
+		t.Errorf("expected warn for enabled sharing services, got %s (%s)", ctrl.Status, ctrl.Detail)
+	}
+	if !strings.Contains(ctrl.Detail, "screen_sharing") || !strings.Contains(ctrl.Detail, "remote_login") {
+		t.Errorf("detail should list enabled services: %s", ctrl.Detail)
+	}
+}
+
+func TestNoRecordsProducesEmptyScore(t *testing.T) {
+	score := NewScoreCalculator().Score(nil)
+	if score.TotalScore != 0 || len(score.Controls) != 0 {
+		t.Errorf("expected empty score, got %+v", score)
+	}
+	if hasControl(score, "Disk encryption at rest") {
+		t.Errorf("no controls should be evaluated without records")
+	}
+}


### PR DESCRIPTION
## Summary

Redesigns the posture risk scoring in `pkg/posture/scoring.go` to be realistic and defensible from an ISO 27001 / SOC 2 perspective. The trigger was a false positive: on Debian/Ubuntu servers, an empty `rpm_packages` result counted as a permanent warning — but a Debian host *should not* have RPM packages. Reworking that surfaced several other false positives that made whole platforms look unhealthy.

## What was wrong

- **Inapplicable checks counted as findings.** Linux profiles collect both `packages_deb` and `packages_rpm`; whichever one doesn't apply to the distro is always empty, so every Linux node carried at least one bogus warning. Same for macOS nodes without Homebrew.
- **Every healthy BitLocker machine failed disk encryption.** Windows profiles store BitLocker rows under the `disk_encryption` category, but the rule only understood the Linux/macOS `encrypted` field — rows with `protection_status` were counted as unencrypted, so fully protected Windows nodes scored a critical fail.
- **Every normal Windows server failed the ports control.** RDP (3389) and SMB (445) were hard fails, yet they listen on effectively every Windows server.
- **Score depended on how many checks ran.** Points were additive, so a well-monitored node accumulated more risk points than a barely-monitored one, and warnings (at 50% weight) could outrank real failures.

## The new model

1. **Applicability-aware controls.** A control can draw evidence from multiple posture categories. All five package sources (deb, rpm, Windows programs, macOS apps, Homebrew) feed a single "Software inventory" control (ISO A.5.9) that passes if *any* source has data and warns only when every collected source is empty (i.e. osquery genuinely can't read the tables). Controls whose categories were never collected are skipped entirely — "not applicable" is no longer reported as "warning".
2. **Normalized score.** `total_score = 100 × earned risk / max possible risk of the controls actually evaluated`. Scores are now comparable across platforms with different check counts, and a node is not penalized for being monitored more thoroughly. Warnings earn 25% of a control's weight (was 50%) — they are review items, not confirmed exposures.
3. **Exception-driven risk level.** Auditors reason in nonconformities, not weighted averages: any failing critical control (e.g. unencrypted disk) makes the node `critical` outright; a failing high control raises it to at least `high`; otherwise the score thresholds decide.
4. **Realistic rule semantics.**
   - Disk encryption handles both schemas per row (`encrypted` and BitLocker's `protection_status`, including osquery's numeric `1`). Unprotected OS drive (C:) → fail; nothing encrypted → fail; partial encryption (unencrypted `/boot`/swap next to a LUKS root) → warn instead of critical fail.
   - Listening ports: plaintext-auth services (telnet, ftp) fail; RDP/SMB/SNMP/VNC warn with a "verify exposure" detail.
   - macOS sharing: removed dead code; any enabled sharing service now warns with the list (previously up to two enabled services silently passed).
5. **Corrected ISO 27001:2022 control mapping** — e.g. disk encryption → A.8.24 (Use of cryptography; A.8.5 is actually Secure authentication), software inventory → A.5.9, listening ports → A.8.20, SSH keys → A.5.17, browser extensions → A.8.19.

## Compatibility

- The `PostureScore` JSON contract is unchanged (`total_score`, `risk_level`, `controls[]` with `pass`/`warn`/`fail`, pass/warn/fail counts) — no SPA changes required.
- Risk levels remain `low`/`medium`/`high`/`critical` with the same thresholds, so node health projection is untouched.
- Expect risk levels to shift on existing fleets: false warnings disappear (scores drop for Debian/RHEL/macOS nodes), while nodes with a failing critical control (unencrypted disk) now report `critical` instead of whatever the additive sum happened to reach.

## Test plan

- [x] 16 new tests in `pkg/posture/scoring_test.go`: empty-RPM-on-Debian / empty-deb-on-RHEL / no-Homebrew-on-macOS produce no findings; BitLocker rows under `disk_encryption` pass; unprotected C: fails and escalates to critical; partial Linux encryption warns; telnet fails while RDP/SMB warn; healthy node scores 0/low; normalization math; skipped uncollected controls; empty input.
- [x] Updated `TestProjectNodeAddsPostureRiskWhenPostureEnabled` expectation from `high` to `critical` (its fixture includes an unencrypted disk, which now correctly escalates).
- [x] `go test ./pkg/posture/... ./cmd/api/handlers/...` passes; `go vet` and `gofmt` clean.