### PR TITLE
Accelerated-mode priming for console and file explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Ultimately the script can also be used to deploy **osctrl** in production system
 
 ### 🏗 Building from source
 
-To build **osctrl** from source, ensure you have [Go](https://golang.org/dl/) installed (version 1.26.5 or higher is recommended). Then, clone the repository and run the following commands:
+To build **osctrl** from source, ensure you have [Go](https://golang.org/dl/) installed (version 1.26.5 is recommended). Then, clone the repository and run the following commands:
 
 ```bash
 git clone https://github.com/jmpsec/osctrl.git

--- a/cmd/api/handlers/console.go
+++ b/cmd/api/handlers/console.go
@@ -45,6 +45,12 @@ type consoleSessionResponse struct {
 	Session  console.Session        `json:"session"`
 	History  []console.HistoryEntry `json:"history"`
 	NodeInfo consoleNodeInfo        `json:"node_info"`
+	// Priming is the priming metadata command dispatched at session
+	// creation. The frontend polls the existing command show/results
+	// endpoints with this command id to render live osquery_info metadata.
+	// It may be nil if priming submission failed (the session is still
+	// usable; acceleration just won't be pre-warmed).
+	Priming *console.Command `json:"priming,omitempty"`
 }
 
 const defaultConsoleQueryReadSeconds = 5
@@ -78,11 +84,21 @@ func (h *HandlersApi) ConsoleSessionCreateHandler(w http.ResponseWriter, r *http
 		apiErrorResponse(w, "error creating console session", http.StatusInternalServerError, err)
 		return
 	}
+	// Dispatch a priming metadata query so the node's next QueryRead
+	// returns an accelerated interval (fast polling) before the operator
+	// types their first command, and live osquery_info metadata can be
+	// surfaced in the console header. A priming failure is non-fatal:
+	// the session is still usable, acceleration just won't be pre-warmed.
+	var priming *console.Command
+	if primingCmd, primingErr := h.Console.SubmitPrimingCommand(session.ID, h.consolePrimingTimeout()); primingErr == nil {
+		priming = &primingCmd
+	}
 	h.auditConsoleVisit(ctx[ctxUser], r, env.ID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, consoleSessionResponse{
 		Session:  session,
 		History:  history,
 		NodeInfo: consoleNodeInfoFromNode(node),
+		Priming:  priming,
 	})
 }
 
@@ -228,6 +244,25 @@ func (h *HandlersApi) consoleCommandTimeout(parsed console.ParsedCommand) time.D
 		return timeout
 	}
 	return time.Duration(seconds*2) * time.Second
+}
+
+// consolePrimingTimeout is the expiration given to the priming metadata
+// query. It is intentionally generous (the accelerated interval doubled
+// plus a minute floor) so the priming query stays pending long enough for
+// the next accelerated QueryRead to deliver it even if the node's first
+// poll after session open arrives a few seconds late.
+func (h *HandlersApi) consolePrimingTimeout() time.Duration {
+	seconds := int64(defaultConsoleQueryReadSeconds)
+	if h.Settings != nil {
+		if configured, err := h.Settings.GetInteger(config.ServiceTLS, settings.AcceleratedSeconds, settings.NoEnvironmentID); err == nil && configured > 0 {
+			seconds = configured
+		}
+	}
+	timeout := time.Duration(seconds*2) * time.Second
+	if timeout < time.Minute {
+		return time.Minute
+	}
+	return timeout
 }
 
 func osqueryTableSupportsPlatform(table types.OsqueryTable, platform string) bool {

--- a/cmd/api/handlers/console_test.go
+++ b/cmd/api/handlers/console_test.go
@@ -89,6 +89,29 @@ func TestConsoleSessionCreateReturnsHistory(t *testing.T) {
 	require.Equal(t, "pwd", resp.History[0].Command.Input)
 }
 
+func TestConsoleSessionCreateDispatchesPrimingCommand(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	req := consoleRequest(http.MethodPost, "/console", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("uuid", node.UUID)
+	rr := httptest.NewRecorder()
+
+	h.ConsoleSessionCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp consoleSessionResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Priming)
+	require.True(t, resp.Priming.Priming)
+	require.Equal(t, console.StatusQueued, resp.Priming.Status)
+	require.NotEmpty(t, resp.Priming.DistributedQueryName)
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", resp.Priming.DistributedQueryName).First(&distributed).Error)
+	require.Equal(t, queries.ConsoleQueryType, distributed.Type)
+	require.True(t, distributed.Hidden)
+}
+
 func TestConsoleSessionCreateReturnsNodeInfo(t *testing.T) {
 	db, h, env, node := setupConsoleHandlers(t)
 	require.NoError(t, db.Model(&node).Updates(map[string]any{

--- a/cmd/api/handlers/file_explorer.go
+++ b/cmd/api/handlers/file_explorer.go
@@ -24,6 +24,12 @@ type fileExplorerPathRequest struct {
 type fileExplorerSessionResponse struct {
 	Session  fileexplorer.Session `json:"session"`
 	NodeInfo consoleNodeInfo      `json:"node_info"`
+	// Priming is the priming metadata request dispatched at session
+	// creation. The frontend polls the new priming results endpoint with
+	// this request id to render live osquery_info metadata, and its
+	// presence in the node's pending queue warms acceleration. May be nil
+	// if priming submission failed.
+	Priming *fileexplorer.Request `json:"priming,omitempty"`
 }
 
 func (h *HandlersApi) FileExplorerSessionCreateHandler(w http.ResponseWriter, r *http.Request) {
@@ -50,10 +56,19 @@ func (h *HandlersApi) FileExplorerSessionCreateHandler(w http.ResponseWriter, r 
 		apiErrorResponse(w, "error creating file explorer session", http.StatusInternalServerError, err)
 		return
 	}
+	// Dispatch a priming metadata query so the node's next QueryRead
+	// returns an accelerated interval (fast polling) before the operator
+	// expands the first directory, and live osquery_info metadata can be
+	// surfaced in the file explorer header. Non-fatal on failure.
+	var priming *fileexplorer.Request
+	if primingReq, primingErr := h.FileExplorer.SubmitPrimingRequest(session.ID, h.fileExplorerRequestTimeout()); primingErr == nil {
+		priming = &primingReq
+	}
 	h.auditFileExplorerAction(ctx[ctxUser], "file explorer session", r, env.ID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, fileExplorerSessionResponse{
 		Session:  session,
 		NodeInfo: consoleNodeInfoFromNode(node),
+		Priming:  priming,
 	})
 }
 
@@ -161,6 +176,33 @@ func (h *HandlersApi) FileExplorerRequestResultsHandler(w http.ResponseWriter, r
 		return
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, results)
+}
+
+// FileExplorerPrimingResultsHandler returns the raw osquery_info rows
+// for the session's priming metadata request. Unlike the list/stat
+// results endpoint (which decodes file columns into Entry structs), this
+// returns the generic row maps so the frontend can render osquery_info
+// columns directly.
+func (h *HandlersApi) FileExplorerPrimingResultsHandler(w http.ResponseWriter, r *http.Request) {
+	_, _, session, ok := h.fileExplorerSessionContext(w, r)
+	if !ok {
+		return
+	}
+	requestID, ok := consolePathUint(w, r, "request_id")
+	if !ok {
+		return
+	}
+	request, err := h.FileExplorer.GetRequest(session.ID, requestID)
+	if err != nil {
+		consoleNotFoundOrError(w, "request not found", "error getting file explorer request", err)
+		return
+	}
+	rows, err := h.FileExplorer.RequestMetadataRows(request.ID)
+	if err != nil {
+		apiErrorResponse(w, "error getting file explorer metadata", http.StatusInternalServerError, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, rows)
 }
 
 func (h *HandlersApi) fileExplorerEnvContext(w http.ResponseWriter, r *http.Request) (environments.TLSEnvironment, ContextValue, bool) {

--- a/cmd/api/handlers/file_explorer_test.go
+++ b/cmd/api/handlers/file_explorer_test.go
@@ -84,6 +84,69 @@ func TestFileExplorerSessionCreateReturnsSession(t *testing.T) {
 	require.Equal(t, "/", resp.Session.Root)
 }
 
+func TestFileExplorerSessionCreateDispatchesPrimingRequest(t *testing.T) {
+	db, h, env, node := setupFileExplorerHandlers(t)
+	req := fileExplorerRequest(http.MethodPost, "/file-explorer", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("uuid", node.UUID)
+	rr := httptest.NewRecorder()
+
+	h.FileExplorerSessionCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var resp fileExplorerSessionResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Priming)
+	require.True(t, resp.Priming.Priming)
+	require.Equal(t, fileexplorer.ActionPriming, resp.Priming.Action)
+	require.NotEmpty(t, resp.Priming.DistributedQueryName)
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", resp.Priming.DistributedQueryName).First(&distributed).Error)
+	require.Equal(t, queries.FileExplorerQueryType, distributed.Type)
+	require.True(t, distributed.Hidden)
+}
+
+func TestFileExplorerPrimingResultsReturnsOsqueryInfoRows(t *testing.T) {
+	db, h, env, node := setupFileExplorerHandlers(t)
+	session, err := h.FileExplorer.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	priming, err := h.FileExplorer.SubmitPrimingRequest(session.ID, time.Second)
+	require.NoError(t, err)
+
+	result, err := json.Marshal([]map[string]string{{"version": "5.13.1", "build_platform": "linux"}})
+	require.NoError(t, err)
+	wrapped, err := json.Marshal(types.QueryWriteData{
+		Name:   priming.DistributedQueryName,
+		Result: result,
+		Status: 0,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{
+		UUID:        node.UUID,
+		Environment: env.UUID,
+		Name:        priming.DistributedQueryName,
+		Data:        string(wrapped),
+		Status:      0,
+	}).Error)
+	require.NoError(t, markFileExplorerHandlerNodeQueryStatus(db, priming.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+
+	req := fileExplorerRequest(http.MethodGet, "/file-explorer/metadata", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("session_id", fmt.Sprint(session.ID))
+	req.SetPathValue("request_id", fmt.Sprint(priming.ID))
+	rr := httptest.NewRecorder()
+
+	h.FileExplorerPrimingResultsHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	require.Equal(t, "5.13.1", rows[0]["version"])
+	require.Equal(t, "linux", rows[0]["build_platform"])
+}
+
 func TestFileExplorerSessionCreateRejectsUserWithoutAdminPermission(t *testing.T) {
 	_, h, env, node := setupFileExplorerHandlers(t)
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -669,6 +669,9 @@ func osctrlAPIService() {
 			muxAPI.Handle(
 				"GET "+_apiPath(apiFileExplorerPath)+"/{env}/sessions/{session_id}/requests/{request_id}/results",
 				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerRequestResultsHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+			muxAPI.Handle(
+				"GET "+_apiPath(apiFileExplorerPath)+"/{env}/sessions/{session_id}/requests/{request_id}/metadata",
+				handlerAuthCheck(http.HandlerFunc(handlersApi.FileExplorerPrimingResultsHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		}
 		// API: saved queries (Track 4)
 		muxAPI.Handle(

--- a/frontend/src/api/file-explorer.ts
+++ b/frontend/src/api/file-explorer.ts
@@ -1,6 +1,7 @@
 import { apiFetch } from './client';
 import type {
   FileExplorerEntry,
+  FileExplorerMetadataRow,
   FileExplorerRequest,
   FileExplorerSession,
   FileExplorerSessionResponse,
@@ -59,6 +60,20 @@ export function getFileExplorerRequestResults(
 ): Promise<FileExplorerEntry[]> {
   return apiFetch<FileExplorerEntry[]>(
     `/api/v1/file-explorer/${encodeURIComponent(env)}/sessions/${sessionId}/requests/${requestId}/results`,
+  );
+}
+
+/** Raw osquery_info row returned by the priming metadata request.
+ *  Re-exported from ./types for callers that import from this module. */
+export type { FileExplorerMetadataRow } from './types';
+
+export function getFileExplorerPrimingMetadata(
+  env: string,
+  sessionId: number,
+  requestId: number,
+): Promise<FileExplorerMetadataRow[]> {
+  return apiFetch<FileExplorerMetadataRow[]>(
+    `/api/v1/file-explorer/${encodeURIComponent(env)}/sessions/${sessionId}/requests/${requestId}/metadata`,
   );
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -283,6 +283,7 @@ export interface ConsoleCommand {
   distributed_query_name?: string;
   status: ConsoleCommandStatus;
   error?: string;
+  priming?: boolean;
   delivered_at?: string;
   completed_at?: string;
   expired_at?: string;
@@ -309,6 +310,9 @@ export interface ConsoleSessionResponse {
   session: ConsoleSession;
   history: ConsoleHistoryEntry[];
   node_info?: ConsoleNodeInfo;
+  /** Priming metadata command dispatched at session open; poll its
+   *  command show/results endpoints to render live osquery_info. */
+  priming?: ConsoleCommand;
 }
 
 // ---------------------------------------------------------------------------
@@ -316,7 +320,7 @@ export interface ConsoleSessionResponse {
 // ---------------------------------------------------------------------------
 
 export type FileExplorerRequestStatus = 'queued' | 'completed' | 'error' | 'expired';
-export type FileExplorerAction = 'list' | 'stat';
+export type FileExplorerAction = 'list' | 'stat' | 'priming';
 
 export interface FileExplorerSession {
   id: number;
@@ -343,6 +347,7 @@ export interface FileExplorerRequest {
   distributed_query_name?: string;
   status: FileExplorerRequestStatus;
   error?: string;
+  priming?: boolean;
   completed_at?: string;
   expired_at?: string;
 }
@@ -364,7 +369,13 @@ export interface FileExplorerEntry {
 export interface FileExplorerSessionResponse {
   session: FileExplorerSession;
   node_info?: ConsoleNodeInfo;
+  /** Priming metadata request dispatched at session open; poll its
+   *  request show/metadata endpoints to render live osquery_info. */
+  priming?: FileExplorerRequest;
 }
+
+/** Raw osquery_info row returned by the priming metadata request. */
+export type FileExplorerMetadataRow = Record<string, unknown>;
 
 // ---------------------------------------------------------------------------
 // Saved queries

--- a/frontend/src/features/nodes/NodeConsolePage.tsx
+++ b/frontend/src/features/nodes/NodeConsolePage.tsx
@@ -31,6 +31,7 @@ type NodeInfoItem = { label: string; value: string };
 const terminalStatuses = new Set(['completed', 'error', 'expired']);
 const consoleHeartbeatMs = 10000;
 type PendingCommand = { command: ConsoleCommand; path?: string };
+type PrimingMetadata = Record<string, unknown>;
 
 export function NodeConsolePage() {
   const { env, uuid } = useParams({ from: '/_app/env/$env/nodes/$uuid/console' });
@@ -47,6 +48,8 @@ export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
   const focusAfterCommandRef = useRef(false);
   const [session, setSession] = useState<ConsoleSession | null>(null);
   const [nodeInfo, setNodeInfo] = useState<ConsoleNodeInfo | null>(null);
+  const [primingCommand, setPrimingCommand] = useState<ConsoleCommand | null>(null);
+  const [primingMetadata, setPrimingMetadata] = useState<PrimingMetadata | null>(null);
   const [entries, setEntries] = useState<Entry[]>([]);
   const [input, setInput] = useState('');
   const [pending, setPending] = useState<PendingCommand | null>(null);
@@ -64,6 +67,7 @@ export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
         setSession(created.session);
         setNodeInfo(created.node_info ?? null);
         setEntries(historyToEntries(created.history));
+        setPrimingCommand(created.priming ?? null);
       })
       .catch((error: unknown) => {
         if (!alive) return;
@@ -102,6 +106,43 @@ export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
     }, consoleHeartbeatMs);
     return () => window.clearInterval(interval);
   }, [env, navigate, sessionID]);
+
+  // Poll the priming metadata command until it reaches a terminal
+  // status, then fetch its osquery_info results and surface them as
+  // live node metadata in the console header. This is what makes the
+  // console "already responsive" on first open: the priming query both
+  // warms acceleration (so the node polls fast) and gives us fresh
+  // osquery version / build / start_time values.
+  const primingCommandId = primingCommand?.id;
+  const primingQuery = useQuery({
+    queryKey: ['console-priming', env, session?.id, primingCommandId],
+    queryFn: () => getConsoleCommand(env, session!.id, primingCommand!.id),
+    enabled: Boolean(session && primingCommand),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && terminalStatuses.has(status) ? false : 1000;
+    },
+    refetchIntervalInBackground: false,
+  });
+
+  useEffect(() => {
+    const command = primingQuery.data;
+    if (!session || !primingCommand || !command || !terminalStatuses.has(command.status)) return;
+    if (command.id !== primingCommand.id) return;
+    if (primingMetadata !== null) return;
+    if (command.status !== 'completed') {
+      setPrimingCommand(null);
+      return;
+    }
+    void getConsoleCommandResults(env, session.id, command.id)
+      .then((rows) => {
+        if (rows.length > 0) {
+          setPrimingMetadata(rows[0] as PrimingMetadata);
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => setPrimingCommand(null));
+  }, [primingQuery.data, env, primingCommand, primingMetadata, session]);
 
   const submitMutation = useMutation({
     mutationFn: async (value: string) => {
@@ -222,7 +263,10 @@ export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
 
   const disabled = !session || Boolean(pending) || submitMutation.isPending;
   const prompt = useMemo(() => (osqueryMode ? 'osquery>' : `${session?.cwd ?? '/'} $`), [osqueryMode, session?.cwd]);
-  const nodeInfoItems = useMemo(() => formatNodeInfoItems(nodeInfo), [nodeInfo]);
+  const nodeInfoItems = useMemo(
+    () => formatNodeInfoItems(nodeInfo, primingMetadata),
+    [nodeInfo, primingMetadata],
+  );
 
   function focusCommandInput() {
     if (disabled) return;
@@ -255,6 +299,15 @@ export function NodeConsolePanel({ env, uuid }: { env: string; uuid: string }) {
               <h1 className="text-base font-semibold leading-5 text-[color:var(--text-1)]">Console</h1>
               <p className="mt-0.5 truncate font-mono-tabular text-xs text-[color:var(--text-3)]">{uuid}</p>
             </div>
+            {primingCommand && (
+              <span
+                className="inline-flex shrink-0 items-center gap-1 rounded border border-[color:var(--border)] bg-[color:var(--bg-2)] px-2 py-1 text-[10px] leading-none text-[color:var(--text-3)]"
+                title="Warming accelerated query polling"
+              >
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                accelerating
+              </span>
+            )}
           </div>
           {nodeInfoItems.length > 0 && (
             <div className="flex flex-wrap gap-1.5">
@@ -365,15 +418,55 @@ function historyToEntries(history: ConsoleHistoryEntry[]): Entry[] {
   return entries;
 }
 
-function formatNodeInfoItems(info: ConsoleNodeInfo | null): NodeInfoItem[] {
-  if (!info) return [];
+function formatNodeInfoItems(info: ConsoleNodeInfo | null, metadata?: PrimingMetadata | null): NodeInfoItem[] {
   const items: NodeInfoItem[] = [];
-  if (info.ip_address) items.push({ label: 'ip', value: info.ip_address });
-  if (info.osquery_user) items.push({ label: 'user', value: info.osquery_user });
-  if (info.osquery_version) items.push({ label: 'osquery', value: info.osquery_version });
-  const platform = [info.platform, info.platform_version].filter(Boolean).join(' ');
-  if (platform) items.push({ label: 'platform', value: platform });
+  const liveVersion = typeof metadata?.version === 'string' ? (metadata.version as string) : '';
+  const liveBuild = typeof metadata?.build_platform === 'string' ? (metadata.build_platform as string) : '';
+  const liveDistro = typeof metadata?.build_distro === 'string' ? (metadata.build_distro as string) : '';
+  const liveStartTime = metadata?.start_time != null ? String(metadata.start_time) : '';
+  const liveConfigValid = typeof metadata?.config_valid === 'string' ? (metadata.config_valid as string) : '';
+
+  if (info) {
+    if (info.ip_address) items.push({ label: 'ip', value: info.ip_address });
+    if (info.osquery_user) items.push({ label: 'user', value: info.osquery_user });
+  }
+  // Prefer live osquery version from the priming query over the
+  // last-seen DB snapshot; fall back to the snapshot if priming
+  // hasn't completed yet.
+  if (liveVersion) items.push({ label: 'osquery', value: liveVersion });
+  else if (info?.osquery_version) items.push({ label: 'osquery', value: info.osquery_version });
+
+  if (liveBuild) {
+    const build = [liveBuild, liveDistro].filter(Boolean).join(' ');
+    items.push({ label: 'build', value: build });
+  }
+  if (liveStartTime) {
+    const secs = Number(liveStartTime);
+    if (!Number.isNaN(secs) && secs > 0) {
+      const started = new Date(secs * 1000);
+      const uptimeMs = Date.now() - started.getTime();
+      if (uptimeMs > 0) {
+        items.push({ label: 'uptime', value: formatUptime(uptimeMs) });
+      }
+    }
+  }
+  if (liveConfigValid) items.push({ label: 'config', value: liveConfigValid });
+
+  if (info) {
+    const platform = [info.platform, info.platform_version].filter(Boolean).join(' ');
+    if (platform) items.push({ label: 'platform', value: platform });
+  }
   return items;
+}
+
+function formatUptime(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
 }
 
 function Line({ text, tone }: { text: string; tone?: 'error' | 'muted' }) {

--- a/frontend/src/features/nodes/NodeFileExplorerTab.tsx
+++ b/frontend/src/features/nodes/NodeFileExplorerTab.tsx
@@ -6,13 +6,19 @@ import { AuthError } from '$/api/client';
 import {
   closeFileExplorerSession,
   createFileExplorerSession,
+  getFileExplorerPrimingMetadata,
   getFileExplorerRequest,
   getFileExplorerRequestResults,
   getFileExplorerSession,
   listFileExplorerDirectory,
   statFileExplorerPath,
 } from '$/api/file-explorer';
-import type { FileExplorerEntry, FileExplorerRequest, FileExplorerSession } from '$/api/types';
+import type {
+  FileExplorerEntry,
+  FileExplorerMetadataRow,
+  FileExplorerRequest,
+  FileExplorerSession,
+} from '$/api/types';
 import { cn } from '$/lib/cn';
 
 type EntriesByDirectory = Record<string, FileExplorerEntry[]>;
@@ -28,6 +34,8 @@ export function NodeFileExplorerTab({ env, uuid }: { env: string; uuid: string }
   const sessionRef = useRef<FileExplorerSession | null>(null);
   const loadingPathsRef = useRef<Set<string>>(new Set());
   const [session, setSession] = useState<FileExplorerSession | null>(null);
+  const [primingRequest, setPrimingRequest] = useState<FileExplorerRequest | null>(null);
+  const [primingMetadata, setPrimingMetadata] = useState<FileExplorerMetadataRow | null>(null);
   const [entriesByDirectory, setEntriesByDirectory] = useState<EntriesByDirectory>({});
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
@@ -91,6 +99,7 @@ export function NodeFileExplorerTab({ env, uuid }: { env: string; uuid: string }
         sessionRef.current = created.session;
         setSession(created.session);
         setExpanded(new Set([created.session.root]));
+        setPrimingRequest(created.priming ?? null);
         void loadDirectory(created.session, created.session.root);
       })
       .catch((createError: unknown) => {
@@ -105,6 +114,36 @@ export function NodeFileExplorerTab({ env, uuid }: { env: string; uuid: string }
       }
     };
   }, [env, loadDirectory, uuid]);
+
+  // Poll the priming metadata request until it reaches a terminal
+  // status, then fetch its osquery_info rows and surface live metadata
+  // in the file explorer header. The priming query's presence in the
+  // node's pending queue also warms acceleration so the first directory
+  // listing is delivered on the next fast poll.
+  useEffect(() => {
+    const activeSession = sessionRef.current;
+    if (!activeSession || !primingRequest) return;
+    let alive = true;
+    void (async () => {
+      try {
+        const completed = await waitForRequest(env, activeSession.id, primingRequest.id);
+        if (!alive || completed.status !== 'completed') {
+          if (alive) setPrimingRequest(null);
+          return;
+        }
+        const rows = await getFileExplorerPrimingMetadata(env, activeSession.id, primingRequest.id);
+        if (!alive) return;
+        if (rows.length > 0) setPrimingMetadata(rows[0] as FileExplorerMetadataRow);
+      } catch {
+        // Priming is best-effort; ignore errors.
+      } finally {
+        if (alive) setPrimingRequest(null);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [env, primingRequest]);
 
   useEffect(() => {
     const sessionID = session?.id;
@@ -170,12 +209,38 @@ export function NodeFileExplorerTab({ env, uuid }: { env: string; uuid: string }
     }
   }
 
+  const primingItems = useMemo(() => formatPrimingItems(primingMetadata), [primingMetadata]);
+
   return (
     <section className="min-h-[360px] border border-[color:var(--border)] rounded-lg bg-[color:var(--bg-1)]">
       <div className="flex items-center justify-between gap-3 border-b border-[color:var(--border)] px-3 py-2">
         <div className="min-w-0">
-          <h2 className="text-sm font-semibold text-[color:var(--text-1)]">File Explorer</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-[color:var(--text-1)]">File Explorer</h2>
+            {primingRequest && (
+              <span
+                className="inline-flex items-center gap-1 rounded border border-[color:var(--border)] bg-[color:var(--bg-2)] px-1.5 py-0.5 text-[10px] leading-none text-[color:var(--text-3)]"
+                title="Warming accelerated query polling"
+              >
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                accelerating
+              </span>
+            )}
+          </div>
           <p className="font-mono-tabular text-[11px] text-[color:var(--text-3)] truncate">{root}</p>
+          {primingItems.length > 0 && (
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {primingItems.map((item) => (
+                <span
+                  key={`${item.label}-${item.value}`}
+                  className="inline-flex max-w-full items-center gap-1.5 rounded border border-[color:var(--border)] bg-[color:var(--bg-2)] px-1.5 py-0.5 text-[10px] leading-none text-[color:var(--text-3)]"
+                >
+                  <span className="uppercase tracking-normal text-[color:var(--text-4)]">{item.label}</span>
+                  <span className="truncate font-mono-tabular text-[color:var(--text-2)]">{item.value}</span>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <button
           type="button"
@@ -436,4 +501,40 @@ function formatSize(size?: number) {
 function formatUnix(value?: number) {
   if (!value) return '';
   return new Date(value * 1000).toLocaleString();
+}
+
+type PrimingItem = { label: string; value: string };
+
+function formatPrimingItems(metadata: FileExplorerMetadataRow | null): PrimingItem[] {
+  if (!metadata) return [];
+  const items: PrimingItem[] = [];
+  const version = typeof metadata.version === 'string' ? (metadata.version as string) : '';
+  const build = typeof metadata.build_platform === 'string' ? (metadata.build_platform as string) : '';
+  const distro = typeof metadata.build_distro === 'string' ? (metadata.build_distro as string) : '';
+  const startTime = metadata.start_time != null ? String(metadata.start_time) : '';
+  const configValid = typeof metadata.config_valid === 'string' ? (metadata.config_valid as string) : '';
+  if (version) items.push({ label: 'osquery', value: version });
+  if (build) {
+    const value = [build, distro].filter(Boolean).join(' ');
+    items.push({ label: 'build', value });
+  }
+  if (startTime) {
+    const secs = Number(startTime);
+    if (!Number.isNaN(secs) && secs > 0) {
+      const uptimeMs = Date.now() - secs * 1000;
+      if (uptimeMs > 0) items.push({ label: 'uptime', value: formatUptimeBrief(uptimeMs) });
+    }
+  }
+  if (configValid) items.push({ label: 'config', value: configValid });
+  return items;
+}
+
+function formatUptimeBrief(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
 }

--- a/pkg/console/manager.go
+++ b/pkg/console/manager.go
@@ -16,6 +16,19 @@ import (
 
 const defaultCommandTimeout = 10 * time.Second
 
+// PrimingMetadataSQL is the read-only osquery statement dispatched when a
+// console session is opened. Its purpose is twofold:
+//  1. Be present in the node's pending distributed queue so that the
+//     next QueryRead returns an accelerated interval — the node switches
+//     to fast polling before the user types their first command.
+//  2. Surface live metadata (osquery version, build platform, start time,
+//     uptime) into the session UI so the operator sees fresh values
+//     rather than the last-seen DB snapshot.
+//
+// It is a single statement (no semicolons) so validateSelect stays happy
+// and osquery treats it atomically.
+const PrimingMetadataSQL = "select version, build_platform, build_distro, start_time, config_valid, optimizations from osquery_info"
+
 type Manager struct {
 	DB      *gorm.DB
 	Queries *queries.Queries
@@ -76,9 +89,13 @@ func (m *Manager) SubmitCommandWithTimeout(sessionID uint, input string, timeout
 	if !session.Active {
 		return Command{}, ParsedCommand{}, fmt.Errorf("console session is closed")
 	}
+	// Only user-issued commands block each other. Priming commands are
+	// excluded from the in-flight count so a still-pending priming query
+	// (which exists to warm acceleration) never gates the operator's
+	// first real command.
 	var pending int64
 	if err := m.DB.Model(&Command{}).
-		Where("session_id = ? AND status IN ?", sessionID, []string{StatusQueued, StatusDelivered}).
+		Where("session_id = ? AND status IN ? AND priming = ?", sessionID, []string{StatusQueued, StatusDelivered}, false).
 		Count(&pending).Error; err != nil {
 		return Command{}, ParsedCommand{}, err
 	}
@@ -148,6 +165,92 @@ func (m *Manager) SubmitCommandWithTimeout(sessionID uint, input string, timeout
 	}
 
 	return command, parsed, nil
+}
+
+// SubmitPrimingCommand dispatches the console priming metadata query for
+// the session. The priming query is a hidden ConsoleQueryType distributed
+// query whose presence in the node's pending queue causes the TLS
+// QueryRead handler to return an accelerated interval — so the node
+// switches to fast polling before the operator types their first command.
+//
+// Unlike SubmitCommand, priming commands are not mutually exclusive with
+// each other or with user commands: a fresh session may legitimately have
+// a priming query in flight when the user submits their first real
+// command, and SubmitCommandWithTimeout's pending-count ignores priming
+// rows for exactly that reason.
+//
+// The returned Command is marked Priming=true so the API layer can
+// surface it separately from operator history.
+func (m *Manager) SubmitPrimingCommand(sessionID uint, timeout time.Duration) (Command, error) {
+	if timeout <= 0 {
+		timeout = defaultCommandTimeout
+	}
+	var session Session
+	if err := m.DB.First(&session, sessionID).Error; err != nil {
+		return Command{}, err
+	}
+	if !session.Active {
+		return Command{}, fmt.Errorf("console session is closed")
+	}
+
+	command := Command{
+		SessionID:     sessionID,
+		Input:         PrimingMetadataSQL,
+		TranslatedSQL: PrimingMetadataSQL,
+		Status:        StatusQueued,
+		Priming:       true,
+	}
+
+	err := m.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&command).Error; err != nil {
+			return err
+		}
+		extra, err := json.Marshal(map[string]uint{"session_id": session.ID, "command_id": command.ID})
+		if err != nil {
+			return err
+		}
+		distributed := queries.DistributedQuery{
+			Name:          queries.GenQueryName(),
+			Query:         PrimingMetadataSQL,
+			Creator:       session.Creator,
+			Active:        true,
+			Hidden:        true,
+			Type:          queries.ConsoleQueryType,
+			EnvironmentID: session.EnvironmentID,
+			Expiration:    time.Now().Add(timeout),
+			Expected:      1,
+			ExtraData:     string(extra),
+		}
+		if err := tx.Create(&distributed).Error; err != nil {
+			return err
+		}
+		nodeQuery := queries.NodeQuery{
+			NodeID:  session.NodeID,
+			QueryID: distributed.ID,
+			Status:  queries.DistributedQueryStatusPending,
+		}
+		if err := tx.Create(&nodeQuery).Error; err != nil {
+			return err
+		}
+		command.DistributedQueryName = distributed.Name
+		return tx.Model(&command).Update("distributed_query_name", distributed.Name).Error
+	})
+	if err != nil {
+		return Command{}, err
+	}
+	return command, nil
+}
+
+// PrimingCommand returns the most recent priming command for a session,
+// or gorm.ErrRecordNotFound if none exists.
+func (m *Manager) PrimingCommand(sessionID uint) (Command, error) {
+	var command Command
+	if err := m.DB.Where("session_id = ? AND priming = ?", sessionID, true).
+		Order("created_at DESC").
+		First(&command).Error; err != nil {
+		return Command{}, err
+	}
+	return command, nil
 }
 
 func (m *Manager) CloseSession(sessionID uint) error {
@@ -260,7 +363,7 @@ func (m *Manager) History(envID, nodeID uint, creator string, limit int) ([]Hist
 	var commands []Command
 	err := m.DB.Model(&Command{}).
 		Joins("JOIN console_sessions ON console_sessions.id = console_commands.session_id").
-		Where("console_sessions.environment_id = ? AND console_sessions.node_id = ? AND console_sessions.creator = ?", envID, nodeID, creator).
+		Where("console_sessions.environment_id = ? AND console_sessions.node_id = ? AND console_sessions.creator = ? AND console_commands.priming = ?", envID, nodeID, creator, false).
 		Order("console_commands.created_at DESC").
 		Limit(limit).
 		Find(&commands).Error

--- a/pkg/console/manager_test.go
+++ b/pkg/console/manager_test.go
@@ -93,6 +93,100 @@ func TestSubmitRejectsWhenCommandInFlight(t *testing.T) {
 	require.Contains(t, err.Error(), "pending")
 }
 
+func TestSubmitPrimingCommandCreatesHiddenConsoleQuery(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	priming, err := manager.SubmitPrimingCommand(session.ID, time.Minute)
+	require.NoError(t, err)
+	require.True(t, priming.Priming)
+	require.Equal(t, console.StatusQueued, priming.Status)
+	require.NotEmpty(t, priming.DistributedQueryName)
+	require.Equal(t, console.PrimingMetadataSQL, priming.TranslatedSQL)
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", priming.DistributedQueryName).First(&distributed).Error)
+	require.Equal(t, queries.ConsoleQueryType, distributed.Type)
+	require.True(t, distributed.Hidden)
+	require.True(t, distributed.Active)
+
+	delivered, accelerate, err := manager.Queries.NodeQueries(node)
+	require.NoError(t, err)
+	require.True(t, accelerate)
+	require.Equal(t, console.PrimingMetadataSQL, delivered[priming.DistributedQueryName])
+}
+
+func TestPrimingCommandDoesNotBlockUserCommand(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	_, err = manager.SubmitPrimingCommand(session.ID, time.Minute)
+	require.NoError(t, err)
+
+	// A priming command is in flight, but the user's first real command
+	// must still be accepted — priming rows are excluded from the
+	// pending-count gate.
+	_, _, err = manager.SubmitCommand(session.ID, "ps")
+	require.NoError(t, err)
+
+	// A second user command while the first is pending is still rejected.
+	_, _, err = manager.SubmitCommand(session.ID, "ls")
+	require.Error(t, err)
+
+	// Sanity: a priming row exists and is queued.
+	var primingCount int64
+	require.NoError(t, db.Model(&console.Command{}).
+		Where("session_id = ? AND priming = ?", session.ID, true).Count(&primingCount).Error)
+	require.Equal(t, int64(1), primingCount)
+}
+
+func TestHistoryExcludesPrimingCommands(t *testing.T) {
+	_, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	_, err = manager.SubmitPrimingCommand(session.ID, time.Minute)
+	require.NoError(t, err)
+	_, _, err = manager.SubmitCommand(session.ID, "pwd")
+	require.NoError(t, err)
+
+	history, err := manager.History(env.ID, node.ID, "alice", 25)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	require.Equal(t, "pwd", history[0].Command.Input)
+}
+
+func TestPrimingCommandResultsReturnOsqueryInfoRows(t *testing.T) {
+	db, manager, env, node := setupConsoleManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	priming, err := manager.SubmitPrimingCommand(session.ID, time.Minute)
+	require.NoError(t, err)
+
+	result, err := json.Marshal([]map[string]string{{"version": "5.13.1", "build_platform": "linux"}})
+	require.NoError(t, err)
+	wrapped, err := json.Marshal(types.QueryWriteData{
+		Name:   priming.DistributedQueryName,
+		Result: result,
+		Status: 0,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{
+		UUID:        node.UUID,
+		Environment: env.UUID,
+		Name:        priming.DistributedQueryName,
+		Data:        string(wrapped),
+		Status:      0,
+	}).Error)
+	require.NoError(t, markNodeQueryStatus(db, priming.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+
+	rows, err := manager.CommandResults(priming.ID)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"version": "5.13.1", "build_platform": "linux"}}, rows)
+}
+
 func TestCloseSessionExpiresPendingCommands(t *testing.T) {
 	db, manager, env, node := setupConsoleManager(t)
 	session, err := manager.CreateSession(env, node, "alice")

--- a/pkg/console/models.go
+++ b/pkg/console/models.go
@@ -50,6 +50,7 @@ type Command struct {
 	DistributedQueryName string         `gorm:"index" json:"distributed_query_name,omitempty"`
 	Status               string         `gorm:"not null;index" json:"status"`
 	Error                string         `json:"error,omitempty"`
+	Priming              bool           `gorm:"not null;default:false;index" json:"priming"`
 	DeliveredAt          *time.Time     `json:"delivered_at,omitempty"`
 	CompletedAt          *time.Time     `json:"completed_at,omitempty"`
 	ExpiredAt            *time.Time     `json:"expired_at,omitempty"`

--- a/pkg/fileexplorer/manager.go
+++ b/pkg/fileexplorer/manager.go
@@ -10,12 +10,21 @@ import (
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
 	"gorm.io/gorm"
 )
 
 const (
 	defaultRequestTimeout = 10 * time.Second
 	maxPendingRequests    = 8
+
+	// PrimingMetadataSQL is the read-only osquery statement dispatched
+	// when a file explorer session is opened. Its presence in the node's
+	// pending distributed queue causes the TLS QueryRead handler to
+	// return an accelerated interval — so the node switches to fast
+	// polling before the operator expands the first directory — and it
+	// also surfaces live osquery runtime metadata into the session.
+	PrimingMetadataSQL = "select version, build_platform, build_distro, start_time, config_valid, optimizations from osquery_info"
 )
 
 type Manager struct {
@@ -99,7 +108,7 @@ func (m *Manager) submitRequest(sessionID uint, action, target string, timeout t
 
 	var pending int64
 	if err := m.DB.Model(&Request{}).
-		Where("session_id = ? AND status = ?", sessionID, StatusQueued).
+		Where("session_id = ? AND status = ? AND priming = ?", sessionID, StatusQueued, false).
 		Count(&pending).Error; err != nil {
 		return Request{}, err
 	}
@@ -171,6 +180,90 @@ func requestSQL(action, target string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported file explorer action %q", action)
 	}
+}
+
+// SubmitPrimingRequest dispatches the file explorer priming metadata
+// query for the session. The priming query is a hidden
+// FileExplorerQueryType distributed query whose presence in the node's
+// pending queue causes the TLS QueryRead handler to return an
+// accelerated interval — so the node switches to fast polling before
+// the operator expands the first directory — and it also surfaces live
+// osquery runtime metadata into the session UI.
+//
+// Priming requests are excluded from the per-session pending cap so a
+// still-running priming query never gates the first directory listing.
+func (m *Manager) SubmitPrimingRequest(sessionID uint, timeout time.Duration) (Request, error) {
+	if timeout <= 0 {
+		timeout = defaultRequestTimeout
+	}
+
+	var session Session
+	if err := m.DB.First(&session, sessionID).Error; err != nil {
+		return Request{}, err
+	}
+	if !session.Active {
+		return Request{}, fmt.Errorf("file explorer session is closed")
+	}
+
+	request := Request{
+		SessionID:     session.ID,
+		Action:        ActionPriming,
+		Path:          "osquery_info",
+		TranslatedSQL: PrimingMetadataSQL,
+		Status:        StatusQueued,
+		Priming:       true,
+	}
+
+	err := m.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&request).Error; err != nil {
+			return err
+		}
+		extra, err := json.Marshal(map[string]uint{"session_id": session.ID, "request_id": request.ID})
+		if err != nil {
+			return err
+		}
+		distributed := queries.DistributedQuery{
+			Name:          queries.GenQueryName(),
+			Query:         PrimingMetadataSQL,
+			Creator:       session.Creator,
+			Active:        true,
+			Hidden:        true,
+			Type:          queries.FileExplorerQueryType,
+			EnvironmentID: session.EnvironmentID,
+			Expiration:    time.Now().Add(timeout),
+			Expected:      1,
+			ExtraData:     string(extra),
+		}
+		if err := tx.Create(&distributed).Error; err != nil {
+			return err
+		}
+		nodeQuery := queries.NodeQuery{
+			NodeID:  session.NodeID,
+			QueryID: distributed.ID,
+			Status:  queries.DistributedQueryStatusPending,
+		}
+		if err := tx.Create(&nodeQuery).Error; err != nil {
+			return err
+		}
+		request.DistributedQueryName = distributed.Name
+		return tx.Model(&request).Update("distributed_query_name", distributed.Name).Error
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return request, nil
+}
+
+// PrimingRequest returns the most recent priming request for a session,
+// or gorm.ErrRecordNotFound if none exists.
+func (m *Manager) PrimingRequest(sessionID uint) (Request, error) {
+	var request Request
+	if err := m.DB.Where("session_id = ? AND priming = ?", sessionID, true).
+		Order("created_at DESC").
+		First(&request).Error; err != nil {
+		return Request{}, err
+	}
+	return request, nil
 }
 
 func (m *Manager) GetRequest(sessionID, requestID uint) (Request, error) {
@@ -263,6 +356,43 @@ func (m *Manager) RequestResults(requestID uint) ([]Entry, error) {
 		return nil
 	})
 	return entries, err
+}
+
+// RequestMetadataRows returns the raw result rows for a priming metadata
+// request (the osquery_info SELECT). Unlike RequestResults, which decodes
+// file columns into Entry structs, this returns the rows as generic maps
+// so the API can pass the osquery_info columns (version, build_platform,
+// start_time, ...) straight through to the frontend.
+func (m *Manager) RequestMetadataRows(requestID uint) ([]map[string]any, error) {
+	request, err := m.RefreshRequestStatus(requestID)
+	if err != nil {
+		return nil, err
+	}
+	rows := []map[string]any{}
+	if request.DistributedQueryName == "" {
+		return rows, nil
+	}
+	err = logging.StreamQueryResults(m.DB, request.DistributedQueryName, func(row logging.OsqueryQueryData) error {
+		decoded, err := decodeRows([]byte(row.Data))
+		if err != nil {
+			return err
+		}
+		rows = append(rows, decoded...)
+		return nil
+	})
+	return rows, err
+}
+
+func decodeRows(data []byte) ([]map[string]any, error) {
+	var wrapped types.QueryWriteData
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Result != nil {
+		data = wrapped.Result
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func isTerminalStatus(status string) bool {

--- a/pkg/fileexplorer/manager_test.go
+++ b/pkg/fileexplorer/manager_test.go
@@ -81,6 +81,81 @@ func TestStatPathCreatesHiddenFileExplorerQuery(t *testing.T) {
 	require.Contains(t, request.TranslatedSQL, "path = '/etc/hosts'")
 }
 
+func TestSubmitPrimingRequestCreatesHiddenFileExplorerQuery(t *testing.T) {
+	db, manager, env, node := setupFileExplorerManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	priming, err := manager.SubmitPrimingRequest(session.ID, time.Minute)
+	require.NoError(t, err)
+	require.True(t, priming.Priming)
+	require.Equal(t, fileexplorer.ActionPriming, priming.Action)
+	require.Equal(t, fileexplorer.StatusQueued, priming.Status)
+	require.NotEmpty(t, priming.DistributedQueryName)
+	require.Equal(t, fileexplorer.PrimingMetadataSQL, priming.TranslatedSQL)
+
+	var distributed queries.DistributedQuery
+	require.NoError(t, db.Where("name = ?", priming.DistributedQueryName).First(&distributed).Error)
+	require.Equal(t, queries.FileExplorerQueryType, distributed.Type)
+	require.True(t, distributed.Hidden)
+	require.True(t, distributed.Active)
+
+	delivered, accelerate, err := manager.Queries.NodeQueries(node)
+	require.NoError(t, err)
+	require.True(t, accelerate)
+	require.Equal(t, fileexplorer.PrimingMetadataSQL, delivered[priming.DistributedQueryName])
+}
+
+func TestPrimingRequestDoesNotCountTowardsPendingCap(t *testing.T) {
+	db, manager, env, node := setupFileExplorerManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+
+	_, err = manager.SubmitPrimingRequest(session.ID, time.Minute)
+	require.NoError(t, err)
+
+	// A priming request is queued but should not count against the
+	// per-session pending cap, so a real list request must still be
+	// accepted.
+	_, err = manager.ListDirectory(session.ID, "/etc", 10*time.Second)
+	require.NoError(t, err)
+
+	var queuedNonPriming int64
+	require.NoError(t, db.Model(&fileexplorer.Request{}).
+		Where("session_id = ? AND status = ? AND priming = ?", session.ID, fileexplorer.StatusQueued, false).
+		Count(&queuedNonPriming).Error)
+	require.Equal(t, int64(1), queuedNonPriming)
+}
+
+func TestRequestMetadataRowsReturnOsqueryInfoRows(t *testing.T) {
+	db, manager, env, node := setupFileExplorerManager(t)
+	session, err := manager.CreateSession(env, node, "alice")
+	require.NoError(t, err)
+	priming, err := manager.SubmitPrimingRequest(session.ID, time.Minute)
+	require.NoError(t, err)
+
+	result, err := json.Marshal([]map[string]string{{"version": "5.13.1", "build_platform": "linux"}})
+	require.NoError(t, err)
+	wrapped, err := json.Marshal(types.QueryWriteData{
+		Name:   priming.DistributedQueryName,
+		Result: result,
+		Status: 0,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&logging.OsqueryQueryData{
+		UUID:        node.UUID,
+		Environment: env.UUID,
+		Name:        priming.DistributedQueryName,
+		Data:        string(wrapped),
+		Status:      0,
+	}).Error)
+	require.NoError(t, markFileExplorerNodeQueryStatus(db, priming.DistributedQueryName, queries.DistributedQueryStatusCompleted))
+
+	rows, err := manager.RequestMetadataRows(priming.ID)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"version": "5.13.1", "build_platform": "linux"}}, rows)
+}
+
 func TestRefreshRequestStatusFromNodeQuery(t *testing.T) {
 	db, manager, env, node := setupFileExplorerManager(t)
 	session, err := manager.CreateSession(env, node, "alice")

--- a/pkg/fileexplorer/models.go
+++ b/pkg/fileexplorer/models.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	ActionList = "list"
-	ActionStat = "stat"
+	ActionList    = "list"
+	ActionStat    = "stat"
+	ActionPriming = "priming"
 
 	StatusQueued    = "queued"
 	StatusCompleted = "completed"
@@ -47,6 +48,7 @@ type Request struct {
 	DistributedQueryName string         `gorm:"index" json:"distributed_query_name,omitempty"`
 	Status               string         `gorm:"not null;index" json:"status"`
 	Error                string         `json:"error,omitempty"`
+	Priming              bool           `gorm:"not null;default:false;index" json:"priming"`
 	CompletedAt          *time.Time     `json:"completed_at,omitempty"`
 	ExpiredAt            *time.Time     `json:"expired_at,omitempty"`
 }


### PR DESCRIPTION
# Accelerated-mode priming for console and file explorer

## Problem

When an operator opens the node console or file explorer, accelerated
query polling only engages **after** the user submits their first
command (console) or first directory listing (file explorer). Until then
the node polls at its default distributed-interval, so the first
interactive command can wait a full poll cycle before it's even
delivered — visible as a long "waiting for node" delay on first use.

## Change

Open a session → immediately dispatch a hidden `osquery_info` priming
query to the target node's pending distributed queue. On the node's next
natural `QueryRead`:

1. `pkg/queries.NodeQueries` returns `accelerate=true` (the query type is
   `ConsoleQueryType`/`FileExplorerQueryType`), so the TLS handler replies
   with `AcceleratedQueryReadResponse{accelerate: N}` — the node switches
   to fast polling (default 5s) **before** the user types anything.
2. The priming query gets delivered and its live results (osquery
   version, build platform, start time, config validity, uptime) are
   surfaced into the session header, replacing the last-seen DB
   snapshot with fresh values.

By the time the operator issues their first command, the node is already
polling fast → near-zero timeout likelihood on the first interaction.

## Behavior / safety constraints

- **Priming never blocks user commands.** `SubmitCommandWithTimeout`'s
  pending-count and the file explorer's pending cap both exclude
  `priming=true` rows, so a still-pending priming query never gates the
  operator's first real command.
- **Priming is excluded from console history** (not user-issued).
- **Priming is non-fatal.** If submission fails, the session is still
  returned; acceleration simply isn't pre-warmed.
- **Schema is additive.** A `Priming` boolean column is added to
  `console_commands` and `file_explorer_requests` via the existing
  `AutoMigrate` in each `NewManager`.
- **Existing routes/auth wrappers are reused.** The console polls the
  existing `GET /console/.../commands/{id}` and `/results` endpoints; the
  file explorer adds one new
  `GET /file-explorer/.../requests/{id}/metadata` route (the existing
  `/results` endpoint decodes file columns into `Entry` structs, so a
  raw-rows endpoint was needed for `osquery_info`).

## API changes

### `POST /api/v1/console/{env}/nodes/{uuid}/sessions`
Response gains an optional `priming` field (`ConsoleCommand`), the
priming command dispatched at session open. Frontend polls the existing
command show/results endpoints with this id.

### `POST /api/v1/file-explorer/{env}/nodes/{uuid}/sessions`
Response gains an optional `priming` field (`FileExplorerRequest`).

### `GET /api/v1/file-explorer/{env}/sessions/{id}/requests/{id}/metadata` (new)
Returns the raw `osquery_info` rows for a priming request (generic
`[]map[string]any`, unlike `/results` which decodes file columns).

## Frontend

- **NodeConsolePage** — captures the priming command, polls it via
  `useQuery`, fetches results on completion, and renders live osquery
  version / build / uptime / config badges in the header. An
  "accelerating" spinner badge appears while priming is in flight.
- **NodeFileExplorerTab** — same pattern via the new metadata endpoint;
  live metadata renders in the file explorer header next to the root
  path, with an "accelerating" badge while priming is in flight.

## Files

**Backend**
- `pkg/console/manager.go`, `pkg/console/models.go` — `PrimingMetadataSQL`,
  `SubmitPrimingCommand`, `PrimingCommand`; pending-count + history
  exclude priming
- `pkg/fileexplorer/manager.go`, `pkg/fileexplorer/models.go` —
  `PrimingMetadataSQL`, `SubmitPrimingRequest`, `PrimingRequest`,
  `RequestMetadataRows`, `ActionPriming`; pending cap excludes priming
- `cmd/api/handlers/console.go` — priming dispatched in
  `ConsoleSessionCreateHandler`, `consolePrimingTimeout`
- `cmd/api/handlers/file_explorer.go` — priming dispatched in
  `FileExplorerSessionCreateHandler`, new `FileExplorerPrimingResultsHandler`
- `cmd/api/main.go` — new metadata route

**Frontend**
- `src/api/types.ts`, `src/api/file-explorer.ts` — priming types +
  `getFileExplorerPrimingMetadata`
- `src/features/nodes/NodeConsolePage.tsx`,
  `src/features/nodes/NodeFileExplorerTab.tsx` — poll + render priming

**Tests**
- `pkg/console/manager_test.go` (+4 tests), `pkg/fileexplorer/manager_test.go`
  (+3 tests), `cmd/api/handlers/console_test.go` (+1),
  `cmd/api/handlers/file_explorer_test.go` (+2)

## Validation

- `go build ./...` — clean
- `go test ./...` — all pass, including new priming tests
- `golangci-lint` on touched packages — only pre-existing issues remain
- `npm run check` (tsc) — clean
- `npm run test` (vitest) — 190/190 pass, including existing
  `NodeConsolePage` (10) and `NodeFileExplorerTab` (6) suites

## Notes

- No tests existed for the priming path before this change; new
  regression tests cover dispatch, non-blocking behavior, history
  exclusion, and result decoding for both console and file explorer.
- The `Priming` column is added via `AutoMigrate` — no manual migration
  step is required for existing deployments.