### PR TITLE
Refactor logger into exporters to allow multiple ones

### DIFF
--- a/cmd/admin/handlers/json-logs.go
+++ b/cmd/admin/handlers/json-logs.go
@@ -122,7 +122,7 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	// Get logs
 	logJSON := []LogJSON{}
-	if logType == types.StatusLog && h.Configuration.Logger.Type == config.LoggingDB {
+	if logType == types.StatusLog && config.LoggerHasType(h.Configuration.Logger, config.LoggingDB) {
 		statusLogs, err := h.DBLogger.StatusLogsLimit(UUID, env.Name, int(limitItems))
 		if err != nil {
 			log.Err(err).Msg("error getting logs")
@@ -141,7 +141,7 @@ func (h *HandlersAdmin) JSONLogsHandler(w http.ResponseWriter, r *http.Request) 
 			}
 			logJSON = append(logJSON, _l)
 		}
-	} else if logType == types.ResultLog && h.Configuration.Logger.Type == config.LoggingDB {
+	} else if logType == types.ResultLog && config.LoggerHasType(h.Configuration.Logger, config.LoggingDB) {
 		resultLogs, err := h.DBLogger.ResultLogsLimit(UUID, env.Name, int(limitItems))
 		if err != nil {
 			log.Err(err).Msg("error getting logs")

--- a/cmd/admin/handlers/templates.go
+++ b/cmd/admin/handlers/templates.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmpsec/osctrl/cmd/admin/sessions"
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/carves"
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/settings"
@@ -20,6 +21,20 @@ import (
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
+
+func configuredLoggerTypes(cfg *config.ServiceParameters) string {
+	if cfg == nil {
+		return ""
+	}
+	return strings.Join(config.LoggerTypes(cfg.Logger), ",")
+}
+
+func configuredDBLogger(cfg *config.ServiceParameters) bool {
+	if cfg == nil {
+		return false
+	}
+	return config.LoggerHasType(cfg.Logger, config.LoggingDB)
+}
 
 // TemplateFiles for building UI layout
 type TemplateFiles struct {
@@ -632,6 +647,8 @@ func (h *HandlersAdmin) QueryLogsHandler(w http.ResponseWriter, r *http.Request)
 		Query:         query,
 		QueryTargets:  parseQueryTarget(query.Target),
 		ServiceConfig: h.Configuration,
+		LoggerTypes:   configuredLoggerTypes(h.Configuration),
+		DBLogger:      configuredDBLogger(h.Configuration),
 	}
 	if err := t.Execute(w, templateData); err != nil {
 		log.Err(err).Msg("template error")
@@ -1107,6 +1124,8 @@ func (h *HandlersAdmin) NodeHandler(w http.ResponseWriter, r *http.Request) {
 		Packs:         packs,
 		Schedule:      schedule,
 		ServiceConfig: h.Configuration,
+		LoggerTypes:   configuredLoggerTypes(h.Configuration),
+		DBLogger:      configuredDBLogger(h.Configuration),
 	}
 	if err := t.Execute(w, templateData); err != nil {
 		log.Err(err).Msg("template error")
@@ -1227,6 +1246,7 @@ func (h *HandlersAdmin) SettingsGETHandler(w http.ResponseWriter, r *http.Reques
 		Environments:    h.allowedEnvironments(ctx[sessions.CtxUser], envAll),
 		CurrentSettings: _settings,
 		ServiceConfig:   toJSONConfigurationService(svcJSON),
+		LoggerTypes:     configuredLoggerTypes(toJSONConfigurationService(svcJSON)),
 	}
 	if err := t.Execute(w, templateData); err != nil {
 		log.Err(err).Msg("template error")

--- a/cmd/admin/handlers/types-templates.go
+++ b/cmd/admin/handlers/types-templates.go
@@ -152,6 +152,8 @@ type QueryLogsTemplateData struct {
 	Metadata      TemplateMetadata
 	LeftMetadata  AsideLeftMetadata
 	ServiceConfig *config.ServiceParameters
+	LoggerTypes   string
+	DBLogger      bool
 }
 
 // EnvironmentsTemplateData for passing data to the environments template
@@ -171,6 +173,7 @@ type SettingsTemplateData struct {
 	Platforms       []string
 	CurrentSettings []settings.SettingValue
 	ServiceConfig   *config.ServiceParameters
+	LoggerTypes     string
 	Metadata        TemplateMetadata
 	LeftMetadata    AsideLeftMetadata
 }
@@ -249,4 +252,6 @@ type NodeTemplateData struct {
 	Schedule      environments.ScheduleConf
 	Packs         environments.PacksEntries
 	ServiceConfig *config.ServiceParameters
+	LoggerTypes   string
+	DBLogger      bool
 }

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -354,9 +354,11 @@ func osctrlAdminService() {
 	}()
 	var loggerDBConfig *config.YAMLConfigurationDB
 	// Set the logger configuration file if we have a DB logger
-	if flagParams.Logger.Type == config.LoggingDB {
+	if config.LoggerHasType(flagParams.Logger, config.LoggingDB) {
 		if flagParams.Logger.LoggerDBSame {
 			loggerDBConfig = flagParams.DB
+		} else {
+			loggerDBConfig = flagParams.Logger.DB
 		}
 	}
 	// Initialize audit log manager

--- a/cmd/admin/templates/queries-logs.html
+++ b/cmd/admin/templates/queries-logs.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-  {{ $metadata := .Metadata }} {{ $serviceConfig := .ServiceConfig }} {{ $leftmeta := .LeftMetadata }} {{ template "page-head" . }}
+  {{ $metadata := .Metadata }} {{ $serviceConfig := .ServiceConfig }} {{ $leftmeta := .LeftMetadata }} {{ $dbLogger := .DBLogger }} {{ $loggerTypes := .LoggerTypes }} {{ template "page-head" . }}
 
   <body class="app header-fixed sidebar-fixed sidebar-lg-show">
     {{ template "page-header" . }}
@@ -66,7 +66,7 @@
                   </tbody>
                 </table>
                 <br />
-                {{ if eq $serviceConfig.Logger.Type "db" }}
+                {{ if $dbLogger }}
                 <div id="downloadLinkContainer" class="alert alert-info" style="display: none">
                   <i class="fas fa-info-circle"></i>
                   <strong>Large Result Set:</strong> The results are too large to display in the table.
@@ -83,7 +83,7 @@
                   </thead>
                 </table>
                 {{ else }}
-                <div class="alert alert-warning" role="alert"><i class="fas fa-exclamation-triangle"></i> The logger is set to <b>{{ $serviceConfig.Logger.Type }}</b> in the service configuration. No results available.</div>
+                <div class="alert alert-warning" role="alert"><i class="fas fa-exclamation-triangle"></i> The logger is set to <b>{{ $loggerTypes }}</b> in the service configuration. No results available.</div>
                 {{ end }}
               </div>
             </div>

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -327,6 +327,25 @@ func initLoggingFlags(params *ServiceParameters) []cli.Flag {
 			Sources:     cli.EnvVars("SERVICE_LOGGER"),
 			Destination: &params.Logger.Type,
 		},
+		&cli.StringFlag{
+			Name:    "loggers",
+			Usage:   "Logger mechanisms to handle status/result logs from nodes as a comma-separated list",
+			Sources: cli.EnvVars("SERVICE_LOGGERS"),
+			Action: func(_ context.Context, _ *cli.Command, v string) error {
+				if v == "" {
+					return nil
+				}
+				parts := strings.Split(v, ",")
+				out := make([]string, 0, len(parts))
+				for _, p := range parts {
+					if p = strings.TrimSpace(p); p != "" {
+						out = append(out, p)
+					}
+				}
+				params.Logger.Types = out
+				return nil
+			},
+		},
 		&cli.BoolFlag{
 			Name:        "logger-db-same",
 			Value:       false,

--- a/pkg/config/loggers.go
+++ b/pkg/config/loggers.go
@@ -1,6 +1,9 @@
 package config
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // S3Logger to hold all S3 configuration values
 type S3Logger struct {
@@ -93,4 +96,44 @@ type LocalLogger struct {
 	MaxAge int `yaml:"maxAge"`
 	// If the rotated log files should be compressed using gzip
 	Compress bool `yaml:"compress"`
+}
+
+// LoggerTypes returns the normalized configured logger/exporter destinations.
+// The legacy single Type value is used when Types is empty.
+func LoggerTypes(cfg *YAMLConfigurationLogger) []string {
+	if cfg == nil {
+		return []string{LoggingDB}
+	}
+	values := cfg.Types
+	if len(values) == 0 {
+		values = []string{cfg.Type}
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return []string{LoggingDB}
+	}
+	return out
+}
+
+// LoggerHasType reports whether a logger/exporter destination is configured.
+func LoggerHasType(cfg *YAMLConfigurationLogger, loggerType string) bool {
+	loggerType = strings.ToLower(strings.TrimSpace(loggerType))
+	for _, configured := range LoggerTypes(cfg) {
+		if configured == loggerType {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -222,6 +222,7 @@ type YAMLConfigurationTLS struct {
 // YAMLConfigurationLogger to hold the logger configuration values
 type YAMLConfigurationLogger struct {
 	Type         string               `yaml:"type"`
+	Types        []string             `yaml:"types" mapstructure:"types"`
 	LoggerDBSame bool                 `yaml:"loggerDBSame"`
 	AlwaysLog    bool                 `yaml:"alwaysLog"`
 	DB           *YAMLConfigurationDB `mapstructure:"db"`

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -1,8 +1,6 @@
 package config
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // Valid values for authentication in configuration
 var validAuth = map[string]bool{
@@ -20,6 +18,7 @@ var validLogging = map[string]bool{
 	LoggingLogstash: true,
 	LoggingKinesis:  true,
 	LoggingS3:       true,
+	LoggingKafka:    true,
 	LoggingElastic:  true,
 }
 
@@ -36,7 +35,13 @@ func ValidateTLSConfigValues(cfg TLSConfiguration) error {
 	if !validAuth[cfg.Service.Auth] {
 		return fmt.Errorf("invalid auth method: %s", cfg.Service.Auth)
 	}
-	if !validLogging[cfg.Logger.Type] {
+	if len(cfg.Logger.Types) > 0 {
+		for _, loggingType := range LoggerTypes(&cfg.Logger) {
+			if !validLogging[loggingType] {
+				return fmt.Errorf("invalid logging method: %s", loggingType)
+			}
+		}
+	} else if !validLogging[cfg.Logger.Type] {
 		return fmt.Errorf("invalid logging method: %s", cfg.Logger.Type)
 	}
 	if !validCarver[cfg.Carver.Type] {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1,0 +1,25 @@
+package config
+
+import "testing"
+
+func TestValidateTLSConfigValuesAcceptsKafkaAndMultipleLoggers(t *testing.T) {
+	err := ValidateTLSConfigValues(TLSConfiguration{
+		Service: YAMLConfigurationService{Auth: AuthNone},
+		Logger:  YAMLConfigurationLogger{Types: []string{LoggingDB, LoggingKafka}},
+		Carver:  YAMLConfigurationCarver{Type: CarverDB},
+	})
+	if err != nil {
+		t.Fatalf("expected kafka and multiple logger types to validate: %v", err)
+	}
+}
+
+func TestValidateTLSConfigValuesRejectsInvalidMultipleLogger(t *testing.T) {
+	err := ValidateTLSConfigValues(TLSConfiguration{
+		Service: YAMLConfigurationService{Auth: AuthNone},
+		Logger:  YAMLConfigurationLogger{Types: []string{LoggingDB, "bogus"}},
+		Carver:  YAMLConfigurationCarver{Type: CarverDB},
+	})
+	if err == nil {
+		t.Fatalf("expected invalid logger type to fail validation")
+	}
+}

--- a/pkg/logging/exporter.go
+++ b/pkg/logging/exporter.go
@@ -1,0 +1,99 @@
+package logging
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// ExportParams contains the metadata shared by every osquery data exporter.
+// QueryName and Status are set only for on-demand query result exports.
+type ExportParams struct {
+	Environment string
+	UUID        string
+	QueryName   string
+	Status      int
+	Debug       bool
+}
+
+// DataExporter is a destination for osquery status, result, and query data.
+type DataExporter interface {
+	Name() string
+	IsEnabled() bool
+	Export(logType string, data []byte, params ExportParams) error
+}
+
+// MultiExporter fans out one osquery payload to multiple destinations.
+// A failing exporter is logged and returned, but does not prevent later
+// exporters from receiving the same payload.
+type MultiExporter struct {
+	exporters []DataExporter
+}
+
+// NewMultiExporter creates a composite exporter from the provided destinations.
+func NewMultiExporter(exporters ...DataExporter) *MultiExporter {
+	return &MultiExporter{exporters: exporters}
+}
+
+// Name returns a comma-separated list of destination names for diagnostics.
+func (m *MultiExporter) Name() string {
+	if m == nil {
+		return ""
+	}
+	names := make([]string, 0, len(m.exporters))
+	for _, exporter := range m.exporters {
+		if exporter == nil {
+			continue
+		}
+		names = append(names, exporter.Name())
+	}
+	return strings.Join(names, ",")
+}
+
+// ExporterNames returns the configured destination names in order.
+func (m *MultiExporter) ExporterNames() []string {
+	if m == nil {
+		return nil
+	}
+	names := make([]string, 0, len(m.exporters))
+	for _, exporter := range m.exporters {
+		if exporter == nil {
+			continue
+		}
+		names = append(names, exporter.Name())
+	}
+	return names
+}
+
+// IsEnabled returns true when at least one contained exporter is enabled.
+func (m *MultiExporter) IsEnabled() bool {
+	if m == nil {
+		return false
+	}
+	for _, exporter := range m.exporters {
+		if exporter != nil && exporter.IsEnabled() {
+			return true
+		}
+	}
+	return false
+}
+
+// Export sends data to every enabled destination.
+func (m *MultiExporter) Export(logType string, data []byte, params ExportParams) error {
+	if m == nil {
+		return nil
+	}
+	var errs []error
+	for _, exporter := range m.exporters {
+		if exporter == nil || !exporter.IsEnabled() {
+			continue
+		}
+		if err := exporter.Export(logType, data, params); err != nil {
+			log.Err(err).Str("exporter", exporter.Name()).Str("type", logType).Msg("error exporting osquery data")
+			errs = append(errs, fmt.Errorf("%s: %w", exporter.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/logging/exporter_adapters.go
+++ b/pkg/logging/exporter_adapters.go
@@ -1,0 +1,179 @@
+package logging
+
+import (
+	"strings"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/types"
+)
+
+func (logDB *LoggerDB) Name() string {
+	return config.LoggingDB
+}
+
+func (logDB *LoggerDB) IsEnabled() bool {
+	return logDB != nil && logDB.Enabled
+}
+
+func (logDB *LoggerDB) Export(logType string, data []byte, params ExportParams) error {
+	if logType == types.QueryLog {
+		logDB.Query(data, params.Environment, params.UUID, params.QueryName, params.Status, params.Debug)
+		return nil
+	}
+	logDB.Log(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (logStdout *LoggerStdout) Name() string {
+	return config.LoggingStdout
+}
+
+func (logStdout *LoggerStdout) IsEnabled() bool {
+	return logStdout != nil && logStdout.Enabled
+}
+
+func (logStdout *LoggerStdout) Export(logType string, data []byte, params ExportParams) error {
+	if logType == types.QueryLog {
+		logStdout.Query(data, params.Environment, params.UUID, params.QueryName, params.Status, params.Debug)
+		return nil
+	}
+	logStdout.Log(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (logFile *LoggerFile) Name() string {
+	return config.LoggingFile
+}
+
+func (logFile *LoggerFile) IsEnabled() bool {
+	return logFile != nil && logFile.Enabled
+}
+
+func (logFile *LoggerFile) Export(logType string, data []byte, params ExportParams) error {
+	if logType == types.QueryLog {
+		logFile.Query(data, params.Environment, params.UUID, params.QueryName, params.Status, params.Debug)
+		return nil
+	}
+	logFile.Log(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (logNone *LoggerNone) Name() string {
+	return config.LoggingNone
+}
+
+func (logNone *LoggerNone) IsEnabled() bool {
+	return logNone != nil && logNone.Enabled
+}
+
+func (logNone *LoggerNone) Export(logType string, data []byte, params ExportParams) error {
+	if logType == types.QueryLog {
+		logNone.Query(data, params.Environment, params.UUID, params.QueryName, params.Status, params.Debug)
+		return nil
+	}
+	logNone.Log(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (logSP *LoggerSplunk) Name() string {
+	return config.LoggingSplunk
+}
+
+func (logSP *LoggerSplunk) IsEnabled() bool {
+	return logSP != nil && logSP.Enabled
+}
+
+func (logSP *LoggerSplunk) Export(logType string, data []byte, params ExportParams) error {
+	logSP.Send(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (logGL *LoggerGraylog) Name() string {
+	return config.LoggingGraylog
+}
+
+func (logGL *LoggerGraylog) IsEnabled() bool {
+	return logGL != nil && logGL.Enabled
+}
+
+func (logGL *LoggerGraylog) Export(logType string, data []byte, params ExportParams) error {
+	logGL.Send(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (logLS *LoggerLogstash) Name() string {
+	return config.LoggingLogstash
+}
+
+func (logLS *LoggerLogstash) IsEnabled() bool {
+	return logLS != nil && logLS.Enabled
+}
+
+func (logLS *LoggerLogstash) Export(logType string, data []byte, params ExportParams) error {
+	logLS.Send(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+// Send routes Logstash exports to the configured protocol.
+func (logLS *LoggerLogstash) Send(logType string, data []byte, environment, uuid string, debug bool) {
+	switch strings.ToLower(logLS.Configuration.Protocol) {
+	case LogstashTCP:
+		logLS.SendTCP(logType, data, environment, uuid, debug)
+	case LogstashUDP:
+		logLS.SendUDP(logType, data, environment, uuid, debug)
+	default:
+		logLS.SendHTTP(logType, data, environment, uuid, debug)
+	}
+}
+
+func (logSK *LoggerKinesis) Name() string {
+	return config.LoggingKinesis
+}
+
+func (logSK *LoggerKinesis) IsEnabled() bool {
+	return logSK != nil && logSK.Enabled
+}
+
+func (logSK *LoggerKinesis) Export(logType string, data []byte, params ExportParams) error {
+	logSK.Send(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (logS3 *LoggerS3) Name() string {
+	return config.LoggingS3
+}
+
+func (logS3 *LoggerS3) IsEnabled() bool {
+	return logS3 != nil && logS3.Enabled
+}
+
+func (logS3 *LoggerS3) Export(logType string, data []byte, params ExportParams) error {
+	logS3.Send(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (l *LoggerKafka) Name() string {
+	return config.LoggingKafka
+}
+
+func (l *LoggerKafka) IsEnabled() bool {
+	return l != nil && l.Enabled
+}
+
+func (l *LoggerKafka) Export(logType string, data []byte, params ExportParams) error {
+	l.Send(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}
+
+func (logE *LoggerElastic) Name() string {
+	return config.LoggingElastic
+}
+
+func (logE *LoggerElastic) IsEnabled() bool {
+	return logE != nil && logE.Enabled
+}
+
+func (logE *LoggerElastic) Export(logType string, data []byte, params ExportParams) error {
+	logE.Send(logType, data, params.Environment, params.UUID, params.Debug)
+	return nil
+}

--- a/pkg/logging/exporter_factory.go
+++ b/pkg/logging/exporter_factory.go
@@ -1,0 +1,154 @@
+package logging
+
+import (
+	"fmt"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/settings"
+)
+
+// configuredExporterTypes returns the new multi-exporter list when provided,
+// otherwise it falls back to the legacy single logger type.
+func configuredExporterTypes(cfg *config.YAMLConfigurationLogger) []string {
+	return config.LoggerTypes(cfg)
+}
+
+// CreateExporters builds the composite exporter used by osctrl-tls.
+func CreateExporters(cfg config.ServiceParameters, mgr *settings.Settings) (*MultiExporter, error) {
+	exporterTypes := configuredExporterTypes(cfg.Logger)
+	exporters := make([]DataExporter, 0, len(exporterTypes)+1)
+	primaryDBConfigured := false
+
+	for _, exporterType := range exporterTypes {
+		exporter, usesPrimaryDB, err := CreateExporter(exporterType, cfg, mgr)
+		if err != nil {
+			return nil, err
+		}
+		if exporter != nil {
+			exporters = append(exporters, exporter)
+		}
+		if exporterType == config.LoggingDB && usesPrimaryDB {
+			primaryDBConfigured = true
+		}
+	}
+
+	if cfg.Logger != nil && cfg.Logger.AlwaysLog && !primaryDBConfigured {
+		if cfg.DB == nil {
+			return nil, fmt.Errorf("missing primary DB configuration for always-log exporter")
+		}
+		dbExporter, err := CreateLoggerDBConfig(cfg.DB)
+		if err != nil {
+			return nil, err
+		}
+		dbExporter.Settings(mgr)
+		exporters = append(exporters, dbExporter)
+	}
+
+	return NewMultiExporter(exporters...), nil
+}
+
+// CreateExporter builds one exporter implementation from its configured type.
+// This is the only place that should switch on exporter type; request-time
+// dispatch goes through the DataExporter interface.
+func CreateExporter(exporterType string, cfg config.ServiceParameters, mgr *settings.Settings) (DataExporter, bool, error) {
+	if cfg.Logger == nil {
+		return nil, false, fmt.Errorf("missing logger configuration")
+	}
+	switch exporterType {
+	case config.LoggingSplunk:
+		s, err := CreateLoggerSplunk(cfg.Logger.Splunk)
+		if err != nil {
+			return nil, false, err
+		}
+		s.Settings(mgr)
+		return s, false, nil
+	case config.LoggingGraylog:
+		g, err := CreateLoggerGraylog(cfg.Logger.Graylog)
+		if err != nil {
+			return nil, false, err
+		}
+		g.Settings(mgr)
+		return g, false, nil
+	case config.LoggingDB:
+		dbConfig := cfg.Logger.DB
+		usesPrimaryDB := false
+		if cfg.Logger.LoggerDBSame || sameConfigDBPtr(cfg.Logger.DB, cfg.DB) {
+			dbConfig = cfg.DB
+			usesPrimaryDB = true
+		}
+		if dbConfig == nil {
+			return nil, false, fmt.Errorf("missing DB logger configuration")
+		}
+		d, err := CreateLoggerDBConfig(dbConfig)
+		if err != nil {
+			return nil, false, err
+		}
+		d.Settings(mgr)
+		return d, usesPrimaryDB, nil
+	case config.LoggingStdout:
+		d, err := CreateLoggerStdout()
+		if err != nil {
+			return nil, false, err
+		}
+		d.Settings(mgr)
+		return d, false, nil
+	case config.LoggingFile:
+		d, err := CreateLoggerFile(cfg.Logger.Local)
+		if err != nil {
+			return nil, false, err
+		}
+		d.Settings(mgr)
+		return d, false, nil
+	case config.LoggingNone:
+		d, err := CreateLoggerNone()
+		if err != nil {
+			return nil, false, err
+		}
+		d.Settings(mgr)
+		return d, false, nil
+	case config.LoggingKinesis:
+		d, err := CreateLoggerKinesis(cfg.Logger.Kinesis)
+		if err != nil {
+			return nil, false, err
+		}
+		d.Settings(mgr)
+		return d, false, nil
+	case config.LoggingS3:
+		d, err := CreateLoggerS3(cfg.Logger.S3)
+		if err != nil {
+			return nil, false, err
+		}
+		d.Settings(mgr)
+		return d, false, nil
+	case config.LoggingLogstash:
+		d, err := CreateLoggerLogstash(cfg.Logger.Logstash)
+		if err != nil {
+			return nil, false, err
+		}
+		d.Settings(mgr)
+		return d, false, nil
+	case config.LoggingKafka:
+		k, err := CreateLoggerKafka(cfg.Logger.Kafka)
+		if err != nil {
+			return nil, false, err
+		}
+		k.Settings(mgr)
+		return k, false, nil
+	case config.LoggingElastic:
+		e, err := CreateLoggerElastic(cfg.Logger.Elastic)
+		if err != nil {
+			return nil, false, err
+		}
+		e.Settings(mgr)
+		return e, false, nil
+	default:
+		return nil, false, fmt.Errorf("unknown exporter type: %s", exporterType)
+	}
+}
+
+func sameConfigDBPtr(loggerOne, loggerTwo *config.YAMLConfigurationDB) bool {
+	if loggerOne == nil || loggerTwo == nil {
+		return false
+	}
+	return sameConfigDB(*loggerOne, *loggerTwo)
+}

--- a/pkg/logging/exporter_test.go
+++ b/pkg/logging/exporter_test.go
@@ -1,0 +1,152 @@
+package logging
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/types"
+)
+
+type exportCall struct {
+	logType string
+	data    string
+	params  ExportParams
+}
+
+type recordingExporter struct {
+	name    string
+	enabled bool
+	err     error
+	calls   []exportCall
+}
+
+func (r *recordingExporter) Name() string {
+	return r.name
+}
+
+func (r *recordingExporter) IsEnabled() bool {
+	return r.enabled
+}
+
+func (r *recordingExporter) Export(logType string, data []byte, params ExportParams) error {
+	r.calls = append(r.calls, exportCall{
+		logType: logType,
+		data:    string(data),
+		params:  params,
+	})
+	return r.err
+}
+
+func TestMultiExporterFansOutAndContinuesAfterError(t *testing.T) {
+	boom := errors.New("boom")
+	first := &recordingExporter{name: "first", enabled: true}
+	disabled := &recordingExporter{name: "disabled", enabled: false}
+	failing := &recordingExporter{name: "failing", enabled: true, err: boom}
+	last := &recordingExporter{name: "last", enabled: true}
+	multi := NewMultiExporter(first, disabled, failing, last)
+
+	params := ExportParams{
+		Environment: "prod",
+		UUID:        "NODE-A",
+		QueryName:   "query-a",
+		Status:      7,
+		Debug:       true,
+	}
+	err := multi.Export(types.QueryLog, []byte(`{"ok":true}`), params)
+	if err == nil {
+		t.Fatalf("expected joined exporter error")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected joined error to include boom, got %v", err)
+	}
+
+	for _, exporter := range []*recordingExporter{first, failing, last} {
+		if len(exporter.calls) != 1 {
+			t.Fatalf("%s calls: got %d want 1", exporter.name, len(exporter.calls))
+		}
+		if exporter.calls[0].logType != types.QueryLog {
+			t.Fatalf("%s log type: got %q want %q", exporter.name, exporter.calls[0].logType, types.QueryLog)
+		}
+		if exporter.calls[0].data != `{"ok":true}` {
+			t.Fatalf("%s data: got %q", exporter.name, exporter.calls[0].data)
+		}
+		if !reflect.DeepEqual(exporter.calls[0].params, params) {
+			t.Fatalf("%s params: got %+v want %+v", exporter.name, exporter.calls[0].params, params)
+		}
+	}
+	if len(disabled.calls) != 0 {
+		t.Fatalf("disabled exporter was called")
+	}
+}
+
+func TestConfiguredExporterTypesPrefersMultiValue(t *testing.T) {
+	got := configuredExporterTypes(&config.YAMLConfigurationLogger{
+		Type:  config.LoggingDB,
+		Types: []string{" stdout ", "STDOUT", "none"},
+	})
+	want := []string{config.LoggingStdout, config.LoggingNone}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configured exporter types: got %#v want %#v", got, want)
+	}
+}
+
+func TestConfiguredExporterTypesFallsBackToLegacyType(t *testing.T) {
+	got := configuredExporterTypes(&config.YAMLConfigurationLogger{Type: config.LoggingNone})
+	want := []string{config.LoggingNone}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configured exporter types: got %#v want %#v", got, want)
+	}
+}
+
+func TestCreateExportersAddsAlwaysLogDBWhenPrimaryDBNotConfigured(t *testing.T) {
+	dbPath := t.TempDir() + "/always-log.db"
+	exporters, err := CreateExporters(config.ServiceParameters{
+		DB: &config.YAMLConfigurationDB{
+			Type:            "sqlite",
+			FilePath:        dbPath,
+			MaxIdleConns:    1,
+			MaxOpenConns:    1,
+			ConnMaxLifetime: 1,
+		},
+		Logger: &config.YAMLConfigurationLogger{
+			Type:      config.LoggingNone,
+			AlwaysLog: true,
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create exporters: %v", err)
+	}
+	got := exporters.ExporterNames()
+	want := []string{config.LoggingNone, config.LoggingDB}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("exporter names: got %#v want %#v", got, want)
+	}
+}
+
+func TestCreateExportersDoesNotDuplicateAlwaysLogDB(t *testing.T) {
+	dbPath := t.TempDir() + "/primary-db.db"
+	exporters, err := CreateExporters(config.ServiceParameters{
+		DB: &config.YAMLConfigurationDB{
+			Type:            "sqlite",
+			FilePath:        dbPath,
+			MaxIdleConns:    1,
+			MaxOpenConns:    1,
+			ConnMaxLifetime: 1,
+		},
+		Logger: &config.YAMLConfigurationLogger{
+			Type:         config.LoggingDB,
+			LoggerDBSame: true,
+			AlwaysLog:    true,
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create exporters: %v", err)
+	}
+	got := exporters.ExporterNames()
+	want := []string{config.LoggingDB}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("exporter names: got %#v want %#v", got, want)
+	}
+}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -5,316 +5,60 @@ import (
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/settings"
-	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/rs/zerolog/log"
 )
 
 // LoggerTLS will be used to handle logging for the TLS endpoint
 type LoggerTLS struct {
-	Logging      string
-	Logger       interface{}
-	AlwaysLogger *LoggerDB
-	Nodes        *nodes.NodeManager
-	Queries      *queries.Queries
+	Logging   string
+	Exporters DataExporter
+	Nodes     *nodes.NodeManager
+	Queries   *queries.Queries
 }
 
 // CreateLoggerTLS to instantiate a new logger for the TLS endpoint
 func CreateLoggerTLS(cfg config.ServiceParameters, mgr *settings.Settings, nodes *nodes.NodeManager, queries *queries.Queries) (*LoggerTLS, error) {
+	exporters, err := CreateExporters(cfg, mgr)
+	if err != nil {
+		return nil, err
+	}
 	l := &LoggerTLS{
-		Logging: cfg.Logger.Type,
-		Nodes:   nodes,
-		Queries: queries,
-	}
-	switch cfg.Logger.Type {
-	case config.LoggingSplunk:
-		s, err := CreateLoggerSplunk(cfg.Logger.Splunk)
-		if err != nil {
-			return nil, err
-		}
-		s.Settings(mgr)
-		l.Logger = s
-	case config.LoggingGraylog:
-		g, err := CreateLoggerGraylog(cfg.Logger.Graylog)
-		if err != nil {
-			return nil, err
-		}
-		g.Settings(mgr)
-		l.Logger = g
-	case config.LoggingDB:
-		if cfg.Logger.LoggerDBSame {
-			d, err := CreateLoggerDBConfig(cfg.DB)
-			if err != nil {
-				return nil, err
-			}
-			d.Settings(mgr)
-			l.Logger = d
-		} else {
-			d, err := CreateLoggerDBConfig(cfg.Logger.DB)
-			if err != nil {
-				return nil, err
-			}
-			d.Settings(mgr)
-			l.Logger = d
-		}
-	case config.LoggingStdout:
-		d, err := CreateLoggerStdout()
-		if err != nil {
-			return nil, err
-		}
-		d.Settings(mgr)
-		l.Logger = d
-	case config.LoggingFile:
-		d, err := CreateLoggerFile(cfg.Logger.Local)
-		if err != nil {
-			return nil, err
-		}
-		d.Settings(mgr)
-		l.Logger = d
-	case config.LoggingNone:
-		d, err := CreateLoggerNone()
-		if err != nil {
-			return nil, err
-		}
-		d.Settings(mgr)
-		l.Logger = d
-	case config.LoggingKinesis:
-		d, err := CreateLoggerKinesis(cfg.Logger.Kinesis)
-		if err != nil {
-			return nil, err
-		}
-		d.Settings(mgr)
-		l.Logger = d
-	case config.LoggingS3:
-		var d *LoggerS3
-		var err error
-		d, err = CreateLoggerS3(cfg.Logger.S3)
-		if err != nil {
-			return nil, err
-		}
-		d.Settings(mgr)
-		l.Logger = d
-	case config.LoggingLogstash:
-		d, err := CreateLoggerLogstash(cfg.Logger.Logstash)
-		if err != nil {
-			return nil, err
-		}
-		d.Settings(mgr)
-		l.Logger = d
-	case config.LoggingKafka:
-		k, err := CreateLoggerKafka(cfg.Logger.Kafka)
-		if err != nil {
-			return nil, err
-		}
-		k.Settings(mgr)
-		l.Logger = k
-	case config.LoggingElastic:
-		e, err := CreateLoggerElastic(cfg.Logger.Elastic)
-		if err != nil {
-			return nil, err
-		}
-		e.Settings(mgr)
-		l.Logger = e
-	}
-	// Initialize the logger that will always log to DB
-	if cfg.Logger.AlwaysLog {
-		always, err := CreateLoggerDBConfig(cfg.DB)
-		if err != nil {
-			return nil, err
-		}
-		always.Settings(mgr)
-		l.AlwaysLogger = always
+		Logging:   exporters.Name(),
+		Exporters: exporters,
+		Nodes:     nodes,
+		Queries:   queries,
 	}
 	return l, nil
 }
 
 // Log will send status/result logs via the configured method of logging
 func (logTLS *LoggerTLS) Log(logType string, data []byte, environment, uuid string, debug bool) {
-	switch logTLS.Logging {
-	case config.LoggingSplunk:
-		l, ok := logTLS.Logger.(*LoggerSplunk)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingSplunk)
-		}
-		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingGraylog:
-		l, ok := logTLS.Logger.(*LoggerGraylog)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingGraylog)
-		}
-		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingDB:
-		l, ok := logTLS.Logger.(*LoggerDB)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingDB)
-		}
-		if l.Enabled {
-			l.Log(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingStdout:
-		l, ok := logTLS.Logger.(*LoggerStdout)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingStdout)
-		}
-		if l.Enabled {
-			l.Log(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingFile:
-		l, ok := logTLS.Logger.(*LoggerFile)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingFile)
-		}
-		if l.Enabled {
-			l.Log(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingNone:
-		l, ok := logTLS.Logger.(*LoggerNone)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingNone)
-		}
-		if l.Enabled {
-			l.Log(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingKinesis:
-		l, ok := logTLS.Logger.(*LoggerKinesis)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingKinesis)
-		}
-		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingS3:
-		l, ok := logTLS.Logger.(*LoggerS3)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingS3)
-		}
-		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingKafka:
-		k, ok := logTLS.Logger.(*LoggerKafka)
-		if !ok {
-			log.Printf("error casting logger to %s", config.LoggingKafka)
-		}
-		if k.Enabled {
-			k.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingElastic:
-		k, ok := logTLS.Logger.(*LoggerElastic)
-		if !ok {
-			log.Printf("error casting logger to %s", config.LoggingElastic)
-		}
-		if k.Enabled {
-			k.Send(logType, data, environment, uuid, debug)
-		}
+	if logTLS == nil || logTLS.Exporters == nil {
+		log.Warn().Str("type", logType).Msg("no osquery data exporters configured")
+		return
 	}
-	// If logs are status, write via always logger
-	if logTLS.AlwaysLogger != nil && logTLS.AlwaysLogger.Enabled && logType == types.StatusLog {
-		// Check if configured logger is DB so we skip logging the same data twice
-		logAlways := true
-		if logTLS.Logger == config.LoggingDB {
-			l, ok := logTLS.Logger.(*LoggerDB)
-			if ok {
-				logAlways = !sameConfigDB(*l.Database.Config, *logTLS.AlwaysLogger.Database.Config)
-			}
-		}
-		if logAlways {
-			logTLS.AlwaysLogger.Log(logType, data, environment, uuid, debug)
-		}
+	if err := logTLS.Exporters.Export(logType, data, ExportParams{
+		Environment: environment,
+		UUID:        uuid,
+		Debug:       debug,
+	}); err != nil {
+		log.Err(err).Str("type", logType).Msg("one or more osquery data exporters failed")
 	}
 }
 
 // QueryLog will send query result logs via the configured method of logging
 func (logTLS *LoggerTLS) QueryLog(logType string, data []byte, environment, uuid, name string, status int, debug bool) {
-	switch logTLS.Logging {
-	case config.LoggingSplunk:
-		l, ok := logTLS.Logger.(*LoggerSplunk)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingSplunk)
-		}
-		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingGraylog:
-		l, ok := logTLS.Logger.(*LoggerGraylog)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingGraylog)
-		}
-		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingDB:
-		l, ok := logTLS.Logger.(*LoggerDB)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingDB)
-		}
-		if l.Enabled {
-			l.Query(data, environment, uuid, name, status, debug)
-		}
-	case config.LoggingStdout:
-		l, ok := logTLS.Logger.(*LoggerStdout)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingStdout)
-		}
-		if l.Enabled {
-			l.Query(data, environment, uuid, name, status, debug)
-		}
-	case config.LoggingFile:
-		l, ok := logTLS.Logger.(*LoggerFile)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingFile)
-		}
-		if l.Enabled {
-			l.Query(data, environment, uuid, name, status, debug)
-		}
-	case config.LoggingNone:
-		l, ok := logTLS.Logger.(*LoggerNone)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingNone)
-		}
-		if l.Enabled {
-			l.Query(data, environment, uuid, name, status, debug)
-		}
-	case config.LoggingKinesis:
-		l, ok := logTLS.Logger.(*LoggerKinesis)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingKinesis)
-		}
-		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingS3:
-		l, ok := logTLS.Logger.(*LoggerS3)
-		if !ok {
-			log.Error().Msgf("error casting logger to %s", config.LoggingS3)
-		}
-		if l.Enabled {
-			l.Send(logType, data, environment, uuid, debug)
-		}
-	case config.LoggingKafka:
-		k, ok := logTLS.Logger.(*LoggerKafka)
-		if !ok {
-			log.Printf("error casting logger to %s", config.LoggingKafka)
-		}
-		if k.Enabled {
-			k.Send(logType, data, environment, uuid, debug)
-		}
+	if logTLS == nil || logTLS.Exporters == nil {
+		log.Warn().Str("type", logType).Str("query", name).Msg("no osquery data exporters configured")
+		return
 	}
-	// Always log results to DB if always logger is enabled
-	if logTLS.AlwaysLogger != nil && logTLS.AlwaysLogger.Enabled {
-		// Check if configured logger is DB so we skip logging the same data twice
-		logAlways := true
-		if logTLS.Logger == config.LoggingDB {
-			l, ok := logTLS.Logger.(*LoggerDB)
-			if ok {
-				logAlways = !sameConfigDB(*l.Database.Config, *logTLS.AlwaysLogger.Database.Config)
-			}
-		}
-		if logAlways {
-			logTLS.AlwaysLogger.Query(data, environment, uuid, name, status, debug)
-		}
+	if err := logTLS.Exporters.Export(logType, data, ExportParams{
+		Environment: environment,
+		UUID:        uuid,
+		QueryName:   name,
+		Status:      status,
+		Debug:       debug,
+	}); err != nil {
+		log.Err(err).Str("type", logType).Str("query", name).Msg("one or more osquery data exporters failed")
 	}
 }

--- a/pkg/logging/logstash.go
+++ b/pkg/logging/logstash.go
@@ -113,6 +113,7 @@ func (logLS *LoggerLogstash) SendUDP(logType string, data []byte, environment, u
 	conn, err := net.Dial("udp", connAddr)
 	if err != nil {
 		log.Err(err).Msg("Error connecting to Logstash")
+		return
 	}
 	defer conn.Close()
 	_, err = conn.Write(data)
@@ -136,6 +137,7 @@ func (logLS *LoggerLogstash) SendTCP(logType string, data []byte, environment, u
 	conn, err := net.Dial("tcp", connAddr)
 	if err != nil {
 		log.Err(err).Msg("Error connecting to Logstash")
+		return
 	}
 	defer conn.Close()
 	_, err = conn.Write(data)

--- a/pkg/logging/process_test.go
+++ b/pkg/logging/process_test.go
@@ -50,10 +50,10 @@ func TestProcessLogQueryResultUpdatesStatusOnlyError(t *testing.T) {
 	nodeMgr := nodes.CreateNodes(db)
 	queryMgr := queries.CreateQueries(db)
 	logger := &LoggerTLS{
-		Logging: config.LoggingNone,
-		Logger:  &LoggerNone{Enabled: false},
-		Nodes:   nodeMgr,
-		Queries: queryMgr,
+		Logging:   config.LoggingNone,
+		Exporters: NewMultiExporter(&LoggerNone{Enabled: false}),
+		Nodes:     nodeMgr,
+		Queries:   queryMgr,
 	}
 	node := nodes.OsqueryNode{NodeKey: "node-key", UUID: "NODE-A", EnvironmentID: 1, Environment: "env"}
 	if err := db.Create(&node).Error; err != nil {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"fmt"
+	"strings"
 
 	"gorm.io/gorm"
 
@@ -322,7 +323,7 @@ func (conf *Settings) SetTLSJSON(cfg *config.ServiceParameters, envID uint) erro
 	if err := conf.SetJSON(config.ServiceTLS, JSONAuth, cfg.Service.Auth, envID); err != nil {
 		return err
 	}
-	if err := conf.SetJSON(config.ServiceTLS, JSONLogger, cfg.Logger.Type, envID); err != nil {
+	if err := conf.SetJSON(config.ServiceTLS, JSONLogger, loggerSettingValue(cfg.Logger), envID); err != nil {
 		return err
 	}
 	if err := conf.SetJSON(config.ServiceTLS, JSONCarver, cfg.Carver.Type, envID); err != nil {
@@ -345,13 +346,17 @@ func (conf *Settings) SetAdminJSON(cfg *config.ServiceParameters, envID uint) er
 	if err := conf.SetJSON(config.ServiceAdmin, JSONAuth, cfg.Service.Auth, envID); err != nil {
 		return err
 	}
-	if err := conf.SetJSON(config.ServiceAdmin, JSONLogger, cfg.Logger.Type, envID); err != nil {
+	if err := conf.SetJSON(config.ServiceAdmin, JSONLogger, loggerSettingValue(cfg.Logger), envID); err != nil {
 		return err
 	}
 	if err := conf.SetJSON(config.ServiceAdmin, JSONSessionKey, cfg.Admin.SessionKey, envID); err != nil {
 		return err
 	}
 	return nil
+}
+
+func loggerSettingValue(cfg *config.YAMLConfigurationLogger) string {
+	return strings.Join(config.LoggerTypes(cfg), ",")
 }
 
 // SetAPIJSON sets all the JSON configuration values for API service


### PR DESCRIPTION
## Summary

- Refactored logging into exporter-based fan-out so events can be sent to multiple configured destinations.
- Added plural logger configuration with `--loggers` / `SERVICE_LOGGERS`, while keeping legacy single logger config as fallback.
- Updated config validation/helpers to normalize, dedupe, and check enabled logger types, including DB logging detection.
- Updated admin log/result views to handle multi-logger configs and only show DB-backed results when DB logging is enabled.
- Added tests around multi-exporter behavior and logger validation.