### PR TITLE
DB health canary and cached data served in `osctrl-tls`

### DIFF
--- a/cmd/tls/handlers/metrics.go
+++ b/cmd/tls/handlers/metrics.go
@@ -37,6 +37,12 @@ var (
 		Help:    "The duration of batch data flushing to backend",
 		Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5},
 	}, []string{"operation"})
+	// DBDegraded is 1 when the DB health monitor reports the database
+	// as degraded (caches are in stale-serve mode), 0 when healthy.
+	dbDegraded = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "osctrl_tls_db_degraded",
+		Help: "1 when the DB health monitor reports the database as degraded and caches are in stale-serve mode, 0 when healthy.",
+	})
 )
 
 func RegisterMetrics(reg prometheus.Registerer) {
@@ -45,4 +51,17 @@ func RegisterMetrics(reg prometheus.Registerer) {
 	reg.MustRegister(logProcessDuration)
 	reg.MustRegister(distributedQueryProcessingDuration)
 	reg.MustRegister(batchFlushDuration)
+	reg.MustRegister(dbDegraded)
+}
+
+// SetDBDegraded updates the db_degraded gauge. Called by the DB
+// health monitor via its OnChange callback. Safe to call even when
+// metrics are not registered (the gauge is a no-op until
+// RegisterMetrics runs).
+func SetDBDegraded(degraded bool) {
+	if degraded {
+		dbDegraded.Set(1)
+	} else {
+		dbDegraded.Set(0)
+	}
 }

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -217,6 +217,23 @@ func osctrlService() {
 		return err == nil && n > 0
 	})
 	log.Info().Msg("Environment cache wired to Redis")
+	// DB health monitor: when enabled, pings the DB on a fixed
+	// interval and switches EnvCache + SettingsCache into stale-serve
+	// mode after N consecutive failures, so osquery nodes keep getting
+	// config/logs during a DB outage. See pkg/backend/health.go.
+	var dbHealth *backend.DBHealth
+	if flagParams.Service.DBHealthCheck {
+		interval := time.Duration(flagParams.Service.DBHealthInterval) * time.Second
+		threshold := uint32(flagParams.Service.DBHealthThreshold)
+		dbHealth = backend.NewDBHealth(db, interval, threshold)
+		dbHealth.SetOnChange(handlers.SetDBDegraded)
+		dbHealth.Start()
+		envCache.SetDBHealth(dbHealth)
+		log.Info().
+			Dur("interval", interval).
+			Uint32("threshold", threshold).
+			Msg("DB health monitor enabled — caches will stale-serve on DB outage")
+	}
 	log.Info().Msg("Initialize settings")
 	settingsmgr = settings.NewSettings(db.Conn)
 	log.Info().Msg("Initialize nodes")
@@ -245,6 +262,9 @@ func osctrlService() {
 		settingsCacheTTL = time.Duration(defaultRefresh) * time.Second
 	}
 	settingsCache := settings.NewRedisSettingsCache(settingsmgr, redis.Client, config.ServiceTLS, settings.NoEnvironmentID, settingsCacheTTL)
+	if dbHealth != nil {
+		settingsCache.SetDBHealth(dbHealth)
+	}
 	log.Info().Msg("TLS settings cache wired to Redis")
 	// Initialize batch writer
 	log.Info().Msg("Initializing batch writer")

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -31,6 +31,22 @@ service:
   postureEnabled: false
   # Only used when postureEnabled is true.
   postureQueryPrefix: "osctrl:posture:"
+  # DB health monitor. When enabled, osctrl-tls pings the database
+  # every dbHealthInterval seconds. After dbHealthThreshold
+  # consecutive failures, EnvCache and SettingsCache switch to
+  # stale-serve mode: cached entries are served on DB miss instead of
+  # returning 500, and TTLs are extended to ~60m so cached envs/settings
+  # stay warm for the duration of the outage. This keeps osquery nodes
+  # that already have a cached env row receiving config/log/query
+  # responses during a DB outage. The stale-serve window is bounded at
+  # 60m so rotated enroll secrets are not accepted indefinitely.
+  # Disabled by default; enable in production where DB blips are
+  # expected and osquery fleet stability is prioritized.
+  dbHealthCheck: false
+  # Seconds between DB health pings.
+  dbHealthInterval: 5
+  # Consecutive failures before caches enter stale-serve mode.
+  dbHealthThreshold: 3
 
 # Database configuration
 db:

