### PR TITLE
Added file explorer to nodes view, powered by accelerated queries

### DIFF
--- a/cmd/api/handlers/features.go
+++ b/cmd/api/handlers/features.go
@@ -8,8 +8,9 @@ import (
 
 // FeaturesResponse advertises server-side feature switches consumed by the SPA.
 type FeaturesResponse struct {
-	Posture     bool `json:"posture"`
-	Accelerated bool `json:"accelerated"`
+	Posture      bool `json:"posture"`
+	Accelerated  bool `json:"accelerated"`
+	FileExplorer bool `json:"file_explorer"`
 }
 
 // FeaturesHandler — GET /api/v1/features.
@@ -18,7 +19,8 @@ func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 		utils.DebugHTTPDump(h.DebugHTTP, r, false)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, FeaturesResponse{
-		Posture:     h.PostureEnabled,
-		Accelerated: h.OsqueryValues.Accelerated,
+		Posture:      h.PostureEnabled,
+		Accelerated:  h.OsqueryValues.Accelerated,
+		FileExplorer: h.OsqueryValues.Query && h.OsqueryValues.Accelerated && h.OsqueryValues.FileExplorer,
 	})
 }

--- a/cmd/api/handlers/features_test.go
+++ b/cmd/api/handlers/features_test.go
@@ -70,3 +70,36 @@ func TestFeaturesHandlerReportsAcceleratedEnabled(t *testing.T) {
 		t.Fatalf("accelerated feature: got false want true")
 	}
 }
