### PR TITLE
Hide posture results and only store latest data

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -552,7 +552,7 @@ export interface PostureScore {
   timestamp: string;
   total_score: number;
   risk_level: string;
-  controls: ControlResult[];
+  controls: ControlResult[] | null;
   pass_count: number;
   warn_count: number;
   fail_count: number;

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -11,7 +11,7 @@ import {
   Outlet,
 } from '@tanstack/react-router';
 import { NodeDetailPage } from './NodeDetailPage';
-import type { NodePosture, OsqueryNode, SavedQueriesPagedResponse, AdminTag } from '$/api/types';
+import type { NodePosture, OsqueryNode, SavedQueriesPagedResponse, AdminTag, PostureScore } from '$/api/types';
 import type { NodeActivityBucket, NodeTileSeries } from '$/api/stats';
 import type { SettingValue } from '$/api/settings';
 import type { Features } from '$/api/features';
@@ -20,6 +20,7 @@ const mockGetNode = vi.fn<() => Promise<OsqueryNode>>();
 const mockListNodeLogs = vi.fn<() => Promise<unknown>>();
 const mockDeleteNode = vi.fn<() => Promise<{ message: string }>>();
 const mockGetNodePosture = vi.fn<() => Promise<NodePosture[]>>();
+const mockGetNodePostureScore = vi.fn<() => Promise<PostureScore>>();
 const mockGetMe = vi.fn<() => Promise<unknown>>();
 const mockListEnvironments = vi.fn<() => Promise<Array<{ name: string; uuid: string }>>>();
 const mockGetNodeActivity = vi.fn<() => Promise<NodeActivityBucket[]>>();
@@ -37,6 +38,7 @@ vi.mock('$/api/nodes', () => ({
   listNodeLogs: (...args: unknown[]) => mockListNodeLogs(...(args as [])),
   deleteNode: (...args: unknown[]) => mockDeleteNode(...(args as [])),
   getNodePosture: (...args: unknown[]) => mockGetNodePosture(...(args as [])),
+  getNodePostureScore: (...args: unknown[]) => mockGetNodePostureScore(...(args as [])),
 }));
 
 vi.mock('$/api/users', () => ({
@@ -288,6 +290,16 @@ describe('NodeDetailPage', () => {
     });
     mockListServiceSettings.mockResolvedValue([]);
     mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockGetNodePostureScore.mockResolvedValue({
+      node_uuid: 'abc12345-0000-0000-0000-000000000001',
+      timestamp: '2026-07-16T09:05:00Z',
+      total_score: 0,
+      risk_level: 'low',
+      controls: [],
+      pass_count: 0,
+      warn_count: 0,
+      fail_count: 0,
+    });
     mockListSavedQueries.mockResolvedValue(makeSavedQueries());
     mockRunQuery.mockResolvedValue({ query_name: 'query-123' });
     mockRunCarve.mockResolvedValue({ query_name: 'carve-123' });
@@ -403,6 +415,47 @@ describe('NodeDetailPage', () => {
     expect(screen.getByText('domain')).toBeInTheDocument();
   });
 
+  it('renders posture score when controls is null', async () => {
+    const user = userEvent.setup();
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
+    mockGetNodePosture.mockResolvedValue([
+      {
+        id: 10,
+        created_at: '2026-07-16T09:00:00Z',
+        updated_at: '2026-07-16T09:05:00Z',
+        node_uuid: 'abc12345-0000-0000-0000-000000000001',
+        environment: 'test-env',
+        category: 'firewall',
+        query_name: 'osctrl:posture:firewall',
+        row_count: 1,
+        summary: JSON.stringify([{ enabled: '1' }]),
+        first_seen: '2026-07-16T09:00:00Z',
+        last_seen: '2026-07-16T09:05:00Z',
+      },
+    ]);
+    mockGetNodePostureScore.mockResolvedValue({
+      node_uuid: 'abc12345-0000-0000-0000-000000000001',
+      timestamp: '2026-07-16T09:05:00Z',
+      total_score: 0,
+      risk_level: 'low',
+      controls: null,
+      pass_count: 0,
+      warn_count: 0,
+      fail_count: 0,
+    } as unknown as PostureScore);
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Posture' }));
+
+    expect(await screen.findByText('Risk score')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /firewall/i })).toBeInTheDocument();
+  });
+
   it('hides posture tab while the posture feature is disabled', async () => {
     renderWithProviders(makeTestRouter());
 
@@ -412,6 +465,43 @@ describe('NodeDetailPage', () => {
 
     expect(screen.queryByRole('tab', { name: 'Posture' })).not.toBeInTheDocument();
     expect(mockGetNodePosture).not.toHaveBeenCalled();
+  });
+
+  it('hides posture query results from the result logs tab', async () => {
+    const user = userEvent.setup();
+    mockListNodeLogs.mockResolvedValue({
+      items: [
+        {
+          created_at: '2026-07-16T09:05:00Z',
+          name: 'osctrl:posture:firewall',
+          action: 'added',
+          columns: '{"enabled":"1"}',
+        },
+        {
+          created_at: '2026-07-16T09:04:00Z',
+          name: 'process inventory',
+          action: 'added',
+          columns: '{"pid":"1","name":"launchd"}',
+        },
+      ],
+      type: 'result',
+      uuid: 'abc12345-0000-0000-0000-000000000001',
+      env: 'test-env',
+      limit: 100,
+    });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Result logs' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('process inventory')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('osctrl:posture:firewall')).not.toBeInTheDocument();
   });
 
   it('shows posture uptime in lifecycle details only when posture is enabled', async () => {

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -57,6 +57,7 @@ interface NodeHeatmapBucket {
 type Tab = 'details' | 'status-logs' | 'result-logs' | 'posture';
 type NodeActionModal = 'query' | 'carve' | 'tag' | null;
 const TAG_TYPE_REGULAR = 6;
+const POSTURE_QUERY_PREFIX = 'osctrl:posture:';
 
 // ---------------------------------------------------------------------------
 // Detail field groups
@@ -462,11 +463,13 @@ function LogsTab({
   uuid,
   type,
   onSearchColumn,
+  filterEntry,
 }: {
   env: string;
   uuid: string;
   type: 'status' | 'result';
   onSearchColumn?: (queryName: string, column: string, value: string) => void;
+  filterEntry?: (entry: NodeLogEntry) => boolean;
 }) {
   const accumulatedRef = useRef<NodeLogEntry[]>([]);
   const sinceRef = useRef<string | undefined>(undefined);
@@ -508,8 +511,11 @@ function LogsTab({
           (newest['created_at'] as string | undefined) ??
           (newest['calendarTime'] as string | undefined);
         if (ts) sinceRef.current = ts;
+      }
+      const nextItems = filterEntry ? res.items.filter(filterEntry) : res.items;
+      if (nextItems.length > 0) {
         // Prepend new entries (newest-first) ahead of already-accumulated ones
-        accumulatedRef.current = [...res.items, ...accumulatedRef.current];
+        accumulatedRef.current = [...nextItems, ...accumulatedRef.current];
       }
       return { ...res, items: accumulatedRef.current };
     },
@@ -1274,6 +1280,9 @@ export function NodeDetailPage() {
             uuid={uuid}
             type="result"
             onSearchColumn={onSearchColumn}
+            filterEntry={(entry) =>
+              !(typeof entry['name'] === 'string' && entry['name'].startsWith(POSTURE_QUERY_PREFIX))
+            }
           />
         )}
       </div>
@@ -2126,6 +2135,7 @@ function PostureTab({ env, uuid }: { env: string; uuid: string }) {
 // PostureScorePanel — risk score gauge + control summary
 // ---------------------------------------------------------------------------
 function PostureScorePanel({ score }: { score: PostureScore }) {
+  const controls = score.controls ?? [];
   const riskColors: Record<string, string> = {
     low: 'var(--success)',
     medium: 'var(--warning)',
@@ -2179,7 +2189,7 @@ function PostureScorePanel({ score }: { score: PostureScore }) {
       </div>
       {/* Control results */}
       <div className="divide-y divide-[color:var(--border)]">
-        {score.controls.map((ctrl) => {
+        {controls.map((ctrl) => {
           const statusColor = ctrl.status === 'pass' ? 'var(--success)' : ctrl.status === 'warn' ? 'var(--warning)' : 'var(--danger)';
           return (
             <div key={ctrl.control_id + ctrl.category} className="px-4 py-2 flex items-start gap-3">

--- a/pkg/posture/posture.go
+++ b/pkg/posture/posture.go
@@ -111,6 +111,12 @@ func migrateNodePosture(db *gorm.DB) error {
 			lastErr = fmt.Errorf("auto-migrate posture table: %w", err)
 			continue
 		}
+		if db.Migrator().HasIndex(&NodePosture{}, "idx_posture_node_uuid") {
+			if err := db.Migrator().DropIndex(&NodePosture{}, "idx_posture_node_uuid"); err != nil && db.Migrator().HasIndex(&NodePosture{}, "idx_posture_node_uuid") {
+				lastErr = fmt.Errorf("drop overbroad posture node index: %w", err)
+				continue
+			}
+		}
 		if db.Migrator().HasIndex(&NodePosture{}, "idx_posture_node") {
 			if err := db.Migrator().DropIndex(&NodePosture{}, "idx_posture_node"); err != nil && db.Migrator().HasIndex(&NodePosture{}, "idx_posture_node") {
 				lastErr = fmt.Errorf("drop legacy posture index: %w", err)

--- a/pkg/posture/posture_test.go
+++ b/pkg/posture/posture_test.go
@@ -152,6 +152,30 @@ func TestIngestResultUpdatesMutableFieldsAndPreservesFirstSeen(t *testing.T) {
 	}
 }
 
+func TestIngestResultKeepsLatestResultPerNodeCategory(t *testing.T) {
+	pm := newTestManager(t)
+	if err := pm.IngestResult("node-a", "dev", QueryPrefix+"users", marshalRows(t, 1)); err != nil {
+		t.Fatalf("first ingest: %v", err)
+	}
+	if err := pm.IngestResult("node-a", "dev", QueryPrefix+"packages", marshalRows(t, 2)); err != nil {
+		t.Fatalf("second ingest: %v", err)
+	}
+
+	records, err := pm.GetByNode("node-a")
+	if err != nil {
+		t.Fatalf("get posture: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected latest posture result per category, got %d records: %+v", len(records), records)
+	}
+	if records[0].Category != "packages" || records[0].RowCount != 2 {
+		t.Fatalf("expected packages posture result, got %+v", records[0])
+	}
+	if records[1].Category != "users" || records[1].RowCount != 1 {
+		t.Fatalf("expected users posture result, got %+v", records[1])
+	}
+}
+
 func TestIngestResultRejectsMalformedColumns(t *testing.T) {
 	pm := newTestManager(t)
 	for _, columns := range []json.RawMessage{
@@ -227,6 +251,23 @@ type legacyNodePosture struct {
 
 func (legacyNodePosture) TableName() string { return "node_posture" }
 
+type categoryUniqueNodePosture struct {
+	ID          uint `gorm:"primarykey"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	NodeUUID    string `gorm:"type:varchar(36);uniqueIndex:idx_posture_node_category"`
+	Environment string
+	Category    string `gorm:"uniqueIndex:idx_posture_node_category;type:varchar(64)"`
+	QueryName   string `gorm:"type:varchar(255)"`
+	RowCount    int
+	Summary     string `gorm:"type:text"`
+	Snapshot    string `gorm:"type:text"`
+	FirstSeen   time.Time
+	LastSeen    time.Time
+}
+
+func (categoryUniqueNodePosture) TableName() string { return "node_posture" }
+
 func TestMigrateNodePostureDeduplicatesLegacyRowsBeforeUniqueIndex(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:posture_migration?mode=memory&cache=shared"), &gorm.Config{})
 	if err != nil {
@@ -261,6 +302,36 @@ func TestMigrateNodePostureDeduplicatesLegacyRowsBeforeUniqueIndex(t *testing.T)
 	}
 	if db.Migrator().HasIndex(&NodePosture{}, "idx_posture_node") {
 		t.Fatal("legacy duplicate index still exists after migration")
+	}
+}
+
+func TestMigrateNodePostureKeepsPreviousNodeCategorySchema(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:posture_node_category_migration?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&categoryUniqueNodePosture{}); err != nil {
+		t.Fatalf("migrate category-unique schema: %v", err)
+	}
+	oldTime := time.Now().Add(-time.Hour)
+	newTime := time.Now()
+	rows := []categoryUniqueNodePosture{
+		{NodeUUID: "NODE-A", Category: "users", Summary: `[{"old":true}]`, UpdatedAt: oldTime},
+		{NodeUUID: "NODE-A", Category: "packages", Summary: `[{"new":true}]`, UpdatedAt: newTime},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("insert previous-schema rows: %v", err)
+	}
+
+	if err := migrateNodePosture(db); err != nil {
+		t.Fatalf("migrate posture table: %v", err)
+	}
+	var retained []NodePosture
+	if err := db.Find(&retained).Error; err != nil {
+		t.Fatalf("read migrated rows: %v", err)
+	}
+	if len(retained) != 2 {
+		t.Fatalf("expected both node/category rows to survive, got %+v", retained)
 	}
 }
 

--- a/pkg/posture/scoring.go
+++ b/pkg/posture/scoring.go
@@ -142,6 +142,7 @@ func NewScoreCalculator() *ScoreCalculator {
 func (sc *ScoreCalculator) Score(records []NodePosture) PostureScore {
 	score := PostureScore{
 		Timestamp: time.Now(),
+		Controls:  []ControlResult{},
 	}
 
 	// Build a lookup: category → parsed rows. A collected category with an

--- a/pkg/posture/scoring_test.go
+++ b/pkg/posture/scoring_test.go
@@ -309,3 +309,14 @@ func TestNoRecordsProducesEmptyScore(t *testing.T) {
 		t.Errorf("no controls should be evaluated without records")
 	}
 }
+
+func TestNoRecordsScoreEncodesControlsAsEmptyArray(t *testing.T) {
+	score := NewScoreCalculator().Score(nil)
+	payload, err := json.Marshal(score)
+	if err != nil {
+		t.Fatalf("marshal score: %v", err)
+	}
+	if !strings.Contains(string(payload), `"controls":[]`) {
+		t.Fatalf("expected controls to encode as [], got %s", payload)
+	}
+}


### PR DESCRIPTION
- Updated posture storage to keep only the latest result per node/category, preventing duplicate old posture rows without losing other posture categories.
- Hid posture query result rows from the node Result logs tab because posture has its own dedicated tab.
- Fixed Posture tab crash when posture score controls is null; backend now emits controls: [] for empty scores.