--- a/pkg/backend/health.go
+++ b/pkg/backend/health.go
@@ -1,0 +1,155 @@
+package backend
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// DegradedReader is the read-only interface for DB health state.
+// Caches and handlers use it to decide whether to serve stale data
+// or extend TTLs during a DB outage.
+type DegradedReader interface {
+	// IsDegraded returns true when the DB has been unreachable for
+	// at least FailureThreshold consecutive checks. Returns to false
+	// on the first successful ping after a degradation window.
+	IsDegraded() bool
+}
+
+// DBHealth monitors database availability by pinging the DB on a
+// fixed interval. It is safe for concurrent use.
+//
+// A background goroutine calls the check function every Interval. If
+// the check fails FailureThreshold times in a row, IsDegraded()
+// flips to true. The first success after degradation flips it back
+// to false.
+//
+// The monitor is opt-in: callers must call Start to launch the
+// goroutine and Stop to shut it down. A nil *DBHealth is always
+// non-degraded — EnvCache treats nil as "no monitoring, behave as
+// before" so existing callers that don't wire a monitor are
+// unaffected.
+type DBHealth struct {
+	checkFn             func() error
+	interval            time.Duration
+	failureThreshold    uint32
+	consecutiveFailures atomic.Uint32
+	degraded            atomic.Bool
+	onChange            func(degraded bool)
+	cancel              context.CancelFunc
+	wg                  sync.WaitGroup
+}
+
+// NewDBHealth creates a DBHealth monitor for the given DBManager.
+// Call Start to begin monitoring and Stop to shut down.
+func NewDBHealth(db *DBManager, interval time.Duration, failureThreshold uint32) *DBHealth {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	if failureThreshold == 0 {
+		failureThreshold = 3
+	}
+	return &DBHealth{
+		checkFn:          db.Check,
+		interval:         interval,
+		failureThreshold: failureThreshold,
+	}
+}
+
+// newDBHealthWithChecker is a test constructor that injects a
+// custom check function instead of relying on a live DBManager.
+func newDBHealthWithChecker(checkFn func() error, interval time.Duration, failureThreshold uint32) *DBHealth {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	if failureThreshold == 0 {
+		failureThreshold = 3
+	}
+	return &DBHealth{
+		checkFn:          checkFn,
+		interval:         interval,
+		failureThreshold: failureThreshold,
+	}
+}
+
+// SetOnChange wires a callback invoked whenever the degraded state
+// transitions. Receives the new state (true = degraded). Used by
+// callers to flip a Prometheus gauge without pkg/backend importing
+// prometheus. Called from the monitor goroutine; callers must ensure
+// their callback is safe to invoke from that goroutine.
+func (h *DBHealth) SetOnChange(fn func(degraded bool)) {
+	h.onChange = fn
+}
+
+// Start launches the background ping goroutine. Calling Start twice
+// without an intervening Stop is a no-op.
+func (h *DBHealth) Start() {
+	if h == nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	h.cancel = cancel
+	h.wg.Add(1)
+	go h.run(ctx)
+}
+
+// Stop shuts down the monitor and waits for the goroutine to exit.
+func (h *DBHealth) Stop() {
+	if h == nil || h.cancel == nil {
+		return
+	}
+	h.cancel()
+	h.wg.Wait()
+	h.cancel = nil
+}
+
+// IsDegraded returns true when the DB has been unreachable for at
+// least FailureThreshold consecutive checks.
+func (h *DBHealth) IsDegraded() bool {
+	if h == nil {
+		return false
+	}
+	return h.degraded.Load()
+}
+
+func (h *DBHealth) run(ctx context.Context) {
+	defer h.wg.Done()
+	ticker := time.NewTicker(h.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.check()
+		}
+	}
+}
+
+func (h *DBHealth) check() {
+	if err := h.checkFn(); err != nil {
+		failures := h.consecutiveFailures.Add(1)
+		if failures == h.failureThreshold {
+			log.Warn().Err(err).Uint32("consecutive_failures", failures).Msg("DB health: entering degraded state")
+			h.degraded.Store(true)
+			if h.onChange != nil {
+				h.onChange(true)
+			}
+		} else if failures > h.failureThreshold {
+			log.Debug().Err(err).Uint32("consecutive_failures", failures).Msg("DB health: still degraded")
+		}
+		return
+	}
+	if h.degraded.Load() {
+		log.Info().Msg("DB health: recovered from degraded state")
+		h.degraded.Store(false)
+		if h.onChange != nil {
+			h.onChange(false)
+		}
+	}
+	h.consecutiveFailures.Store(0)
+	h.degraded.Store(false)
+}

