### PR TITLE
`osctrl-api`: health endpoint reports backend degradation via `HTTP 204`

### DIFF
--- a/cmd/api/handlers/get.go
+++ b/cmd/api/handlers/get.go
@@ -14,6 +14,7 @@ import (
 // @Tags system
 // @Produce json
 // @Success 200 {string} string
+// @Success 204 {string} string "Degraded — backend unreachable, serving from cache"
 // @Failure 400 {object} types.ApiErrorResponse "Bad request"
 // @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
 // @Failure 403 {object} types.ApiErrorResponse "Forbidden"
@@ -27,6 +28,15 @@ func (h *HandlersApi) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	// Debug HTTP if enabled
 	if h.DebugHTTPConfig.EnableHTTP {
 		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	// Report degraded backend as 204. The API is still serving
+	// read paths from stale-serve caches; 204 — rather than 503 —
+	// lets LBs/operators distinguish the degraded state without
+	// dropping traffic that the service is intentionally still
+	// handling.
+	if h.DBHealth != nil && h.DBHealth.IsDegraded() {
+		w.WriteHeader(http.StatusNoContent)
+		return
 	}
 	// Send response
 	utils.HTTPResponse(w, "", http.StatusOK, []byte(okContent))

--- a/cmd/api/handlers/get_test.go
+++ b/cmd/api/handlers/get_test.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/backend"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeDegradedReader struct {
+	degraded bool
+}
+
+func (f *fakeDegradedReader) IsDegraded() bool { return f.degraded }
+
+var _ backend.DegradedReader = (*fakeDegradedReader)(nil)
+
+// newHealthTestHandler builds a HandlersApi with the debug-HTTP
+// config initialized (the health handler dereferences it for the
+// debug dump even when debugging is disabled).
+func newHealthTestHandler(opts ...HandlersOption) *HandlersApi {
+	opts = append([]HandlersOption{WithDebugHTTP(&config.YAMLConfigurationDebug{})}, opts...)
+	return CreateHandlersApi(opts...)
+}
+
+// TestHealthHandler_200 verifies the health endpoint returns
+// HTTP 200 with the OK body when no DB health monitor is wired
+// (the default).
+func TestHealthHandler_200(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/health", nil)
+	h := newHealthTestHandler()
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(h.HealthHandler).ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, okContent, rr.Body.String())
+}
+
+// TestHealthHandler_DegradedReturns204 verifies the health
+// endpoint returns HTTP 204 (and no body) when the DB health
+// monitor reports the backend as degraded.
+func TestHealthHandler_DegradedReturns204(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/health", nil)
+	health := &fakeDegradedReader{degraded: true}
+	h := newHealthTestHandler(WithDBHealth(health))
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(h.HealthHandler).ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Empty(t, rr.Body.String())
+}
+
+// TestHealthHandler_DegradedReaderNilKeeps200 verifies that wiring
+// a nil monitor keeps the legacy 200 behavior (defense in depth —
+// main.go already passes nil when the monitor is disabled).
+func TestHealthHandler_DegradedReaderNilKeeps200(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/health", nil)
+	h := newHealthTestHandler(WithDBHealth(nil))
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(h.HealthHandler).ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, okContent, rr.Body.String())
+}
+
+// TestHealthHandler_RecoveredReturns200 verifies that when the
+// monitor reports the backend recovered, the health endpoint
+// returns 200 again.
+func TestHealthHandler_RecoveredReturns200(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/health", nil)
+	health := &fakeDegradedReader{degraded: false}
+	h := newHealthTestHandler(WithDBHealth(health))
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(h.HealthHandler).ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, okContent, rr.Body.String())
+}

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/backend"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
@@ -67,6 +68,10 @@ type HandlersApi struct {
 	// simultaneously — the SPA renders one button per advertised
 	// method.
 	SAMLEnabled bool
+	// DBHealth, when wired via WithDBHealth, lets HealthHandler
+	// report backend degradation. nil means "no monitor" and the
+	// health endpoint reports healthy as before.
+	DBHealth backend.DegradedReader
 }
 
 type HandlersOption func(*HandlersApi)
@@ -240,6 +245,15 @@ func WithOIDC(enabled bool) HandlersOption {
 func WithSAML(enabled bool) HandlersOption {
 	return func(h *HandlersApi) {
 		h.SAMLEnabled = enabled
+	}
+}
+
+// WithDBHealth wires a DB health monitor so HealthHandler can
+// report backend degradation (HTTP 204) instead of always reporting
+// 200. Pass nil to keep the legacy "always healthy" behavior.
+func WithDBHealth(hl backend.DegradedReader) HandlersOption {
+	return func(h *HandlersApi) {
+		h.DBHealth = hl
 	}
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -427,6 +427,7 @@ func osctrlAPIService() {
 		handlers.WithJWTSecret([]byte(flagParams.JWT.JWTSecret)),
 		handlers.WithOIDC(flagParams.OIDC != nil && flagParams.OIDC.Enabled),
 		handlers.WithSAML(flagParams.SAML != nil && flagParams.SAML.Enabled),
+		handlers.WithDBHealth(dbHealth), // nil when DB health monitor disabled
 	)
 
 	// ///////////////////////// API


### PR DESCRIPTION
# osctrl-api: health endpoint reports backend degradation via HTTP 204

## Problem

The `/health` endpoint on `osctrl-api` always returned HTTP 200, even when the DB health monitor (wired in the preceding API outage-resistance change) had flipped `EnvCache` into stale-serve mode. Operators and load balancers had no way to distinguish a healthy `osctrl-api` from one that was serving cached data because the backend was down.

## Change

`HealthHandler` now consults the wired `backend.DegradedReader` and returns **HTTP 204** (no body) when the backend is degraded, instead of always returning 200. When no monitor is wired (or it reports healthy), the legacy 200 + "✅" body is unchanged. Mirrors the equivalent change already applied to `osctrl-tls`.

- **`cmd/api/handlers/get.go`** — `HealthHandler` checks `h.DBHealth.IsDegraded()`; on true it writes 204 and returns, otherwise the previous 200 path runs. The OpenAPI annotation is updated to advertise the new 204 success code.
- **`cmd/api/handlers/handlers.go`** — Added a `DBHealth backend.DegradedReader` field to `HandlersApi` and a `WithDBHealth` option.
- **`cmd/api/main.go`** — Wired `handlers.WithDBHealth(dbHealth)` at handler construction. `dbHealth` is `nil` when `--db-health-check` is disabled, so the field's nil check preserves the legacy behavior automatically.
- **`cmd/api/handlers/get_test.go`** (new) — Added `TestHealthHandler_200` (no monitor → 200), `TestHealthHandler_DegradedReturns204` (degraded → 204 + empty body), `TestHealthHandler_DegradedReaderNilKeeps200` (nil monitor → 200, defense in depth), and `TestHealthHandler_RecoveredReturns200` (monitor reports healthy → 200). A `newHealthTestHandler` helper initializes the `DebugHTTPConfig` the handler dereferences.

## Why 204 and not 503

The service is still serving read paths from stale-serve caches — that is the whole point of the canary wired in the API outage-resistance change. Returning 503 would make load balancers drop traffic to a service that is intentionally still handling requests, defeating the outage resistance. 204 signals "degraded but alive" so operators/LBs can distinguish the state without failing the health check. Same rationale as the `osctrl-tls` health change.

## Validation

- `go build ./cmd/api/...` — clean
- `go vet ./cmd/api/...` — clean
- `go test ./cmd/api/... ./cmd/tls/...` — all pass, including the four new tests in `cmd/api/handlers/get_test.go`