### PR TITLE
Fix for authentication config in `osctrl-api`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # IDE metadata
 .vscode
 .idea
+.claude
+.codex
 
 # Logs
 *.log

--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// osctrl-api reads its config either from flags/env vars or from a YAML
+// file via --config. The YAML path replaces flagParams wholesale, so any
+// section loadedYAMLToServiceParams forgets to carry over is silently
+// dropped — which is exactly how the SAML/OIDC sections went missing:
+// federated login stayed off no matter what the operator configured,
+// with no error anywhere. These tests pin the wiring.
+
+const ssoConfigYAML = `
+service:
+  listener: 127.0.0.1
+  port: 9000
+  auth: jwt
+db:
+  type: postgres
+jwt:
+  jwtSecret: "not-a-real-secret-just-for-parsing"
+saml:
+  enabled: true
+  entityId: https://osctrl.example.com/api/v1/auth/saml/metadata
+  acsUrl: https://osctrl.example.com/api/v1/auth/saml/acs
+  metadataUrl: https://idp.example.com/realms/osctrl/protocol/saml/descriptor
+  usernameAttribute: preferred_username
+  jitProvision: true
+  forceAuthn: false
+oidc:
+  enabled: true
+  issuerUrl: https://idp.example.com/realms/osctrl
+  clientId: osctrl-api
+  clientSecret: shhh
+  redirectUrl: https://osctrl.example.com/api/v1/auth/oidc/callback
+  scopes:
+    - openid
+    - profile
+  usernameClaim: nickname
+  requiredGroups:
+    - osctrl-admins
+  jitProvision: true
+  usePKCE: true
+`
+
+func writeTempConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "api.yml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	return path
+}
+
+func TestLoadedYAMLCarriesSSOSections(t *testing.T) {
+	cfg, err := loadYAMLConfiguration(writeTempConfig(t, ssoConfigYAML))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration: %v", err)
+	}
+	params := loadedYAMLToServiceParams(cfg, "api.yml")
+
+	if params.OIDC == nil {
+		t.Fatal("OIDC params are nil — the oidc section was dropped")
+	}
+	if params.SAML == nil {
+		t.Fatal("SAML params are nil — the saml section was dropped")
+	}
+
+	// main.go gates provider init on Enabled; if it doesn't survive the
+	// round-trip, the routes are never registered and /auth/methods
+	// advertises password-only.
+	if !params.OIDC.Enabled {
+		t.Error("OIDC.Enabled = false, want true")
+	}
+	if !params.SAML.Enabled {
+		t.Error("SAML.Enabled = false, want true")
+	}
+
+	if got, want := params.OIDC.IssuerURL, "https://idp.example.com/realms/osctrl"; got != want {
+		t.Errorf("OIDC.IssuerURL = %q, want %q", got, want)
+	}
+	if got, want := params.OIDC.ClientID, "osctrl-api"; got != want {
+		t.Errorf("OIDC.ClientID = %q, want %q", got, want)
+	}
+	if got, want := params.OIDC.UsernameClaim, "nickname"; got != want {
+		t.Errorf("OIDC.UsernameClaim = %q, want %q", got, want)
+	}
+	if !params.OIDC.UsePKCE {
+		t.Error("OIDC.UsePKCE = false, want true")
+	}
+	if got, want := len(params.OIDC.Scopes), 2; got != want {
+		t.Errorf("len(OIDC.Scopes) = %d, want %d", got, want)
+	}
+	if got, want := len(params.OIDC.RequiredGroups), 1; got != want {
+		t.Errorf("len(OIDC.RequiredGroups) = %d, want %d", got, want)
+	}
+
+	// EntityID and ACSURL are passed to InitSAML as separate arguments,
+	// so an empty value here means metadata registration silently
+	// mismatches whatever the IdP has on file.
+	if got, want := params.SAML.EntityID, "https://osctrl.example.com/api/v1/auth/saml/metadata"; got != want {
+		t.Errorf("SAML.EntityID = %q, want %q", got, want)
+	}
+	if got, want := params.SAML.ACSURL, "https://osctrl.example.com/api/v1/auth/saml/acs"; got != want {
+		t.Errorf("SAML.ACSURL = %q, want %q", got, want)
+	}
+	if got, want := params.SAML.MetaDataURL, "https://idp.example.com/realms/osctrl/protocol/saml/descriptor"; got != want {
+		t.Errorf("SAML.MetaDataURL = %q, want %q", got, want)
+	}
+	if got, want := params.SAML.UsernameAttribute, "preferred_username"; got != want {
+		t.Errorf("SAML.UsernameAttribute = %q, want %q", got, want)
+	}
+	if params.SAML.ForceAuthn {
+		t.Error("SAML.ForceAuthn = true, want false — an explicit false must override the default")
+	}
+}
+
+func TestSAMLForceAuthnDefaultsTrueWhenOmitted(t *testing.T) {
+	// forceAuthn is a bool, so an omitted key is indistinguishable from
+	// an explicit false once unmarshalled. The --saml-force-authn flag
+	// defaults to true; the YAML path has to match it, otherwise "log
+	// out" appears not to work — the IdP re-auths from its own cookie.
+	const body = `
+service:
+  auth: jwt
+saml:
+  enabled: true
+  metadataUrl: https://idp.example.com/metadata
+`
+	cfg, err := loadYAMLConfiguration(writeTempConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration: %v", err)
+	}
+	if !cfg.SAML.ForceAuthn {
+		t.Error("SAML.ForceAuthn = false, want true when the key is omitted")
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -149,6 +149,13 @@ var validAuth = map[string]bool{
 // Function to load the configuration from a single YAML file
 func loadYAMLConfiguration(file string) (config.APIConfiguration, error) {
 	var cfg config.APIConfiguration
+	// saml.forceAuthn defaults to true — same as the --saml-force-authn
+	// flag. Without this the YAML path would silently land on false for
+	// any config file that omits the key, which most operators read as
+	// "logout didn't work" (the IdP silently re-auths from its own SSO
+	// cookie). A zero-value bool can't distinguish "absent" from
+	// "explicitly false", so the default has to live here.
+	viper.SetDefault("saml.forceAuthn", true)
 	// Load file and read config
 	viper.SetConfigFile(file)
 	viper.SetConfigType(config.YAMLConfigType)

--- a/cmd/api/utils.go
+++ b/cmd/api/utils.go
@@ -16,6 +16,8 @@ func loadedYAMLToServiceParams(yml config.APIConfiguration, loadedFile string) *
 		DB:                &yml.DB,
 		Redis:             &yml.Redis,
 		Osquery:           &yml.Osquery,
+		SAML:              &yml.SAML,
+		OIDC:              &yml.OIDC,
 		JWT:               &yml.JWT,
 		TLS:               &yml.TLS,
 		Logger:            &yml.Logger,

--- a/deploy/config/api.yml
+++ b/deploy/config/api.yml
@@ -72,6 +72,75 @@ osquery:
   accelerated: false
   fileExplorer: false
 
+# SAML 2.0 federated login. Disabled by default; when `enabled` is true
+# the API fetches the IdP metadata at startup and REFUSES TO START if
+# that fails, rather than serving a login page with a broken SSO button.
+# The SPA discovers this via GET /api/v1/auth/methods and renders a
+# "Continue with SAML" button automatically — no frontend rebuild needed.
+#
+# Register osctrl with the IdP by pointing it at the SP metadata URL:
+#   https://<host>/api/v1/auth/saml/metadata
+#
+# Note: certPath, keyPath, rootUrl, loginUrl and spInitiated are legacy
+# fields consumed only by osctrl-admin; osctrl-api ignores them.
+# See docs/auth-providers.md for per-IdP walkthroughs.
+saml:
+  enabled: false
+  # SP entity ID — what the IdP knows us by, conventionally the metadata URL
+  entityId: ""
+  # Where the IdP POSTs the SAMLResponse; must end with /api/v1/auth/saml/acs
+  acsUrl: ""
+  certPath: ""
+  keyPath: ""
+  # IdP metadata XML — fetched once at startup for signing certs + SSO endpoint
+  metadataUrl: ""
+  rootUrl: ""
+  loginUrl: ""
+  # IdP session-termination URL (e.g. https://<tenant>.auth0.com/v2/logout).
+  # Returned to the SPA on logout so the IdP session dies too; without it
+  # the next SSO click silently re-authenticates.
+  logoutUrl: ""
+  # Auto-create osctrl users on first login, as non-admin
+  jitProvision: false
+  # Attribute (Name or FriendlyName) whose value becomes the osctrl username.
+  # Empty = use the NameID verbatim. Usernames must match ^[a-zA-Z0-9_-]{1,64}$,
+  # so email-format NameIDs are rejected — point this at a short handle instead.
+  usernameAttribute: ""
+  # PEM cert + RSA key for signing outbound AuthnRequests. Both must be set
+  # to enable signing; some IdPs require it and all should support it.
+  signingCertPath: ""
+  signingKeyPath: ""
+  # Force re-authentication at the IdP on every login. Defaults true — it is
+  # the substitute for SAML SLO, which is not implemented yet.
+  forceAuthn: true
+  spInitiated: false
+
+# OIDC federated login. Same posture as SAML above: disabled by default,
+# fail-fast on discovery errors at startup, advertised to the SPA through
+# /api/v1/auth/methods. Both protocols can be enabled at the same time.
+oidc:
+  enabled: false
+  # Realm root — /.well-known/openid-configuration is appended automatically
+  issuerUrl: ""
+  clientId: ""
+  clientSecret: ""
+  # Must match the IdP client config and end with /api/v1/auth/oidc/callback
+  redirectUrl: ""
+  # Empty defaults to [openid, profile, email]
+  scopes: []
+  # Empty defaults to preferred_username. Same charset rule as SAML applies,
+  # so `email` and Auth0's `sub` will be rejected — use `nickname` there.
+  usernameClaim: ""
+  # Empty defaults to `groups`
+  groupsClaim: ""
+  # Login is denied unless the user belongs to at least one of these.
+  # Empty disables the group gate.
+  requiredGroups: []
+  # Auto-create osctrl users on first login, as non-admin
+  jitProvision: false
+  # PKCE (S256) for the authorization code flow
+  usePKCE: false
+
 # JWT authentication configuration
 jwt:
   jwtSecret: ""

--- a/docs/auth-providers.md
+++ b/docs/auth-providers.md
@@ -7,6 +7,7 @@ for each tested provider.
 
 ## Table of contents
 
+- [Configuration modes](#configuration-modes)
 - [Environment variables reference](#environment-variables-reference)
 - [Username rules](#username-rules)
 - [OIDC](#oidc)
@@ -22,6 +23,30 @@ for each tested provider.
 - [Logout and IdP session termination](#logout-and-idp-session-termination)
 - [Running OIDC and SAML simultaneously](#running-oidc-and-saml-simultaneously)
 - [Troubleshooting](#troubleshooting)
+
+---
+
+## Configuration modes
+
+osctrl-api takes its settings from **either** flags/environment variables
+**or** a YAML file — not both. When `--config` is passed (which is what
+the systemd unit written by `deploy/provision.sh` does), the YAML file is
+the only source: environment variables are not merged in and are ignored.
+
+So pick the one that matches how you run the service:
+
+- **Provisioned / systemd deployments** — edit the `saml:` and `oidc:`
+  sections of `config/osctrl-api.yml`. Run
+  `osctrl-api config-generate` to emit a fresh file with both sections
+  present, or copy them from
+  [`deploy/config/api.yml`](../deploy/config/api.yml).
+- **Containers or a hand-rolled invocation with no `--config`** — use the
+  environment variables below.
+
+The YAML keys are the camelCase equivalents of the flags
+(`OIDC_ISSUER_URL` → `oidc.issuerUrl`, `SAML_ACS_URL` → `saml.acsUrl`,
+and so on). A complete annotated example of both sections lives in
+`deploy/config/api.yml`.
 
 ---
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -104,6 +104,8 @@ type APIConfiguration struct {
 	DB      YAMLConfigurationDB      `mapstructure:"db"`
 	Redis   YAMLConfigurationRedis   `mapstructure:"redis"`
 	Osquery YAMLConfigurationOsquery `mapstructure:"osquery"`
+	SAML    YAMLConfigurationSAML    `mapstructure:"saml"`
+	OIDC    YAMLConfigurationOIDC    `mapstructure:"oidc"`
 	JWT     YAMLConfigurationJWT     `mapstructure:"jwt"`
 	TLS     YAMLConfigurationTLS     `mapstructure:"tls"`
 	Logger  YAMLConfigurationLogger  `mapstructure:"logger"`

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -37,6 +37,7 @@ func GenerateAdminConfigFile(path string, cfg *ServiceParameters, overwrite bool
 		Osquery: *cfg.Osquery,
 		Osctrld: *cfg.Osctrld,
 		SAML:    *cfg.SAML,
+		OIDC:    *cfg.OIDC,
 		JWT:     *cfg.JWT,
 		TLS:     *cfg.TLS,
 		Logger:  *cfg.Logger,
@@ -54,9 +55,12 @@ func GenerateAPIConfigFile(path string, cfg *ServiceParameters, overwrite bool) 
 		DB:      *cfg.DB,
 		Redis:   *cfg.Redis,
 		Osquery: *cfg.Osquery,
+		SAML:    *cfg.SAML,
+		OIDC:    *cfg.OIDC,
 		JWT:     *cfg.JWT,
 		TLS:     *cfg.TLS,
 		Logger:  *cfg.Logger,
+		Carver:  *cfg.Carver,
 		Debug:   *cfg.Debug,
 	}
 	return GenerateGenericConfigFile(path, cfgAPI, overwrite)


### PR DESCRIPTION
## Fix for authentication config in osctrl-api

### Problem
When `osctrl-api` was launched with `--config` (the path used by the provisioned systemd unit and containers), the SAML and OIDC sections of the YAML file were silently dropped. `loadedYAMLToServiceParams` never copied `cfg.SAML` or `cfg.OIDC` into the `ServiceParameters` struct, so federated login stayed off no matter what the operator configured — with no error logged anywhere. The SPA kept advertising password-only auth via `/api/v1/auth/methods`.

A second, related bug: `saml.forceAuthn` defaulted to `false` on the YAML path, while the `--saml-force-authn` flag defaults to `true`. Operators read the resulting behavior as "logout didn't work" — the IdP silently re-authenticated from its own SSO cookie.

### Changes
- `cmd/api/utils.go`: carry `SAML` and `OIDC` from the parsed YAML into `ServiceParameters` so the providers actually initialize.
- `cmd/api/main.go`: set `viper.SetDefault("saml.forceAuthn", true)` so the YAML path matches the flag default when the key is omitted.
- `pkg/config/types.go`: add the `SAML` and `OIDC` fields to `APIConfiguration` so the sections round-trip through `config-generate`.
- `pkg/config/utils.go`: emit `SAML`, `OIDC`, and the previously-missing `Carver` block when generating an API config file.
- `deploy/config/api.yml`: ship annotated `saml:` and `oidc:` sections as a ready-to-edit reference.
- `docs/auth-providers.md`: document the two configuration modes (flags/env vs YAML) and how they map to the systemd deployment.
- `cmd/api/config_test.go`: pin the wiring — YAML → `ServiceParams` must preserve both SSO sections, `Enabled` flags, key fields (EntityID, ACSURL, IssuerURL, ClientID, PKCE, scopes, required groups), and the `forceAuthn` default-true-when-omitted behavior.
- `.gitignore`: ignore `.claude` and `.codex` agent metadata directories.

### Validation
- `go test ./cmd/api ./pkg/config` — new config tests pass.
- Manual: `osctrl-api config-generate` now emits `saml:` and `oidc:` blocks; starting the service with a YAML containing `oidc.enabled: true` registers the OIDC routes and `/auth/methods` advertises OIDC.

### Risk Notes
This is an auth-wiring change. The fix is additive for the YAML path only — flag/env invocation is unchanged. Operators who were relying on the bug (YAML SSO silently disabled) will see SSO come online on next restart, which is the intended behavior but worth flagging in release notes.