### PR TITLE
Cleanup `refresh_envs` from `osctrl-tls`, `osctrl-api` and `frontend`

### DIFF
--- a/cmd/api/settings.go
+++ b/cmd/api/settings.go
@@ -17,12 +17,6 @@ func loadingSettings(mgr *settings.Settings, cfg *config.ServiceParameters) erro
 			return fmt.Errorf("failed to add %s to settings: %w", settings.ServiceMetrics, err)
 		}
 	}
-	// Check if service settings for environments refresh is ready
-	if !mgr.IsValue(config.ServiceAPI, settings.RefreshEnvs, settings.NoEnvironmentID) {
-		if err := mgr.NewIntegerValue(config.ServiceAPI, settings.RefreshEnvs, int64(defaultRefresh), settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("failed to add %s to settings: %w", settings.RefreshEnvs, err)
-		}
-	}
 	// Check if service settings for settings refresh is ready
 	if !mgr.IsValue(config.ServiceAPI, settings.RefreshSettings, settings.NoEnvironmentID) {
 		if err := mgr.NewIntegerValue(config.ServiceAPI, settings.RefreshSettings, int64(defaultRefresh), settings.NoEnvironmentID); err != nil {

--- a/cmd/api/settings_test.go
+++ b/cmd/api/settings_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestLoadingSettingsDoesNotSeedRefreshEnvs(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	mgr := settings.NewSettings(db)
+
+	require.NoError(t, loadingSettings(mgr, &config.ServiceParameters{
+		Service: &config.YAMLConfigurationService{},
+		Logger:  &config.YAMLConfigurationLogger{},
+		Carver:  &config.YAMLConfigurationCarver{},
+	}))
+
+	_, err = mgr.RetrieveValue(config.ServiceAPI, "refresh_envs", settings.NoEnvironmentID)
+	require.Error(t, err)
+}

--- a/cmd/tls/settings.go
+++ b/cmd/tls/settings.go
@@ -15,12 +15,6 @@ func loadingSettings(mgr *settings.Settings, cfg *config.ServiceParameters) erro
 			return fmt.Errorf("failed to add %s to configuration: %w", settings.AcceleratedSeconds, err)
 		}
 	}
-	// Check if service settings for environments refresh is ready
-	if !mgr.IsValue(config.ServiceTLS, settings.RefreshEnvs, settings.NoEnvironmentID) {
-		if err := mgr.NewIntegerValue(config.ServiceTLS, settings.RefreshEnvs, int64(defaultRefresh), settings.NoEnvironmentID); err != nil {
-			return fmt.Errorf("failed to add %s to configuration: %w", settings.RefreshEnvs, err)
-		}
-	}
 	// Check if service settings for enroll/remove oneliner links is ready
 	if !mgr.IsValue(config.ServiceTLS, settings.OnelinerExpiration, settings.NoEnvironmentID) {
 		if err := mgr.NewBooleanValue(config.ServiceTLS, settings.OnelinerExpiration, defaultOnelinerExpiration, settings.NoEnvironmentID); err != nil {

--- a/cmd/tls/settings_test.go
+++ b/cmd/tls/settings_test.go
@@ -25,3 +25,18 @@ func TestLoadingSettingsDefaultsAcceleratedSecondsToFive(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(5), got)
 }
+
+func TestLoadingSettingsDoesNotSeedRefreshEnvs(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	mgr := settings.NewSettings(db)
+
+	require.NoError(t, loadingSettings(mgr, &config.ServiceParameters{
+		Service: &config.YAMLConfigurationService{},
+		Logger:  &config.YAMLConfigurationLogger{},
+		Carver:  &config.YAMLConfigurationCarver{},
+	}))
+
+	_, err = mgr.RetrieveValue(config.ServiceTLS, "refresh_envs", settings.NoEnvironmentID)
+	require.Error(t, err)
+}

--- a/frontend/src/features/settings/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/SettingsPage.test.tsx
@@ -110,6 +110,20 @@ describe('SettingsPage', () => {
     expect(screen.getByText('NodeDashboard')).toBeInTheDocument();
   });
 
+  it('hides stale refresh_envs rows for tls and api settings', async () => {
+    mockList.mockResolvedValue([
+      makeSetting({ ID: 1, Name: 'refresh_envs', Service: 'tls', Info: 'legacy env refresh interval' }),
+      makeSetting({ ID: 2, Name: 'accelerated_seconds', Service: 'tls', Info: 'Console acceleration' }),
+    ]);
+
+    renderWithProviders(makeTestRouter('/_app/settings/tls'));
+
+    await waitFor(() => {
+      expect(screen.getByText('accelerated_seconds')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('refresh_envs')).not.toBeInTheDocument();
+  });
+
   it('shows empty state when no settings exist', async () => {
     mockList.mockResolvedValue([]);
     renderWithProviders(makeTestRouter());

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -19,6 +19,10 @@ import { formatRelative } from '$/lib/time';
 // the user-facing labels add the `osctrl-` prefix for readability.
 const SERVICES = ['tls', 'admin', 'api'] as const;
 type Service = (typeof SERVICES)[number];
+const HIDDEN_SETTINGS_BY_SERVICE: Partial<Record<Service, ReadonlySet<string>>> = {
+  tls: new Set(['refresh_envs']),
+  api: new Set(['refresh_envs']),
+};
 
 export function SettingsPage() {
   usePageTitle('Settings');
@@ -41,7 +45,9 @@ export function SettingsPage() {
     return null;
   }
 
-  const items = data ?? [];
+  const items = (data ?? []).filter(
+    (setting) => !HIDDEN_SETTINGS_BY_SERVICE[service]?.has(setting.Name),
+  );
 
   return (
     <div className="flex flex-col h-full min-h-0">

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -72,7 +72,6 @@ const (
 
 // Names for all possible settings values for services
 const (
-	RefreshEnvs        string = "refresh_envs"
 	RefreshSettings    string = "refresh_settings"
 	CleanupSessions    string = "cleanup_sessions"
 	CleanupExpired     string = "cleanup_expired"
@@ -532,15 +531,6 @@ func (conf *Settings) IsValue(service, name string, envID uint) bool {
 func (conf *Settings) IsJSON(service, name string, envID uint) bool {
 	_, err := conf.RetrieveJSON(service, name, envID)
 	return err == nil
-}
-
-// RefreshEnvs gets the interval in seconds to refresh environments by service
-func (conf *Settings) RefreshEnvs(service string) int64 {
-	value, err := conf.RetrieveValue(service, RefreshEnvs, NoEnvironmentID)
-	if err != nil {
-		return 0
-	}
-	return value.Integer
 }
 
 // RefreshSettings gets the interval in seconds to refresh settings by service


### PR DESCRIPTION
Removing all references to `refresh_envs` since environments are now cached using Redis.