--- a/pkg/backend/health_test.go
+++ b/pkg/backend/health_test.go
@@ -1,0 +1,134 @@
+package backend
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDBHealth_FailureReachesThreshold(t *testing.T) {
+	var calls atomic.Uint32
+	h := newDBHealthWithChecker(
+		func() error {
+			calls.Add(1)
+			return errors.New("db down")
+		},
+		10*time.Millisecond,
+		2,
+	)
+
+	h.check()
+	assert.Equal(t, uint32(1), h.consecutiveFailures.Load(),
+		"first failed ping should increment failures to 1")
+	assert.False(t, h.IsDegraded(),
+		"degraded must not flip until threshold is reached")
+
+	h.check()
+	assert.Equal(t, uint32(2), h.consecutiveFailures.Load())
+	assert.True(t, h.IsDegraded(),
+		"degraded must flip on reaching the failure threshold")
+}
+
+func TestDBHealth_RecoveryClearsDegraded(t *testing.T) {
+	var fail atomic.Bool
+	h := newDBHealthWithChecker(
+		func() error {
+			if fail.Load() {
+				return errors.New("db down")
+			}
+			return nil
+		},
+		10*time.Millisecond,
+		1,
+	)
+
+	fail.Store(true)
+	h.check()
+	assert.True(t, h.IsDegraded(), "should be degraded after threshold failures")
+
+	fail.Store(false)
+	h.check()
+	assert.False(t, h.IsDegraded(), "should recover on first success")
+	assert.Equal(t, uint32(0), h.consecutiveFailures.Load())
+}
+
+func TestDBHealth_OnChangeFiresOnTransition(t *testing.T) {
+	var fail atomic.Bool
+	var lastReported atomic.Bool
+	var transitionCount atomic.Uint32
+	h := newDBHealthWithChecker(
+		func() error {
+			if fail.Load() {
+				return errors.New("db down")
+			}
+			return nil
+		},
+		10*time.Millisecond,
+		1,
+	)
+	h.SetOnChange(func(degraded bool) {
+		lastReported.Store(degraded)
+		transitionCount.Add(1)
+	})
+
+	fail.Store(true)
+	h.check()
+	assert.True(t, h.IsDegraded())
+	assert.True(t, lastReported.Load(), "OnChange should report degraded=true on entry")
+	assert.Equal(t, uint32(1), transitionCount.Load(), "first transition")
+
+	fail.Store(false)
+	h.check()
+	assert.False(t, h.IsDegraded())
+	assert.False(t, lastReported.Load(), "OnChange should report degraded=false on recovery")
+	assert.Equal(t, uint32(2), transitionCount.Load(), "second transition")
+}
+
+func TestDBHealth_OnChangeDoesNotFireBelowThreshold(t *testing.T) {
+	h := newDBHealthWithChecker(
+		func() error { return errors.New("db down") },
+		10*time.Millisecond,
+		5,
+	)
+	var calls atomic.Uint32
+	h.SetOnChange(func(degraded bool) { calls.Add(1) })
+
+	for i := 0; i < 4; i++ {
+		h.check()
+	}
+	assert.False(t, h.IsDegraded())
+	assert.Equal(t, uint32(0), calls.Load(),
+		"OnChange must not fire before threshold reached")
+}
+
+func TestDBHealth_NilMonitorIsNeverDegraded(t *testing.T) {
+	var h *DBHealth
+	assert.False(t, h.IsDegraded(), "nil *DBHealth must report non-degraded")
+}
+
+func TestDBHealth_StartStopReturns(t *testing.T) {
+	h := newDBHealthWithChecker(
+		func() error { return nil },
+		5*time.Millisecond,
+		100,
+	)
+	h.Start()
+	time.Sleep(20 * time.Millisecond)
+	h.Stop()
+}
+
+func TestDBHealth_StartIsIdempotent(t *testing.T) {
+	h := newDBHealthWithChecker(
+		func() error { return nil },
+		5*time.Millisecond,
+		100,
+	)
+	h.Start()
+	// Second Start should not launch a second goroutine (cancel is
+	// overwritten, which would leak the first). We can't assert on
+	// goroutine count cheaply, but we can assert Stop still returns.
+	h.Stop()
+}

--- a/pkg/cache/in-memory.go
+++ b/pkg/cache/in-memory.go
@@ -104,6 +104,23 @@ func (c *MemoryCache[T]) Get(ctx context.Context, key string) (T, bool) {
 	return item.Value, true
 }
 
+// GetStale returns a cached item even if its TTL has expired but
+// the cleanup goroutine has not yet evicted it. Callers use this as
+// a fallback when the primary data source is unavailable (e.g. DB
+// outage). Returns (zero, false) when the key was never written or
+// has already been evicted by the cleanup goroutine.
+func (c *MemoryCache[T]) GetStale(ctx context.Context, key string) (T, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	item, found := c.items[key]
+	if !found {
+		var zero T
+		return zero, false
+	}
+	return item.Value, true
+}
+
 // Set adds an item to the cache with expiration
 func (c *MemoryCache[T]) Set(ctx context.Context, key string, value T, duration time.Duration) {
 	var expiration int64

--- a/pkg/cache/in-memory_test.go
+++ b/pkg/cache/in-memory_test.go
@@ -180,3 +180,37 @@ func TestMemoryCache_DifferentTypes(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, person, retrievedPerson)
 }
