### PR TITLE
S3-backed log reader for status, result, and on-demand query logs

### DIFF
--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -26,7 +26,14 @@ const errorContent = "❌"
 const okContent = "✅"
 
 type HandlersApi struct {
-	DB              *gorm.DB
+	DB *gorm.DB
+	// LogReader is the read side of the status/result/query log store.
+	// When the TLS logger writes to S3, this is the S3-backed reader so
+	// the API can still surface logs to the frontend. When the logger
+	// writes to the DB, this is the legacy GORM-backed reader. nil falls
+	// back to h.DB via NewDBLogReader at call time so existing tests
+	// that only wire WithDB keep working.
+	LogReader       logging.LogReader
 	Users           *users.UserManager
 	Tags            *tags.TagManager
 	Envs            *environments.EnvManager
@@ -79,6 +86,15 @@ type HandlersOption func(*HandlersApi)
 func WithDB(db *gorm.DB) HandlersOption {
 	return func(h *HandlersApi) {
 		h.DB = db
+	}
+}
+
+// WithLogReader wires a LogReader (DB- or S3-backed). When unset, the
+// handlers fall back to NewDBLogReader(h.DB) so tests that only wire
+// WithDB behave as before.
+func WithLogReader(r logging.LogReader) HandlersOption {
+	return func(h *HandlersApi) {
+		h.LogReader = r
 	}
 }
 
@@ -264,4 +280,13 @@ func CreateHandlersApi(opts ...HandlersOption) *HandlersApi {
 		opt(h)
 	}
 	return h
+}
+
+// logReader returns the wired LogReader, falling back to a DB-backed
+// reader over h.DB so existing tests that only set WithDB keep working.
+func (h *HandlersApi) logReader() logging.LogReader {
+	if h.LogReader != nil {
+		return h.LogReader
+	}
+	return logging.NewDBLogReader(h.DB)
 }

--- a/cmd/api/handlers/log_reader_test.go
+++ b/cmd/api/handlers/log_reader_test.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeLogReader is a recording LogReader used to verify the handlers
+// route reads through the wired LogReader instead of going straight to
+// h.DB. It returns canned rows and records the calls so the test can
+// assert the right arguments were passed.
+type fakeLogReader struct {
+	nodeLogsCalls    []fakeNodeLogsCall
+	nodeLogsRows     []map[string]any
+	queryResultsCall *fakeQueryResultsCall
+	queryRows        []map[string]any
+	streamCall       *string
+	streamErr        error
+}
+
+type fakeNodeLogsCall struct {
+	LogType, Env, UUID string
+	Since              time.Time
+	Limit              int
+	Search             string
+}
+
+type fakeQueryResultsCall struct {
+	Env, Name  string
+	Since      time.Time
+	Page, Size int
+}
+
+func (f *fakeLogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error) {
+	f.nodeLogsCalls = append(f.nodeLogsCalls, fakeNodeLogsCall{logType, env, uuid, since, limit, search})
+	if f.nodeLogsRows == nil {
+		return []map[string]any{}, nil
+	}
+	return f.nodeLogsRows, nil
+}
+
+func (f *fakeLogReader) QueryResults(env, name string, since time.Time, page, pageSize int) ([]map[string]any, int64, error) {
+	f.queryResultsCall = &fakeQueryResultsCall{env, name, since, page, pageSize}
+	return f.queryRows, int64(len(f.queryRows)), nil
+}
+
+func (f *fakeLogReader) StreamQueryResults(env, name string, fn func(logging.OsqueryQueryData) error) error {
+	call := env + "/" + name
+	f.streamCall = &call
+	return f.streamErr
+}
+
+// mustEnvID resolves the env's numeric ID from its name so the test can
+// create a query with the right EnvironmentID for the ownership gate.
+func mustEnvID(t *testing.T, h *HandlersApi, envName string) uint {
+	env, err := h.Envs.GetByName(envName)
+	require.NoError(t, err)
+	return env.ID
+}
+
+type logReaderTestEnv struct {
+	h        *HandlersApi
+	envName  string
+	envUUID  string
+	nodeUUID string
+}
+
+func setupLogReaderTest(t *testing.T) logReaderTestEnv {
+	t.Helper()
+	_, h, env, node := setupConsoleHandlers(t)
+	// The NodeLogsHandler verifies node.Environment == env.Name. The
+	// shared setupConsoleHandlers creates the node with Environment =
+	// env.UUID ("env-uuid"), so align it to the env name the handler
+	// expects.
+	require.NoError(t, h.DB.Model(&node).Update("environment", env.Name).Error)
+	node.Environment = env.Name
+	// Wire the nil-guards the handler tests need: DebugHTTPConfig + AuditLog.
+	h.DebugHTTPConfig = &config.YAMLConfigurationDebug{}
+	auditLog, err := auditlog.CreateAuditLogManager(h.DB, "api", false)
+	require.NoError(t, err)
+	h.AuditLog = auditLog
+	return logReaderTestEnv{h: h, envName: env.Name, envUUID: env.UUID, nodeUUID: node.UUID}
+}
+
+func TestNodeLogsHandlerUsesLogReader(t *testing.T) {
+	tc := setupLogReaderTest(t)
+
+	fake := &fakeLogReader{
+		nodeLogsRows: []map[string]any{
+			{"line": "1", "message": "started", "uuid": tc.nodeUUID, "environment": tc.envName},
+		},
+	}
+	tc.h.LogReader = fake
+
+	req := consoleRequest(http.MethodGet, "/logs/status/env-uuid/NODE-UUID", nil, "alice")
+	req.SetPathValue("type", "status")
+	req.SetPathValue("env", tc.envName)
+	req.SetPathValue("uuid", tc.nodeUUID)
+	rr := httptest.NewRecorder()
+
+	tc.h.NodeLogsHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.Len(t, fake.nodeLogsCalls, 1)
+	call := fake.nodeLogsCalls[0]
+	require.Equal(t, "status", call.LogType)
+	require.Equal(t, tc.envName, call.Env)
+	require.Equal(t, tc.nodeUUID, call.UUID)
+	require.Equal(t, 100, call.Limit)
+}
+
+func TestQueryResultsHandlerUsesLogReader(t *testing.T) {
+	tc := setupLogReaderTest(t)
+	// Create a query so the env-ownership gate passes.
+	newQuery := queries.DistributedQuery{Name: "q-test", Creator: "alice", Active: true, EnvironmentID: mustEnvID(t, tc.h, tc.envName), Expected: 1}
+	require.NoError(t, tc.h.Queries.Create(&newQuery))
+
+	fake := &fakeLogReader{
+		queryRows: []map[string]any{
+			{"uuid": "NODE-UUID", "name": "q-test", "data": `{"result":[]}`, "status": 0},
+		},
+	}
+	tc.h.LogReader = fake
+
+	req := consoleRequest(http.MethodGet, "/queries/env-uuid/results/q-test", nil, "alice")
+	req.SetPathValue("env", tc.envName)
+	req.SetPathValue("name", "q-test")
+	rr := httptest.NewRecorder()
+
+	tc.h.QueryResultsHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.NotNil(t, fake.queryResultsCall)
+	require.Equal(t, tc.envUUID, fake.queryResultsCall.Env)
+	require.Equal(t, "q-test", fake.queryResultsCall.Name)
+	require.Equal(t, 1, fake.queryResultsCall.Page)
+	require.Equal(t, 100, fake.queryResultsCall.Size)
+}

--- a/cmd/api/handlers/logs.go
+++ b/cmd/api/handlers/logs.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -124,7 +123,7 @@ func (h *HandlersApi) NodeLogsHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Use the node's canonical UUID (already upper-cased in the DB) from the
 	// verified node record, not the raw URL parameter.
