### PR TITLE
Persistance in backend for each service configuration from YAML

### DIFF
--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/posture"
 	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/serviceconfig"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/types"
@@ -44,6 +45,7 @@ type HandlersApi struct {
 	FileExplorer    *fileexplorer.Manager
 	Carves          *carves.Carves
 	Settings        *settings.Settings
+	ServiceConfig   *serviceconfig.ServiceConfigManager
 	Activity        activityReader
 	GeoIP           *geoip.GeoIPResolver
 	Posture         *posture.PostureManager
@@ -155,6 +157,12 @@ func WithCarves(carves *carves.Carves) HandlersOption {
 func WithSettings(settings *settings.Settings) HandlersOption {
 	return func(h *HandlersApi) {
 		h.Settings = settings
+	}
+}
+
+func WithServiceConfig(mgr *serviceconfig.ServiceConfigManager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.ServiceConfig = mgr
 	}
 }
 

--- a/cmd/api/handlers/service_config.go
+++ b/cmd/api/handlers/service_config.go
@@ -1,0 +1,154 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/serviceconfig"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+// ServiceConfigHandler - GET Handler for all service config sections
+// @Summary List all service config sections
+// @Description Returns all service configuration sections across all services.
+// @Tags service-config
+// @Produce json
+// @Success 200 {array} serviceconfig.ServiceConfig
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/service-config [get]
+func (h *HandlersApi) ServiceConfigHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	if h.ServiceConfig == nil {
+		apiErrorResponse(w, "service config not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	sections, err := h.ServiceConfig.GetAll(serviceconfig.NoEnvironmentID)
+	if err != nil {
+		apiErrorResponse(w, "error getting service config", http.StatusInternalServerError, err)
+		return
+	}
+	log.Debug().Msg("Returned all service config sections")
+	h.AuditLog.Visit(ctx[ctxUser], r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, sections)
+}
+
+// ServiceConfigServiceHandler - GET Handler for all sections of one service
+// @Summary List service config sections for a service
+// @Description Returns all configuration sections for the given service.
+// @Tags service-config
+// @Produce json
+// @Param service path string true "Service name"
+// @Success 200 {array} serviceconfig.ServiceConfig
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/service-config/{service} [get]
+func (h *HandlersApi) ServiceConfigServiceHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	if h.ServiceConfig == nil {
+		apiErrorResponse(w, "service config not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	service := r.PathValue("service")
+	if service == "" {
+		apiErrorResponse(w, "missing service", http.StatusBadRequest, nil)
+		return
+	}
+	if !h.ServiceConfig.VerifyService(service) {
+		apiErrorResponse(w, "invalid service", http.StatusBadRequest, nil)
+		return
+	}
+	sections, err := h.ServiceConfig.GetAllByService(service, serviceconfig.NoEnvironmentID)
+	if err != nil {
+		apiErrorResponse(w, "error getting service config", http.StatusInternalServerError, err)
+		return
+	}
+	log.Debug().Msgf("Returned service config for %s", service)
+	h.AuditLog.Visit(ctx[ctxUser], r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, sections)
+}
+
+// ServiceConfigSectionHandler - GET Handler for a single config section
+// @Summary Get one service config section
+// @Description Returns a single configuration section by service and section name.
+// @Tags service-config
+// @Produce json
+// @Param service path string true "Service name"
+// @Param section path string true "Section name"
+// @Success 200 {object} serviceconfig.ServiceConfig
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/service-config/{service}/{section} [get]
+func (h *HandlersApi) ServiceConfigSectionHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	if h.ServiceConfig == nil {
+		apiErrorResponse(w, "service config not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	service := r.PathValue("service")
+	if service == "" {
+		apiErrorResponse(w, "missing service", http.StatusBadRequest, nil)
+		return
+	}
+	if !h.ServiceConfig.VerifyService(service) {
+		apiErrorResponse(w, "invalid service", http.StatusBadRequest, nil)
+		return
+	}
+	section := r.PathValue("section")
+	if section == "" {
+		apiErrorResponse(w, "missing section", http.StatusBadRequest, nil)
+		return
+	}
+	if !h.ServiceConfig.VerifySection(service, section) {
+		apiErrorResponse(w, "invalid section", http.StatusBadRequest, nil)
+		return
+	}
+	sc, err := h.ServiceConfig.GetSection(service, section, serviceconfig.NoEnvironmentID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErrorResponse(w, "section not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error getting section", http.StatusInternalServerError, err)
+		return
+	}
+	log.Debug().Msgf("Returned service config %s/%s", service, section)
+	h.AuditLog.Visit(ctx[ctxUser], r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, sc)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/posture"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/ratelimit"
+	"github.com/jmpsec/osctrl/pkg/serviceconfig"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/types"
@@ -97,6 +98,8 @@ const (
 	apiTagsPath = "/tags"
 	// API settings path
 	apiSettingsPath = "/settings"
+	// API service config path
+	apiServiceConfigPath = "/service-config"
 	// API features path
 	apiFeaturesPath = "/features"
 	// API file explorer path
@@ -374,6 +377,11 @@ func osctrlAPIService() {
 	if err := loadingSettings(settingsmgr, flagParams); err != nil {
 		log.Fatal().Msgf("Error loading settings - %v", err)
 	}
+	log.Info().Msg("Seeding service config from YAML")
+	serviceConfigMgr := serviceconfig.NewServiceConfigManager(db.Conn)
+	if err := serviceConfigMgr.Seed(config.ServiceAPI, flagParams, settings.NoEnvironmentID); err != nil {
+		log.Fatal().Msgf("Error seeding service config - %v", err)
+	}
 	// Initialize audit log manager
 	if flagParams.Service.AuditLog {
 		log.Info().Msg("Initialize audit log")
@@ -432,6 +440,7 @@ func osctrlAPIService() {
 		handlers.WithFileExplorer(fileexplorermgr),
 		handlers.WithCarves(filecarves),
 		handlers.WithSettings(settingsmgr),
+		handlers.WithServiceConfig(serviceConfigMgr),
 		handlers.WithActivityReader(activity.NewRedisStore(redis.Client, activity.DefaultPrefix, activity.DefaultRetentionDays, 8*24*time.Hour)),
 		handlers.WithGeoIP(geoIPResolver),
 		handlers.WithPosture(posturemgr),
@@ -865,6 +874,16 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"PATCH "+_apiPath(apiSettingsPath)+"/{service}/{name}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingPatchHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	// API: service config (read-only phase 1)
+	muxAPI.Handle(
+		"GET "+_apiPath(apiServiceConfigPath),
+		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiServiceConfigPath)+"/{service}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigServiceHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiServiceConfigPath)+"/{service}/{section}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigSectionHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// API: audit log
 	if flagParams.Service.AuditLog {
 		muxAPI.Handle(

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/posture"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/ratelimit"
+	"github.com/jmpsec/osctrl/pkg/serviceconfig"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/utils"
@@ -256,6 +257,11 @@ func osctrlService() {
 	log.Info().Msg("Loading service settings")
 	if err := loadingSettings(settingsmgr, flagParams); err != nil {
 		log.Fatal().Msgf("Error loading settings - %v", err)
+	}
+	log.Info().Msg("Seeding service config from YAML")
+	serviceConfigMgr := serviceconfig.NewServiceConfigManager(db.Conn)
+	if err := serviceConfigMgr.Seed(config.ServiceTLS, flagParams, settings.NoEnvironmentID); err != nil {
+		log.Fatal().Msgf("Error seeding service config - %v", err)
 	}
 	settingsCacheTTL := time.Duration(settingsmgr.RefreshSettings(config.ServiceTLS)) * time.Second
 	if settingsCacheTTL <= 0 {

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -1,0 +1,295 @@
+// Package serviceconfig persists the structured YAML configuration sections
+// (logger, carver, SAML, OIDC, metrics, TLS, etc.) per service into the
+// database. Each row holds one section as a JSON-encoded blob, mirroring the
+// YAML structure so it can be round-tripped back to YAML or rendered in the
+// frontend.
+//
+// Phase 1 is read-only: sections are seeded from the YAML file on first boot
+// (create-if-missing) and served via GET endpoints. The YAML file remains the
+// live source of truth. Phase 2 will allow editing editable sections from the
+// API, and phase 3 will let services consume the DB values at startup so the
+// YAML can shrink to connection-only settings.
+package serviceconfig
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// SourceYAML marks a row seeded from the YAML file.
+const SourceYAML string = "yaml"
+
+// SourceDB marks a row that has been edited through the API.
+const SourceDB string = "db"
+
+// validServices mirrors pkg/settings.ValidServices. Duplicated here to
+// avoid an import cycle (pkg/settings imports pkg/config, and this package
+// also imports pkg/config; importing pkg/settings would be fine today but
+// keeps the dependency graph clean if settings ever grows a dependency on
+// serviceconfig).
+var validServices = map[string]struct{}{
+	config.ServiceTLS: {},
+	config.ServiceAPI: {},
+}
+
+// ServiceConfig stores one YAML configuration section for a service.
+type ServiceConfig struct {
+	gorm.Model
+	Name          string `gorm:"uniqueIndex:idx_service_config_unique"`
+	Service       string `gorm:"uniqueIndex:idx_service_config_unique"`
+	EnvironmentID uint   `gorm:"uniqueIndex:idx_service_config_unique"`
+	Type          string // always "json" for now
+	Value         string `gorm:"type:text"`
+	Source        string // "yaml" or "db"
+	Editable      bool
+	Info          string
+}
+
+// ServiceConfigManager manages the service_config table.
+type ServiceConfigManager struct {
+	DB *gorm.DB
+}
+
+// SectionSpec describes one section in the registry.
+type SectionSpec struct {
+	Name     string
+	Editable bool
+	Info     string
+}
+
+// SectionRegistry maps each service to the sections it owns. The order
+// of the slice defines the display order in the frontend. Sections marked
+// Editable=false (db, redis, and other connection / secret-bearing sections)
+// can never be written through the API.
+var SectionRegistry = map[string][]SectionSpec{
+	config.ServiceTLS: {
+		{"service", false, "Core service listener, port, log level, auth mode"},
+		{"db", false, "Backend connection — not DB-editable"},
+		{"batchWriter", false, "DB batch writer tuning"},
+		{"redis", false, "Redis connection — not DB-editable"},
+		{"osquery", false, "osquery feature toggles"},
+		{"configEndpoints", false, "Config endpoint fan-out targets"},
+		{"osctrld", false, "osctrld integration"},
+		{"metrics", false, "Prometheus metrics endpoint"},
+		{"tls", false, "TLS termination certificate/key paths"},
+		{"logger", false, "Log sinks (future: editable)"},
+		{"carver", false, "File carver configuration"},
+		{"debug", false, "HTTP debug dump settings"},
+	},
+	config.ServiceAPI: {
+		{"service", false, "Core service listener, port, log level, auth mode"},
+		{"db", false, "Backend connection — not DB-editable"},
+		{"redis", false, "Redis connection — not DB-editable"},
+		{"osquery", false, "osquery tables and feature toggles"},
+		{"saml", false, "SAML federated login configuration"},
+		{"oidc", false, "OIDC federated login configuration"},
+		{"jwt", false, "JWT signing configuration"},
+		{"tls", false, "TLS termination certificate/key paths"},
+		{"logger", false, "Log sinks (future: editable)"},
+		{"carver", false, "File carver configuration"},
+		{"debug", false, "HTTP debug dump settings"},
+	},
+}
+
+// NewServiceConfigManager initializes the manager and auto-migrates the
+// service_config table.
+func NewServiceConfigManager(backend *gorm.DB) *ServiceConfigManager {
+	m := &ServiceConfigManager{DB: backend}
+	if err := backend.AutoMigrate(&ServiceConfig{}); err != nil {
+		log.Fatal().Msgf("Failed to AutoMigrate table (service_config): %v", err)
+	}
+	return m
+}
+
+// VerifyService checks that the service is one of the known services.
+func (m *ServiceConfigManager) VerifyService(service string) bool {
+	_, ok := validServices[service]
+	return ok
+}
+
+// VerifySection checks that the section is registered for the given service.
+func (m *ServiceConfigManager) VerifySection(service, section string) bool {
+	for _, spec := range SectionRegistry[service] {
+		if spec.Name == section {
+			return true
+		}
+	}
+	return false
+}
+
+// Seed persists all sections from the YAML-loaded ServiceParameters into the
+// database using create-if-missing semantics. If a row already exists for a
+// (service, section, envID) tuple it is left untouched — the YAML never
+// overwrites a DB-edited value. This makes seeding idempotent and safe to run
+// on every boot.
+func (m *ServiceConfigManager) Seed(service string, cfg *config.ServiceParameters, envID uint) error {
+	if !m.VerifyService(service) {
+		return fmt.Errorf("unknown service %q", service)
+	}
+	if cfg == nil {
+		return fmt.Errorf("nil ServiceParameters for %s", service)
+	}
+	values, err := sectionValues(service, cfg)
+	if err != nil {
+		return fmt.Errorf("marshal sections for %s: %w", service, err)
+	}
+	for _, spec := range SectionRegistry[service] {
+		raw, ok := values[spec.Name]
+		if !ok {
+			continue
+		}
+		entry := ServiceConfig{
+			Name:          spec.Name,
+			Service:       service,
+			EnvironmentID: envID,
+			Type:          "json",
+			Value:         raw,
+			Source:        SourceYAML,
+			Editable:      spec.Editable,
+			Info:          spec.Info,
+		}
+		// ON CONFLICT DO NOTHING — create-if-missing. We use a unique
+		// index on (service, name, environment_id, deleted_at) to guard
+		// against duplicate seeds under concurrent boot. The clause.OnConflict
+		// with DoNothing handles the SQLite/Postgres/MySQL cases GORM
+		// supports.
+		if err := m.DB.Clauses(clause.OnConflict{DoNothing: true}).Create(&entry).Error; err != nil {
+			return fmt.Errorf("seed %s/%s: %w", service, spec.Name, err)
+		}
+	}
+	log.Debug().Msgf("Seeded service config for %s (%d sections)", service, len(SectionRegistry[service]))
+	return nil
+}
+
+// GetSection retrieves one section by service and name.
+func (m *ServiceConfigManager) GetSection(service, name string, envID uint) (ServiceConfig, error) {
+	var sc ServiceConfig
+	if err := m.DB.Where("service = ? AND name = ? AND environment_id = ?", service, name, envID).First(&sc).Error; err != nil {
+		return ServiceConfig{}, err
+	}
+	return sc, nil
+}
+
+// GetAllByService retrieves all sections for a service.
+func (m *ServiceConfigManager) GetAllByService(service string, envID uint) ([]ServiceConfig, error) {
+	var values []ServiceConfig
+	if err := m.DB.Where("service = ? AND environment_id = ?", service, envID).Find(&values).Error; err != nil {
+		return values, err
+	}
+	return values, nil
+}
+
+// GetAll retrieves all sections across all services.
+func (m *ServiceConfigManager) GetAll(envID uint) ([]ServiceConfig, error) {
+	var values []ServiceConfig
+	if err := m.DB.Where("environment_id = ?", envID).Find(&values).Error; err != nil {
+		return values, err
+	}
+	return values, nil
+}
+
+// sectionValues extracts each registered section from ServiceParameters and
+// marshals it to JSON. Returns a map of section-name → JSON-string.
+func sectionValues(service string, cfg *config.ServiceParameters) (map[string]string, error) {
+	out := make(map[string]string, len(SectionRegistry[service]))
+	add := func(name string, v any) error {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("marshal %s: %w", name, err)
+		}
+		out[name] = string(raw)
+		return nil
+	}
+	// Common sections present in both services.
+	if cfg.Service != nil {
+		if err := add("service", cfg.Service); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.DB != nil {
+		if err := add("db", cfg.DB); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.Redis != nil {
+		if err := add("redis", cfg.Redis); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.Osquery != nil {
+		if err := add("osquery", cfg.Osquery); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.TLS != nil {
+		if err := add("tls", cfg.TLS); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.Logger != nil {
+		if err := add("logger", cfg.Logger); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.Carver != nil {
+		if err := add("carver", cfg.Carver); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.Debug != nil {
+		if err := add("debug", cfg.Debug); err != nil {
+			return nil, err
+		}
+	}
+	// TLS-only sections.
+	if service == config.ServiceTLS {
+		if cfg.BatchWriter != nil {
+			if err := add("batchWriter", cfg.BatchWriter); err != nil {
+				return nil, err
+			}
+		}
+		if cfg.ConfigEndpoints != nil {
+			if err := add("configEndpoints", cfg.ConfigEndpoints); err != nil {
+				return nil, err
+			}
+		}
+		if cfg.Osctrld != nil {
+			if err := add("osctrld", cfg.Osctrld); err != nil {
+				return nil, err
+			}
+		}
+		if cfg.Metrics != nil {
+			if err := add("metrics", cfg.Metrics); err != nil {
+				return nil, err
+			}
+		}
+	}
+	// API-only sections.
+	if service == config.ServiceAPI {
+		if cfg.SAML != nil {
+			if err := add("saml", cfg.SAML); err != nil {
+				return nil, err
+			}
+		}
+		if cfg.OIDC != nil {
+			if err := add("oidc", cfg.OIDC); err != nil {
+				return nil, err
+			}
+		}
+		if cfg.JWT != nil {
+			if err := add("jwt", cfg.JWT); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
+}
+
+// NoEnvironmentID is the sentinel environment ID for global (non-env-scoped)
+// config rows. Mirrors settings.NoEnvironmentID.
+const NoEnvironmentID = 0

--- a/pkg/serviceconfig/serviceconfig_test.go
+++ b/pkg/serviceconfig/serviceconfig_test.go
@@ -1,0 +1,296 @@
+package serviceconfig
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory"), &gorm.Config{})
+	require.NoError(t, err, "Failed to open in-memory database")
+	require.NoError(t, db.AutoMigrate(&ServiceConfig{}), "Failed to migrate schema")
+	return db
+}
+
+func testTLSParams() *config.ServiceParameters {
+	return &config.ServiceParameters{
+		Service: &config.YAMLConfigurationService{
+			Listener: "0.0.0.0",
+			Port:     9000,
+			Host:     "tls.example.com",
+			Auth:     config.AuthNone,
+		},
+		DB: &config.YAMLConfigurationDB{
+			Type: config.DBTypeSQLite,
+			Name: "osctrl",
+		},
+		Redis: &config.YAMLConfigurationRedis{
+			Host: "127.0.0.1",
+			Port: 6379,
+		},
+		Osquery: &config.YAMLConfigurationOsquery{
+			Version:    "5.12.1",
+			TablesFile: "./data/5.12.1.json",
+		},
+		ConfigEndpoints: &config.YAMLConfigurationEndpoints{
+			{Environment: "prod", Secret: "s3cr3t"},
+		},
+		Osctrld: &config.YAMLConfigurationOsctrld{Enabled: false},
+		Metrics: &config.YAMLConfigurationMetrics{Enabled: true, Port: 9090},
+		TLS:     &config.YAMLConfigurationTLS{Termination: true, CertificateFile: "/certs/tls.crt"},
+		Logger:  &config.YAMLConfigurationLogger{Type: config.LoggingDB, LoggerDBSame: true},
+		Carver:  &config.YAMLConfigurationCarver{Type: config.CarverLocal, Local: &config.LocalCarver{CarvesDir: "/carves"}},
+		Debug:   &config.YAMLConfigurationDebug{EnableHTTP: false},
+		BatchWriter: &config.YAMLConfigurationWriter{
+			WriterBatchSize:  50,
+			WriterBufferSize: 2000,
+		},
+	}
+}
+
+func testAPIParams() *config.ServiceParameters {
+	return &config.ServiceParameters{
+		Service: &config.YAMLConfigurationService{
+			Listener: "0.0.0.0",
+			Port:     8000,
+			Host:     "api.example.com",
+			Auth:     config.AuthJWT,
+		},
+		DB: &config.YAMLConfigurationDB{
+			Type: config.DBTypePostgres,
+			Host: "db.internal",
+		},
+		Redis: &config.YAMLConfigurationRedis{Host: "127.0.0.1"},
+		Osquery: &config.YAMLConfigurationOsquery{
+			Version:    "5.12.1",
+			TablesFile: "./data/5.12.1.json",
+		},
+		SAML: &config.YAMLConfigurationSAML{Enabled: true, EntityID: "https://api/saml"},
+		OIDC: &config.YAMLConfigurationOIDC{Enabled: false, IssuerURL: "https://idp"},
+		JWT:  &config.YAMLConfigurationJWT{JWTSecret: "secret", HoursToExpire: 3},
+		TLS:  &config.YAMLConfigurationTLS{Termination: true},
+		Logger: &config.YAMLConfigurationLogger{
+			Type: config.LoggingStdout,
+			DB:   &config.YAMLConfigurationDB{},
+		},
+		Carver: &config.YAMLConfigurationCarver{Type: config.CarverDB},
+		Debug:  &config.YAMLConfigurationDebug{EnableHTTP: false},
+	}
+}
+
+// Seed must create a row for every registered section when none exist.
+func TestSeed_CreatesAllSections(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	rows, err := m.GetAllByService(config.ServiceTLS, 0)
+	require.NoError(t, err)
+	assert.Len(t, rows, len(SectionRegistry[config.ServiceTLS]))
+
+	// Every registered section name should be present.
+	names := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		names[r.Name] = true
+		assert.Equal(t, SourceYAML, r.Source)
+		assert.False(t, r.Editable) // phase 1 — none editable
+		assert.Equal(t, "json", r.Type)
+	}
+	for _, spec := range SectionRegistry[config.ServiceTLS] {
+		assert.True(t, names[spec.Name], "missing section %s", spec.Name)
+	}
+}
+
+// Seed must be idempotent: running it twice must not duplicate or overwrite
+// rows.
+func TestSeed_Idempotent(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	rows, err := m.GetAllByService(config.ServiceTLS, 0)
+	require.NoError(t, err)
+	assert.Len(t, rows, len(SectionRegistry[config.ServiceTLS]))
+}
+
+// Seed must not overwrite a row that was already edited via the DB (source=db).
+// This is the key safety property: once an operator edits a section, subsequent
+// boots must not clobber it.
+func TestSeed_DoesNotOverwriteDBEditedRow(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	// Simulate an operator edit: change the logger section to source=db.
+	sc, err := m.GetSection(config.ServiceTLS, "logger", 0)
+	require.NoError(t, err)
+	require.NoError(t, db.Model(&sc).Updates(map[string]any{
+		"source": SourceDB,
+		"value":  `{"type":"stdout","edited":true}`,
+	}).Error)
+
+	// Re-seed with a different logger config — the DB value must survive.
+	cfg.Logger.Type = config.LoggingGraylog
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	sc2, err := m.GetSection(config.ServiceTLS, "logger", 0)
+	require.NoError(t, err)
+	assert.Equal(t, SourceDB, sc2.Source)
+	assert.Equal(t, `{"type":"stdout","edited":true}`, sc2.Value)
+}
+
+// The seeded JSON must round-trip back to the original struct.
+func TestSeed_JSONRoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	sc, err := m.GetSection(config.ServiceTLS, "service", 0)
+	require.NoError(t, err)
+
+	var got config.YAMLConfigurationService
+	require.NoError(t, json.Unmarshal([]byte(sc.Value), &got))
+	assert.Equal(t, cfg.Service.Listener, got.Listener)
+	assert.Equal(t, cfg.Service.Port, got.Port)
+	assert.Equal(t, cfg.Service.Host, got.Host)
+	assert.Equal(t, cfg.Service.Auth, got.Auth)
+}
+
+// API sections (saml, oidc, jwt) must be seeded for the API service but absent
+// for TLS, and vice-versa for batchWriter/configEndpoints/osctrld/metrics.
+func TestSeed_ServiceSpecificSections(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+
+	require.NoError(t, m.Seed(config.ServiceAPI, testAPIParams(), 0))
+	require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), 0))
+
+	apiRows, err := m.GetAllByService(config.ServiceAPI, 0)
+	require.NoError(t, err)
+	tlsRows, err := m.GetAllByService(config.ServiceTLS, 0)
+	require.NoError(t, err)
+
+	apiNames := sectionNames(apiRows)
+	tlsNames := sectionNames(tlsRows)
+
+	assert.Contains(t, apiNames, "saml")
+	assert.Contains(t, apiNames, "oidc")
+	assert.Contains(t, apiNames, "jwt")
+	assert.NotContains(t, apiNames, "batchWriter")
+	assert.NotContains(t, apiNames, "metrics")
+	assert.NotContains(t, apiNames, "osctrld")
+
+	assert.Contains(t, tlsNames, "batchWriter")
+	assert.Contains(t, tlsNames, "configEndpoints")
+	assert.Contains(t, tlsNames, "osctrld")
+	assert.Contains(t, tlsNames, "metrics")
+	assert.NotContains(t, tlsNames, "saml")
+	assert.NotContains(t, tlsNames, "oidc")
+	assert.NotContains(t, tlsNames, "jwt")
+}
+
+// Seed must reject an unknown service.
+func TestSeed_UnknownService(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	err := m.Seed("bogus", testTLSParams(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown service")
+}
+
+// Seed must reject a nil config.
+func TestSeed_NilConfig(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	err := m.Seed(config.ServiceTLS, nil, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil ServiceParameters")
+}
+
+// GetSection must return ErrRecordNotFound for a missing section.
+func TestGetSection_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	_, err := m.GetSection(config.ServiceTLS, "nonexistent", 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+// GetAll must return sections for both services.
+func TestGetAll(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+
+	require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), 0))
+	require.NoError(t, m.Seed(config.ServiceAPI, testAPIParams(), 0))
+
+	all, err := m.GetAll(0)
+	require.NoError(t, err)
+	expected := len(SectionRegistry[config.ServiceTLS]) + len(SectionRegistry[config.ServiceAPI])
+	assert.Len(t, all, expected)
+}
+
+// VerifyService and VerifySection must correctly validate inputs.
+func TestVerifyServiceAndSection(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+
+	assert.True(t, m.VerifyService(config.ServiceTLS))
+	assert.True(t, m.VerifyService(config.ServiceAPI))
+	assert.False(t, m.VerifyService("bogus"))
+
+	assert.True(t, m.VerifySection(config.ServiceTLS, "logger"))
+	assert.True(t, m.VerifySection(config.ServiceAPI, "saml"))
+	assert.False(t, m.VerifySection(config.ServiceTLS, "saml"))
+	assert.False(t, m.VerifySection(config.ServiceAPI, "metrics"))
+	assert.False(t, m.VerifySection("bogus", "logger"))
+}
+
+// Seeding with different environment IDs must produce independent rows.
+func TestSeed_PerEnvironmentIsolation(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 5))
+
+	rows0, err := m.GetAllByService(config.ServiceTLS, 0)
+	require.NoError(t, err)
+	rows5, err := m.GetAllByService(config.ServiceTLS, 5)
+	require.NoError(t, err)
+
+	assert.Len(t, rows0, len(SectionRegistry[config.ServiceTLS]))
+	assert.Len(t, rows5, len(SectionRegistry[config.ServiceTLS]))
+	for _, r := range rows0 {
+		assert.Equal(t, uint(0), r.EnvironmentID)
+	}
+	for _, r := range rows5 {
+		assert.Equal(t, uint(5), r.EnvironmentID)
+	}
+}
+
+func sectionNames(rows []ServiceConfig) map[string]bool {
+	out := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		out[r.Name] = true
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Persists structured YAML configuration sections (logger, carver, SAML, OIDC, metrics, TLS, etc.) per service into a new `service_config` database table, seeded from the YAML file on first boot and exposed via read-only API endpoints.

### Problem

Every service boots by loading a YAML file into `config.ServiceParameters`. The structured sections — logger, carver, SAML, OIDC, JWT, metrics, TLS, debug — are never persisted to the DB and can't be inspected from the UI. Only a handful of scalar runtime knobs live in `setting_values`.

### Changes

**New package `pkg/serviceconfig`**
- `ServiceConfig` GORM model: one row per (service, section, environment) with a unique composite index. `Value` holds the JSON-encoded YAML section; `Source` tracks `yaml` vs `db`; `Editable` gates future writes (all `false` in phase 1).
- `SectionRegistry` declaratively maps which sections belong to which service (12 for TLS, 11 for API). Connection/secret sections (`db`, `redis`) are flagged non-editable.
- `Seed` uses `ON CONFLICT DO NOTHING` for create-if-missing semantics — idempotent and never overwrites a DB-edited row.
- 10 tests covering idempotency, no-overwrite of DB-edited rows, JSON round-trip, service-specific sections, per-environment isolation, and input validation.

**Seeding wired into startup**
- `cmd/tls/main.go` and `cmd/api/main.go` call `Seed` right after `loadingSettings`, persisting the YAML-loaded config into `service_config`.

**Read-only API handlers** (`cmd/api/handlers/service_config.go`)

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/service-config` | All sections across all services |
| GET | `/api/v1/service-config/{service}` | All sections for one service |
| GET | `/api/v1/service-config/{service}/{section}` | One section |

All require `AdminLevel` permissions, validate service/section against the registry, audit-log reads, and return 404 for missing sections. Wired through `HandlersApi.ServiceConfig` + `WithServiceConfig`.

### Design notes

- **No risk to existing settings**: new table, new package, no changes to `SettingValue` or `loadingSettings`.
- **No risk to runtime**: phase 1 is read-only mirror; services still consume `ServiceParameters` from YAML exactly as before.
- **Security**: connection sections (`db`, `redis`) are flagged `editable=false` and never writable through the API.
- **Auditable**: every read hits `AuditLog.Visit`; future writes will hit `AuditLog.SettingsAction`.

### Validation

- `go build ./...`
- `go test ./...` — all packages pass, including 10 new tests in `pkg/serviceconfig`
- `golangci-lint run ./pkg/serviceconfig/...` — 0 issues
- `gofmt` clean on all new/modified files

### Evolution path

| Phase | What changes |
|-------|-------------|
| 1 (this PR) | Seed from YAML → DB. API read endpoints. YAML still live source of truth. |
| 2 | `editable` sections can be PUT from the frontend. DB value takes precedence. |
| 3 | Services read config from DB at startup; YAML becomes an override/bootstrap. |
| 4 | YAML shrinks to `db` + `redis` + bootstrap. Logger, carver, auth, metrics, TLS, debug all DB-managed. |