### PR TITLE
`osctrl-tls`: health endpoint reports backend degradation via `HTTP 204`

### DIFF
--- a/cmd/tls/handlers/get.go
+++ b/cmd/tls/handlers/get.go
@@ -12,8 +12,18 @@ func (h *HandlersTLS) RootHandler(w http.ResponseWriter, r *http.Request) {
 	utils.HTTPResponse(w, "", http.StatusOK, []byte("💥"))
 }
 
-// HealthHandler for health requests
+// HealthHandler for health requests. Returns HTTP 200 when the
+// backend is healthy (or no DB health monitor is wired), and HTTP
+// 204 when the DB health monitor reports the backend as degraded.
+// 204 — rather than 503 — is used because the service is still
+// serving osquery nodes from stale-serve caches; the non-200 code
+// lets load balancers / operators distinguish the degraded state
+// without dropping traffic.
 func (h *HandlersTLS) HealthHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DBHealth != nil && h.DBHealth.IsDegraded() {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusOK, []byte("✅"))
 }

--- a/cmd/tls/handlers/get_test.go
+++ b/cmd/tls/handlers/get_test.go
@@ -5,8 +5,17 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/jmpsec/osctrl/pkg/backend"
 	"github.com/stretchr/testify/assert"
 )
+
+type fakeDegradedReader struct {
+	degraded bool
+}
+
+func (f *fakeDegradedReader) IsDegraded() bool { return f.degraded }
+
+var _ backend.DegradedReader = (*fakeDegradedReader)(nil)
 
 func TestRootHandler(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
@@ -21,6 +30,33 @@ func TestRootHandler(t *testing.T) {
 func TestHealthHandler(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/health", nil)
 	h := CreateHandlersTLS()
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(h.HealthHandler)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "✅", rr.Body.String())
+}
+
+// TestHealthHandlerDegraded verifies the health endpoint returns
+// HTTP 204 (and no body) when the DB health monitor reports the
+// backend as degraded.
+func TestHealthHandlerDegraded(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/health", nil)
+	health := &fakeDegradedReader{degraded: true}
+	h := CreateHandlersTLS(WithDBHealth(health))
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(h.HealthHandler)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Empty(t, rr.Body.String())
+}
+
+// TestHealthHandlerDegradedReaderNil verifies that wiring a nil
+// monitor keeps the legacy 200 behavior (defense in depth — main.go
+// already passes nil when the monitor is disabled).
+func TestHealthHandlerDegradedReaderNil(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/health", nil)
+	h := CreateHandlersTLS(WithDBHealth(nil))
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.HealthHandler)
 	handler.ServeHTTP(rr, req)

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/backend"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
@@ -73,6 +74,10 @@ type HandlersTLS struct {
 	DebugHTTP       *zerolog.Logger
 	DebugHTTPConfig *config.YAMLConfigurationDebug
 	AuditLog        *auditlog.AuditLogManager
+	// DBHealth, when wired via WithDBHealth, lets HealthHandler
+	// report backend degradation. nil means "no monitor" and the
+	// health endpoint reports healthy as before.
+	DBHealth backend.DegradedReader
 }
 
 // TLSResponse to be returned to requests
@@ -96,6 +101,15 @@ func WithEnvs(envs *environments.EnvManager) Option {
 func WithEnvCache(ec *environments.EnvCache) Option {
 	return func(h *HandlersTLS) {
 		h.EnvCache = ec
+	}
+}
+
+// WithDBHealth wires a DB health monitor so HealthHandler can report
+// backend degradation (HTTP 204) instead of always reporting 200.
+// Pass nil to keep the legacy "always healthy" behavior.
+func WithDBHealth(hl backend.DegradedReader) Option {
+	return func(h *HandlersTLS) {
+		h.DBHealth = hl
 	}
 }
 

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -334,6 +334,7 @@ func osctrlService() {
 		handlers.WithConfigEndpoints(flagParams.ConfigEndpoints),
 		handlers.WithDebugHTTP(flagParams.Debug),
 		handlers.WithAuditLog(auditLog),
+		handlers.WithDBHealth(dbHealth), // nil when DB health monitor disabled
 	)
 	// ///////////////////////// ALL CONTENT IS UNAUTHENTICATED FOR TLS
 	log.Info().Msg("Initializing router")


### PR DESCRIPTION
# osctrl-tls: health endpoint reports backend degradation via HTTP 204

## Problem

The `/health` endpoint on `osctrl-tls` always returned HTTP 200, even when the DB health monitor (added in `resistant-backend-outage-tls`) had flipped the service into stale-serve mode. Operators and load balancers had no way to distinguish a healthy `osctrl-tls` from one that was serving cached data because the backend was down.

## Change

`HealthHandler` now consults the wired `backend.DegradedReader` and returns **HTTP 204** (no body) when the backend is degraded, instead of always returning 200. When no monitor is wired (or it reports healthy), the legacy 200 + "✅" body is unchanged.

- **`cmd/tls/handlers/get.go`** — `HealthHandler` checks `h.DBHealth.IsDegraded()`; on true it writes 204 and returns, otherwise the previous 200 path runs.
- **`cmd/tls/handlers/handlers.go`** — Added a `DBHealth backend.DegradedReader` field to `HandlersTLS` and a `WithDBHealth` option.
- **`cmd/tls/main.go`** — Wired `handlers.WithDBHealth(dbHealth)` at handler construction. `dbHealth` is `nil` when `--db-health-check` is disabled, so the field's nil check preserves the legacy behavior automatically.
- **`cmd/tls/handlers/get_test.go`** — Added `TestHealthHandlerDegraded` (asserts 204 + empty body) and `TestHealthHandlerDegradedReaderNil` (asserts the nil-monitor path still returns 200 + "✅").

## Why 204 and not 503

The service is still serving osquery nodes from stale-serve caches — that is the whole point of the canary added in the TLS branch. Returning 503 would make load balancers drop traffic to a service that is intentionally still handling requests, defeating the outage resistance. 204 signals "degraded but alive" so operators/LBs can distinguish the state without failing the health check.

## Validation

- `go build ./cmd/tls/...` — clean
- `go vet ./cmd/tls/... ./cmd/api/...` — clean
- `go test ./cmd/tls/handlers/` — passes, including the two new tests