+
+// TestMemoryCache_GetStaleReturnsExpiredValue verifies that GetStale
+// returns a value whose TTL has expired but which the cleanup
+// goroutine has not yet evicted. This is the stale-serve fallback
+// used during DB outages.
+func TestMemoryCache_GetStaleReturnsExpiredValue(t *testing.T) {
+	c := NewMemoryCache[string](WithCleanupInterval[string](1 * time.Hour))
+	defer c.Stop()
+
+	ctx := context.Background()
+	c.Set(ctx, "key", "value", 10*time.Millisecond)
+
+	// Wait long enough for the TTL to expire but not for cleanup.
+	time.Sleep(30 * time.Millisecond)
+
+	// Normal Get treats it as a miss.
+	_, found := c.Get(ctx, "key")
+	assert.False(t, found, "Get should miss an expired item")
+
+	// GetStale returns the value anyway.
+	val, found := c.GetStale(ctx, "key")
+	assert.True(t, found, "GetStale should return the expired item")
+	assert.Equal(t, "value", val)
+}
+
+// TestMemoryCache_GetStaleReturnsFalseForMissing verifies GetStale
+// does not invent values for keys that were never written.
+func TestMemoryCache_GetStaleReturnsFalseForMissing(t *testing.T) {
+	c := NewMemoryCache[string]()
+	defer c.Stop()
+
+	_, found := c.GetStale(context.Background(), "never-written")
+	assert.False(t, found)
+}

--- a/pkg/cache/redis-json.go
+++ b/pkg/cache/redis-json.go
@@ -51,6 +51,20 @@ func (c *RedisJSONCache[T]) Set(ctx context.Context, key string, value T, ttl ti
 	return c.client.Set(ctx, c.cacheKey(key), data, ttl).Err()
 }
 