+
+func TestFeaturesHandlerReportsFileExplorerOnlyWhenQueryAcceleratedAndEnabled(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cfg  config.YAMLConfigurationOsquery
+		want bool
+	}{
+		{name: "disabled by default", cfg: config.YAMLConfigurationOsquery{}, want: false},
+		{name: "requires query", cfg: config.YAMLConfigurationOsquery{Accelerated: true, FileExplorer: true}, want: false},
+		{name: "requires accelerated", cfg: config.YAMLConfigurationOsquery{Query: true, FileExplorer: true}, want: false},
+		{name: "enabled", cfg: config.YAMLConfigurationOsquery{Query: true, Accelerated: true, FileExplorer: true}, want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &HandlersApi{}
+			WithOsqueryValues(tt.cfg)(h)
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/features", nil)
+			w := httptest.NewRecorder()
+
+			h.FeaturesHandler(w, r)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status: got %d want 200", w.Code)
+			}
+			var resp FeaturesResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.FileExplorer != tt.want {
+				t.Fatalf("file explorer feature: got %t want %t", resp.FileExplorer, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/api/handlers/file_explorer.go
+++ b/cmd/api/handlers/file_explorer.go
@@ -1,0 +1,222 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/utils"
+	"gorm.io/gorm"
+)
+
+type fileExplorerPathRequest struct {
+	Path string `json:"path"`
+}
+
+type fileExplorerSessionResponse struct {
+	Session  fileexplorer.Session `json:"session"`
+	NodeInfo consoleNodeInfo      `json:"node_info"`
+}
+
+func (h *HandlersApi) FileExplorerSessionCreateHandler(w http.ResponseWriter, r *http.Request) {
+	env, ctx, ok := h.fileExplorerEnvContext(w, r)
+	if !ok {
+		return
+	}
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
+		apiErrorResponse(w, "missing node uuid", http.StatusBadRequest, nil)
+		return
+	}
+	node, err := h.Nodes.GetByUUIDEnv(uuid, env.ID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErrorResponse(w, "node not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error getting node", http.StatusInternalServerError, err)
+		return
+	}
+	session, err := h.FileExplorer.CreateSession(env, node, ctx[ctxUser])
+	if err != nil {
+		apiErrorResponse(w, "error creating file explorer session", http.StatusInternalServerError, err)
+		return
+	}
+	h.auditFileExplorerAction(ctx[ctxUser], "file explorer session", r, env.ID)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, fileExplorerSessionResponse{
+		Session:  session,
+		NodeInfo: consoleNodeInfoFromNode(node),
+	})
+}
+
+func (h *HandlersApi) FileExplorerSessionShowHandler(w http.ResponseWriter, r *http.Request) {
+	env, ctx, session, ok := h.fileExplorerSessionContext(w, r)
+	if !ok {
+		return
+	}
+	session, err := h.FileExplorer.TouchSession(session.ID)
+	if err != nil {
+		apiErrorResponse(w, "error refreshing file explorer session", http.StatusInternalServerError, err)
+		return
+	}
+	h.auditFileExplorerAction(ctx[ctxUser], "file explorer session", r, env.ID)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, session)
+}
+
+func (h *HandlersApi) FileExplorerSessionDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	_, _, session, ok := h.fileExplorerSessionContext(w, r)
+	if !ok {
+		return
+	}
+	if err := h.FileExplorer.CloseSession(session.ID); err != nil {
+		apiErrorResponse(w, "error closing file explorer session", http.StatusInternalServerError, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: "file explorer session closed"})
+}
+
+func (h *HandlersApi) FileExplorerListHandler(w http.ResponseWriter, r *http.Request) {
+	env, ctx, session, ok := h.fileExplorerSessionContext(w, r)
+	if !ok {
+		return
+	}
+	path, ok := fileExplorerRequestPath(w, r)
+	if !ok {
+		return
+	}
+	request, err := h.FileExplorer.ListDirectory(session.ID, path, h.fileExplorerRequestTimeout())
+	if err != nil {
+		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
+		return
+	}
+	h.auditFileExplorerAction(ctx[ctxUser], "file explorer list", r, env.ID)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, request)
+}
+
+func (h *HandlersApi) FileExplorerStatHandler(w http.ResponseWriter, r *http.Request) {
+	env, ctx, session, ok := h.fileExplorerSessionContext(w, r)
+	if !ok {
+		return
+	}
+	path, ok := fileExplorerRequestPath(w, r)
+	if !ok {
+		return
+	}
+	request, err := h.FileExplorer.StatPath(session.ID, path, h.fileExplorerRequestTimeout())
+	if err != nil {
+		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
+		return
+	}
+	h.auditFileExplorerAction(ctx[ctxUser], "file explorer stat", r, env.ID)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, request)
+}
+
+func (h *HandlersApi) FileExplorerRequestShowHandler(w http.ResponseWriter, r *http.Request) {
+	_, _, session, ok := h.fileExplorerSessionContext(w, r)
+	if !ok {
+		return
+	}
+	requestID, ok := consolePathUint(w, r, "request_id")
+	if !ok {
+		return
+	}
+	request, err := h.FileExplorer.GetRequest(session.ID, requestID)
+	if err != nil {
+		consoleNotFoundOrError(w, "request not found", "error getting file explorer request", err)
+		return
+	}
+	request, err = h.FileExplorer.RefreshRequestStatus(request.ID)
+	if err != nil {
+		apiErrorResponse(w, "error refreshing file explorer request", http.StatusInternalServerError, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, request)
+}
+
+func (h *HandlersApi) FileExplorerRequestResultsHandler(w http.ResponseWriter, r *http.Request) {
+	_, _, session, ok := h.fileExplorerSessionContext(w, r)
+	if !ok {
+		return
+	}
+	requestID, ok := consolePathUint(w, r, "request_id")
+	if !ok {
+		return
+	}
+	request, err := h.FileExplorer.GetRequest(session.ID, requestID)
+	if err != nil {
+		consoleNotFoundOrError(w, "request not found", "error getting file explorer request", err)
+		return
+	}
+	results, err := h.FileExplorer.RequestResults(request.ID)
+	if err != nil {
+		apiErrorResponse(w, "error getting file explorer results", http.StatusInternalServerError, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, results)
+}
+
+func (h *HandlersApi) fileExplorerEnvContext(w http.ResponseWriter, r *http.Request) (environments.TLSEnvironment, ContextValue, bool) {
+	if h.FileExplorer == nil {
+		apiErrorResponse(w, "file explorer unavailable", http.StatusNotFound, nil)
+		return environments.TLSEnvironment{}, nil, false
+	}
+	return h.consoleEnvContext(w, r)
+}
+
+func (h *HandlersApi) fileExplorerSessionContext(w http.ResponseWriter, r *http.Request) (environments.TLSEnvironment, ContextValue, fileexplorer.Session, bool) {
+	env, ctx, ok := h.fileExplorerEnvContext(w, r)
+	if !ok {
+		return environments.TLSEnvironment{}, nil, fileexplorer.Session{}, false
+	}
+	sessionID, ok := consolePathUint(w, r, "session_id")
+	if !ok {
+		return environments.TLSEnvironment{}, nil, fileexplorer.Session{}, false
+	}
+	session, err := h.FileExplorer.GetSession(sessionID)
+	if err != nil {
+		consoleNotFoundOrError(w, "session not found", "error getting file explorer session", err)
+		return environments.TLSEnvironment{}, nil, fileexplorer.Session{}, false
+	}
+	if session.EnvironmentID != env.ID {
+		apiErrorResponse(w, "session not found", http.StatusNotFound, nil)
+		return environments.TLSEnvironment{}, nil, fileexplorer.Session{}, false
+	}
+	if session.Creator != ctx[ctxUser] {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use file explorer session by user %s", ctx[ctxUser]))
+		return environments.TLSEnvironment{}, nil, fileexplorer.Session{}, false
+	}
+	return env, ctx, session, true
+}
+
+func fileExplorerRequestPath(w http.ResponseWriter, r *http.Request) (string, bool) {
+	var body fileExplorerPathRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing POST body", http.StatusBadRequest, err)
+		return "", false
+	}
+	return body.Path, true
+}
+
+func (h *HandlersApi) fileExplorerRequestTimeout() time.Duration {
+	seconds := int64(defaultConsoleQueryReadSeconds)
+	if h.Settings != nil {
+		if configured, err := h.Settings.GetInteger(config.ServiceTLS, settings.AcceleratedSeconds, settings.NoEnvironmentID); err == nil && configured > 0 {
+			seconds = configured
+		}
+	}
+	return time.Duration(seconds*2) * time.Second
+}
+
+func (h *HandlersApi) auditFileExplorerAction(user, action string, r *http.Request, envID uint) {
+	if h.AuditLog != nil {
+		h.AuditLog.QueryAction(user, action, strings.Split(r.RemoteAddr, ":")[0], envID)
+	}
+}

--- a/cmd/api/handlers/file_explorer_test.go
+++ b/cmd/api/handlers/file_explorer_test.go
@@ -1,0 +1,187 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
+	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupFileExplorerHandlers(t *testing.T) (*gorm.DB, *HandlersApi, environments.TLSEnvironment, nodes.OsqueryNode) {
+	t.Helper()
+
+	dsn := "file:" + strings.NewReplacer("/", "_", " ", "_").Replace(t.Name()) + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&logging.OsqueryQueryData{}))
+
+	envs := environments.CreateEnvironment(db)
+	nodesmgr := nodes.CreateNodes(db)
+	queryManager := queries.CreateQueries(db)
+	fileExplorerManager := fileexplorer.NewManager(db, queryManager)
+	userManager := users.CreateUserManager(db)
+	settingsManager := settings.NewSettings(db)
+
+	env := environments.TLSEnvironment{UUID: "env-uuid", Name: "env"}
+	require.NoError(t, db.Create(&env).Error)
+	node := nodes.OsqueryNode{UUID: "NODE-UUID", Platform: "linux", EnvironmentID: env.ID, Environment: env.UUID}
+	require.NoError(t, db.Create(&node).Error)
+
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "alice"}))
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "bob"}))
+	require.NoError(t, userManager.CreatePermission(users.UserPermission{
+		Username:      "alice",
+		AccessType:    int(users.AdminLevel),
+		AccessValue:   true,
+		Environment:   env.UUID,
+		EnvironmentID: env.ID,
+	}))
+
+	h := CreateHandlersApi(
+		WithDB(db),
+		WithEnvs(envs),
+		WithUsers(userManager),
+		WithNodes(nodesmgr),
+		WithQueries(queryManager),
+		WithSettings(settingsManager),
+		WithFileExplorer(fileExplorerManager),
+	)
+	return db, h, env, node
+}
+
+func TestFileExplorerSessionCreateReturnsSession(t *testing.T) {
+	_, h, env, node := setupFileExplorerHandlers(t)
+
+	req := fileExplorerRequest(http.MethodPost, "/file-explorer", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("uuid", node.UUID)
+	rr := httptest.NewRecorder()
+
+	h.FileExplorerSessionCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp fileExplorerSessionResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotZero(t, resp.Session.ID)
+	require.Equal(t, node.UUID, resp.Session.NodeUUID)
+	require.Equal(t, "/", resp.Session.Root)
+}
+
+func TestFileExplorerSessionCreateRejectsUserWithoutAdminPermission(t *testing.T) {
+	_, h, env, node := setupFileExplorerHandlers(t)
+
+	req := fileExplorerRequest(http.MethodPost, "/file-explorer", nil, "bob")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("uuid", node.UUID)
+	rr := httptest.NewRecorder()
+
+	h.FileExplorerSessionCreateHandler(rr, req)
+	require.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestFileExplorerListCreatesRequest(t *testing.T) {
+	db, h, env, node := setupFileExplorerHandlers(t)
+	session, err := h.FileExplorer.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	req := fileExplorerRequest(http.MethodPost, "/file-explorer/list", []byte(`{"path":"/etc"}`), "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	rr := httptest.NewRecorder()
+
+	h.FileExplorerListHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var request fileexplorer.Request
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &request))
+	require.Equal(t, fileexplorer.ActionList, request.Action)
+	require.Equal(t, "/etc", request.Path)
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", request.DistributedQueryName).First(&distributed).Error)
+	require.Equal(t, queries.FileExplorerQueryType, distributed.Type)
+	require.True(t, distributed.Hidden)
+}
+
+func TestFileExplorerRequestResultsReturnsEntries(t *testing.T) {
+	db, h, env, node := setupFileExplorerHandlers(t)
+	session, err := h.FileExplorer.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	request, err := h.FileExplorer.ListDirectory(session.ID, "/etc", time.Second)
+	require.NoError(t, err)
+
+	result, err := json.Marshal([]map[string]string{{
+		"path":      "/etc/hosts",
+		"filename":  "hosts",
+		"directory": "/etc",
+		"type":      "regular",
+		"size":      "123",
+	}})
+	require.NoError(t, err)
+	wrapped, err := json.Marshal(types.QueryWriteData{
+		Name:   request.DistributedQueryName,
+		Result: result,
+		Status: 0,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{
+		UUID:        node.UUID,
+		Environment: env.UUID,
+		Name:        request.DistributedQueryName,
+		Data:        string(wrapped),
+		Status:      0,
+	}).Error)
+	require.NoError(t, markFileExplorerHandlerNodeQueryStatus(db, request.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+
+	req := fileExplorerRequest(http.MethodGet, "/file-explorer/results", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	req.SetPathValue("request_id", fmt.Sprint(request.ID))
+	rr := httptest.NewRecorder()
+
+	h.FileExplorerRequestResultsHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var entries []fileexplorer.Entry
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &entries))
+	require.Equal(t, []fileexplorer.Entry{{
+		Path:      "/etc/hosts",
+		Filename:  "hosts",
+		Directory: "/etc",
+		Type:      "regular",
+		Size:      123,
+	}}, entries)
+}
+
+func fileExplorerRequest(method, target string, body []byte, username string) *http.Request {
+	req := httptest.NewRequest(method, target, bytes.NewReader(body))
+	ctx := context.WithValue(req.Context(), ContextKey(contextAPI), ContextValue{ctxUser: username})
+	return req.WithContext(ctx)
+}
+
+func markFileExplorerHandlerNodeQueryStatus(db *gorm.DB, queryName, status string) error {
+	var distributed queries.DistributedQuery
+	if err := db.Where("name = ?", queryName).First(&distributed).Error; err != nil {
+		return err
+	}
+	return db.Model(&queries.NodeQuery{}).
+		Where("query_id = ?", distributed.ID).
+		Update("status", status).Error
+}

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/geoip"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
@@ -32,6 +33,7 @@ type HandlersApi struct {
 	Nodes           *nodes.NodeManager
 	Queries         *queries.Queries
 	Console         *console.Manager
+	FileExplorer    *fileexplorer.Manager
 	Carves          *carves.Carves
 	Settings        *settings.Settings
 	Activity        activityReader
@@ -114,6 +116,12 @@ func WithQueries(queries *queries.Queries) HandlersOption {
 func WithConsole(consoleManager *console.Manager) HandlersOption {
 	return func(h *HandlersApi) {
 		h.Console = consoleManager
+	}
+}
+
+func WithFileExplorer(fileExplorerManager *fileexplorer.Manager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.FileExplorer = fileExplorerManager
 	}
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/geoip"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
@@ -98,6 +99,8 @@ const (
 	apiSettingsPath = "/settings"
 	// API features path
 	apiFeaturesPath = "/features"
+	// API file explorer path
+	apiFileExplorerPath = "/file-explorer"
 	// API audit logs path
 	apiAuditLogsPath = "/audit-logs"
 	// API logs path
@@ -125,6 +128,7 @@ var (
 	nodesmgr             *nodes.NodeManager
 	queriesmgr           *queries.Queries
 	consolemgr           *console.Manager
+	fileexplorermgr      *fileexplorer.Manager
 	filecarves           *carves.Carves
 	handlersApi          *handlers.HandlersApi
 	app                  *cli.Command
@@ -320,6 +324,8 @@ func osctrlAPIService() {
 	queriesmgr = queries.CreateQueries(db.Conn)
 	log.Info().Msg("Initialize console")
 	consolemgr = console.NewManager(db.Conn, queriesmgr)
+	log.Info().Msg("Initialize file explorer")
+	fileexplorermgr = fileexplorer.NewManager(db.Conn, queriesmgr)
 	log.Info().Msg("Initialize carves")
 	filecarves = carves.CreateFileCarves(db.Conn, flagParams.Carver.Type, nil)
 	log.Info().Msg("Loading service settings")
@@ -380,6 +386,7 @@ func osctrlAPIService() {
 		handlers.WithNodes(nodesmgr),
 		handlers.WithQueries(queriesmgr),
 		handlers.WithConsole(consolemgr),
+		handlers.WithFileExplorer(fileexplorermgr),
 		handlers.WithCarves(filecarves),
 		handlers.WithSettings(settingsmgr),
 		handlers.WithActivityReader(activity.NewRedisStore(redis.Client, activity.DefaultPrefix, activity.DefaultRetentionDays, 8*24*time.Hour)),
@@ -613,6 +620,30 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"GET "+_apiPath("/console")+"/{env}/sessions/{session_id}/commands/{command_id}/results",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.ConsoleCommandResultsHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		if flagParams.Osquery.Accelerated && flagParams.Osquery.FileExplorer {
+			// API: accelerated per-node file explorer
+			muxAPI.Handle(
+				"POST "+_apiPath(apiFileExplorerPath)+"/{env}/nodes/{uuid}/sessions",
+				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerSessionCreateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+			muxAPI.Handle(
+				"GET "+_apiPath(apiFileExplorerPath)+"/{env}/sessions/{session_id}",
+				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerSessionShowHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+			muxAPI.Handle(
+				"DELETE "+_apiPath(apiFileExplorerPath)+"/{env}/sessions/{session_id}",
+				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerSessionDeleteHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+			muxAPI.Handle(
+				"POST "+_apiPath(apiFileExplorerPath)+"/{env}/sessions/{session_id}/list",
+				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerListHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+			muxAPI.Handle(
+				"POST "+_apiPath(apiFileExplorerPath)+"/{env}/sessions/{session_id}/stat",
+				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerStatHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+			muxAPI.Handle(
+				"GET "+_apiPath(apiFileExplorerPath)+"/{env}/sessions/{session_id}/requests/{request_id}",
+				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerRequestShowHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+			muxAPI.Handle(
+				"GET "+_apiPath(apiFileExplorerPath)+"/{env}/sessions/{session_id}/requests/{request_id}/results",
+				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerRequestResultsHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		}
 		// API: saved queries (Track 4)
 		muxAPI.Handle(
 			"GET "+_apiPath(apiSavedQueriesPath)+"/{env}",

--- a/cmd/tls/handlers/console_acceleration_test.go
+++ b/cmd/tls/handlers/console_acceleration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/settings"
@@ -87,6 +88,29 @@ func TestShouldAccelerateQueryReadForActiveConsoleSession(t *testing.T) {
 		Platform:      "linux",
 		Active:        true,
 	}).Error)
+	require.True(t, handler.shouldAccelerateQueryRead(node, false))
+}
+
+func TestShouldAccelerateQueryReadForActiveFileExplorerSession(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&fileexplorer.Session{}))
+	queryManager := queries.CreateQueries(db)
+	handler := &HandlersTLS{Queries: queryManager}
+	node := nodes.OsqueryNode{ID: 7, UUID: "NODE-UUID", EnvironmentID: 1}
+
+	require.NoError(t, db.Create(&fileexplorer.Session{
+		EnvironmentID: node.EnvironmentID,
+		NodeID:        node.ID,
+		NodeUUID:      node.UUID,
+		Creator:       "alice",
+		Platform:      "linux",
+		Root:          "/",
+		Active:        true,
+	}).Error)
+
+	require.False(t, handler.shouldAccelerateQueryRead(node, false))
+	handler.OsqueryValues = &config.YAMLConfigurationOsquery{FileExplorer: true}
 	require.True(t, handler.shouldAccelerateQueryRead(node, false))
 }
 

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/posture"
@@ -274,7 +275,7 @@ func (h *HandlersTLS) shouldAccelerateQueryRead(node nodes.OsqueryNode, queryAcc
 	if queryAccelerated {
 		return true
 	}
-	return h.hasActiveConsoleSession(node)
+	return h.hasActiveConsoleSession(node) || h.hasActiveFileExplorerSession(node)
 }
 
 func (h *HandlersTLS) hasActiveConsoleSession(node nodes.OsqueryNode) bool {
@@ -286,6 +287,23 @@ func (h *HandlersTLS) hasActiveConsoleSession(node nodes.OsqueryNode) bool {
 		Where("node_id = ? AND node_uuid = ? AND environment_id = ? AND active = ? AND updated_at >= ?", node.ID, node.UUID, node.EnvironmentID, true, time.Now().Add(-consoleSessionFreshness)).
 		Count(&count).Error; err != nil {
 		log.Debug().Err(err).Msg("error checking active console session for accelerated query read")
+		return false
+	}
+	return count > 0
+}
+
+func (h *HandlersTLS) hasActiveFileExplorerSession(node nodes.OsqueryNode) bool {
+	if h.OsqueryValues == nil || !h.OsqueryValues.FileExplorer {
+		return false
+	}
+	if node.ID == 0 || node.UUID == "" || node.EnvironmentID == 0 || h.Queries == nil || h.Queries.DB == nil {
+		return false
+	}
+	var count int64
+	if err := h.Queries.DB.Model(&fileexplorer.Session{}).
+		Where("node_id = ? AND node_uuid = ? AND environment_id = ? AND active = ? AND updated_at >= ?", node.ID, node.UUID, node.EnvironmentID, true, time.Now().Add(-consoleSessionFreshness)).
+		Count(&count).Error; err != nil {
+		log.Debug().Err(err).Msg("error checking active file explorer session for accelerated query read")
 		return false
 	}
 	return count > 0

--- a/deploy/config/api.yml
+++ b/deploy/config/api.yml
@@ -69,6 +69,8 @@ osquery:
   config: true
   query: true
   carve: true
+  accelerated: false
+  fileExplorer: false
 
 # JWT authentication configuration
 jwt:

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -71,6 +71,7 @@ osquery:
   query: true
   carve: true
   accelerated: false
+  fileExplorer: false
 
 # Osctrl daemon configuration
 osctrld:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -62,6 +62,7 @@ services:
       - SERVICE_TRUSTED_PROXIES=172.16.0.0/12
       #### osquery settings ####
       - OSQUERY_ACCELERATED=true
+      - OSQUERY_FILE_EXPLORER=true
     networks:
       - osctrl-dev-backend
     ports:
@@ -156,6 +157,7 @@ services:
       #### osquery settings ####
       - OSQUERY_TABLES=/usr/src/app/deploy/osquery/data/${OSQUERY_VERSION}.json
       - OSQUERY_ACCELERATED=true
+      - OSQUERY_FILE_EXPLORER=true
       #### Database settings ####
       - DB_HOST=osctrl-postgres
       - DB_NAME=${POSTGRES_DB_NAME}

--- a/frontend/src/api/features.ts
+++ b/frontend/src/api/features.ts
@@ -3,6 +3,7 @@ import { apiFetch } from './client';
 export interface Features {
   posture: boolean;
   accelerated: boolean;
+  file_explorer: boolean;
 }
 
 export function getFeatures(): Promise<Features> {

--- a/frontend/src/api/file-explorer.ts
+++ b/frontend/src/api/file-explorer.ts
@@ -1,0 +1,79 @@
+import { apiFetch } from './client';
+import type {
+  FileExplorerEntry,
+  FileExplorerRequest,
+  FileExplorerSession,
+  FileExplorerSessionResponse,
+} from './types';
+
+export function createFileExplorerSession(env: string, uuid: string): Promise<FileExplorerSessionResponse> {
+  return apiFetch<FileExplorerSessionResponse>(
+    `/api/v1/file-explorer/${encodeURIComponent(env)}/nodes/${encodeURIComponent(uuid)}/sessions`,
+    { method: 'POST' },
+  );
+}
+
+export function getFileExplorerSession(env: string, sessionId: number): Promise<FileExplorerSession> {
+  return apiFetch<FileExplorerSession>(
+    `/api/v1/file-explorer/${encodeURIComponent(env)}/sessions/${sessionId}`,
+  );
+}
+
+export function closeFileExplorerSession(env: string, sessionId: number): Promise<{ message: string }> {
+  return apiFetch<{ message: string }>(
+    `/api/v1/file-explorer/${encodeURIComponent(env)}/sessions/${sessionId}`,
+    { method: 'DELETE' },
+  );
+}
+
+export function listFileExplorerDirectory(
+  env: string,
+  sessionId: number,
+  path: string,
+): Promise<FileExplorerRequest> {
+  return submitFileExplorerPath(env, sessionId, 'list', path);
+}
+
+export function statFileExplorerPath(
+  env: string,
+  sessionId: number,
+  path: string,
+): Promise<FileExplorerRequest> {
+  return submitFileExplorerPath(env, sessionId, 'stat', path);
+}
+
+export function getFileExplorerRequest(
+  env: string,
+  sessionId: number,
+  requestId: number,
+): Promise<FileExplorerRequest> {
+  return apiFetch<FileExplorerRequest>(
+    `/api/v1/file-explorer/${encodeURIComponent(env)}/sessions/${sessionId}/requests/${requestId}`,
+  );
+}
+
+export function getFileExplorerRequestResults(
+  env: string,
+  sessionId: number,
+  requestId: number,
+): Promise<FileExplorerEntry[]> {
+  return apiFetch<FileExplorerEntry[]>(
+    `/api/v1/file-explorer/${encodeURIComponent(env)}/sessions/${sessionId}/requests/${requestId}/results`,
+  );
+}
+
+function submitFileExplorerPath(
+  env: string,
+  sessionId: number,
+  action: 'list' | 'stat',
+  path: string,
+): Promise<FileExplorerRequest> {
+  return apiFetch<FileExplorerRequest>(
+    `/api/v1/file-explorer/${encodeURIComponent(env)}/sessions/${sessionId}/${action}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path }),
+    },
+  );
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -312,6 +312,61 @@ export interface ConsoleSessionResponse {
 }
 
 // ---------------------------------------------------------------------------
+// File explorer types
+// ---------------------------------------------------------------------------
+
+export type FileExplorerRequestStatus = 'queued' | 'completed' | 'error' | 'expired';
+export type FileExplorerAction = 'list' | 'stat';
+
+export interface FileExplorerSession {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  environment_id: number;
+  node_id: number;
+  node_uuid: string;
+  creator: string;
+  platform: string;
+  root: string;
+  active: boolean;
+  closed_at?: string;
+}
+
+export interface FileExplorerRequest {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  session_id: number;
+  action: FileExplorerAction;
+  path: string;
+  translated_sql?: string;
+  distributed_query_name?: string;
+  status: FileExplorerRequestStatus;
+  error?: string;
+  completed_at?: string;
+  expired_at?: string;
+}
+
+export interface FileExplorerEntry {
+  path: string;
+  filename: string;
+  directory: string;
+  type: string;
+  size?: number;
+  mode?: string;
+  uid?: string;
+  gid?: string;
+  mtime?: number;
+  atime?: number;
+  ctime?: number;
+}
+
+export interface FileExplorerSessionResponse {
+  session: FileExplorerSession;
+  node_info?: ConsoleNodeInfo;
+}
+
+// ---------------------------------------------------------------------------
 // Saved queries
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/components/chrome/AppShell.test.tsx
+++ b/frontend/src/components/chrome/AppShell.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppShell } from './AppShell';
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouterState: () => ({ location: { pathname: '/_app/env/dev' } }),
+}));
+
+vi.mock('./SideNav', () => ({
+  SideNav: ({ className }: { className?: string }) => <aside className={className}>Nav</aside>,
+}));
+
+vi.mock('./TopBar', () => ({
+  TopBar: () => <header>Top</header>,
+}));
+
+vi.mock('./CommandPalette', () => ({
+  CommandPalette: () => null,
+}));
+
+describe('AppShell', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    });
+  });
+
+  it('makes main the fixed-height scroll container for sticky descendants', () => {
+    const { container } = render(
+      <AppShell username="alice">
+        <section>Page content</section>
+      </AppShell>,
+    );
+
+    const root = container.firstElementChild;
+    expect(root).toHaveClass('h-screen');
+    expect(root).toHaveClass('overflow-hidden');
+    expect(root).not.toHaveClass('min-h-screen');
+
+    const main = screen.getByRole('main');
+    expect(main).toHaveClass('min-h-0');
+    expect(main).toHaveClass('overflow-auto');
+  });
+});

--- a/frontend/src/components/chrome/AppShell.tsx
+++ b/frontend/src/components/chrome/AppShell.tsx
@@ -50,7 +50,7 @@ export function AppShell({ children, username }: AppShellProps) {
   }, [pathname]);
 
   return (
-    <div className="flex min-h-screen bg-[color:var(--bg-0)]">
+    <div className="flex h-screen overflow-hidden bg-[color:var(--bg-0)]">
       {/* Desktop rail — hidden on phones in favor of the drawer below.
           Collapsible to an icon-only strip; preference persists. */}
       <SideNav
@@ -84,13 +84,13 @@ export function AppShell({ children, username }: AppShellProps) {
         </div>
       </div>
 
-      <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+      <div className="flex min-h-0 flex-col flex-1 min-w-0 overflow-hidden">
         <TopBar
           username={username}
           onCommandPalette={() => setPaletteOpen(true)}
           onMenuToggle={() => setNavOpen((o) => !o)}
         />
-        <main className="flex-1 overflow-auto">{children}</main>
+        <main className="min-h-0 flex-1 overflow-auto">{children}</main>
       </div>
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
     </div>

--- a/frontend/src/features/environments/EnvConfigPage.test.tsx
+++ b/frontend/src/features/environments/EnvConfigPage.test.tsx
@@ -180,7 +180,7 @@ describe('EnvConfigPage', () => {
       data: '{"options":{"logger_plugin":"tls"}}',
     });
     mockGetPostureProfiles.mockResolvedValue([]);
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false, file_explorer: false });
   });
 
   it('loads the fully rendered tab from the assembled config endpoint', async () => {
@@ -224,7 +224,7 @@ describe('EnvConfigPage', () => {
 
   it('loads posture profiles only after opening the picker', async () => {
     const user = userEvent.setup();
-    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false, file_explorer: false });
 
     renderWithProviders();
 
@@ -243,7 +243,7 @@ describe('EnvConfigPage', () => {
 
   it('distinguishes a profile load failure from an empty profile list', async () => {
     const user = userEvent.setup();
-    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false, file_explorer: false });
     mockGetPostureProfiles.mockRejectedValue(new Error('profiles unavailable'));
 
     renderWithProviders();

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -83,6 +83,10 @@ vi.mock('$/api/tags', () => ({
   tagNode: (...args: unknown[]) => mockTagNode(...(args as [])),
 }));
 
+vi.mock('./NodeFileExplorerTab', () => ({
+  NodeFileExplorerTab: () => <div data-testid="file-explorer-panel" />,
+}));
+
 vi.mock('$/api/client', () => ({
   isAuthenticated: () => true,
   getCsrfToken: () => 'test-csrf',
@@ -289,7 +293,7 @@ describe('NodeDetailPage', () => {
       total: [],
     });
     mockListServiceSettings.mockResolvedValue([]);
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false, file_explorer: false });
     mockGetNodePostureScore.mockResolvedValue({
       node_uuid: 'abc12345-0000-0000-0000-000000000001',
       timestamp: '2026-07-16T09:05:00Z',
@@ -373,7 +377,7 @@ describe('NodeDetailPage', () => {
 
   it('shows posture data for the selected node', async () => {
     const user = userEvent.setup();
-    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false, file_explorer: false });
     mockGetNodePosture.mockResolvedValue([
       {
         id: 10,
@@ -417,7 +421,7 @@ describe('NodeDetailPage', () => {
 
   it('renders posture score when controls is null', async () => {
     const user = userEvent.setup();
-    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false, file_explorer: false });
     mockGetNodePosture.mockResolvedValue([
       {
         id: 10,
@@ -505,7 +509,7 @@ describe('NodeDetailPage', () => {
   });
 
   it('shows posture uptime in lifecycle details only when posture is enabled', async () => {
-    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false, file_explorer: false });
     mockGetNode.mockResolvedValue(
       makeNode({
         uptime: {
@@ -589,7 +593,7 @@ describe('NodeDetailPage', () => {
   });
 
   it('hides node uptime while posture is disabled', async () => {
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false, file_explorer: false });
     mockGetNode.mockResolvedValue(
       makeNode({
         uptime: {
@@ -614,7 +618,7 @@ describe('NodeDetailPage', () => {
   });
 
   it('shows the console action only when accelerated queries are enabled', async () => {
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true, file_explorer: false });
     const router = makeTestRouter();
 
     renderWithProviders(router);
@@ -627,7 +631,7 @@ describe('NodeDetailPage', () => {
   });
 
   it('hides the console action when accelerated queries are disabled', async () => {
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false, file_explorer: false });
 
     renderWithProviders(makeTestRouter());
 
@@ -639,7 +643,7 @@ describe('NodeDetailPage', () => {
   });
 
   it('hides the console action from non-admin users even when accelerated queries are enabled', async () => {
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true, file_explorer: false });
     mockGetMe.mockResolvedValue({
       admin: false,
       permissions: {
@@ -656,8 +660,49 @@ describe('NodeDetailPage', () => {
     expect(screen.queryByRole('link', { name: /console/i })).not.toBeInTheDocument();
   });
 
+  it('shows the file explorer tab when file explorer is enabled', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true, file_explorer: true });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('tab', { name: /file explorer/i })).toBeInTheDocument();
+  });
+
+  it('lets the file explorer details panel stick to the page scroll container', async () => {
+    const user = userEvent.setup();
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true, file_explorer: true });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: /file explorer/i }));
+
+    const panel = screen.getByRole('tabpanel', { name: /file explorer/i });
+    expect(panel).toHaveClass('overflow-visible');
+    expect(panel).not.toHaveClass('overflow-auto');
+  });
+
+  it('hides the file explorer tab when file explorer is disabled', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true, file_explorer: false });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('tab', { name: /file explorer/i })).not.toBeInTheDocument();
+  });
+
   it('wraps single-node actions away from the hostname block', async () => {
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: true, file_explorer: false });
 
     renderWithProviders(makeTestRouter());
 

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -36,6 +36,7 @@ import { EmptyState } from '$/components/data/EmptyState';
 import { SearchInput } from '$/components/data/SearchInput';
 import { ModalShell } from '$/components/feedback/ModalShell';
 import { HealthBadge, TagChips } from './nodeSignals';
+import { NodeFileExplorerTab } from './NodeFileExplorerTab';
 
 // NodeHeatmapBucket is the merged per-node activity grid the heatmap renders.
 // status/result/query come from the DB-backed logging buckets (full history,
@@ -54,7 +55,7 @@ interface NodeHeatmapBucket {
 // Tabs
 // ---------------------------------------------------------------------------
 
-type Tab = 'details' | 'status-logs' | 'result-logs' | 'posture';
+type Tab = 'details' | 'status-logs' | 'result-logs' | 'posture' | 'file-explorer';
 type NodeActionModal = 'query' | 'carve' | 'tag' | null;
 const TAG_TYPE_REGULAR = 6;
 const POSTURE_QUERY_PREFIX = 'osctrl:posture:';
@@ -588,6 +589,7 @@ const TABS = [
   { id: 'status-logs' as Tab, label: 'Status logs' },
   { id: 'result-logs' as Tab, label: 'Result logs' },
   { id: 'posture' as Tab, label: 'Posture' },
+  { id: 'file-explorer' as Tab, label: 'File Explorer' },
 ] as const;
 
 export function NodeDetailPage() {
@@ -608,16 +610,24 @@ export function NodeDetailPage() {
   });
   const postureEnabled = features?.posture === true;
   const acceleratedEnabled = features?.accelerated === true;
+  const fileExplorerEnabled = features?.file_explorer === true;
   const visibleTabs = useMemo(
-    () => TABS.filter((tab) => tab.id !== 'posture' || postureEnabled),
-    [postureEnabled],
+    () => TABS.filter((tab) => {
+      if (tab.id === 'posture') return postureEnabled;
+      if (tab.id === 'file-explorer') return fileExplorerEnabled;
+      return true;
+    }),
+    [fileExplorerEnabled, postureEnabled],
   );
 
   useEffect(() => {
     if (activeTab === 'posture' && !postureEnabled) {
       setActiveTab('details');
     }
-  }, [activeTab, postureEnabled]);
+    if (activeTab === 'file-explorer' && !fileExplorerEnabled) {
+      setActiveTab('details');
+    }
+  }, [activeTab, fileExplorerEnabled, postureEnabled]);
 
   function handleTabKeyDown(e: React.KeyboardEvent) {
     const currentIndex = visibleTabs.findIndex((t) => t.id === activeTab);
@@ -1031,7 +1041,10 @@ export function NodeDetailPage() {
         role="tabpanel"
         id={`panel-${activeTab}`}
         aria-labelledby={`tab-${activeTab}`}
-        className="flex-1 overflow-auto min-h-0"
+        className={cn(
+          'flex-1 min-h-0',
+          activeTab === 'file-explorer' ? 'overflow-visible' : 'overflow-auto',
+        )}
       >
         {activeTab === 'details' && node && (() => {
           // Pull the parsed system_info enrichment that the API now exposes
@@ -1269,6 +1282,9 @@ export function NodeDetailPage() {
 
         {activeTab === 'posture' && postureEnabled && (
           <PostureTab env={env} uuid={uuid} />
+        )}
+        {activeTab === 'file-explorer' && fileExplorerEnabled && (
+          <NodeFileExplorerTab env={env} uuid={uuid} />
         )}
         {activeTab === 'status-logs' && (
           <LogsTab env={env} uuid={uuid} type="status" />

--- a/frontend/src/features/nodes/NodeFileExplorerTab.test.tsx
+++ b/frontend/src/features/nodes/NodeFileExplorerTab.test.tsx
@@ -1,0 +1,250 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NodeFileExplorerTab } from './NodeFileExplorerTab';
+import type { FileExplorerEntry, FileExplorerRequest, FileExplorerSessionResponse } from '$/api/types';
+
+const api = vi.hoisted(() => ({
+  createFileExplorerSession: vi.fn(),
+  closeFileExplorerSession: vi.fn(),
+  getFileExplorerSession: vi.fn(),
+  listFileExplorerDirectory: vi.fn(),
+  statFileExplorerPath: vi.fn(),
+  getFileExplorerRequest: vi.fn(),
+  getFileExplorerRequestResults: vi.fn(),
+  runCarve: vi.fn(),
+}));
+
+vi.mock('$/api/file-explorer', () => ({
+  createFileExplorerSession: api.createFileExplorerSession,
+  closeFileExplorerSession: api.closeFileExplorerSession,
+  getFileExplorerSession: api.getFileExplorerSession,
+  listFileExplorerDirectory: api.listFileExplorerDirectory,
+  statFileExplorerPath: api.statFileExplorerPath,
+  getFileExplorerRequest: api.getFileExplorerRequest,
+  getFileExplorerRequestResults: api.getFileExplorerRequestResults,
+}));
+
+vi.mock('$/api/carves', () => ({
+  runCarve: api.runCarve,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    params,
+    children,
+    ...props
+  }: {
+    to: string;
+    params: { env: string; name: string };
+    children: React.ReactNode;
+  }) => (
+    <a
+      href={to.replace('$env', params.env).replace('$name', params.name)}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+describe('NodeFileExplorerTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.closeFileExplorerSession.mockResolvedValue({ message: 'closed' });
+    api.getFileExplorerSession.mockResolvedValue(makeSessionResponse().session);
+    api.getFileExplorerRequest.mockResolvedValue(makeRequest({ id: 10, path: '/', status: 'completed' }));
+    api.getFileExplorerRequestResults.mockResolvedValue([
+      makeEntry({ path: '/etc', filename: 'etc', directory: '/', type: 'directory' }),
+      makeEntry({ path: '/README', filename: 'README', directory: '/', type: 'regular', size: 42 }),
+    ]);
+    api.listFileExplorerDirectory.mockResolvedValue(makeRequest({ id: 10, path: '/' }));
+    api.createFileExplorerSession.mockResolvedValue(makeSessionResponse());
+    api.runCarve.mockResolvedValue({ query_name: 'carve-selected' });
+  });
+
+  it('opens a session and lists the root directory', async () => {
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(api.createFileExplorerSession).toHaveBeenCalledWith('env', 'NODE');
+    });
+    expect(api.listFileExplorerDirectory).toHaveBeenCalledWith('env', 1, '/');
+    expect(await screen.findByRole('treeitem', { name: /etc directory/i })).toBeInTheDocument();
+    expect(screen.getByRole('treeitem', { name: /README file/i })).toBeInTheDocument();
+  });
+
+  it('loads a child directory when expanded', async () => {
+    const user = userEvent.setup();
+    api.listFileExplorerDirectory
+      .mockResolvedValueOnce(makeRequest({ id: 10, path: '/' }))
+      .mockResolvedValueOnce(makeRequest({ id: 11, path: '/etc' }));
+    api.getFileExplorerRequest
+      .mockResolvedValueOnce(makeRequest({ id: 10, path: '/', status: 'completed' }))
+      .mockResolvedValueOnce(makeRequest({ id: 11, path: '/etc', status: 'completed' }));
+    api.getFileExplorerRequestResults
+      .mockResolvedValueOnce([
+        makeEntry({ path: '/etc', filename: 'etc', directory: '/', type: 'directory' }),
+      ])
+      .mockResolvedValueOnce([
+        makeEntry({ path: '/etc/hosts', filename: 'hosts', directory: '/etc', type: 'regular' }),
+      ]);
+
+    renderExplorer();
+
+    const etc = await screen.findByRole('treeitem', { name: /etc directory/i });
+    await user.click(etc);
+
+    await waitFor(() => {
+      expect(api.listFileExplorerDirectory).toHaveBeenLastCalledWith('env', 1, '/etc');
+    });
+    expect(await screen.findByRole('treeitem', { name: /hosts file/i })).toBeInTheDocument();
+  });
+
+  it('keeps the details panel sticky while the page scrolls', async () => {
+    renderExplorer();
+
+    await screen.findByRole('treeitem', { name: /etc directory/i });
+
+    const details = screen.getByRole('complementary', { name: /file details/i });
+    expect(details).toHaveClass('lg:sticky');
+    expect(details).toHaveClass('lg:top-3');
+  });
+
+  it('starts a node-targeted carve for the selected path', async () => {
+    const user = userEvent.setup();
+
+    renderExplorer();
+
+    await user.click(await screen.findByRole('treeitem', { name: /etc directory/i }));
+    await user.click(screen.getByRole('button', { name: /carve selected/i }));
+
+    await waitFor(() => {
+      expect(api.runCarve).toHaveBeenCalledWith('env', {
+        path: '/etc',
+        uuid_list: ['NODE'],
+      });
+    });
+    expect(await screen.findByText(/created new/i)).toBeInTheDocument();
+    expect(screen.queryByText(/carve-selected/i)).not.toBeInTheDocument();
+    const carveLink = screen.getByRole('link', { name: /carve/i });
+    expect(carveLink).toHaveAttribute('href', '/_app/env/env/carves/carve-selected');
+    expect(within(carveLink).getByText('carve')).toBeInTheDocument();
+    expect(carveLink.querySelector('svg')).not.toBeNull();
+  });
+
+  it('refreshes the selected directory', async () => {
+    const user = userEvent.setup();
+    api.listFileExplorerDirectory
+      .mockResolvedValueOnce(makeRequest({ id: 10, path: '/' }))
+      .mockResolvedValueOnce(makeRequest({ id: 11, path: '/etc' }))
+      .mockResolvedValueOnce(makeRequest({ id: 12, path: '/etc' }));
+    api.getFileExplorerRequest
+      .mockResolvedValueOnce(makeRequest({ id: 10, path: '/', status: 'completed' }))
+      .mockResolvedValueOnce(makeRequest({ id: 11, path: '/etc', status: 'completed' }))
+      .mockResolvedValueOnce(makeRequest({ id: 12, path: '/etc', status: 'completed' }));
+    api.getFileExplorerRequestResults
+      .mockResolvedValueOnce([
+        makeEntry({ path: '/etc', filename: 'etc', directory: '/', type: 'directory' }),
+      ])
+      .mockResolvedValueOnce([
+        makeEntry({ path: '/etc/hosts', filename: 'hosts', directory: '/etc', type: 'regular' }),
+      ])
+      .mockResolvedValueOnce([
+        makeEntry({ path: '/etc/services', filename: 'services', directory: '/etc', type: 'regular' }),
+      ]);
+
+    renderExplorer();
+
+    await user.click(await screen.findByRole('treeitem', { name: /etc directory/i }));
+    expect(await screen.findByRole('treeitem', { name: /hosts file/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+
+    await waitFor(() => {
+      expect(api.listFileExplorerDirectory).toHaveBeenLastCalledWith('env', 1, '/etc');
+    });
+    expect(await screen.findByRole('treeitem', { name: /services file/i })).toBeInTheDocument();
+  });
+
+  it('shows a spinner with loading text while a directory request is pending', async () => {
+    const user = userEvent.setup();
+    api.listFileExplorerDirectory
+      .mockResolvedValueOnce(makeRequest({ id: 10, path: '/' }))
+      .mockResolvedValueOnce(makeRequest({ id: 11, path: '/etc' }));
+    api.getFileExplorerRequest.mockImplementation((_env: string, _sessionId: number, requestId: number) => {
+      if (requestId === 10) return Promise.resolve(makeRequest({ id: 10, path: '/', status: 'completed' }));
+      return new Promise(() => undefined);
+    });
+    api.getFileExplorerRequestResults.mockResolvedValueOnce([
+      makeEntry({ path: '/etc', filename: 'etc', directory: '/', type: 'directory' }),
+    ]);
+
+    renderExplorer();
+
+    const etc = await screen.findByRole('treeitem', { name: /etc directory/i });
+    await user.click(etc);
+    await user.click(etc);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Loading...').length).toBeGreaterThan(0);
+    });
+  });
+});
+
+function renderExplorer() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <NodeFileExplorerTab env="env" uuid="NODE" />
+    </QueryClientProvider>,
+  );
+}
+
+function makeSessionResponse(): FileExplorerSessionResponse {
+  return {
+    session: {
+      id: 1,
+      created_at: '2026-08-02T00:00:00Z',
+      updated_at: '2026-08-02T00:00:00Z',
+      environment_id: 1,
+      node_id: 2,
+      node_uuid: 'NODE',
+      creator: 'alice',
+      platform: 'linux',
+      root: '/',
+      active: true,
+    },
+    node_info: {
+      ip_address: '10.0.0.1',
+      osquery_user: 'root',
+      osquery_version: '5.23.1',
+      platform: 'linux',
+      platform_version: '22.04',
+    },
+  };
+}
+
+function makeRequest(overrides: Partial<FileExplorerRequest> = {}): FileExplorerRequest {
+  return {
+    id: 1,
+    created_at: '2026-08-02T00:00:00Z',
+    updated_at: '2026-08-02T00:00:00Z',
+    session_id: 1,
+    action: 'list',
+    path: '/',
+    status: 'queued',
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<FileExplorerEntry> = {}): FileExplorerEntry {
+  return {
+    path: '/',
+    filename: '',
+    directory: '/',
+    type: 'directory',
+    ...overrides,
+  };
+}

--- a/frontend/src/features/nodes/NodeFileExplorerTab.tsx
+++ b/frontend/src/features/nodes/NodeFileExplorerTab.tsx
@@ -1,0 +1,439 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Link } from '@tanstack/react-router';
+import { Archive, ChevronDown, ChevronRight, ExternalLink, File, Folder, Loader2, RefreshCw } from 'lucide-react';
+import { runCarve } from '$/api/carves';
+import { AuthError } from '$/api/client';
+import {
+  closeFileExplorerSession,
+  createFileExplorerSession,
+  getFileExplorerRequest,
+  getFileExplorerRequestResults,
+  getFileExplorerSession,
+  listFileExplorerDirectory,
+  statFileExplorerPath,
+} from '$/api/file-explorer';
+import type { FileExplorerEntry, FileExplorerRequest, FileExplorerSession } from '$/api/types';
+import { cn } from '$/lib/cn';
+
+type EntriesByDirectory = Record<string, FileExplorerEntry[]>;
+type CarveStatus =
+  | { kind: 'success'; name: string }
+  | { kind: 'error'; message: string };
+
+const terminalStatuses = new Set(['completed', 'error', 'expired']);
+const heartbeatMs = 10000;
+const maxPolls = 30;
+
+export function NodeFileExplorerTab({ env, uuid }: { env: string; uuid: string }) {
+  const sessionRef = useRef<FileExplorerSession | null>(null);
+  const loadingPathsRef = useRef<Set<string>>(new Set());
+  const [session, setSession] = useState<FileExplorerSession | null>(null);
+  const [entriesByDirectory, setEntriesByDirectory] = useState<EntriesByDirectory>({});
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<FileExplorerEntry | null>(null);
+  const [carving, setCarving] = useState(false);
+  const [carveStatus, setCarveStatus] = useState<CarveStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateLoadingPath = useCallback((path: string, loading: boolean) => {
+    const next = new Set(loadingPathsRef.current);
+    if (loading) next.add(path);
+    else next.delete(path);
+    loadingPathsRef.current = next;
+    setLoadingPaths(next);
+  }, []);
+
+  const runRequest = useCallback(async (activeSession: FileExplorerSession, request: FileExplorerRequest) => {
+    const completed = await waitForRequest(env, activeSession.id, request.id);
+    if (completed.status !== 'completed') {
+      throw new Error(completed.error || `Request ${completed.status}`);
+    }
+    return getFileExplorerRequestResults(env, activeSession.id, request.id);
+  }, [env]);
+
+  const loadDirectory = useCallback(async (activeSession: FileExplorerSession, path: string) => {
+    if (loadingPathsRef.current.has(path)) return;
+    updateLoadingPath(path, true);
+    setError(null);
+    try {
+      const request = await listFileExplorerDirectory(env, activeSession.id, path);
+      const rows = await runRequest(activeSession, request);
+      setEntriesByDirectory((current) => ({ ...current, [path]: sortEntries(rows) }));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Could not list directory');
+    } finally {
+      updateLoadingPath(path, false);
+    }
+  }, [env, runRequest, updateLoadingPath]);
+
+  const statEntry = useCallback(async (entry: FileExplorerEntry) => {
+    const activeSession = sessionRef.current;
+    if (!activeSession) return;
+    setSelected(entry);
+    setCarveStatus(null);
+    if (entry.type === 'directory') return;
+    setError(null);
+    try {
+      const request = await statFileExplorerPath(env, activeSession.id, entry.path);
+      const rows = await runRequest(activeSession, request);
+      setSelected(rows[0] ?? entry);
+    } catch (statError) {
+      setError(statError instanceof Error ? statError.message : 'Could not stat path');
+    }
+  }, [env, runRequest]);
+
+  useEffect(() => {
+    let alive = true;
+    void createFileExplorerSession(env, uuid)
+      .then((created) => {
+        if (!alive) return;
+        sessionRef.current = created.session;
+        setSession(created.session);
+        setExpanded(new Set([created.session.root]));
+        void loadDirectory(created.session, created.session.root);
+      })
+      .catch((createError: unknown) => {
+        if (!alive) return;
+        setError(createError instanceof Error ? createError.message : 'Could not open file explorer');
+      });
+    return () => {
+      alive = false;
+      const current = sessionRef.current;
+      if (current?.active) {
+        void closeFileExplorerSession(env, current.id).catch(() => undefined);
+      }
+    };
+  }, [env, loadDirectory, uuid]);
+
+  useEffect(() => {
+    const sessionID = session?.id;
+    if (!sessionID) return undefined;
+    const interval = window.setInterval(() => {
+      void getFileExplorerSession(env, sessionID)
+        .then((fresh) => {
+          sessionRef.current = fresh;
+          setSession(fresh);
+        })
+        .catch(() => undefined);
+    }, heartbeatMs);
+    return () => window.clearInterval(interval);
+  }, [env, session?.id]);
+
+  const root = session?.root ?? '/';
+  const rootEntries = entriesByDirectory[root] ?? [];
+  const rootLoading = loadingPaths.has(root);
+  const refreshPath = selected?.type === 'directory' ? selected.path : selected?.directory || root;
+  const refreshLoading = loadingPaths.has(refreshPath);
+
+  function onRefresh() {
+    const activeSession = sessionRef.current;
+    if (!activeSession) return;
+    void loadDirectory(activeSession, refreshPath);
+  }
+
+  async function onCarveSelected() {
+    if (!selected || carving) return;
+    setCarving(true);
+    setCarveStatus(null);
+    try {
+      const result = await runCarve(env, { path: selected.path, uuid_list: [uuid] });
+      setCarveStatus({ kind: 'success', name: result.query_name });
+    } catch (carveError) {
+      if (carveError instanceof AuthError) {
+        window.location.href = '/login';
+        return;
+      }
+      setCarveStatus({
+        kind: 'error',
+        message: carveError instanceof Error ? carveError.message : 'Carve failed',
+      });
+    } finally {
+      setCarving(false);
+    }
+  }
+
+  async function onEntryClick(entry: FileExplorerEntry) {
+    await statEntry(entry);
+    if (entry.type !== 'directory') return;
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(entry.path)) next.delete(entry.path);
+      else next.add(entry.path);
+      return next;
+    });
+    if (!entriesByDirectory[entry.path] && !loadingPathsRef.current.has(entry.path)) {
+      const activeSession = sessionRef.current;
+      if (activeSession) {
+        void loadDirectory(activeSession, entry.path);
+      }
+    }
+  }
+
+  return (
+    <section className="min-h-[360px] border border-[color:var(--border)] rounded-lg bg-[color:var(--bg-1)]">
+      <div className="flex items-center justify-between gap-3 border-b border-[color:var(--border)] px-3 py-2">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold text-[color:var(--text-1)]">File Explorer</h2>
+          <p className="font-mono-tabular text-[11px] text-[color:var(--text-3)] truncate">{root}</p>
+        </div>
+        <button
+          type="button"
+          aria-label={`Refresh ${refreshPath}`}
+          onClick={onRefresh}
+          disabled={!session || refreshLoading}
+          className={cn(
+            'inline-flex h-8 items-center justify-center gap-2 rounded border border-[color:var(--border)] px-2.5',
+            'text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
+            'disabled:opacity-50 disabled:cursor-not-allowed',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+          )}
+        >
+          {refreshLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+          <span className="text-xs">{refreshLoading ? 'Loading...' : 'Refresh'}</span>
+        </button>
+      </div>
+
+      {error && (
+        <div role="alert" className="border-b border-[color:var(--border)] px-3 py-2 text-xs text-[color:var(--danger)]">
+          {error}
+        </div>
+      )}
+
+      <div className="grid min-h-[320px] grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="overflow-auto">
+          {rootLoading && rootEntries.length === 0 ? (
+            <LoadingRow depth={0} />
+          ) : (
+            <div role="tree" aria-label="Node files" className="py-1">
+              {renderEntries(rootEntries, 0, expanded, loadingPaths, entriesByDirectory, selected?.path, onEntryClick)}
+            </div>
+          )}
+        </div>
+        <FileDetails
+          env={env}
+          entry={selected}
+          carving={carving}
+          carveStatus={carveStatus}
+          onCarveSelected={onCarveSelected}
+        />
+      </div>
+    </section>
+  );
+}
+
+function renderEntries(
+  entries: FileExplorerEntry[],
+  depth: number,
+  expanded: Set<string>,
+  loadingPaths: Set<string>,
+  entriesByDirectory: EntriesByDirectory,
+  selectedPath: string | undefined,
+  onEntryClick: (entry: FileExplorerEntry) => void,
+): ReactNode {
+  return entries.map((entry) => {
+    const isDirectory = entry.type === 'directory';
+    const isExpanded = expanded.has(entry.path);
+    const isLoading = loadingPaths.has(entry.path);
+    const isSelected = selectedPath === entry.path;
+    const childEntries = entriesByDirectory[entry.path]?.filter((child) => child.path !== entry.path);
+    const name = entry.filename || entry.path;
+    return (
+      <div key={entry.path}>
+        <button
+          type="button"
+          role="treeitem"
+          aria-expanded={isDirectory ? isExpanded : undefined}
+          aria-selected={isSelected || undefined}
+          aria-label={`${name} ${isDirectory ? 'directory' : 'file'}`}
+          onClick={() => onEntryClick(entry)}
+          className={cn(
+            'grid w-full grid-cols-[auto_auto_minmax(0,1fr)_auto] items-center gap-2 px-3 py-1.5 text-left text-xs',
+            'text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)] hover:text-[color:var(--text-1)]',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+            isSelected && 'bg-[color:var(--bg-2)] text-[color:var(--text-1)]',
+          )}
+          style={{ paddingLeft: `${12 + depth * 18}px` }}
+        >
+          {isDirectory ? (
+            isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />
+          ) : (
+            <span className="h-3.5 w-3.5" />
+          )}
+          {isDirectory ? <Folder className="h-3.5 w-3.5" /> : <File className="h-3.5 w-3.5" />}
+          <span className="truncate font-medium">{name}</span>
+          <span className="font-mono-tabular text-[10px] text-[color:var(--text-3)]">
+            {isLoading ? <LoadingInline /> : formatSize(entry.size)}
+          </span>
+        </button>
+        {isDirectory && isExpanded && isLoading && !childEntries && <LoadingRow depth={depth + 1} />}
+        {isDirectory && isExpanded && childEntries && renderEntries(
+          childEntries,
+          depth + 1,
+          expanded,
+          loadingPaths,
+          entriesByDirectory,
+          selectedPath,
+          onEntryClick,
+        )}
+      </div>
+    );
+  });
+}
+
+function FileDetails({
+  env,
+  entry,
+  carving,
+  carveStatus,
+  onCarveSelected,
+}: {
+  env: string;
+  entry: FileExplorerEntry | null;
+  carving: boolean;
+  carveStatus: CarveStatus | null;
+  onCarveSelected: () => void;
+}) {
+  const rows = useMemo(() => {
+    if (!entry) return [];
+    return [
+      ['Path', entry.path],
+      ['Type', entry.type],
+      ['Size', formatSize(entry.size)],
+      ['Mode', entry.mode ?? ''],
+      ['UID', entry.uid ?? ''],
+      ['GID', entry.gid ?? ''],
+      ['Modified', formatUnix(entry.mtime)],
+      ['Accessed', formatUnix(entry.atime)],
+      ['Changed', formatUnix(entry.ctime)],
+    ].filter(([, value]) => value !== '');
+  }, [entry]);
+
+  return (
+    <aside
+      aria-label="File details"
+      className={cn(
+        'border-t border-[color:var(--border)] bg-[color:var(--bg-0)] p-3',
+        'lg:sticky lg:top-3 lg:self-start lg:border-l lg:border-t-0',
+        'lg:max-h-[calc(100vh-1.5rem)] lg:overflow-auto',
+      )}
+    >
+      <h3 className="mb-2 text-xs font-semibold text-[color:var(--text-1)]">Details</h3>
+      {entry ? (
+        <dl className="space-y-2">
+          {rows.map(([label, value]) => (
+            <div key={label}>
+              <dt className="text-[10px] uppercase tracking-[0.12em] text-[color:var(--text-3)]">{label}</dt>
+              <dd className="break-all font-mono-tabular text-xs text-[color:var(--text-1)]">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <div className="text-xs text-[color:var(--text-3)]">No selection</div>
+      )}
+      <div className="mt-4 rounded-md border border-[color:var(--border)] bg-[color:var(--bg-1)] p-3">
+        <h4 className="text-xs font-semibold text-[color:var(--text-1)]">Carve</h4>
+        <p className="mt-1 break-all font-mono-tabular text-[11px] text-[color:var(--text-3)]">
+          {entry?.path ?? 'No path selected'}
+        </p>
+        <button
+          type="button"
+          onClick={onCarveSelected}
+          disabled={!entry || carving}
+          className={cn(
+            'mt-3 inline-flex h-8 w-full items-center justify-center gap-2 rounded border border-[color:var(--border)] px-3',
+            'bg-[color:var(--signal)] text-xs font-medium text-black hover:bg-[color:var(--signal-bright)]',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+          )}
+        >
+          {carving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Archive className="h-3.5 w-3.5" />}
+          {carving ? 'Starting...' : 'Carve selected'}
+        </button>
+        {carveStatus?.kind === 'success' && (
+          <p
+            className="mt-2 text-xs text-[color:var(--success)]"
+          >
+            Created new{' '}
+            <Link
+              to="/_app/env/$env/carves/$name"
+              params={{ env, name: carveStatus.name }}
+              className={cn(
+                'inline-flex items-center gap-1 font-medium underline decoration-current/40 underline-offset-2',
+                'hover:text-[color:var(--signal)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+              )}
+            >
+              carve
+              <ExternalLink className="h-3 w-3" aria-hidden="true" />
+            </Link>
+          </p>
+        )}
+        {carveStatus?.kind === 'error' && (
+          <p
+            role="alert"
+            className="mt-2 break-all text-xs text-[color:var(--danger)]"
+          >
+            {carveStatus.message}
+          </p>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function LoadingInline() {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <Loader2 className="h-3 w-3 animate-spin" />
+      Loading...
+    </span>
+  );
+}
+
+function LoadingRow({ depth }: { depth: number }) {
+  return (
+    <div
+      className="flex items-center gap-2 px-3 py-2 text-xs text-[color:var(--text-3)]"
+      style={{ paddingLeft: `${12 + depth * 18}px` }}
+    >
+      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      Loading...
+    </div>
+  );
+}
+
+async function waitForRequest(env: string, sessionId: number, requestId: number): Promise<FileExplorerRequest> {
+  for (let i = 0; i < maxPolls; i += 1) {
+    const request = await getFileExplorerRequest(env, sessionId, requestId);
+    if (terminalStatuses.has(request.status)) {
+      return request;
+    }
+    await delay(1000);
+  }
+  throw new Error('file explorer request timed out');
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function sortEntries(entries: FileExplorerEntry[]) {
+  return [...entries].sort((a, b) => {
+    if (a.type === 'directory' && b.type !== 'directory') return -1;
+    if (a.type !== 'directory' && b.type === 'directory') return 1;
+    return (a.filename || a.path).localeCompare(b.filename || b.path);
+  });
+}
+
+function formatSize(size?: number) {
+  if (!size) return '';
+  if (size >= 1_000_000_000) return `${(size / 1_000_000_000).toFixed(1)} GB`;
+  if (size >= 1_000_000) return `${(size / 1_000_000).toFixed(1)} MB`;
+  if (size >= 1_000) return `${(size / 1_000).toFixed(0)} KB`;
+  return `${size} B`;
+}
+
+function formatUnix(value?: number) {
+  if (!value) return '';
+  return new Date(value * 1000).toLocaleString();
+}

--- a/frontend/src/features/nodes/NodesTablePage.test.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.test.tsx
@@ -222,7 +222,7 @@ describe('NodesTablePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockListServiceSettings.mockResolvedValue([]);
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false, file_explorer: false });
     mockGetStats.mockResolvedValue(makeStatsResponse());
     mockGetNodeActivityTilesBatch.mockResolvedValue({
       'ABC12345-0000-0000-0000-000000000001': makeTileSeries(),
@@ -384,7 +384,7 @@ describe('NodesTablePage', () => {
   });
 
   it('shows uptime and posture risk badge when posture is enabled', async () => {
-    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: true, accelerated: false, file_explorer: false });
     mockListNodes.mockResolvedValue(
       makeResponse({
         items: [
@@ -495,7 +495,7 @@ describe('NodesTablePage', () => {
   });
 
   it('hides posture quick signals when posture is disabled', async () => {
-    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false });
+    mockGetFeatures.mockResolvedValue({ posture: false, accelerated: false, file_explorer: false });
     mockListNodes.mockResolvedValue(
       makeResponse({
         items: [

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -10,8 +10,12 @@ const STORAGE_KEY = 'osctrl.theme';
 
 export function getInitialTheme(): Theme {
   if (typeof window === 'undefined') return DEFAULT_THEME;
-  const stored = window.localStorage.getItem(STORAGE_KEY);
-  if (stored === 'dark' || stored === 'light') return stored;
+  try {
+    const stored = window.localStorage?.getItem(STORAGE_KEY);
+    if (stored === 'dark' || stored === 'light') return stored;
+  } catch {
+    /* localStorage blocked — fall back to system/default */
+  }
   // first visit: follow system preference
   if (window.matchMedia?.('(prefers-color-scheme: light)').matches) return 'light';
   return DEFAULT_THEME;

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -902,6 +902,13 @@ func initOsqueryFlags(params *ServiceParameters) []cli.Flag {
 			Destination: &params.Osquery.Accelerated,
 		},
 		&cli.BoolFlag{
+			Name:        "osquery-file-explorer",
+			Value:       false,
+			Usage:       "Enable on-demand node file explorer queries",
+			Sources:     cli.EnvVars("OSQUERY_FILE_EXPLORER"),
+			Destination: &params.Osquery.FileExplorer,
+		},
+		&cli.BoolFlag{
 			Name:        "read-only-configuration",
 			Value:       false,
 			Usage:       "Disable configuration changes via admin or api services",

--- a/pkg/config/flags_test.go
+++ b/pkg/config/flags_test.go
@@ -57,3 +57,29 @@ func TestOsqueryAcceleratedFlagDefaultsOff(t *testing.T) {
 		t.Fatalf("osquery-accelerated flag destination does not wire Osquery.Accelerated")
 	}
 }
+
+func TestOsqueryFileExplorerFlagDefaultsOff(t *testing.T) {
+	params := &ServiceParameters{Osquery: &YAMLConfigurationOsquery{}}
+	flags := initOsqueryFlags(params)
+
+	if params.Osquery.FileExplorer {
+		t.Fatalf("file explorer osquery default: got true want false")
+	}
+
+	var fileExplorerFlag *cli.BoolFlag
+	for _, flag := range flags {
+		if f, ok := flag.(*cli.BoolFlag); ok && f.Name == "osquery-file-explorer" {
+			fileExplorerFlag = f
+			break
+		}
+	}
+	if fileExplorerFlag == nil {
+		t.Fatalf("missing osquery-file-explorer flag")
+	}
+	if fileExplorerFlag.Value {
+		t.Fatalf("osquery-file-explorer flag default: got true want false")
+	}
+	if fileExplorerFlag.Destination != &params.Osquery.FileExplorer {
+		t.Fatalf("osquery-file-explorer flag destination does not wire Osquery.FileExplorer")
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -168,14 +168,15 @@ type YAMLConfigurationRedis struct {
 
 // YAMLConfigurationOsquery to hold the osquery configuration values
 type YAMLConfigurationOsquery struct {
-	Version     string `yaml:"version"`
-	TablesFile  string `yaml:"tablesFile"`
-	Logger      bool   `yaml:"logger"`
-	Config      bool   `yaml:"config"`
-	Query       bool   `yaml:"query"`
-	Carve       bool   `yaml:"carve"`
-	Accelerated bool   `yaml:"accelerated"`
-	ReadOnly    bool   `yaml:"readOnly"`
+	Version      string `yaml:"version"`
+	TablesFile   string `yaml:"tablesFile"`
+	Logger       bool   `yaml:"logger"`
+	Config       bool   `yaml:"config"`
+	Query        bool   `yaml:"query"`
+	Carve        bool   `yaml:"carve"`
+	Accelerated  bool   `yaml:"accelerated"`
+	FileExplorer bool   `yaml:"fileExplorer"`
+	ReadOnly     bool   `yaml:"readOnly"`
 }
 
 // YAMLConfigurationEndpoints to hold the configuration endpoints that will receive osquery configuration updates

--- a/pkg/console/parser.go
+++ b/pkg/console/parser.go
@@ -2,18 +2,16 @@ package console
 
 import (
 	"fmt"
-	"path"
 	"regexp"
 	"strings"
+
+	"github.com/jmpsec/osctrl/pkg/filequery"
 )
 
 var forbiddenShellSyntax = regexp.MustCompile(`[|&;<>]`)
 
 func DefaultCWD(platform string) string {
-	if strings.EqualFold(platform, "windows") {
-		return `C:\`
-	}
-	return "/"
+	return filequery.DefaultRoot(platform)
 }
 
 func Parse(input, cwd, platform string) (ParsedCommand, error) {
@@ -57,14 +55,14 @@ func ParseInput(input, cwd, platform string, osqueryMode bool) (ParsedCommand, e
 		if forbiddenShellSyntax.MatchString(args) {
 			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
 		}
-		target := resolvePath(args, cwd, platform)
+		target := filequery.ResolvePath(args, cwd, platform)
 		return ParsedCommand{Kind: CommandCarve, Command: "get", Path: target}, nil
 	case "ls":
 		if forbiddenShellSyntax.MatchString(args) {
 			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
 		}
-		target := resolvePath(args, cwd, platform)
-		sql := fmt.Sprintf("select path, filename, directory, type, size, mode, uid, gid, mtime from file where directory = %s", quoteSQL(target))
+		target := filequery.ResolvePath(args, cwd, platform)
+		sql := filequery.ListDirectorySQL(target)
 		return ParsedCommand{Kind: CommandRemote, Command: "ls", Path: target, SQL: sql}, nil
 	case "stat":
 		if args == "" {
@@ -73,8 +71,8 @@ func ParseInput(input, cwd, platform string, osqueryMode bool) (ParsedCommand, e
 		if forbiddenShellSyntax.MatchString(args) {
 			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
 		}
-		target := resolvePath(args, cwd, platform)
-		sql := fmt.Sprintf("select path, filename, directory, type, size, mode, uid, gid, mtime, atime, ctime from file where path = %s", quoteSQL(target))
+		target := filequery.ResolvePath(args, cwd, platform)
+		sql := filequery.StatPathSQL(target)
 		return ParsedCommand{Kind: CommandRemote, Command: "stat", Path: target, SQL: sql}, nil
 	case "ps":
 		if args != "" {
@@ -88,8 +86,8 @@ func ParseInput(input, cwd, platform string, osqueryMode bool) (ParsedCommand, e
 		if forbiddenShellSyntax.MatchString(args) {
 			return ParsedCommand{}, fmt.Errorf("shell syntax is not supported")
 		}
-		target := resolvePath(args, cwd, platform)
-		sql := fmt.Sprintf("select path, type from file where path = %s and type = 'directory'", quoteSQL(target))
+		target := filequery.ResolvePath(args, cwd, platform)
+		sql := fmt.Sprintf("select path, type from file where path = '%s' and type = 'directory'", strings.ReplaceAll(target, "'", "''"))
 		return ParsedCommand{Kind: CommandRemote, Command: "cd", Path: target, SQL: sql}, nil
 	case "sql":
 		sql := strings.TrimSpace(args)
@@ -124,61 +122,6 @@ func validateSelect(sql string) error {
 		}
 	}
 	return nil
-}
-
-func resolvePath(arg, cwd, platform string) string {
-	arg = strings.TrimSpace(arg)
-	if arg == "" {
-		arg = cwd
-	}
-	if strings.EqualFold(platform, "windows") {
-		return resolveWindowsPath(arg, cwd)
-	}
-	if strings.HasPrefix(arg, "/") {
-		return path.Clean(arg)
-	}
-	return path.Clean(path.Join(cwd, arg))
-}
-
-func resolveWindowsPath(arg, cwd string) string {
-	arg = strings.ReplaceAll(arg, "/", `\`)
-	cwd = strings.ReplaceAll(cwd, "/", `\`)
-	if isWindowsAbs(arg) {
-		return cleanWindowsPath(arg)
-	}
-	return cleanWindowsPath(strings.TrimRight(cwd, `\`) + `\` + arg)
-}
-
-func isWindowsAbs(p string) bool {
-	return len(p) >= 3 && p[1] == ':' && p[2] == '\\'
-}
-
-func cleanWindowsPath(p string) string {
-	p = strings.ReplaceAll(p, `/`, `\`)
-	parts := []string{}
-	for _, part := range strings.Split(p, `\`) {
-		if part == "" || part == "." {
-			continue
-		}
-		if part == ".." {
-			if len(parts) > 1 {
-				parts = parts[:len(parts)-1]
-			}
-			continue
-		}
-		parts = append(parts, part)
-	}
-	if len(parts) == 0 {
-		return `C:\`
-	}
-	if len(parts) == 1 && strings.HasSuffix(parts[0], ":") {
-		return parts[0] + `\`
-	}
-	return strings.Join(parts, `\`)
-}
-
-func quoteSQL(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 func helpText() string {

--- a/pkg/fileexplorer/manager.go
+++ b/pkg/fileexplorer/manager.go
@@ -1,0 +1,270 @@
+package fileexplorer
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/filequery"
+	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"gorm.io/gorm"
+)
+
+const (
+	defaultRequestTimeout = 10 * time.Second
+	maxPendingRequests    = 8
+)
+
+type Manager struct {
+	DB      *gorm.DB
+	Queries *queries.Queries
+}
+
+func NewManager(db *gorm.DB, queryManager *queries.Queries) *Manager {
+	if err := db.AutoMigrate(&Session{}, &Request{}); err != nil {
+		panic(fmt.Sprintf("failed to migrate file explorer tables: %v", err))
+	}
+	return &Manager{DB: db, Queries: queryManager}
+}
+
+func (m *Manager) CreateSession(env environments.TLSEnvironment, node nodes.OsqueryNode, creator string) (Session, error) {
+	session := Session{
+		EnvironmentID: env.ID,
+		NodeID:        node.ID,
+		NodeUUID:      node.UUID,
+		Creator:       creator,
+		Platform:      node.Platform,
+		Root:          filequery.DefaultRoot(node.Platform),
+		Active:        true,
+	}
+	if err := m.DB.Create(&session).Error; err != nil {
+		return Session{}, err
+	}
+	return session, nil
+}
+
+func (m *Manager) GetSession(sessionID uint) (Session, error) {
+	var session Session
+	if err := m.DB.First(&session, sessionID).Error; err != nil {
+		return Session{}, err
+	}
+	return session, nil
+}
+
+func (m *Manager) TouchSession(sessionID uint) (Session, error) {
+	if err := m.DB.Model(&Session{}).
+		Where("id = ? AND active = ?", sessionID, true).
+		UpdateColumn("updated_at", time.Now()).Error; err != nil {
+		return Session{}, err
+	}
+	return m.GetSession(sessionID)
+}
+
+func (m *Manager) CloseSession(sessionID uint) error {
+	now := time.Now()
+	return m.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&Session{}).Where("id = ?", sessionID).
+			Updates(map[string]any{"active": false, "closed_at": &now}).Error; err != nil {
+			return err
+		}
+		return tx.Model(&Request{}).
+			Where("session_id = ? AND status = ?", sessionID, StatusQueued).
+			Updates(map[string]any{"status": StatusExpired, "expired_at": &now}).Error
+	})
+}
+
+func (m *Manager) ListDirectory(sessionID uint, target string, timeout time.Duration) (Request, error) {
+	return m.submitRequest(sessionID, ActionList, target, timeout)
+}
+
+func (m *Manager) StatPath(sessionID uint, target string, timeout time.Duration) (Request, error) {
+	return m.submitRequest(sessionID, ActionStat, target, timeout)
+}
+
+func (m *Manager) submitRequest(sessionID uint, action, target string, timeout time.Duration) (Request, error) {
+	if timeout <= 0 {
+		timeout = defaultRequestTimeout
+	}
+
+	var session Session
+	if err := m.DB.First(&session, sessionID).Error; err != nil {
+		return Request{}, err
+	}
+	if !session.Active {
+		return Request{}, fmt.Errorf("file explorer session is closed")
+	}
+
+	var pending int64
+	if err := m.DB.Model(&Request{}).
+		Where("session_id = ? AND status = ?", sessionID, StatusQueued).
+		Count(&pending).Error; err != nil {
+		return Request{}, err
+	}
+	if pending >= maxPendingRequests {
+		return Request{}, fmt.Errorf("too many file explorer requests are still pending")
+	}
+
+	resolved := filequery.ResolvePath(target, session.Root, session.Platform)
+	sql, err := requestSQL(action, resolved)
+	if err != nil {
+		return Request{}, err
+	}
+
+	request := Request{
+		SessionID:     session.ID,
+		Action:        action,
+		Path:          resolved,
+		TranslatedSQL: sql,
+		Status:        StatusQueued,
+	}
+
+	err = m.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&request).Error; err != nil {
+			return err
+		}
+
+		extra, err := json.Marshal(map[string]uint{"session_id": session.ID, "request_id": request.ID})
+		if err != nil {
+			return err
+		}
+		distributed := queries.DistributedQuery{
+			Name:          queries.GenQueryName(),
+			Query:         sql,
+			Creator:       session.Creator,
+			Active:        true,
+			Hidden:        true,
+			Type:          queries.FileExplorerQueryType,
+			EnvironmentID: session.EnvironmentID,
+			Expiration:    time.Now().Add(timeout),
+			Expected:      1,
+			ExtraData:     string(extra),
+		}
+		if err := tx.Create(&distributed).Error; err != nil {
+			return err
+		}
+		nodeQuery := queries.NodeQuery{
+			NodeID:  session.NodeID,
+			QueryID: distributed.ID,
+			Status:  queries.DistributedQueryStatusPending,
+		}
+		if err := tx.Create(&nodeQuery).Error; err != nil {
+			return err
+		}
+		request.DistributedQueryName = distributed.Name
+		return tx.Model(&request).Update("distributed_query_name", distributed.Name).Error
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return request, nil
+}
+
+func requestSQL(action, target string) (string, error) {
+	switch action {
+	case ActionList:
+		return filequery.ListDirectorySQL(target), nil
+	case ActionStat:
+		return filequery.StatPathSQL(target), nil
+	default:
+		return "", fmt.Errorf("unsupported file explorer action %q", action)
+	}
+}
+
+func (m *Manager) GetRequest(sessionID, requestID uint) (Request, error) {
+	var request Request
+	if err := m.DB.Where("session_id = ?", sessionID).First(&request, requestID).Error; err != nil {
+		return Request{}, err
+	}
+	return request, nil
+}
+
+func (m *Manager) RefreshRequestStatus(requestID uint) (Request, error) {
+	var request Request
+	if err := m.DB.First(&request, requestID).Error; err != nil {
+		return Request{}, err
+	}
+	if request.DistributedQueryName == "" || isTerminalStatus(request.Status) {
+		return request, nil
+	}
+
+	var distributed queries.DistributedQuery
+	if err := m.DB.Where("name = ?", request.DistributedQueryName).First(&distributed).Error; err != nil {
+		return Request{}, err
+	}
+	var nodeQuery queries.NodeQuery
+	if err := m.DB.Where("query_id = ?", distributed.ID).First(&nodeQuery).Error; err != nil {
+		return Request{}, err
+	}
+
+	now := time.Now()
+	updates := map[string]any{}
+	switch nodeQuery.Status {
+	case queries.DistributedQueryStatusPending:
+		if distributed.Expiration.Before(now) {
+			updates["status"] = StatusExpired
+			updates["expired_at"] = &now
+			if err := m.expireDistributedQuery(distributed.ID); err != nil {
+				return Request{}, err
+			}
+		}
+	case queries.DistributedQueryStatusCompleted:
+		updates["status"] = StatusCompleted
+		updates["completed_at"] = &now
+	case queries.DistributedQueryStatusError:
+		updates["status"] = StatusError
+		updates["error"] = "osquery returned an error for this file explorer request"
+		updates["completed_at"] = &now
+	case queries.DistributedQueryStatusExpired:
+		updates["status"] = StatusExpired
+		updates["expired_at"] = &now
+	}
+	if len(updates) > 0 {
+		if err := m.DB.Model(&request).Updates(updates).Error; err != nil {
+			return Request{}, err
+		}
+		if err := m.DB.First(&request, requestID).Error; err != nil {
+			return Request{}, err
+		}
+	}
+	return request, nil
+}
+
+func (m *Manager) expireDistributedQuery(queryID uint) error {
+	return m.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&queries.DistributedQuery{}).
+			Where("id = ?", queryID).
+			Updates(map[string]any{"expired": true, "active": false}).Error; err != nil {
+			return err
+		}
+		return tx.Model(&queries.NodeQuery{}).
+			Where("query_id = ? AND status = ?", queryID, queries.DistributedQueryStatusPending).
+			Update("status", queries.DistributedQueryStatusExpired).Error
+	})
+}
+
+func (m *Manager) RequestResults(requestID uint) ([]Entry, error) {
+	request, err := m.RefreshRequestStatus(requestID)
+	if err != nil {
+		return nil, err
+	}
+	entries := []Entry{}
+	if request.DistributedQueryName == "" {
+		return entries, nil
+	}
+	err = logging.StreamQueryResults(m.DB, request.DistributedQueryName, func(row logging.OsqueryQueryData) error {
+		decoded, err := decodeEntries([]byte(row.Data))
+		if err != nil {
+			return err
+		}
+		entries = append(entries, decoded...)
+		return nil
+	})
+	return entries, err
+}
+
+func isTerminalStatus(status string) bool {
+	return status == StatusCompleted || status == StatusError || status == StatusExpired
+}

--- a/pkg/fileexplorer/manager_test.go
+++ b/pkg/fileexplorer/manager_test.go
@@ -1,0 +1,149 @@
+package fileexplorer_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
+	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupFileExplorerManager(t *testing.T) (*gorm.DB, *fileexplorer.Manager, environments.TLSEnvironment, nodes.OsqueryNode) {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&environments.TLSEnvironment{}, &nodes.OsqueryNode{}, &logging.OsqueryQueryData{}))
+
+	env := environments.TLSEnvironment{UUID: "env-uuid", Name: "env"}
+	require.NoError(t, db.Create(&env).Error)
+	node := nodes.OsqueryNode{UUID: "NODE-UUID", Platform: "linux", EnvironmentID: env.ID, Environment: env.UUID}
+	require.NoError(t, db.Create(&node).Error)
+
+	queryManager := queries.CreateQueries(db)
+	return db, fileexplorer.NewManager(db, queryManager), env, node
+}
+
+func TestCreateSessionDefaultsRootByPlatform(t *testing.T) {
+	_, manager, env, node := setupFileExplorerManager(t)
+	node.Platform = "windows"
+
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	require.True(t, session.Active)
+	require.Equal(t, node.UUID, session.NodeUUID)
+	require.Equal(t, `C:\`, session.Root)
+}
+
+func TestListDirectoryCreatesHiddenFileExplorerQuery(t *testing.T) {
+	db, manager, env, node := setupFileExplorerManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	request, err := manager.ListDirectory(session.ID, "/etc", 10*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, fileexplorer.ActionList, request.Action)
+	require.Equal(t, fileexplorer.StatusQueued, request.Status)
+	require.Equal(t, "/etc", request.Path)
+	require.Contains(t, request.TranslatedSQL, "from file")
+	require.Contains(t, request.TranslatedSQL, "directory = '/etc'")
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", request.DistributedQueryName).First(&distributed).Error)
+	require.Equal(t, queries.FileExplorerQueryType, distributed.Type)
+	require.True(t, distributed.Hidden)
+	require.True(t, distributed.Active)
+	require.Equal(t, uint(1), uint(distributed.Expected))
+	require.Equal(t, env.ID, distributed.EnvironmentID)
+
+	var nodeQuery queries.NodeQuery
+	require.NoError(t, db.Where("query_id = ?", distributed.ID).First(&nodeQuery).Error)
+	require.Equal(t, node.ID, nodeQuery.NodeID)
+}
+
+func TestStatPathCreatesHiddenFileExplorerQuery(t *testing.T) {
+	_, manager, env, node := setupFileExplorerManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	request, err := manager.StatPath(session.ID, "/etc/hosts", 10*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, fileexplorer.ActionStat, request.Action)
+	require.Equal(t, "/etc/hosts", request.Path)
+	require.Contains(t, request.TranslatedSQL, "path = '/etc/hosts'")
+}
+
+func TestRefreshRequestStatusFromNodeQuery(t *testing.T) {
+	db, manager, env, node := setupFileExplorerManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	request, err := manager.ListDirectory(session.ID, "/etc", 10*time.Second)
+	require.NoError(t, err)
+
+	require.NoError(t, markFileExplorerNodeQueryStatus(db, request.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+	got, err := manager.RefreshRequestStatus(request.ID)
+	require.NoError(t, err)
+	require.Equal(t, fileexplorer.StatusCompleted, got.Status)
+	require.NotNil(t, got.CompletedAt)
+}
+
+func TestRequestResultsDecodeStoredQueryWriteData(t *testing.T) {
+	db, manager, env, node := setupFileExplorerManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	request, err := manager.ListDirectory(session.ID, "/etc", 10*time.Second)
+	require.NoError(t, err)
+
+	result, err := json.Marshal([]map[string]any{{
+		"path":      "/etc/hosts",
+		"filename":  "hosts",
+		"directory": "/etc",
+		"type":      "regular",
+		"size":      123,
+		"mode":      "0644",
+	}})
+	require.NoError(t, err)
+	wrapped, err := json.Marshal(types.QueryWriteData{
+		Name:   request.DistributedQueryName,
+		Result: result,
+		Status: 0,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{
+		UUID:        node.UUID,
+		Environment: env.UUID,
+		Name:        request.DistributedQueryName,
+		Data:        string(wrapped),
+		Status:      0,
+	}).Error)
+	require.NoError(t, markFileExplorerNodeQueryStatus(db, request.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+
+	entries, err := manager.RequestResults(request.ID)
+	require.NoError(t, err)
+	require.Equal(t, []fileexplorer.Entry{{
+		Path:      "/etc/hosts",
+		Filename:  "hosts",
+		Directory: "/etc",
+		Type:      "regular",
+		Size:      123,
+		Mode:      "0644",
+	}}, entries)
+}
+
+func markFileExplorerNodeQueryStatus(db *gorm.DB, queryName, status string) error {
+	var distributed queries.DistributedQuery
+	if err := db.Where("name = ?", queryName).First(&distributed).Error; err != nil {
+		return err
+	}
+	return db.Model(&queries.NodeQuery{}).
+		Where("query_id = ?", distributed.ID).
+		Update("status", status).Error
+}

--- a/pkg/fileexplorer/models.go
+++ b/pkg/fileexplorer/models.go
@@ -1,0 +1,70 @@
+package fileexplorer
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	ActionList = "list"
+	ActionStat = "stat"
+
+	StatusQueued    = "queued"
+	StatusCompleted = "completed"
+	StatusError     = "error"
+	StatusExpired   = "expired"
+)
+
+type Session struct {
+	ID            uint           `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+	EnvironmentID uint           `gorm:"not null;index" json:"environment_id"`
+	NodeID        uint           `gorm:"not null;index" json:"node_id"`
+	NodeUUID      string         `gorm:"not null;index" json:"node_uuid"`
+	Creator       string         `gorm:"not null;index" json:"creator"`
+	Platform      string         `json:"platform"`
+	Root          string         `gorm:"not null" json:"root"`
+	Active        bool           `gorm:"not null;default:true" json:"active"`
+	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
+}
+
+func (Session) TableName() string {
+	return "file_explorer_sessions"
+}
+
+type Request struct {
+	ID                   uint           `gorm:"primarykey" json:"id"`
+	CreatedAt            time.Time      `json:"created_at"`
+	UpdatedAt            time.Time      `json:"updated_at"`
+	DeletedAt            gorm.DeletedAt `gorm:"index" json:"-"`
+	SessionID            uint           `gorm:"not null;index" json:"session_id"`
+	Action               string         `gorm:"not null;index" json:"action"`
+	Path                 string         `gorm:"not null" json:"path"`
+	TranslatedSQL        string         `json:"translated_sql"`
+	DistributedQueryName string         `gorm:"index" json:"distributed_query_name,omitempty"`
+	Status               string         `gorm:"not null;index" json:"status"`
+	Error                string         `json:"error,omitempty"`
+	CompletedAt          *time.Time     `json:"completed_at,omitempty"`
+	ExpiredAt            *time.Time     `json:"expired_at,omitempty"`
+}
+
+func (Request) TableName() string {
+	return "file_explorer_requests"
+}
+
+type Entry struct {
+	Path      string `json:"path"`
+	Filename  string `json:"filename"`
+	Directory string `json:"directory"`
+	Type      string `json:"type"`
+	Size      int64  `json:"size,omitempty"`
+	Mode      string `json:"mode,omitempty"`
+	UID       string `json:"uid,omitempty"`
+	GID       string `json:"gid,omitempty"`
+	MTime     int64  `json:"mtime,omitempty"`
+	ATime     int64  `json:"atime,omitempty"`
+	CTime     int64  `json:"ctime,omitempty"`
+}

--- a/pkg/fileexplorer/results.go
+++ b/pkg/fileexplorer/results.go
@@ -1,0 +1,68 @@
+package fileexplorer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/jmpsec/osctrl/pkg/types"
+)
+
+func decodeEntries(data []byte) ([]Entry, error) {
+	var wrapped types.QueryWriteData
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Result != nil {
+		data = wrapped.Result
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return nil, err
+	}
+	entries := make([]Entry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, Entry{
+			Path:      stringValue(row["path"]),
+			Filename:  stringValue(row["filename"]),
+			Directory: stringValue(row["directory"]),
+			Type:      stringValue(row["type"]),
+			Size:      int64Value(row["size"]),
+			Mode:      stringValue(row["mode"]),
+			UID:       stringValue(row["uid"]),
+			GID:       stringValue(row["gid"]),
+			MTime:     int64Value(row["mtime"]),
+			ATime:     int64Value(row["atime"]),
+			CTime:     int64Value(row["ctime"]),
+		})
+	}
+	return entries, nil
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func int64Value(value any) int64 {
+	switch v := value.(type) {
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case float64:
+		return int64(v)
+	case json.Number:
+		i, _ := v.Int64()
+		return i
+	case string:
+		i, _ := strconv.ParseInt(v, 10, 64)
+		return i
+	default:
+		return 0
+	}
+}

--- a/pkg/filequery/filequery.go
+++ b/pkg/filequery/filequery.go
@@ -1,0 +1,77 @@
+package filequery
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+func DefaultRoot(platform string) string {
+	if strings.EqualFold(platform, "windows") {
+		return `C:\`
+	}
+	return "/"
+}
+
+func ResolvePath(input, current, platform string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		input = current
+	}
+	if strings.EqualFold(platform, "windows") {
+		return resolveWindowsPath(input, current)
+	}
+	if strings.HasPrefix(input, "/") {
+		return path.Clean(input)
+	}
+	return path.Clean(path.Join(current, input))
+}
+
+func ListDirectorySQL(directory string) string {
+	return fmt.Sprintf("select path, filename, directory, type, size, mode, uid, gid, mtime from file where directory = %s", quoteSQL(directory))
+}
+
+func StatPathSQL(target string) string {
+	return fmt.Sprintf("select path, filename, directory, type, size, mode, uid, gid, mtime, atime, ctime from file where path = %s", quoteSQL(target))
+}
+
+func resolveWindowsPath(input, current string) string {
+	input = strings.ReplaceAll(input, "/", `\`)
+	current = strings.ReplaceAll(current, "/", `\`)
+	if isWindowsAbs(input) {
+		return cleanWindowsPath(input)
+	}
+	return cleanWindowsPath(strings.TrimRight(current, `\`) + `\` + input)
+}
+
+func isWindowsAbs(p string) bool {
+	return len(p) >= 3 && p[1] == ':' && p[2] == '\\'
+}
+
+func cleanWindowsPath(p string) string {
+	p = strings.ReplaceAll(p, `/`, `\`)
+	parts := []string{}
+	for _, part := range strings.Split(p, `\`) {
+		if part == "" || part == "." {
+			continue
+		}
+		if part == ".." {
+			if len(parts) > 1 {
+				parts = parts[:len(parts)-1]
+			}
+			continue
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) == 0 {
+		return `C:\`
+	}
+	if len(parts) == 1 && strings.HasSuffix(parts[0], ":") {
+		return parts[0] + `\`
+	}
+	return strings.Join(parts, `\`)
+}
+
+func quoteSQL(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}

--- a/pkg/filequery/filequery_test.go
+++ b/pkg/filequery/filequery_test.go
@@ -1,0 +1,32 @@
+package filequery_test
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/filequery"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultRoot(t *testing.T) {
+	require.Equal(t, `C:\`, filequery.DefaultRoot("windows"))
+	require.Equal(t, "/", filequery.DefaultRoot("linux"))
+	require.Equal(t, "/", filequery.DefaultRoot("darwin"))
+	require.Equal(t, "/", filequery.DefaultRoot(""))
+}
+
+func TestResolvePath(t *testing.T) {
+	require.Equal(t, "/etc/ssh", filequery.ResolvePath("ssh", "/etc", "linux"))
+	require.Equal(t, "/var/log", filequery.ResolvePath("/var/log", "/etc", "linux"))
+	require.Equal(t, `C:\Windows\System32`, filequery.ResolvePath(`Windows\System32`, `C:\`, "windows"))
+	require.Equal(t, `D:\Logs`, filequery.ResolvePath(`D:\Logs`, `C:\`, "windows"))
+}
+
+func TestListDirectorySQLEscapesPath(t *testing.T) {
+	got := filequery.ListDirectorySQL(`/tmp/alice's files`)
+	require.Equal(t, "select path, filename, directory, type, size, mode, uid, gid, mtime from file where directory = '/tmp/alice''s files'", got)
+}
+
+func TestStatPathSQLEscapesPath(t *testing.T) {
+	got := filequery.StatPathSQL(`/tmp/alice's file`)
+	require.Equal(t, "select path, filename, directory, type, size, mode, uid, gid, mtime, atime, ctime from file where path = '/tmp/alice''s file'", got)
+}

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -45,6 +45,8 @@ const (
 	MetadataQueryType string = "metadata"
 	// ConsoleQueryType defines a hidden accelerated query used by node consoles
 	ConsoleQueryType string = "console"
+	// FileExplorerQueryType defines a hidden accelerated query used by node file explorer tabs
+	FileExplorerQueryType string = "file_explorer"
 )
 
 const (
@@ -192,7 +194,7 @@ func (q *Queries) NodeQueries(node nodes.OsqueryNode) (QueryReadQueries, bool, e
 	accelerate := false
 	for _, _q := range results {
 		qs[_q.Name] = _q.Query
-		if _q.Type == ConsoleQueryType {
+		if IsInternalQueryType(_q.Type) {
 			accelerate = true
 		}
 	}
@@ -200,10 +202,14 @@ func (q *Queries) NodeQueries(node nodes.OsqueryNode) (QueryReadQueries, bool, e
 	return qs, accelerate, nil
 }
 
+func IsInternalQueryType(qtype string) bool {
+	return qtype == ConsoleQueryType || qtype == FileExplorerQueryType
+}
+
 // Gets all queries by target (active/completed/all/all-full/deleted/hidden/expired)
 func (q *Queries) Gets(target, qtype string, envid uint) ([]DistributedQuery, error) {
 	var queries []DistributedQuery
-	if qtype == ConsoleQueryType {
+	if IsInternalQueryType(qtype) {
 		return queries, nil
 	}
 	switch target {
@@ -617,7 +623,7 @@ func (q *Queries) SetNodeQueriesAsExpired(queryID uint) error {
 //
 // page is 1-indexed. pageSize is clamped to [1, 500] with default 50.
 func (q *Queries) GetByEnvTargetPaged(envID uint, target, qtype, search string, page, pageSize int, sortColumn string, desc bool) (QueryListPage, error) {
-	if qtype == ConsoleQueryType {
+	if IsInternalQueryType(qtype) {
 		return QueryListPage{Items: []DistributedQuery{}}, nil
 	}
 	if pageSize <= 0 {

--- a/pkg/queries/queries_test.go
+++ b/pkg/queries/queries_test.go
@@ -123,6 +123,28 @@ func TestNodeQueriesAcceleratesConsoleQueries(t *testing.T) {
 	require.NotContains(t, otherResult, "console-query")
 }
 
+func TestNodeQueriesAcceleratesFileExplorerQueries(t *testing.T) {
+	db := testDB(t)
+	q, testNodes, _ := setupTestData(t, db)
+
+	fileExplorerQuery := queries.DistributedQuery{
+		Name:          "file-explorer-query",
+		Query:         "select path from file where directory = '/'",
+		Type:          queries.FileExplorerQueryType,
+		Hidden:        true,
+		Active:        true,
+		EnvironmentID: 1,
+		Expiration:    time.Now().Add(time.Hour),
+	}
+	require.NoError(t, q.Create(&fileExplorerQuery))
+	require.NoError(t, q.CreateNodeQueries([]uint{testNodes[0].ID}, fileExplorerQuery.ID))
+
+	result, accelerate, err := q.NodeQueries(testNodes[0])
+	require.NoError(t, err)
+	require.True(t, accelerate)
+	require.Equal(t, "select path from file where directory = '/'", result["file-explorer-query"])
+}
+
 func TestNodeQueriesSkipsExpiredPendingQueries(t *testing.T) {
 	db := testDB(t)
 	q, testNodes, _ := setupTestData(t, db)


### PR DESCRIPTION
## Summary

- Added a gated File Explorer tab to the node detail view, backed by on-demand accelerated osquery queries.
- Added API/session plumbing for file explorer requests, directory listing, stat results, request polling, and session cleanup.
- Added shared file-query helpers and reused them from the console file commands.
- Hid internal file explorer queries from normal query listings while keeping them accelerated for active sessions.
- Added the frontend file explorer UI with lazy directory expansion, refresh, loading spinners, sticky details, selected-path carve action, and a link to the created carve.
- Added `osquery.fileExplorer` config/flag support and dev compose wiring for `osctrl-api` and `osctrl-tls`.
- Fixed the app shell scroll frame so sticky panels work inside the main app viewport.

## Validation

- `GOCACHE=/tmp/osctrl-gocache go test ./...`
- `npm run check`
- `npm test`