### PR TITLE
Resist backend outage via DB health canary in `osctrl-api`

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -314,6 +314,24 @@ func osctrlAPIService() {
 	envs = environments.CreateEnvironment(db.Conn)
 	envCache := environments.NewRedisEnvCache(*envs, redis.Client)
 	log.Info().Msg("Environment cache wired to Redis")
+	// DB health monitor: when enabled, pings the DB on a fixed
+	// interval and switches EnvCache into stale-serve mode after N
+	// consecutive failures, so the API keeps responding to read-only
+	// env lookups (used by handlers that hit EnvCache) during a DB
+	// outage. Writes still require the DB and will fail. See
+	// pkg/backend/health.go.
+	var dbHealth *backend.DBHealth
+	if flagParams.Service.DBHealthCheck {
+		interval := time.Duration(flagParams.Service.DBHealthInterval) * time.Second
+		threshold := uint32(flagParams.Service.DBHealthThreshold)
+		dbHealth = backend.NewDBHealth(db, interval, threshold)
+		dbHealth.Start()
+		envCache.SetDBHealth(dbHealth)
+		log.Info().
+			Dur("interval", interval).
+			Uint32("threshold", threshold).
+			Msg("DB health monitor enabled — EnvCache will stale-serve on DB outage")
+	}
 	// Security & compliance posture system (disabled by default)
 	var posturemgr *posture.PostureManager
 	if flagParams.Service.PostureEnabled {

--- a/deploy/config/api.yml
+++ b/deploy/config/api.yml
@@ -36,6 +36,23 @@ service:
   # hides posture controls. When true, the API serves posture data
   # from the shared database (collected by osctrl-tls).
   postureEnabled: false
+  # DB health monitor. When enabled, osctrl-api pings the database
+  # every dbHealthInterval seconds. After dbHealthThreshold
+  # consecutive failures, EnvCache switches to stale-serve mode:
+  # cached entries are served on DB miss instead of returning 500,
+  # and TTLs are extended to ~60m so cached envs stay warm for the
+  # duration of the outage. This keeps the API responding to
+  # read-only env lookups (used by handlers that consult EnvCache)
+  # during a DB outage. Write paths still require the DB and will
+  # fail. The stale-serve window is bounded at 60m so rotated
+  # enroll secrets are not accepted indefinitely.
+  # Disabled by default; enable in production where DB blips are
+  # expected and API availability for read paths is prioritized.
+  dbHealthCheck: false
+  # Seconds between DB health pings.
+  dbHealthInterval: 5
+  # Consecutive failures before EnvCache enters stale-serve mode.
+  dbHealthThreshold: 3
 
 # Database configuration
 db:

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -190,6 +190,27 @@ func InitAPIFlags(params *ServiceParameters) []cli.Flag {
 	allFlags = append(allFlags, initOsqueryFlags(params)...)
 	allFlags = append(allFlags, initCarverFlags(params, ServiceAPI)...)
 	allFlags = append(allFlags, initDebugFlags(params, ServiceAPI)...)
+	allFlags = append(allFlags, &cli.BoolFlag{
+		Name:        "db-health-check",
+		Value:       false,
+		Usage:       "Enable a background DB liveness monitor. After --db-health-threshold consecutive ping failures, EnvCache switches to stale-serve mode (serve cached entries on DB miss, extend TTLs) so the API keeps responding to read-only env lookups during a DB outage. Disabled by default.",
+		Sources:     cli.EnvVars("DB_HEALTH_CHECK"),
+		Destination: &params.Service.DBHealthCheck,
+	},
+		&cli.IntFlag{
+			Name:        "db-health-interval",
+			Value:       5,
+			Usage:       "Seconds between DB health pings when --db-health-check is enabled.",
+			Sources:     cli.EnvVars("DB_HEALTH_INTERVAL"),
+			Destination: &params.Service.DBHealthInterval,
+		},
+		&cli.IntFlag{
+			Name:        "db-health-threshold",
+			Value:       3,
+			Usage:       "Consecutive DB ping failures required before EnvCache enters stale-serve mode.",
+			Sources:     cli.EnvVars("DB_HEALTH_THRESHOLD"),
+			Destination: &params.Service.DBHealthThreshold,
+		})
 	return allFlags
 }
 


### PR DESCRIPTION
# osctrl-api: resist backend outage via DB health canary + EnvCache stale-serve

## Problem

`osctrl-api` had no defense against transient backend outages: every request that resolved an environment hit the DB through `EnvCache`, and a DB miss returned 500. A short DB blip would take down read-only API routes (env lookups, platforms, audit, etc.) for the whole fleet.

`osctrl-tls` already solved this in `resistant-backend-outage-tls` (commit `8dafca90`) by adding a `pkg/backend.DBHealth` canary that pings the DB on a fixed interval and, after N consecutive failures, flips `EnvCache`/`SettingsCache` into stale-serve mode (serve cached entries on DB miss, extend TTLs to ~60m).

## Change

Ports the same pattern to `osctrl-api`, reusing the now-shared `pkg/backend.DBHealth` and the `EnvCache.SetDBHealth`/`GetStale` plumbing already merged in the TLS branch.

- **`pkg/config/flags.go`** — Adds `--db-health-check`, `--db-health-interval`, `--db-health-threshold` (and matching `DB_HEALTH_*` env vars) to `InitAPIFlags`. The `YAMLConfigurationService` struct already had the `DBHealth*` fields from the TLS branch, so `types.go` needed no change.
- **`cmd/api/main.go`** — After `NewRedisEnvCache`, conditionally constructs `backend.NewDBHealth(db, interval, threshold)`, starts the monitor, and wires it via `envCache.SetDBHealth(dbHealth)`. On a DB outage, `EnvCache.GetByUUID` now serves the stale cached env row instead of 500, and writes during degradation use `envCacheDegradedTTL` (60m) so the cache stays warm.
- **`deploy/config/api.yml`** — Documents the three new `dbHealth*` keys under `service:` with the same semantics as `tls.yml`.

## Scope and limitations

- **Read-only paths only.** Env CRUD, query runs, carve runs, and other write paths still hit the DB directly and will fail during an outage — by design. The canary protects the env-resolution read path that the API's read handlers depend on.
- **No settings cache.** `osctrl-tls` also wires `RedisSettingsCache.SetDBHealth`; osctrl-api does not currently use `RedisSettingsCache`, so there is no settings-cache half to wire here. Adding one would be a separate change.
- **No Prometheus gauge.** osctrl-api has no metrics surface, so the `SetDBDegraded` callback from the TLS branch is not wired. `IsDegraded()` is still consumed by EnvCache; if a metrics endpoint is added to the API later, the same callback pattern applies.
- **Bounded stale window.** The degraded TTL is capped at 60m so rotated enroll secrets are not accepted indefinitely — the same trade-off documented in the TLS branch.

## Validation

- `go build ./cmd/api/...` — clean
- `go vet ./cmd/api/...` — clean
- `go test ./pkg/backend ./pkg/environments ./pkg/cache ./pkg/config ./pkg/settings` — all pass (covers the `DBHealth` canary, `EnvCache` stale-serve, and `GetStale` cache fallbacks added in the TLS branch)

No new tests were added; the behavioral change in the API is a 7-line wiring block in `cmd/api/main.go` exercising code paths already covered by the TLS branch's tests in `pkg/backend`/`pkg/environments`.