+// GetStale retrieves the cached value ignoring whether it has
+// technically expired. Redis only returns a value if the key still
+// exists; expired keys are deleted by Redis on read or by the
+// background eviction, so "stale" here means "still present in Redis
+// past the TTL we set". Callers use this as a last-resort fallback
+// when the primary data source (e.g. the DB) is unavailable.
+//
+// Returns (value, true, nil) when the key exists regardless of its
+// remaining TTL, and (zero, false, nil) when Redis does not have the
+// key. Redis errors are returned as-is.
+func (c *RedisJSONCache[T]) GetStale(ctx context.Context, key string) (T, bool, error) {
+	return c.Get(ctx, key)
+}
+
 // Delete removes a cached value.
 func (c *RedisJSONCache[T]) Delete(ctx context.Context, key string) error {
 	return c.client.Del(ctx, c.cacheKey(key)).Err()

--- a/pkg/cache/redis-json_test.go
+++ b/pkg/cache/redis-json_test.go
@@ -49,6 +49,34 @@ func TestRedisJSONCacheDelete(t *testing.T) {
 	require.False(t, ok)
 }
 
+// TestRedisJSONCacheGetStaleReturnsValue verifies GetStale returns
+// a value that is still present in Redis. The fake store does not
+// enforce TTL eviction, so this mirrors the "TTL expired but Redis
+// has not yet evicted" window during a DB outage.
+func TestRedisJSONCacheGetStaleReturnsValue(t *testing.T) {
+	client, _ := newRedisJSONTestClient(t)
+	cache := NewRedisJSONCache[redisJSONTestValue](client, "test:json")
+
+	ctx := context.Background()
+	require.NoError(t, cache.Set(ctx, "stale", redisJSONTestValue{Name: "stale"}, time.Second))
+
+	got, ok, err := cache.GetStale(ctx, "stale")
+	require.NoError(t, err)
+	require.True(t, ok, "GetStale should return a value that Redis still holds")
+	require.Equal(t, "stale", got.Name)
+}
+
+// TestRedisJSONCacheGetStaleMissingKey verifies GetStale returns
+// ok=false for a key that was never written.
+func TestRedisJSONCacheGetStaleMissingKey(t *testing.T) {
+	client, _ := newRedisJSONTestClient(t)
+	cache := NewRedisJSONCache[redisJSONTestValue](client, "test:json")
+
+	_, ok, err := cache.GetStale(context.Background(), "never")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
 func newRedisJSONTestClient(t *testing.T) (*redis.Client, *redisJSONFakeStore) {
 	t.Helper()
 

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -127,6 +127,27 @@ func InitTLSFlags(params *ServiceParameters) []cli.Flag {
 	allFlags = append(allFlags, initS3LoggingFlags(params)...)
 	allFlags = append(allFlags, initKafkaFlags(params)...)
 	allFlags = append(allFlags, initDebugFlags(params, ServiceTLS)...)
+	allFlags = append(allFlags, &cli.BoolFlag{
+		Name:        "db-health-check",
+		Value:       false,
+		Usage:       "Enable a background DB liveness monitor. After --db-health-threshold consecutive ping failures, EnvCache and SettingsCache switch to stale-serve mode (serve cached entries on DB miss, extend TTLs) so osquery nodes keep getting config/logs during a DB outage. Disabled by default.",
+		Sources:     cli.EnvVars("DB_HEALTH_CHECK"),
+		Destination: &params.Service.DBHealthCheck,
+	},
+		&cli.IntFlag{
+			Name:        "db-health-interval",
+			Value:       5,
+			Usage:       "Seconds between DB health pings when --db-health-check is enabled.",
+			Sources:     cli.EnvVars("DB_HEALTH_INTERVAL"),
+			Destination: &params.Service.DBHealthInterval,
+		},
+		&cli.IntFlag{
+			Name:        "db-health-threshold",
+			Value:       3,
+			Usage:       "Consecutive DB ping failures required before EnvCache and SettingsCache enter stale-serve mode.",
+			Sources:     cli.EnvVars("DB_HEALTH_THRESHOLD"),
+			Destination: &params.Service.DBHealthThreshold,
+		})
 	return allFlags
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -140,6 +140,15 @@ type YAMLConfigurationService struct {
 	// Default empty → forwarding headers are ignored and the
 	// connection's RemoteAddr is used.
 	TrustedProxies string `yaml:"trustedProxies"`
+	// DBHealthCheck enables a background DB liveness monitor.
+	// When true, the service pings the DB every DBHealthInterval
+	// seconds and, after DBHealthThreshold consecutive failures,
+	// switches EnvCache and SettingsCache into stale-serve mode
+	// (serve cached entries on DB miss, extend TTLs) so osquery
+	// nodes keep getting config/logs during a DB outage.
+	DBHealthCheck     bool `yaml:"dbHealthCheck"`
+	DBHealthInterval  int  `yaml:"dbHealthInterval"`
+	DBHealthThreshold int  `yaml:"dbHealthThreshold"`
 }
 
 // YAMLConfigurationDB to hold all backend configuration values

--- a/pkg/environments/env-cache.go
+++ b/pkg/environments/env-cache.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	redis "github.com/go-redis/redis/v8"
+	"github.com/jmpsec/osctrl/pkg/backend"
 	"github.com/jmpsec/osctrl/pkg/cache"
 )
 
@@ -25,6 +26,14 @@ const (
 	// PATCHes are picked up immediately; this TTL only bounds the worst
 	// case. 5m keeps DB load low while limiting staleness.
 	envCacheTTL = 5 * time.Minute
+	// envCacheDegradedTTL is the TTL used when the DB health monitor
+	// reports the database as degraded. Extending the TTL during a DB
+	// outage keeps cached envs available longer so the service can
+	// keep serving osquery nodes that already have a cached env row.
+	// Capped at 60m so a long outage does not serve enroll secrets
+	// indefinitely — rotated secrets would still be accepted for up
+	// to this window, which is the documented trade-off.
+	envCacheDegradedTTL = 60 * time.Minute
 )
 
 // EnvCache provides cached access to TLS environments
@@ -42,6 +51,11 @@ type EnvCache struct {
 	// the DB. Set via SetInvalidationCheck for compatibility with
 	// external invalidation signals.
 	invalidationCheck func(ctx context.Context, uuid string) bool
+
+	// dbHealth, when non-nil, gates stale-serve and TTL extension
+	// during DB outages. nil means "no monitor" and the cache behaves
+	// as before: TTL expiry + DB miss returns an error.
+	dbHealth backend.DegradedReader
 }
 
 // NewEnvCache creates a new environment cache
@@ -73,7 +87,23 @@ func (ec *EnvCache) SetInvalidationCheck(fn func(ctx context.Context, uuid strin
 	ec.invalidationCheck = fn
 }
 
-// GetByUUID retrieves an environment by UUID, using cache when available
+// SetDBHealth wires a DB health monitor. When the monitor reports
+// the database as degraded, GetByUUID serves stale cached entries
+// instead of returning an error on a DB miss, and writes during
+// degradation use envCacheDegradedTTL so the cache stays warm longer.
+// Pass nil to disable stale-serve (the default).
+func (ec *EnvCache) SetDBHealth(h backend.DegradedReader) {
+	ec.dbHealth = h
+}
+
+// GetByUUID retrieves an environment by UUID, using cache when available.
+//
+// During a DB outage (when a DB health monitor is wired via SetDBHealth
+// and reports IsDegraded), GetByUUID serves a stale cached entry on a
+// DB miss instead of returning an error. This keeps osquery nodes
+// that already have a cached env row serving requests (config, log,
+// query) for the duration of the outage, bounded by envCacheStaleMaxAge
+// so rotated enroll secrets are not accepted indefinitely.
 func (ec *EnvCache) GetByUUID(ctx context.Context, uuid string) (TLSEnvironment, error) {
 	// Check if a cross-process invalidation signal has been received
 	// (e.g., osctrl-api patched the config and set a Redis key).
@@ -93,9 +123,18 @@ func (ec *EnvCache) GetByUUID(ctx context.Context, uuid string) (TLSEnvironment,
 
 		env, err := ec.envs.GetByUUID(uuid)
 		if err != nil {
+			if ec.dbHealth != nil && ec.dbHealth.IsDegraded() {
+				if stale, found, _ := ec.redisCache.GetStale(ctx, uuid); found {
+					return stale, nil
+				}
+			}
 			return TLSEnvironment{}, err
 		}
-		_ = ec.redisCache.Set(ctx, uuid, env, envCacheTTL)
+		ttl := envCacheTTL
+		if ec.dbHealth != nil && ec.dbHealth.IsDegraded() {
+			ttl = envCacheDegradedTTL
+		}
+		_ = ec.redisCache.Set(ctx, uuid, env, ttl)
 		return env, nil
 	}
 
@@ -107,10 +146,19 @@ func (ec *EnvCache) GetByUUID(ctx context.Context, uuid string) (TLSEnvironment,
 	// Not in cache, fetch from database
 	env, err := ec.envs.GetByUUID(uuid)
 	if err != nil {
+		if ec.dbHealth != nil && ec.dbHealth.IsDegraded() {
+			if stale, found := ec.cache.GetStale(ctx, uuid); found {
+				return stale, nil
+			}
+		}
 		return TLSEnvironment{}, err
 	}
 
-	ec.cache.Set(ctx, uuid, env, envCacheTTL)
+	ttl := envCacheTTL
+	if ec.dbHealth != nil && ec.dbHealth.IsDegraded() {
+		ttl = envCacheDegradedTTL
+	}
+	ec.cache.Set(ctx, uuid, env, ttl)
 
 	return env, nil
 }

--- a/pkg/environments/env_cache_test.go
+++ b/pkg/environments/env_cache_test.go
@@ -1,0 +1,106 @@
+package environments
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDegradedReader is a test-only DegradedReader whose state flips
+// via setDegraded.
+type fakeDegradedReader struct {
+	degraded bool
+}
+
+func (f *fakeDegradedReader) IsDegraded() bool   { return f.degraded }
+func (f *fakeDegradedReader) setDegraded(b bool) { f.degraded = b }
+
+// TestEnvCache_StaleServeOnDegraded verifies that when the DB health
+// monitor reports the database as degraded, GetByUUID serves the
+// stale in-memory cached entry instead of returning an error after
+// the env is deleted from the DB (simulating a DB outage where the
+// row is no longer reachable).
+func TestEnvCache_StaleServeOnDegraded(t *testing.T) {
+	db := setupTestDB(t)
+
+	env := TLSEnvironment{UUID: "uuid-stale", Name: "stale-env", Hostname: "h.example.com"}
+	require.NoError(t, db.Create(&env).Error)
+
+	mgr := CreateEnvironment(db)
+	ec := NewEnvCache(*mgr)
+	defer ec.Close()
+
+	health := &fakeDegradedReader{}
+	ec.SetDBHealth(health)
+
+	ctx := context.Background()
+
+	// Prime the in-memory cache.
+	got, err := ec.GetByUUID(ctx, "uuid-stale")
+	require.NoError(t, err)
+	assert.Equal(t, "stale-env", got.Name)
+
+	// Simulate DB outage: soft-delete the row so GetByUUID's DB
+	// query returns "record not found".
+	require.NoError(t, db.Where("uuid = ?", "uuid-stale").Delete(&TLSEnvironment{}).Error)
+
+	// With degradation OFF, the expired cache entry should NOT be
+	// served — GetByUUID returns the DB error.
+	health.setDegraded(false)
+	// Mark the cache entry as expired without letting the cleanup
+	// goroutine evict it (long cleanup interval in NewEnvCache by
+	// default is envCacheTTL = 5m).
+	ec.cache.Set(ctx, "uuid-stale", env, 5*time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	_, err = ec.GetByUUID(ctx, "uuid-stale")
+	assert.Error(t, err, "without degradation, an expired entry + DB miss should error")
+
+	// Re-prime the cache, then expire it again.
+	ec.cache.Set(ctx, "uuid-stale", env, 5*time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+
+	// With degradation ON, the expired-but-present entry should be
+	// served as stale instead of erroring.
+	health.setDegraded(true)
+	got, err = ec.GetByUUID(ctx, "uuid-stale")
+	assert.NoError(t, err, "degraded mode should serve stale entry without error")
+	assert.Equal(t, "stale-env", got.Name)
+}
+
+// TestEnvCache_NoStaleServeWhenNotDegraded verifies the default
+// behavior is unchanged when no DB health monitor is wired: a DB
+// miss returns an error.
+func TestEnvCache_NoStaleServeWhenNotDegraded(t *testing.T) {
+	db := setupTestDB(t)
+	mgr := CreateEnvironment(db)
+	ec := NewEnvCache(*mgr)
+	defer ec.Close()
+
+	// No SetDBHealth call — dbHealth is nil.
+	_, err := ec.GetByUUID(context.Background(), "never-existed")
+	assert.Error(t, err)
+}
+
+// TestEnvCache_NilDegradedReaderIsNoOp verifies that a nil
+// DegradedReader (the default) keeps GetByUUID on the normal path.
+func TestEnvCache_SetDBHealthNilIsNoOp(t *testing.T) {
+	db := setupTestDB(t)
+	env := TLSEnvironment{UUID: "uuid-nil", Name: "nil-health", Hostname: "h.example.com"}
+	require.NoError(t, db.Create(&env).Error)
+
+	mgr := CreateEnvironment(db)
+	ec := NewEnvCache(*mgr)
+	defer ec.Close()
+
+	ec.SetDBHealth(nil) // no-op
+	got, err := ec.GetByUUID(context.Background(), "uuid-nil")
+	require.NoError(t, err)
+	assert.Equal(t, "nil-health", got.Name)
+}
+
+// Compile-time check that *fakeDegradedReader satisfies the interface.
+var _ backend.DegradedReader = (*fakeDegradedReader)(nil)

--- a/pkg/settings/settings-cache.go
+++ b/pkg/settings/settings-cache.go
@@ -6,10 +6,16 @@ import (
 	"time"
 
 	redis "github.com/go-redis/redis/v8"
+	"github.com/jmpsec/osctrl/pkg/backend"
 	"github.com/jmpsec/osctrl/pkg/cache"
 )
 
 const redisSettingsCacheName = "osctrl:tls:settings"
+
+// settingsCacheDegradedTTL extends the cache TTL during a DB outage
+// so the service keeps serving cached settings to osquery nodes.
+// 60m matches the EnvCache degraded TTL for a consistent outage window.
+const settingsCacheDegradedTTL = 60 * time.Minute
 
 // RedisSettingsCache caches a service/env settings map in Redis.
 type RedisSettingsCache struct {
@@ -18,6 +24,7 @@ type RedisSettingsCache struct {
 	service  string
 	envID    uint
 	ttl      time.Duration
+	dbHealth backend.DegradedReader
 }
 
 // NewRedisSettingsCache creates a Redis-backed cache for settings.GetMap.
@@ -34,6 +41,14 @@ func NewRedisSettingsCache(settings *Settings, client *redis.Client, service str
 	}
 }
 
+// SetDBHealth wires a DB health monitor. When the monitor reports the
+// database as degraded, GetMap serves a stale cached entry on a DB
+// miss instead of returning an error, and writes during degradation
+// use settingsCacheDegradedTTL. Pass nil to disable (the default).
+func (c *RedisSettingsCache) SetDBHealth(h backend.DegradedReader) {
+	c.dbHealth = h
+}
+
 // GetMap returns the cached settings map, refetching from DB on Redis miss/error.
 func (c *RedisSettingsCache) GetMap(ctx context.Context) (MapSettings, error) {
 	key := c.key()
@@ -45,9 +60,18 @@ func (c *RedisSettingsCache) GetMap(ctx context.Context) (MapSettings, error) {
 
 	values, err := c.settings.GetMap(c.service, c.envID)
 	if err != nil {
+		if c.dbHealth != nil && c.dbHealth.IsDegraded() {
+			if stale, found, _ := c.cache.GetStale(ctx, key); found {
+				return stale, nil
+			}
+		}
 		return MapSettings{}, err
 	}
-	_ = c.cache.Set(ctx, key, values, c.ttl)
+	ttl := c.ttl
+	if c.dbHealth != nil && c.dbHealth.IsDegraded() {
+		ttl = settingsCacheDegradedTTL
+	}
+	_ = c.cache.Set(ctx, key, values, ttl)
 	return values, nil
 }
 

--- a/pkg/settings/settings-cache_test.go
+++ b/pkg/settings/settings-cache_test.go
@@ -47,3 +47,19 @@ func TestRedisSettingsCacheRefreshesAfterInvalidation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(10), got[AcceleratedSeconds].Integer)
 }
+
+// TestRedisSettingsCacheSetDBHealthIsNoOp verifies that wiring a
+// nil DegradedReader (the default) does not change GetMap behavior.
+func TestRedisSettingsCacheSetDBHealthIsNoOp(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	conf := &Settings{DB: db}
+	require.NoError(t, conf.NewIntegerValue(config.ServiceTLS, AcceleratedSeconds, 7, NoEnvironmentID))
+
+	client, _ := newSettingsRedisTestClient(t)
+	cache := NewRedisSettingsCache(conf, client, config.ServiceTLS, NoEnvironmentID, time.Minute)
+	cache.SetDBHealth(nil) // no-op
+
+	got, err := cache.GetMap(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(7), got[AcceleratedSeconds].Integer)
+}


### PR DESCRIPTION
## DB health canary + cache stale-serve for osctrl-tls

### Problem
When `osctrl-tls` loses its database connection at runtime, the service stays alive (no fatals) but degrades to 500s on every DB-dependent endpoint — including `EnrollHandler`, `ConfigHandler`, `LogHandler`, and `QueryRead/WriteHandler` — after the ~5-minute `EnvCache` TTL expires. With a large osquery fleet, this means nodes stop getting config, can't re-enroll, and can't report logs for the duration of the outage. The service already survives the outage process-wise; it just stops being useful.

### Changes
Add an opt-in DB health monitor to `osctrl-tls` that detects sustained DB outages and switches `EnvCache` and `SettingsCache` into **stale-serve mode**: cached entries are served past their TTL on a DB miss instead of returning an error, and TTLs on fresh writes are extended so the cache stays warm for the duration of the outage.

**`pkg/backend/health.go`** (new) — `DBHealth` monitor:
- Background goroutine pings the DB via `DBManager.Check()` every `Interval` (default 5s).
- After `FailureThreshold` consecutive failures (default 3, ~15s), `IsDegraded()` flips to `true`; the first success clears it.
- `SetOnChange(func(degraded bool))` fires on transitions — used to flip the Prometheus gauge without `pkg/backend` importing prometheus.
- `nil *DBHealth` is always non-degraded, so unwired callers are unaffected.

**`pkg/cache/redis-json.go` + `in-memory.go`** — `GetStale` method:
- `RedisJSONCache.GetStale` returns a value still present in Redis regardless of TTL (Redis evicts lazily, so "stale" = past TTL but not yet evicted).
- `MemoryCache.GetStale` returns a value whose TTL has expired but which the cleanup goroutine hasn't evicted yet.

**`pkg/environments/env-cache.go`** — stale-serve + TTL extension:
- `SetDBHealth(h)` wires the monitor.
- On a DB miss during degradation, `GetByUUID` falls back to `GetStale` instead of erroring.
- On a DB hit during degradation, writes use `envCacheDegradedTTL` (60m) instead of `envCacheTTL` (5m) so refreshed entries stay warm longer.

**`pkg/settings/settings-cache.go`** — same stale-serve + TTL extension pattern for `RedisSettingsCache.GetMap`.

**`cmd/tls/main.go`** — wiring:
- New `--db-health-check`, `--db-health-interval`, `--db-health-threshold` flags (TLS-only, not shared with API/Admin).
- When enabled, starts the monitor and wires it into `EnvCache` + `RedisSettingsCache`.

**`cmd/tls/handlers/metrics.go`** — `osctrl_tls_db_degraded` gauge (0/1), flipped via the `OnChange` callback so external alerting can fire before the 5m TTL runs out.

**`deploy/config/tls.yml`** — documented the three new fields with the security trade-off note.

**`pkg/config/types.go` + `flags.go`** — added `DBHealthCheck`, `DBHealthInterval`, `DBHealthThreshold` to `YAMLConfigurationService` and registered TLS-only flags.

### Behavior
- **DB healthy (default)**: unchanged. Caches serve the 5m TTL as before; DB misses return errors as before.
- **DB degraded** (≥3 consecutive ping failures): `EnvCache.GetByUUID` and `SettingsCache.GetMap` serve stale cached entries on a DB miss instead of erroring, keeping `/enroll`, `/config`, `/log`, `/distributed` responding for nodes that already have a cached env row. Fresh writes during the outage use a 60m TTL so the cache stays warm.
- **DB recovers**: first successful ping flips the gauge back to 0 and caches resume normal TTLs.
- **Disabled** (`--db-health-check=false`, the default): no monitor goroutine, no stale-serve, behavior identical to today.

### Security trade-off
Serving a stale env row means a rotated enroll secret is rejected for up to the stale window. The degraded TTL is capped at 60m so rotated secrets are not accepted indefinitely. This matches the existing 5m TTL worst-case window that already exists for Redis invalidation failures, just extended for outage scenarios. Documented in `deploy/config/tls.yml`.

### Tests
- `pkg/backend/health_test.go` — threshold/recovery/OnChange/nil-monitor/Start-Stop.
- `pkg/environments/env_cache_test.go` — stale-serve on degraded, no-stale-serve when not degraded, nil health is a no-op.
- `pkg/cache/in-memory_test.go` — `GetStale` returns expired-but-present value; returns false for missing keys.
- `pkg/cache/redis-json_test.go` — `GetStale` returns present value; returns false for missing keys.
- `pkg/settings/settings-cache_test.go` — `SetDBHealth(nil)` is a no-op.

### Validation
- `go test ./...` — all packages pass.
- `go vet ./...` — clean.
- `osctrl-tls config-generate` — emits the new `dbHealthCheck`/`dbHealthInterval`/`dbHealthThreshold` fields.

### Not covered by tests
The `RedisSettingsCache` stale-serve path is not directly tested because the in-process fake Redis store doesn't enforce TTL eviction, making it impossible to simulate "TTL expired but key still present" without a real Redis. The underlying `RedisJSONCache.GetStale` is tested directly, and the settings cache uses the same method.

### Risk Notes
This is an opt-in, additive change behind a default-off flag. The existing 5m TTL behavior is unchanged when the flag is disabled. The stale-serve window only activates on confirmed DB degradation (3 consecutive failures), not on transient blips. Operators enabling this in production should alert on the `osctrl_tls_db_degraded` gauge so they are aware when stale data is being served.