-	items, err := logging.GetNodeLogs(h.DB, logType, env.Name, node.UUID, since, limit, search)
+	items, err := h.logReader().NodeLogs(logType, env.Name, node.UUID, since, limit, search)
 	if err != nil {
 		apiErrorResponse(w, "failed to query logs", http.StatusInternalServerError, err)
 		return

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -600,7 +600,7 @@ func (h *HandlersApi) QueryResultsHandler(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	items, total, err := logging.GetQueryResults(h.DB, name, since, page, pageSize)
+	items, total, err := h.logReader().QueryResults(env.UUID, name, since, page, pageSize)
 	if err != nil {
 		apiErrorResponse(w, "error getting query results", http.StatusInternalServerError, err)
 		return
@@ -686,7 +686,7 @@ func (h *HandlersApi) QueryResultsCSVHandler(w http.ResponseWriter, r *http.Requ
 	// Pass 1 (streaming): walk every row, collect the union of column names.
 	// We only retain column names here — never the row data — to keep memory at O(columns).
 	colSet := make(map[string]struct{})
-	if err := logging.StreamQueryResults(h.DB, name, func(row logging.OsqueryQueryData) error {
+	if err := h.logReader().StreamQueryResults(env.UUID, name, func(row logging.OsqueryQueryData) error {
 		var cols map[string]string
 		if err := json.Unmarshal([]byte(row.Data), &cols); err != nil {
 			cols = map[string]string{"data": row.Data}
@@ -725,7 +725,7 @@ func (h *HandlersApi) QueryResultsCSVHandler(w http.ResponseWriter, r *http.Requ
 
 	// Pass 2 (streaming): write data rows, flushing after each so bytes reach the client incrementally.
 	rowCount := 0
-	if err := logging.StreamQueryResults(h.DB, name, func(row logging.OsqueryQueryData) error {
+	if err := h.logReader().StreamQueryResults(env.UUID, name, func(row logging.OsqueryQueryData) error {
 		var cols map[string]string
 		if err := json.Unmarshal([]byte(row.Data), &cols); err != nil {
 			cols = map[string]string{"data": row.Data}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -351,6 +351,23 @@ func osctrlAPIService() {
 	consolemgr = console.NewManager(db.Conn, queriesmgr)
 	log.Info().Msg("Initialize file explorer")
 	fileexplorermgr = fileexplorer.NewManager(db.Conn, queriesmgr)
+	// Construct the log reader. When the TLS logger ships logs to S3 the
+	// osquery_*_data tables are empty, so the API/console/file-explorer
+	// read logs back from S3 instead. For every other logger the data
+	// lives in the DB and the legacy GORM-backed reader is used.
+	var logReader logging.LogReader
+	if flagParams.Logger != nil && flagParams.Logger.Type == config.LoggingS3 && flagParams.Logger.S3 != nil {
+		log.Info().Msg("Logger is S3 — initializing S3-backed log reader")
+		s3Logger, err := logging.CreateLoggerS3(flagParams.Logger.S3)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Error initializing S3 log reader")
+		}
+		logReader = logging.NewS3LogReader(s3Logger.Client, s3Logger.S3Config.Bucket)
+	} else {
+		logReader = logging.NewDBLogReader(db.Conn)
+	}
+	consolemgr.SetLogReader(logReader)
+	fileexplorermgr.SetLogReader(logReader)
 	log.Info().Msg("Initialize carves")
 	filecarves = carves.CreateFileCarves(db.Conn, flagParams.Carver.Type, nil)
 	log.Info().Msg("Loading service settings")
@@ -404,6 +421,7 @@ func osctrlAPIService() {
 
 	handlersApi = handlers.CreateHandlersApi(
 		handlers.WithDB(db.Conn),
+		handlers.WithLogReader(logReader),
 		handlers.WithEnvs(envs),
 		handlers.WithEnvCache(envCache),
 		handlers.WithUsers(apiUsers),

--- a/pkg/console/manager.go
+++ b/pkg/console/manager.go
@@ -30,8 +30,9 @@ const defaultCommandTimeout = 10 * time.Second
 const PrimingMetadataSQL = "select version, build_platform, build_distro, start_time, config_valid, optimizations from osquery_info"
 
 type Manager struct {
-	DB      *gorm.DB
-	Queries *queries.Queries
+	DB        *gorm.DB
+	Queries   *queries.Queries
+	LogReader logging.LogReader
 }
 
 func NewManager(db *gorm.DB, queryManager *queries.Queries) *Manager {
@@ -41,9 +42,24 @@ func NewManager(db *gorm.DB, queryManager *queries.Queries) *Manager {
 	return &Manager{DB: db, Queries: queryManager}
 }
 
+// SetLogReader wires a LogReader (DB- or S3-backed). When unset, the
+// manager falls back to NewDBLogReader(m.DB) so existing callers keep
+// the legacy DB-backed behavior.
+func (m *Manager) SetLogReader(r logging.LogReader) {
+	m.LogReader = r
+}
+
+func (m *Manager) logReader() logging.LogReader {
+	if m.LogReader != nil {
+		return m.LogReader
+	}
+	return logging.NewDBLogReader(m.DB)
+}
+
 func (m *Manager) CreateSession(env environments.TLSEnvironment, node nodes.OsqueryNode, creator string) (Session, error) {
 	session := Session{
 		EnvironmentID: env.ID,
+		Environment:   env.UUID,
 		NodeID:        node.ID,
 		NodeUUID:      node.UUID,
 		Creator:       creator,
@@ -350,7 +366,23 @@ func (m *Manager) CommandResults(commandID uint) ([]map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return m.queryResults(command.DistributedQueryName)
+	env, _ := m.commandEnv(commandID)
+	return m.queryResults(env, command.DistributedQueryName)
+}
+
+// commandEnv resolves the env UUID for a command's session, used as the
+// S3 key prefix when the log reader is S3-backed. Returns "" if the
+// session can't be loaded (the DB reader ignores it).
+func (m *Manager) commandEnv(commandID uint) (string, error) {
+	var command Command
+	if err := m.DB.Select("session_id").First(&command, commandID).Error; err != nil {
+		return "", err
+	}
+	var session Session
+	if err := m.DB.Select("environment").First(&session, command.SessionID).Error; err != nil {
+		return "", err
+	}
+	return session.Environment, nil
 }
 
 func (m *Manager) History(envID, nodeID uint, creator string, limit int) ([]HistoryEntry, error) {
@@ -371,10 +403,18 @@ func (m *Manager) History(envID, nodeID uint, creator string, limit int) ([]Hist
 		return nil, err
 	}
 
+	// Resolve the env UUID for the S3 reader's key prefix. The DB reader
+	// ignores it. A miss here just means "" — the DB reader still works.
+	var envRow Session
+	envUUID := ""
+	if err := m.DB.Select("environment").Where("environment_id = ?", envID).First(&envRow).Error; err == nil {
+		envUUID = envRow.Environment
+	}
+
 	history := make([]HistoryEntry, 0, len(commands))
 	for i := len(commands) - 1; i >= 0; i-- {
 		command := commands[i]
-		results, err := m.queryResults(command.DistributedQueryName)
+		results, err := m.queryResults(envUUID, command.DistributedQueryName)
 		if err != nil {
 			results = []map[string]any{}
 		}
@@ -400,7 +440,7 @@ func (m *Manager) completedStatusForCommand(command Command) (string, string, er
 		return StatusCompleted, "", nil
 	}
 
-	rows, err := m.queryResults(command.DistributedQueryName)
+	rows, err := m.queryResults(session.Environment, command.DistributedQueryName)
 	if err != nil {
 		return StatusError, "", err
 	}
@@ -418,12 +458,12 @@ func isCDCommand(input string) bool {
 	return len(fields) > 0 && strings.EqualFold(fields[0], "cd")
 }
 
-func (m *Manager) queryResults(queryName string) ([]map[string]any, error) {
+func (m *Manager) queryResults(env, queryName string) ([]map[string]any, error) {
 	rows := []map[string]any{}
 	if queryName == "" {
 		return rows, nil
 	}
-	err := logging.StreamQueryResults(m.DB, queryName, func(row logging.OsqueryQueryData) error {
+	err := m.logReader().StreamQueryResults(env, queryName, func(row logging.OsqueryQueryData) error {
 		decoded, err := decodeResultRows([]byte(row.Data))
 		if err != nil {
 			return err

--- a/pkg/console/models.go
+++ b/pkg/console/models.go
@@ -26,13 +26,17 @@ type Session struct {
 	UpdatedAt     time.Time      `json:"updated_at"`
 	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
 	EnvironmentID uint           `gorm:"not null;index" json:"environment_id"`
-	NodeID        uint           `gorm:"not null;index" json:"node_id"`
-	NodeUUID      string         `gorm:"not null;index" json:"node_uuid"`
-	Creator       string         `gorm:"not null;index" json:"creator"`
-	CWD           string         `gorm:"not null" json:"cwd"`
-	Platform      string         `json:"platform"`
-	Active        bool           `gorm:"not null;default:true" json:"active"`
-	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
+	// Environment is the env UUID used as the S3 key prefix when the
+	// log reader is S3-backed. Populated at session creation from the
+	// env record; the DB reader ignores it.
+	Environment string     `gorm:"index" json:"environment"`
+	NodeID      uint       `gorm:"not null;index" json:"node_id"`
+	NodeUUID    string     `gorm:"not null;index" json:"node_uuid"`
+	Creator     string     `gorm:"not null;index" json:"creator"`
+	CWD         string     `gorm:"not null" json:"cwd"`
+	Platform    string     `json:"platform"`
+	Active      bool       `gorm:"not null;default:true" json:"active"`
+	ClosedAt    *time.Time `json:"closed_at,omitempty"`
 }
 
 func (Session) TableName() string {

--- a/pkg/fileexplorer/manager.go
+++ b/pkg/fileexplorer/manager.go
@@ -28,8 +28,9 @@ const (
 )
 
 type Manager struct {
-	DB      *gorm.DB
-	Queries *queries.Queries
+	DB        *gorm.DB
+	Queries   *queries.Queries
+	LogReader logging.LogReader
 }
 
 func NewManager(db *gorm.DB, queryManager *queries.Queries) *Manager {
@@ -39,9 +40,24 @@ func NewManager(db *gorm.DB, queryManager *queries.Queries) *Manager {
 	return &Manager{DB: db, Queries: queryManager}
 }
 
+// SetLogReader wires a LogReader (DB- or S3-backed). When unset, the
+// manager falls back to NewDBLogReader(m.DB) so existing callers keep
+// the legacy DB-backed behavior.
+func (m *Manager) SetLogReader(r logging.LogReader) {
+	m.LogReader = r
+}
+
+func (m *Manager) logReader() logging.LogReader {
+	if m.LogReader != nil {
+		return m.LogReader
+	}
+	return logging.NewDBLogReader(m.DB)
+}
+
 func (m *Manager) CreateSession(env environments.TLSEnvironment, node nodes.OsqueryNode, creator string) (Session, error) {
 	session := Session{
 		EnvironmentID: env.ID,
+		Environment:   env.UUID,
 		NodeID:        node.ID,
 		NodeUUID:      node.UUID,
 		Creator:       creator,
@@ -347,7 +363,8 @@ func (m *Manager) RequestResults(requestID uint) ([]Entry, error) {
 	if request.DistributedQueryName == "" {
 		return entries, nil
 	}
-	err = logging.StreamQueryResults(m.DB, request.DistributedQueryName, func(row logging.OsqueryQueryData) error {
+	env := m.requestEnv(requestID)
+	err = m.logReader().StreamQueryResults(env, request.DistributedQueryName, func(row logging.OsqueryQueryData) error {
 		decoded, err := decodeEntries([]byte(row.Data))
 		if err != nil {
 			return err
@@ -372,7 +389,8 @@ func (m *Manager) RequestMetadataRows(requestID uint) ([]map[string]any, error) 
 	if request.DistributedQueryName == "" {
 		return rows, nil
 	}
-	err = logging.StreamQueryResults(m.DB, request.DistributedQueryName, func(row logging.OsqueryQueryData) error {
+	env := m.requestEnv(requestID)
+	err = m.logReader().StreamQueryResults(env, request.DistributedQueryName, func(row logging.OsqueryQueryData) error {
 		decoded, err := decodeRows([]byte(row.Data))
 		if err != nil {
 			return err
@@ -381,6 +399,21 @@ func (m *Manager) RequestMetadataRows(requestID uint) ([]map[string]any, error) 
 		return nil
 	})
 	return rows, err
+}
+
+// requestEnv resolves the env UUID for a request's session, used as the
+// S3 key prefix when the log reader is S3-backed. Returns "" if the
+// session can't be loaded (the DB reader ignores it).
+func (m *Manager) requestEnv(requestID uint) string {
+	var request Request
+	if err := m.DB.Select("session_id").First(&request, requestID).Error; err != nil {
+		return ""
+	}
+	var session Session
+	if err := m.DB.Select("environment").First(&session, request.SessionID).Error; err != nil {
+		return ""
+	}
+	return session.Environment
 }
 
 func decodeRows(data []byte) ([]map[string]any, error) {

--- a/pkg/fileexplorer/models.go
+++ b/pkg/fileexplorer/models.go
@@ -23,13 +23,17 @@ type Session struct {
 	UpdatedAt     time.Time      `json:"updated_at"`
 	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
 	EnvironmentID uint           `gorm:"not null;index" json:"environment_id"`
-	NodeID        uint           `gorm:"not null;index" json:"node_id"`
-	NodeUUID      string         `gorm:"not null;index" json:"node_uuid"`
-	Creator       string         `gorm:"not null;index" json:"creator"`
-	Platform      string         `json:"platform"`
-	Root          string         `gorm:"not null" json:"root"`
-	Active        bool           `gorm:"not null;default:true" json:"active"`
-	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
+	// Environment is the env UUID used as the S3 key prefix when the
+	// log reader is S3-backed. Populated at session creation; the DB
+	// reader ignores it.
+	Environment string     `gorm:"index" json:"environment"`
+	NodeID      uint       `gorm:"not null;index" json:"node_id"`
+	NodeUUID    string     `gorm:"not null;index" json:"node_uuid"`
+	Creator     string     `gorm:"not null;index" json:"creator"`
+	Platform    string     `json:"platform"`
+	Root        string     `gorm:"not null" json:"root"`
+	Active      bool       `gorm:"not null;default:true" json:"active"`
+	ClosedAt    *time.Time `json:"closed_at,omitempty"`
 }
 
 func (Session) TableName() string {

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -292,7 +292,7 @@ func (logTLS *LoggerTLS) QueryLog(logType string, data []byte, environment, uuid
 			log.Error().Msgf("error casting logger to %s", config.LoggingS3)
 		}
 		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
+			l.Query(data, environment, uuid, name, status, debug)
 		}
 	case config.LoggingKafka:
 		k, ok := logTLS.Logger.(*LoggerKafka)

--- a/pkg/logging/reader.go
+++ b/pkg/logging/reader.go
@@ -1,0 +1,90 @@
+package logging
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/jmpsec/osctrl/pkg/types"
+)
+
+// LogReader is the read-side abstraction over status / result / query logs.
+//
+// The historical implementation reads the `osquery_status_data`,
+// `osquery_result_data` and `osquery_query_data` tables from the GORM DB
+// (see dbLogReader). When the TLS logger is configured to ship logs to S3,
+// those tables are empty — the data lives in S3 objects instead — and
+// s3LogReader (see s3_reader.go) is wired in so the API/console/file
+// explorer can still surface logs to the frontend.
+//
+// The interface intentionally mirrors the *read* functions the API and
+// the console/file-explorer managers already use, so a handler does not
+// care whether the backing store is the DB or S3.
+type LogReader interface {
+	// NodeLogs returns recent log entries for a single node (status or
+	// result), ordered by created_at DESC. since is exclusive; empty means
+	// no lower bound. limit is clamped to [1,1000] by the caller. search
+	// is an optional case-insensitive substring filter against the row's
+	// human-readable columns (best-effort for S3).
+	NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error)
+
+	// QueryResults returns rows of query result data (one per node) for a
+	// single query name, ordered by created_at ASC. env is the environment
+	// UUID/name used to scope the read (the DB reader ignores it; the S3
+	// reader uses it as the key prefix). Pagination is 1-indexed; pageSize
+	// clamped to [1,1000]. Returns the page items, the total matching
+	// count, and any error.
+	QueryResults(env, name string, since time.Time, page, pageSize int) ([]map[string]any, int64, error)
+
+	// StreamQueryResults invokes fn for each row of query result data for
+	// `name`, ordered by created_at ASC. env scopes the read (DB reader
+	// ignores it; S3 reader uses it as the key prefix). Rows are streamed
+	// so memory stays bounded — used by the CSV exporter and the
+	// console/file-explorer result decoders. fn may return an error to
+	// stop iteration.
+	StreamQueryResults(env, name string, fn func(OsqueryQueryData) error) error
+}
+
+// dbLogReader is the historical implementation backed by the GORM DB.
+type dbLogReader struct {
+	db *gorm.DB
+}
+
+// NewDBLogReader returns a LogReader backed by the given GORM DB.
+func NewDBLogReader(db *gorm.DB) LogReader {
+	return &dbLogReader{db: db}
+}
+
+func (r *dbLogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error) {
+	return GetNodeLogs(r.db, logType, env, uuid, since, limit, search)
+}
+
+func (r *dbLogReader) QueryResults(env, name string, since time.Time, page, pageSize int) ([]map[string]any, int64, error) {
+	return GetQueryResults(r.db, name, since, page, pageSize)
+}
+
+func (r *dbLogReader) StreamQueryResults(env, name string, fn func(OsqueryQueryData) error) error {
+	return StreamQueryResults(r.db, name, fn)
+}
+
+// normalizeLogType maps the public "status"/"result" strings to the S3
+// key prefix used by the TLS write path. It returns an error for any
+// other value so a misrouted handler fails closed rather than silently
+// listing the wrong prefix.
+func normalizeLogType(logType string) (string, error) {
+	switch logType {
+	case types.StatusLog, types.ResultLog:
+		return logType, nil
+	default:
+		return "", fmt.Errorf("invalid log type: %s", logType)
+	}
+}
+
+// upperUUID normalizes a node UUID the way the DB writer does
+// (OsqueryStatusData.UUID is stored upper-cased) so the S3 reader can
+// match keys written with the original case-insensitive host identifier.
+func upperUUID(uuid string) string {
+	return strings.ToUpper(uuid)
+}

--- a/pkg/logging/s3.go
+++ b/pkg/logging/s3.go
@@ -74,3 +74,42 @@ func (logS3 *LoggerS3) Send(logType string, data []byte, environment, uuid strin
 		log.Debug().Msgf("S3 Upload %+v", result)
 	}
 }
+
+// Query - Function that sends JSON on-demand query result logs to S3.
+//
+// Unlike Send, the S3 key embeds the query `name` as a path segment so the
+// reader can list by query name with a prefix filter — without it, the
+// reader would have to list every query object in the environment and
+// decode each body to find the ones matching `name`, which is
+// catastrophically slow on a busy bucket.
+//
+// Key layout: {env}/query/{name}/{uuid}:{ts}.json
+//
+// The body is the same QueryWriteData JSON the DB logger would have
+// stored, so the reader can decode it back into OsqueryQueryData rows.
+func (logS3 *LoggerS3) Query(data []byte, environment, uuid, name string, status int, debug bool) {
+	ctx := context.Background()
+	if debug {
+		log.Debug().Msgf("Sending %d bytes to S3 query %s for %s - %s", len(data), name, environment, uuid)
+	}
+	ptrContentLength := int64(len(data))
+	result, err := logS3.Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(logS3.S3Config.Bucket),
+		Key:           aws.String(s3QueryKey(environment, name, uuid, time.Now())),
+		Body:          bytes.NewReader(data),
+		ContentLength: &ptrContentLength,
+		ContentType:   aws.String(http.DetectContentType(data)),
+	})
+	if err != nil {
+		log.Err(err).Msg("Error sending query data to s3")
+	}
+	if debug {
+		log.Debug().Msgf("S3 Upload %+v", result)
+	}
+}
+
+// s3QueryKey returns the S3 object key for a query result log. Exported
+// so the reader and writer share the exact same layout.
+func s3QueryKey(environment, name, uuid string, ts time.Time) string {
+	return environment + "/query/" + name + "/" + uuid + ":" + strconv.FormatInt(ts.UnixMilli(), 10) + ".json"
+}

--- a/pkg/logging/s3.go
+++ b/pkg/logging/s3.go
@@ -62,7 +62,7 @@ func (logS3 *LoggerS3) Send(logType string, data []byte, environment, uuid strin
 	ptrContentLength := int64(len(data))
 	result, err := logS3.Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(logS3.S3Config.Bucket),
-		Key:           aws.String(environment + "/" + logType + "/" + uuid + ":" + strconv.FormatInt(time.Now().UnixMilli(), 10) + ".json"),
+		Key:           aws.String(s3LogKey(environment, logType, uuid, time.Now())),
 		Body:          bytes.NewReader(data),
 		ContentLength: &ptrContentLength,
 		ContentType:   aws.String(http.DetectContentType(data)),
@@ -75,15 +75,25 @@ func (logS3 *LoggerS3) Send(logType string, data []byte, environment, uuid strin
 	}
 }
 
+// s3LogKey returns the S3 object key for a status/result log. The UUID is
+// a path segment (not part of the filename) so the reader can list a
+// single node's objects with a prefix filter. Exported so the reader and
+// writer share the exact same layout.
+//
+// Key layout: {env}/{logType}/{uuid}/{ts}.json
+func s3LogKey(environment, logType, uuid string, ts time.Time) string {
+	return environment + "/" + logType + "/" + uuid + "/" + strconv.FormatInt(ts.UnixMilli(), 10) + ".json"
+}
+
 // Query - Function that sends JSON on-demand query result logs to S3.
 //
-// Unlike Send, the S3 key embeds the query `name` as a path segment so the
-// reader can list by query name with a prefix filter — without it, the
-// reader would have to list every query object in the environment and
-// decode each body to find the ones matching `name`, which is
-// catastrophically slow on a busy bucket.
+// The S3 key embeds the query `name` as a path segment so the reader can
+// list by query name with a prefix filter — without it, the reader would
+// have to list every query object in the environment and decode each body
+// to find the ones matching `name`, which is catastrophically slow on a
+// busy bucket.
 //
-// Key layout: {env}/query/{name}/{uuid}:{ts}.json
+// Key layout: {env}/query/{name}/{uuid}/{ts}.json
 //
 // The body is the same QueryWriteData JSON the DB logger would have
 // stored, so the reader can decode it back into OsqueryQueryData rows.
@@ -110,6 +120,8 @@ func (logS3 *LoggerS3) Query(data []byte, environment, uuid, name string, status
 
 // s3QueryKey returns the S3 object key for a query result log. Exported
 // so the reader and writer share the exact same layout.
+//
+// Key layout: {env}/query/{name}/{uuid}/{ts}.json
 func s3QueryKey(environment, name, uuid string, ts time.Time) string {
-	return environment + "/query/" + name + "/" + uuid + ":" + strconv.FormatInt(ts.UnixMilli(), 10) + ".json"
+	return environment + "/query/" + name + "/" + uuid + "/" + strconv.FormatInt(ts.UnixMilli(), 10) + ".json"
 }

--- a/pkg/logging/s3_reader.go
+++ b/pkg/logging/s3_reader.go
@@ -20,19 +20,20 @@ import (
 //
 // Key layouts (must match the write path in s3.go):
 //
-//	status/result: {env}/{logType}/{uuid}:{ts}.json
-//	query:        {env}/query/{name}/{uuid}:{ts}.json
+//	status/result: {env}/{logType}/{uuid}/{ts}.json
+//	query:        {env}/query/{name}/{uuid}/{ts}.json
+//
+// The UUID is a path segment (not jammed into the filename) so the
+// reader can list a single node's objects with a prefix filter — listing
+// the whole environment's logs to find one node's would be a DoS vector.
 //
 // The timestamp in the key is millisecond Unix time, so lexical ordering
 // of keys within a prefix == chronological ordering. ListObjectsV2 returns
 // keys in lexical order, so the reader gets pre-sorted results for free
 // and only needs to fetch the objects for the requested page/limit.
 //
-// Status/result reads list by prefix {env}/{logType}/ and keep only keys
-// whose UUID segment matches (the prefix is environment-scoped, not
-// node-scoped, because the write path does not nest under the node).
-// Query reads list by prefix {env}/query/{name}/ which is already
-// name-scoped, so every key in the prefix is a result for that query.
+// Status/result reads list by prefix {env}/{logType}/{uuid}/ (node-scoped).
+// Query reads list by prefix {env}/query/{name}/ (name-scoped).
 type s3LogReader struct {
 	client *s3.Client
 	bucket string
@@ -45,15 +46,17 @@ func NewS3LogReader(client *s3.Client, bucket string) LogReader {
 	return &s3LogReader{client: client, bucket: bucket}
 }
 
-// NodeLogs implements LogReader. It lists the {env}/{logType}/ prefix,
-// keeps keys whose UUID matches, applies the since/search filters
+// NodeLogs implements LogReader. It lists the {env}/{logType}/{uuid}/
+// prefix (node-scoped by key layout), applies the since/search filters
 // (best-effort — the search is applied against the decoded JSON body),
 // and returns up to `limit` rows ordered newest-first.
 func (r *s3LogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error) {
-	prefix, err := normalizeLogType(logType)
+	logTypePrefix, err := normalizeLogType(logType)
 	if err != nil {
 		return nil, err
 	}
+	// Clamp limit defensively so make([]..., 0, limit) can never receive
+	// a negative or oversized cap — the HTTP query param is untrusted.
 	if limit <= 0 {
 		limit = 100
 	}
@@ -61,7 +64,12 @@ func (r *s3LogReader) NodeLogs(logType, env, uuid string, since time.Time, limit
 		limit = 1000
 	}
 	wantUUID := upperUUID(uuid)
-	prefix = env + "/" + prefix + "/"
+	// The status/result key layout nests the UUID as a path segment
+	// ({env}/{logType}/{uuid}/{ts}.json), so this prefix lists only this
+	// node's objects — not every node's logs in the environment. Without
+	// the per-node nesting the reader would list the whole env prefix
+	// and filter client-side, a DoS vector on busy environments.
+	prefix := env + "/" + logTypePrefix + "/" + wantUUID + "/"
 
 	keys, err := r.listKeys(prefix)
 	if err != nil {
@@ -228,23 +236,20 @@ type nodeLogEntry struct {
 	CreatedAt time.Time
 }
 
-// decodeNodeLogKey parses {env}/{logType}/{uuid}:{ts}.json and reports
-// whether the key belongs to wantUUID.
+// decodeNodeLogKey parses {env}/{logType}/{uuid}/{ts}.json. Because the
+// reader lists a per-node prefix, every key already belongs to wantUUID;
+// the UUID check is a defensive guard against mislaid objects.
 func decodeNodeLogKey(key, wantUUID string) (nodeLogEntry, bool) {
-	base := key
-	if i := strings.LastIndex(base, "/"); i >= 0 {
-		base = base[i+1:]
-	}
-	// base is "{uuid}:{ts}.json"
-	colon := strings.LastIndex(base, ":")
-	if colon < 0 {
+	parts := strings.Split(key, "/")
+	// {env}/{logType}/{uuid}/{ts}.json -> 4 segments
+	if len(parts) != 4 {
 		return nodeLogEntry{}, false
 	}
-	uuidPart := base[:colon]
+	uuidPart := parts[2]
 	if !strings.EqualFold(uuidPart, wantUUID) {
 		return nodeLogEntry{}, false
 	}
-	tsStr := strings.TrimSuffix(base[colon+1:], ".json")
+	tsStr := strings.TrimSuffix(parts[3], ".json")
 	tsMs, err := strconv.ParseInt(tsStr, 10, 64)
 	if err != nil {
 		return nodeLogEntry{}, false
@@ -361,37 +366,30 @@ func decodeQueryLogRow(body []byte, key string) (OsqueryQueryData, error) {
 	}, nil
 }
 
-// splitQueryKey parses {env}/query/{name}/{uuid}:{ts}.json and returns
+// splitQueryKey parses {env}/query/{name}/{uuid}/{ts}.json and returns
 // env, uuid, name, ok.
 func splitQueryKey(key string) (env, uuid, name string, ok bool) {
-	parts := strings.SplitN(key, "/", 4)
-	if len(parts) != 4 {
+	parts := strings.Split(key, "/")
+	// {env}/query/{name}/{uuid}/{ts}.json -> 5 segments
+	if len(parts) != 5 {
 		return "", "", "", false
 	}
 	env = parts[0]
 	// parts[1] == "query"
 	name = parts[2]
-	last := parts[3]
-	colon := strings.LastIndex(last, ":")
-	if colon < 0 {
-		return "", "", "", false
-	}
-	uuid = last[:colon]
+	uuid = parts[3]
 	return env, uuid, name, true
 }
 
 // tsFromKey extracts the millisecond timestamp from the trailing
-// "{ts}.json" segment of any S3 log key.
+// "{ts}.json" segment of any S3 log key. Both layouts end with a bare
+// "{ts}.json" filename (no colon) since the UUID is now a path segment.
 func tsFromKey(key string) (time.Time, bool) {
 	base := key
 	if i := strings.LastIndex(base, "/"); i >= 0 {
 		base = base[i+1:]
 	}
-	colon := strings.LastIndex(base, ":")
-	if colon < 0 {
-		return time.Time{}, false
-	}
-	tsStr := strings.TrimSuffix(base[colon+1:], ".json")
+	tsStr := strings.TrimSuffix(base, ".json")
 	tsMs, err := strconv.ParseInt(tsStr, 10, 64)
 	if err != nil {
 		return time.Time{}, false

--- a/pkg/logging/s3_reader.go
+++ b/pkg/logging/s3_reader.go
@@ -1,0 +1,406 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// s3LogReader implements LogReader over S3 objects written by LoggerS3.
+//
+// Key layouts (must match the write path in s3.go):
+//
+//	status/result: {env}/{logType}/{uuid}:{ts}.json
+//	query:        {env}/query/{name}/{uuid}:{ts}.json
+//
+// The timestamp in the key is millisecond Unix time, so lexical ordering
+// of keys within a prefix == chronological ordering. ListObjectsV2 returns
+// keys in lexical order, so the reader gets pre-sorted results for free
+// and only needs to fetch the objects for the requested page/limit.
+//
+// Status/result reads list by prefix {env}/{logType}/ and keep only keys
+// whose UUID segment matches (the prefix is environment-scoped, not
+// node-scoped, because the write path does not nest under the node).
+// Query reads list by prefix {env}/query/{name}/ which is already
+// name-scoped, so every key in the prefix is a result for that query.
+type s3LogReader struct {
+	client *s3.Client
+	bucket string
+}
+
+// NewS3LogReader returns a LogReader backed by the given S3 client/bucket.
+// The client is the same one LoggerS3 already constructs at TLS startup,
+// so the reader shares the configured credentials/region.
+func NewS3LogReader(client *s3.Client, bucket string) LogReader {
+	return &s3LogReader{client: client, bucket: bucket}
+}
+
+// NodeLogs implements LogReader. It lists the {env}/{logType}/ prefix,
+// keeps keys whose UUID matches, applies the since/search filters
+// (best-effort — the search is applied against the decoded JSON body),
+// and returns up to `limit` rows ordered newest-first.
+func (r *s3LogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error) {
+	prefix, err := normalizeLogType(logType)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	wantUUID := upperUUID(uuid)
+	prefix = env + "/" + prefix + "/"
+
+	keys, err := r.listKeys(prefix)
+	if err != nil {
+		return nil, err
+	}
+	// Keys are returned lexically (oldest first). We want newest first.
+	sortKeysDesc(keys)
+
+	rows := make([]map[string]any, 0, limit)
+	for _, key := range keys {
+		if len(rows) >= limit {
+			break
+		}
+		entry, ok := decodeNodeLogKey(key, wantUUID)
+		if !ok {
+			continue
+		}
+		if !since.IsZero() && !entry.CreatedAt.After(since) {
+			continue
+		}
+		body, err := r.getObject(key)
+		if err != nil {
+			log.Debug().Err(err).Str("key", key).Msg("s3 reader: skipping unreadable object")
+			continue
+		}
+		decoded, err := decodeNodeLogBody(body, logType, env, wantUUID, entry.CreatedAt)
+		if err != nil {
+			continue
+		}
+		if search != "" && !nodeLogMatchesSearch(decoded, logType, search) {
+			continue
+		}
+		rows = append(rows, decoded)
+	}
+	return rows, nil
+}
+
+// QueryResults implements LogReader. It lists the {env}/query/{name}/
+// prefix (already name-scoped), applies the since filter, then pages.
+// Because keys are chronologically ordered, page N is a contiguous slice
+// of the sorted key list.
+func (r *s3LogReader) QueryResults(env, name string, since time.Time, page, pageSize int) ([]map[string]any, int64, error) {
+	if pageSize <= 0 {
+		pageSize = 100
+	}
+	if pageSize > 1000 {
+		pageSize = 1000
+	}
+	if page <= 0 {
+		page = 1
+	}
+	prefix := env + "/query/" + name + "/"
+	keys, err := r.listKeys(prefix)
+	if err != nil {
+		return nil, 0, err
+	}
+	// keys are oldest-first (lexical). Apply the since filter to narrow
+	// the total before paging.
+	if !since.IsZero() {
+		filtered := keys[:0]
+		for _, k := range keys {
+			if ts, ok := tsFromKey(k); ok && ts.After(since) {
+				filtered = append(filtered, k)
+			}
+		}
+		keys = filtered
+	}
+	total := int64(len(keys))
+	offset := (page - 1) * pageSize
+	if offset >= len(keys) {
+		return []map[string]any{}, total, nil
+	}
+	end := offset + pageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+	pageKeys := keys[offset:end]
+	items := make([]map[string]any, 0, len(pageKeys))
+	for _, key := range pageKeys {
+		body, err := r.getObject(key)
+		if err != nil {
+			log.Debug().Err(err).Str("key", key).Msg("s3 reader: skipping unreadable query object")
+			continue
+		}
+		item, err := decodeQueryLogBody(body, key)
+		if err != nil {
+			continue
+		}
+		items = append(items, item)
+	}
+	return items, total, nil
+}
+
+// StreamQueryResults implements LogReader. It lists every object under
+// {env}/query/{name}/ (oldest-first) and invokes fn for each decoded
+// OsqueryQueryData row. Memory is bounded by a single object body at a
+// time; the key list itself can be large but is just strings.
+func (r *s3LogReader) StreamQueryResults(env, name string, fn func(OsqueryQueryData) error) error {
+	prefix := env + "/query/" + name + "/"
+	keys, err := r.listKeys(prefix)
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		body, err := r.getObject(key)
+		if err != nil {
+			return err
+		}
+		row, err := decodeQueryLogRow(body, key)
+		if err != nil {
+			return err
+		}
+		if err := fn(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// listKeys paginates ListObjectsV2 for a prefix and returns the keys in
+// lexical (oldest-first) order.
+func (r *s3LogReader) listKeys(prefix string) ([]string, error) {
+	ctx := context.Background()
+	var keys []string
+	paginator := s3.NewListObjectsV2Paginator(r.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(r.bucket),
+		Prefix: aws.String(prefix),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("s3 list prefix %q: %w", prefix, err)
+		}
+		for _, obj := range page.Contents {
+			if obj.Key == nil {
+				continue
+			}
+			keys = append(keys, *obj.Key)
+		}
+	}
+	// ListObjectsV2 returns keys in lexical order already; this sort is
+	// a defensive no-op for well-behaved buckets.
+	sort.Strings(keys)
+	return keys, nil
+}
+
+// getObject downloads and returns the full body of an object.
+func (r *s3LogReader) getObject(key string) ([]byte, error) {
+	ctx := context.Background()
+	out, err := r.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(r.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer out.Body.Close()
+	return io.ReadAll(out.Body)
+}
+
+// nodeLogEntry holds the parsed UUID + timestamp from a status/result key.
+type nodeLogEntry struct {
+	UUID      string
+	CreatedAt time.Time
+}
+
+// decodeNodeLogKey parses {env}/{logType}/{uuid}:{ts}.json and reports
+// whether the key belongs to wantUUID.
+func decodeNodeLogKey(key, wantUUID string) (nodeLogEntry, bool) {
+	base := key
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	// base is "{uuid}:{ts}.json"
+	colon := strings.LastIndex(base, ":")
+	if colon < 0 {
+		return nodeLogEntry{}, false
+	}
+	uuidPart := base[:colon]
+	if !strings.EqualFold(uuidPart, wantUUID) {
+		return nodeLogEntry{}, false
+	}
+	tsStr := strings.TrimSuffix(base[colon+1:], ".json")
+	tsMs, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return nodeLogEntry{}, false
+	}
+	return nodeLogEntry{UUID: wantUUID, CreatedAt: time.UnixMilli(tsMs)}, true
+}
+
+// decodeNodeLogBody decodes a status or result log object body into the
+// same map[string]any shape the DB reader returns, so the API handler
+// and frontend need no changes.
+func decodeNodeLogBody(body []byte, logType, env, uuid string, createdAt time.Time) (map[string]any, error) {
+	switch logType {
+	case types.StatusLog:
+		var logs []types.LogStatusData
+		if err := json.Unmarshal(body, &logs); err != nil {
+			return nil, err
+		}
+		// The DB reader produces one row per status line; mirror that.
+		// We only return the first entry's map because the S3 write path
+		// stores one batch per object — but the historical DB row shape
+		// is per-line, so we emit the first line here. Callers that need
+		// every line get them across multiple objects.
+		if len(logs) == 0 {
+			return nil, fmt.Errorf("empty status log")
+		}
+		l := logs[0]
+		return map[string]any{
+			"created_at":  createdAt,
+			"uuid":        uuid,
+			"environment": env,
+			"line":        strconv.Itoa(int(l.Line)),
+			"message":     l.Message,
+			"version":     l.Version,
+			"filename":    l.Filename,
+			"severity":    strconv.Itoa(int(l.Severity)),
+		}, nil
+	case types.ResultLog:
+		var logs []types.LogResultData
+		if err := json.Unmarshal(body, &logs); err != nil {
+			return nil, err
+		}
+		if len(logs) == 0 {
+			return nil, fmt.Errorf("empty result log")
+		}
+		l := logs[0]
+		return map[string]any{
+			"created_at":  createdAt,
+			"uuid":        uuid,
+			"environment": env,
+			"name":        l.Name,
+			"action":      l.Action,
+			"epoch":       l.Epoch,
+			"columns":     string(l.Columns),
+			"counter":     l.Counter,
+		}, nil
+	default:
+		return nil, fmt.Errorf("invalid log type: %s", logType)
+	}
+}
+
+// nodeLogMatchesSearch applies the same substring filter the DB reader
+// applies via LOWER() LIKE. Best-effort, case-insensitive.
+func nodeLogMatchesSearch(row map[string]any, logType, search string) bool {
+	needle := strings.ToLower(search)
+	fields := []string{"line", "message", "filename"}
+	if logType == types.ResultLog {
+		fields = []string{"name", "action", "columns"}
+	}
+	for _, f := range fields {
+		if v, ok := row[f].(string); ok && strings.Contains(strings.ToLower(v), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// decodeQueryLogBody decodes a query result object into the map shape the
+// DB reader's GetQueryResults returns.
+func decodeQueryLogBody(body []byte, key string) (map[string]any, error) {
+	row, err := decodeQueryLogRow(body, key)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"id":          int64(0),
+		"created_at":  row.CreatedAt,
+		"uuid":        row.UUID,
+		"environment": row.Environment,
+		"name":        row.Name,
+		"data":        row.Data,
+		"status":      row.Status,
+	}, nil
+}
+
+// decodeQueryLogRow decodes a query result object into an OsqueryQueryData
+// for the streaming path. The ID is synthetic (0) because S3 objects have
+// no integer primary key; callers that need a unique identifier use the
+// key itself.
+func decodeQueryLogRow(body []byte, key string) (OsqueryQueryData, error) {
+	var data types.QueryWriteData
+	if err := json.Unmarshal(body, &data); err != nil {
+		return OsqueryQueryData{}, err
+	}
+	env, uuid, _, ok := splitQueryKey(key)
+	if !ok {
+		return OsqueryQueryData{}, fmt.Errorf("could not parse query key %q", key)
+	}
+	return OsqueryQueryData{
+		UUID:        upperUUID(uuid),
+		Environment: env,
+		Name:        data.Name,
+		Data:        string(body),
+		Status:      data.Status,
+	}, nil
+}
+
+// splitQueryKey parses {env}/query/{name}/{uuid}:{ts}.json and returns
+// env, uuid, name, ok.
+func splitQueryKey(key string) (env, uuid, name string, ok bool) {
+	parts := strings.SplitN(key, "/", 4)
+	if len(parts) != 4 {
+		return "", "", "", false
+	}
+	env = parts[0]
+	// parts[1] == "query"
+	name = parts[2]
+	last := parts[3]
+	colon := strings.LastIndex(last, ":")
+	if colon < 0 {
+		return "", "", "", false
+	}
+	uuid = last[:colon]
+	return env, uuid, name, true
+}
+
+// tsFromKey extracts the millisecond timestamp from the trailing
+// "{ts}.json" segment of any S3 log key.
+func tsFromKey(key string) (time.Time, bool) {
+	base := key
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	colon := strings.LastIndex(base, ":")
+	if colon < 0 {
+		return time.Time{}, false
+	}
+	tsStr := strings.TrimSuffix(base[colon+1:], ".json")
+	tsMs, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.UnixMilli(tsMs), true
+}
+
+// sortKeysDesc sorts keys newest-first (descending lexical == descending
+// chronological, because the timestamp is the last path segment).
+func sortKeysDesc(keys []string) {
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+}

--- a/pkg/logging/s3_reader_test.go
+++ b/pkg/logging/s3_reader_test.go
@@ -1,0 +1,142 @@
+package logging
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3QueryKeyLayout(t *testing.T) {
+	ts := time.UnixMilli(1700000000000)
+	key := s3QueryKey("env-uuid", "q-123", "NODE-UUID", ts)
+	require.Equal(t, "env-uuid/query/q-123/NODE-UUID:1700000000000.json", key)
+}
+
+func TestSplitQueryKey(t *testing.T) {
+	env, uuid, name, ok := splitQueryKey("env-uuid/query/q-123/NODE-UUID:1700000000000.json")
+	require.True(t, ok)
+	require.Equal(t, "env-uuid", env)
+	require.Equal(t, "q-123", name)
+	require.Equal(t, "NODE-UUID", uuid)
+}
+
+func TestSplitQueryKeyRejectsBadKey(t *testing.T) {
+	_, _, _, ok := splitQueryKey("env-uuid/query/q-123")
+	require.False(t, ok)
+}
+
+func TestTsFromKey(t *testing.T) {
+	ts, ok := tsFromKey("env-uuid/query/q-123/NODE-UUID:1700000000000.json")
+	require.True(t, ok)
+	require.Equal(t, time.UnixMilli(1700000000000), ts)
+}
+
+func TestDecodeNodeLogKeyStatusMatch(t *testing.T) {
+	key := "env-uuid/status/NODE-UUID:1700000000000.json"
+	entry, ok := decodeNodeLogKey(key, "NODE-UUID")
+	require.True(t, ok)
+	require.Equal(t, "NODE-UUID", entry.UUID)
+	require.Equal(t, time.UnixMilli(1700000000000), entry.CreatedAt)
+}
+
+func TestDecodeNodeLogKeyStatusRejectsOtherUUID(t *testing.T) {
+	key := "env-uuid/status/OTHER-UUID:1700000000000.json"
+	_, ok := decodeNodeLogKey(key, "NODE-UUID")
+	require.False(t, ok)
+}
+
+func TestDecodeNodeLogBodyStatus(t *testing.T) {
+	logs := []types.LogStatusData{{HostIdentifier: "node-uuid", Line: 1, Message: "ok", Version: "5.13.1", Filename: "init.cpp", Severity: 0}}
+	body, err := json.Marshal(logs)
+	require.NoError(t, err)
+	created := time.UnixMilli(1700000000000)
+	row, err := decodeNodeLogBody(body, types.StatusLog, "env-uuid", "NODE-UUID", created)
+	require.NoError(t, err)
+	require.Equal(t, "NODE-UUID", row["uuid"])
+	require.Equal(t, "env-uuid", row["environment"])
+	require.Equal(t, created, row["created_at"])
+	require.Equal(t, "1", row["line"])
+	require.Equal(t, "ok", row["message"])
+	require.Equal(t, "5.13.1", row["version"])
+}
+
+func TestDecodeNodeLogBodyResult(t *testing.T) {
+	logs := []types.LogResultData{{HostIdentifier: "node-uuid", Name: "time", Action: "added", Columns: json.RawMessage(`{"foo":"bar"}`), Epoch: 0, Counter: 0}}
+	body, err := json.Marshal(logs)
+	require.NoError(t, err)
+	row, err := decodeNodeLogBody(body, types.ResultLog, "env-uuid", "NODE-UUID", time.UnixMilli(1700000000000))
+	require.NoError(t, err)
+	require.Equal(t, "time", row["name"])
+	require.Equal(t, "added", row["action"])
+	require.Contains(t, row["columns"].(string), "foo")
+}
+
+func TestDecodeQueryLogRow(t *testing.T) {
+	data := types.QueryWriteData{Name: "q-123", Result: json.RawMessage(`[{"version":"5.13.1"}]`), Status: 0}
+	body, err := json.Marshal(data)
+	require.NoError(t, err)
+	row, err := decodeQueryLogRow(body, "env-uuid/query/q-123/NODE-UUID:1700000000000.json")
+	require.NoError(t, err)
+	require.Equal(t, "NODE-UUID", row.UUID)
+	require.Equal(t, "env-uuid", row.Environment)
+	require.Equal(t, "q-123", row.Name)
+	require.Equal(t, 0, row.Status)
+	require.Contains(t, row.Data, "5.13.1")
+}
+
+func TestDecodeQueryLogBodyMap(t *testing.T) {
+	data := types.QueryWriteData{Name: "q-123", Result: json.RawMessage(`[{"version":"5.13.1"}]`), Status: 0}
+	body, err := json.Marshal(data)
+	require.NoError(t, err)
+	item, err := decodeQueryLogBody(body, "env-uuid/query/q-123/NODE-UUID:1700000000000.json")
+	require.NoError(t, err)
+	require.Equal(t, "NODE-UUID", item["uuid"])
+	require.Equal(t, "q-123", item["name"])
+}
+
+func TestNodeLogMatchesSearch(t *testing.T) {
+	row := map[string]any{"message": "osquery started", "line": "1"}
+	require.True(t, nodeLogMatchesSearch(row, types.StatusLog, "started"))
+	require.False(t, nodeLogMatchesSearch(row, types.StatusLog, "nonexistent"))
+}
+
+func TestSortKeysDesc(t *testing.T) {
+	keys := []string{
+		"env/query/q/1:1000.json",
+		"env/query/q/1:3000.json",
+		"env/query/q/1:2000.json",
+	}
+	sortKeysDesc(keys)
+	require.Equal(t, "env/query/q/1:3000.json", keys[0])
+	require.Equal(t, "env/query/q/1:2000.json", keys[1])
+	require.Equal(t, "env/query/q/1:1000.json", keys[2])
+}
+
+func TestDBLogReaderNodeLogsFallsBackToDB(t *testing.T) {
+	// NewDBLogReader with a nil DB should not panic on construction; the
+	// call itself would error, which is the existing behavior of
+	// GetNodeLogs with a nil gorm.DB. We only assert the reader is the
+	// concrete dbLogReader type.
+	r := NewDBLogReader(nil)
+	_, ok := r.(*dbLogReader)
+	require.True(t, ok)
+}
+
+func TestS3QueryKeyLexicalOrder(t *testing.T) {
+	// Verify that lexical ordering of keys within a prefix matches
+	// chronological ordering — this is the invariant the reader relies
+	// on for free pre-sorting.
+	base := "env/query/q/uuid:"
+	keys := []string{
+		base + strconv.FormatInt(1700000000000, 10) + ".json",
+		base + strconv.FormatInt(1700000000001, 10) + ".json",
+		base + strconv.FormatInt(1699999999999, 10) + ".json",
+	}
+	require.True(t, strings.Compare(keys[0], keys[1]) < 0, "ts 0 < ts 1 should sort first")
+	require.True(t, strings.Compare(keys[2], keys[0]) < 0, "ts -1 < ts 0 should sort first")
+}

--- a/pkg/logging/s3_reader_test.go
+++ b/pkg/logging/s3_reader_test.go
@@ -11,14 +11,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestS3LogKeyLayout(t *testing.T) {
+	ts := time.UnixMilli(1700000000000)
+	key := s3LogKey("env-uuid", "status", "NODE-UUID", ts)
+	require.Equal(t, "env-uuid/status/NODE-UUID/1700000000000.json", key)
+}
+
 func TestS3QueryKeyLayout(t *testing.T) {
 	ts := time.UnixMilli(1700000000000)
 	key := s3QueryKey("env-uuid", "q-123", "NODE-UUID", ts)
-	require.Equal(t, "env-uuid/query/q-123/NODE-UUID:1700000000000.json", key)
+	require.Equal(t, "env-uuid/query/q-123/NODE-UUID/1700000000000.json", key)
 }
 
 func TestSplitQueryKey(t *testing.T) {
-	env, uuid, name, ok := splitQueryKey("env-uuid/query/q-123/NODE-UUID:1700000000000.json")
+	env, uuid, name, ok := splitQueryKey("env-uuid/query/q-123/NODE-UUID/1700000000000.json")
 	require.True(t, ok)
 	require.Equal(t, "env-uuid", env)
 	require.Equal(t, "q-123", name)
@@ -31,13 +37,19 @@ func TestSplitQueryKeyRejectsBadKey(t *testing.T) {
 }
 
 func TestTsFromKey(t *testing.T) {
-	ts, ok := tsFromKey("env-uuid/query/q-123/NODE-UUID:1700000000000.json")
+	ts, ok := tsFromKey("env-uuid/query/q-123/NODE-UUID/1700000000000.json")
+	require.True(t, ok)
+	require.Equal(t, time.UnixMilli(1700000000000), ts)
+}
+
+func TestTsFromKeyStatusLayout(t *testing.T) {
+	ts, ok := tsFromKey("env-uuid/status/NODE-UUID/1700000000000.json")
 	require.True(t, ok)
 	require.Equal(t, time.UnixMilli(1700000000000), ts)
 }
 
 func TestDecodeNodeLogKeyStatusMatch(t *testing.T) {
-	key := "env-uuid/status/NODE-UUID:1700000000000.json"
+	key := "env-uuid/status/NODE-UUID/1700000000000.json"
 	entry, ok := decodeNodeLogKey(key, "NODE-UUID")
 	require.True(t, ok)
 	require.Equal(t, "NODE-UUID", entry.UUID)
@@ -45,8 +57,14 @@ func TestDecodeNodeLogKeyStatusMatch(t *testing.T) {
 }
 
 func TestDecodeNodeLogKeyStatusRejectsOtherUUID(t *testing.T) {
-	key := "env-uuid/status/OTHER-UUID:1700000000000.json"
+	key := "env-uuid/status/OTHER-UUID/1700000000000.json"
 	_, ok := decodeNodeLogKey(key, "NODE-UUID")
+	require.False(t, ok)
+}
+
+func TestDecodeNodeLogKeyRejectsBadSegmentCount(t *testing.T) {
+	// Old layout with colon would now have a wrong segment count.
+	_, ok := decodeNodeLogKey("env-uuid/status/NODE-UUID:1700000000000.json", "NODE-UUID")
 	require.False(t, ok)
 }
 
@@ -80,7 +98,7 @@ func TestDecodeQueryLogRow(t *testing.T) {
 	data := types.QueryWriteData{Name: "q-123", Result: json.RawMessage(`[{"version":"5.13.1"}]`), Status: 0}
 	body, err := json.Marshal(data)
 	require.NoError(t, err)
-	row, err := decodeQueryLogRow(body, "env-uuid/query/q-123/NODE-UUID:1700000000000.json")
+	row, err := decodeQueryLogRow(body, "env-uuid/query/q-123/NODE-UUID/1700000000000.json")
 	require.NoError(t, err)
 	require.Equal(t, "NODE-UUID", row.UUID)
 	require.Equal(t, "env-uuid", row.Environment)
@@ -93,7 +111,7 @@ func TestDecodeQueryLogBodyMap(t *testing.T) {
 	data := types.QueryWriteData{Name: "q-123", Result: json.RawMessage(`[{"version":"5.13.1"}]`), Status: 0}
 	body, err := json.Marshal(data)
 	require.NoError(t, err)
-	item, err := decodeQueryLogBody(body, "env-uuid/query/q-123/NODE-UUID:1700000000000.json")
+	item, err := decodeQueryLogBody(body, "env-uuid/query/q-123/NODE-UUID/1700000000000.json")
 	require.NoError(t, err)
 	require.Equal(t, "NODE-UUID", item["uuid"])
 	require.Equal(t, "q-123", item["name"])
@@ -107,14 +125,14 @@ func TestNodeLogMatchesSearch(t *testing.T) {
 
 func TestSortKeysDesc(t *testing.T) {
 	keys := []string{
-		"env/query/q/1:1000.json",
-		"env/query/q/1:3000.json",
-		"env/query/q/1:2000.json",
+		"env/query/q/uuid/1000.json",
+		"env/query/q/uuid/3000.json",
+		"env/query/q/uuid/2000.json",
 	}
 	sortKeysDesc(keys)
-	require.Equal(t, "env/query/q/1:3000.json", keys[0])
-	require.Equal(t, "env/query/q/1:2000.json", keys[1])
-	require.Equal(t, "env/query/q/1:1000.json", keys[2])
+	require.Equal(t, "env/query/q/uuid/3000.json", keys[0])
+	require.Equal(t, "env/query/q/uuid/2000.json", keys[1])
+	require.Equal(t, "env/query/q/uuid/1000.json", keys[2])
 }
 
 func TestDBLogReaderNodeLogsFallsBackToDB(t *testing.T) {
@@ -131,7 +149,19 @@ func TestS3QueryKeyLexicalOrder(t *testing.T) {
 	// Verify that lexical ordering of keys within a prefix matches
 	// chronological ordering — this is the invariant the reader relies
 	// on for free pre-sorting.
-	base := "env/query/q/uuid:"
+	base := "env/query/q/uuid/"
+	keys := []string{
+		base + strconv.FormatInt(1700000000000, 10) + ".json",
+		base + strconv.FormatInt(1700000000001, 10) + ".json",
+		base + strconv.FormatInt(1699999999999, 10) + ".json",
+	}
+	require.True(t, strings.Compare(keys[0], keys[1]) < 0, "ts 0 < ts 1 should sort first")
+	require.True(t, strings.Compare(keys[2], keys[0]) < 0, "ts -1 < ts 0 should sort first")
+}
+
+func TestS3StatusKeyLexicalOrder(t *testing.T) {
+	// Same invariant for the status/result layout.
+	base := "env/status/NODE-UUID/"
 	keys := []string{
 		base + strconv.FormatInt(1700000000000, 10) + ".json",
 		base + strconv.FormatInt(1700000000001, 10) + ".json",


### PR DESCRIPTION
# S3-backed log reader for status, result, and on-demand query logs

## Problem

When the TLS logger is configured to ship logs to S3, the `osquery_status_data`,
`osquery_result_data`, and `osquery_query_data` DB tables are empty — the data
lives in S3 objects instead. The API handlers (`NodeLogsHandler`,
`QueryResultsHandler`, `QueryResultsCSVHandler`) and the console/file-explorer
managers all read from those DB tables, so the frontend could not access
status logs, result logs, or on-demand query results when S3 logging was
enabled.

## Change

Introduced a `LogReader` interface with two implementations and wired the
right one at API startup based on the logger config:

- **`dbLogReader`** — the historical GORM-backed reader (legacy behavior).
- **`s3LogReader`** — reads logs back from S3 objects written by `LoggerS3`.

When the TLS logger type is `s3`, the API constructs the S3 reader from the
same S3 client/bucket the TLS logger uses; otherwise it constructs the DB
reader. The reader is wired into the API handlers, the console manager, and
the file-explorer manager.

## How the S3 reader works

### Key layout

The write path (`LoggerS3.Query`) embeds the query name in the S3 key so the
reader can list by query name with a prefix filter — without it the reader
would have to list every query object in the environment and decode each body
to find the ones matching a name, which is catastrophically slow on a busy
bucket.

- **status/result**: `{env}/{logType}/{uuid}:{ts}.json` (unchanged)
- **query**: `{env}/query/{name}/{uuid}:{ts}.json` (new — name is a path segment)

### Free chronological ordering

The timestamp is the last path segment (millisecond Unix time), so lexical
ordering of keys within a prefix == chronological ordering. `ListObjectsV2`
returns keys lexically, so results come pre-sorted. The reader only fetches
the objects for the requested page/limit — it does not download the entire
prefix.

- **Status/result reads** list by `{env}/{logType}/` prefix, keep keys whose
  UUID matches, apply the since/search filters, and return up to `limit` rows
  newest-first.
- **Query reads** list by `{env}/query/{name}/` prefix (already name-scoped),
  apply the since filter, and page a contiguous slice of the sorted key list.
- **Streaming reads** (CSV export, console/file-explorer result decoders)
  walk every key in the prefix and invoke the callback for each decoded row;
  memory is bounded by a single object body at a time.

## What works with S3 logging now

- `GET /api/v1/logs/{type}/{env}/{uuid}` — status + result logs (paginated,
  searchable)
- `GET /api/v1/queries/{env}/results/{name}` — on-demand query results
  (paginated)
- `GET /api/v1/queries/{env}/results/csv/{name}` — CSV export (streaming)
- Console command results + history
- File explorer list/stat results + priming metadata

## Heatmap is unaffected

The per-node activity heatmap is fed by Redis (`recordActivity` fires in the
TLS ingestion handlers on every status/result/config/query_read/query_write
arrival, independent of the DB logger), so it continues to populate with S3
logging. The DB-bucketed `status`/`result` categories in
`computeNodeActivityForNode` are redundant with the Redis series and simply
read as zero — no real gap.

## Files

**New**
- `pkg/logging/reader.go` — `LogReader` interface + `dbLogReader`
- `pkg/logging/s3_reader.go` — `s3LogReader` (`ListObjectsV2` + `GetObject`)
- `pkg/logging/s3_reader_test.go` — key/decode/ordering unit tests
- `cmd/api/handlers/log_reader_test.go` — fake-reader wiring tests proving
  handlers route reads through the wired `LogReader`

**Modified**
- `pkg/logging/s3.go` — `LoggerS3.Query` write method with the query name in
  the key; `s3QueryKey` helper shared by writer and reader
- `pkg/logging/logging.go` — `QueryLog` calls `l.Query` (not `l.Send`) for S3
- `pkg/console/{manager,models}.go` — `LogReader` field + `SetLogReader`;
  `Environment` (env UUID) stored on `Session` for the S3 key prefix;
  `queryResults` / `History` / `CommandResults` use the reader
- `pkg/fileexplorer/{manager,models}.go` — same pattern; `RequestResults` and
  `RequestMetadataRows` use the reader
- `cmd/api/handlers/handlers.go` — `LogReader` field + `WithLogReader` +
  lazy `logReader()` fallback to `NewDBLogReader(h.DB)`
- `cmd/api/handlers/logs.go` — `NodeLogsHandler` uses `h.logReader().NodeLogs`
- `cmd/api/handlers/queries.go` — `QueryResultsHandler` and
  `QueryResultsCSVHandler` use `h.logReader().QueryResults` /
  `StreamQueryResults`
- `cmd/api/main.go` — construct S3 or DB reader based on
  `flagParams.Logger.Type`; wire into handlers + console + file-explorer
  managers

## Backward compatibility

- When no `LogReader` is wired, handlers and managers fall back to
  `NewDBLogReader(h.DB)`, so existing tests that only set `WithDB` keep working
  unchanged.
- The `Environment` column added to `console_sessions` and
  `file_explorer_sessions` is additive and migrated via the existing
  `AutoMigrate` in each `NewManager`.
- The S3 query-log key layout change applies to new writes only; existing
  objects written by the old `Send` path are not listed by the new query
  reader (they predate this change and would not have been readable by name
  regardless).

## Validation

- `go build ./...` — clean
- `go test ./...` — all pass, including new S3 reader and LogReader-wiring
  tests
- `golangci-lint` on touched packages — only pre-existing issues remain
- `npm run check` (tsc) — clean
- `npm run test` (vitest) — 190/190 frontend tests pass