### PR TITLE
Frontend component to display service config values

### DIFF
--- a/frontend/src/api/service-config.ts
+++ b/frontend/src/api/service-config.ts
@@ -1,0 +1,46 @@
+/**
+ * Service config API client.
+ *
+ * Read-only access to the service_config table, which mirrors the structured
+ * YAML configuration sections (logger, carver, SAML, OIDC, metrics, TLS, …)
+ * per service into the database. Each section is stored as a JSON-encoded
+ * blob. Phase 1 is read-only; phase 2 will add a PUT for editable sections.
+ */
+import { apiFetch } from './client';
+
+/** Wire shape matching pkg/serviceconfig.ServiceConfig. */
+export interface ServiceConfig {
+  ID: number;
+  CreatedAt: string;
+  UpdatedAt: string;
+  Name: string;
+  Service: string;
+  EnvironmentID: number;
+  Type: string;
+  Value: string;
+  Source: string;
+  Editable: boolean;
+  Info: string;
+}
+
+/** GET /api/v1/service-config — all sections across all services. */
+export function listAllServiceConfig(): Promise<ServiceConfig[]> {
+  return apiFetch<ServiceConfig[]>('/api/v1/service-config');
+}
+
+/** GET /api/v1/service-config/{service} — all sections for one service. */
+export function listServiceConfig(service: string): Promise<ServiceConfig[]> {
+  return apiFetch<ServiceConfig[]>(
+    `/api/v1/service-config/${encodeURIComponent(service)}`,
+  );
+}
+
+/** GET /api/v1/service-config/{service}/{section} — one section. */
+export function getServiceConfig(
+  service: string,
+  section: string,
+): Promise<ServiceConfig> {
+  return apiFetch<ServiceConfig>(
+    `/api/v1/service-config/${encodeURIComponent(service)}/${encodeURIComponent(section)}`,
+  );
+}

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -16,7 +16,6 @@ export interface SettingValue {
   Name: string;
   Service: string;
   EnvironmentID: number;
-  JSON: boolean;
   Type: SettingType;
   String: string;
   Boolean: boolean;
@@ -24,19 +23,9 @@ export interface SettingValue {
   Info: string;
 }
 
-/** GET /api/v1/settings — every setting across all services (super-admin). */
-export function listAllSettings(): Promise<SettingValue[]> {
-  return apiFetch<SettingValue[]>('/api/v1/settings');
-}
-
-/** GET /api/v1/settings/{service} — non-JSON settings for one service. */
+/** GET /api/v1/settings/{service} — settings for one service. */
 export function listServiceSettings(service: string): Promise<SettingValue[]> {
   return apiFetch<SettingValue[]>(`/api/v1/settings/${encodeURIComponent(service)}`);
-}
-
-/** GET /api/v1/settings/{service}/json — JSON-typed settings only. */
-export function listServiceJSONSettings(service: string): Promise<SettingValue[]> {
-  return apiFetch<SettingValue[]>(`/api/v1/settings/${encodeURIComponent(service)}/json`);
 }
 
 export interface SettingPatchRequest {

--- a/frontend/src/components/chrome/SideNav.tsx
+++ b/frontend/src/components/chrome/SideNav.tsx
@@ -152,6 +152,8 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
     pathname.startsWith('/_app/environments') || pathname === '/environments';
   const isSettingsActive =
     pathname.startsWith('/_app/settings') || pathname.startsWith('/settings');
+  const isServiceConfigActive =
+    pathname.startsWith('/_app/config') || pathname.startsWith('/config');
   const isAuditActive = pathname.startsWith('/_app/audit') || pathname === '/audit';
   // Dashboard is now env-scoped at /_app/env/{env}
   const dashboardPath = `/_app/env/${currentEnv}`;
@@ -419,6 +421,19 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
               }
             >
               Settings
+            </NavItem>
+            <NavItem
+              collapsed={collapsed}
+              active={isServiceConfigActive}
+              to="/_app/config/api"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M3 7l9-4 9 4-9 4-9-4z" />
+                  <path d="M3 7v6l9 4 9-4V7" />
+                </svg>
+              }
+            >
+              Service Config
             </NavItem>
           </nav>
         </>

--- a/frontend/src/features/service-config/ServiceConfigPage.test.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRouter,
+  createRoute,
+  createRootRoute,
+  RouterProvider,
+  Outlet,
+} from '@tanstack/react-router';
+import { ServiceConfigPage } from './ServiceConfigPage';
+import type { ServiceConfig } from '$/api/service-config';
+
+const mockList = vi.fn<(service: string) => Promise<ServiceConfig[]>>();
+
+vi.mock('$/api/service-config', () => ({
+  listServiceConfig: (service: string) => mockList(service),
+}));
+
+vi.mock('$/api/client', () => ({
+  isAuthenticated: () => true,
+  AuthError: class AuthError extends Error {
+    readonly status = 401;
+    constructor() {
+      super('Unauthorized');
+    }
+  },
+  ApiError: class ApiError extends Error {
+    constructor(msg: string, public status: number, public code?: string) {
+      super(msg);
+    }
+  },
+}));
+
+// Monaco Editor is lazy-loaded and not available in jsdom.
+vi.mock('@monaco-editor/react', () => ({
+  Editor: ({ value }: { value: string }) => (
+    <div data-testid="monaco-editor" data-value={value} />
+  ),
+}));
+
+function makeSection(overrides: Partial<ServiceConfig> = {}): ServiceConfig {
+  return {
+    ID: 1,
+    CreatedAt: new Date().toISOString(),
+    UpdatedAt: new Date().toISOString(),
+    Name: 'logger',
+    Service: 'api',
+    EnvironmentID: 0,
+    Type: 'json',
+    Value: '{"type":"stdout"}',
+    Source: 'yaml',
+    Editable: false,
+    Info: 'Log sinks',
+    ...overrides,
+  };
+}
+
+function makeTestRouter(initialPath = '/_app/config/api') {
+  const rootRoute = createRootRoute({ component: Outlet });
+  const appRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/_app',
+    component: Outlet,
+  });
+  const configRoute = createRoute({
+    getParentRoute: () => appRoute,
+    path: 'config/$service',
+    component: ServiceConfigPage,
+  });
+  const loginRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/login',
+    component: () => <div data-testid="login">Login</div>,
+  });
+  const routeTree = rootRoute.addChildren([
+    appRoute.addChildren([configRoute]),
+    loginRoute,
+  ]);
+  const history = createMemoryHistory({ initialEntries: [initialPath] });
+  return createRouter({ routeTree, history });
+}
+
+function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ServiceConfigPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders service config sections with their names and badges', async () => {
+    mockList.mockResolvedValue([
+      makeSection(),
+      makeSection({
+        ID: 2,
+        Name: 'saml',
+        Value: '{"enabled":true}',
+        Source: 'db',
+        Editable: true,
+        Info: 'SAML federated login',
+      }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('logger')).toBeInTheDocument();
+    });
+    expect(screen.getByText('saml')).toBeInTheDocument();
+    expect(screen.getByText('yaml')).toBeInTheDocument();
+    expect(screen.getByText('db')).toBeInTheDocument();
+    expect(screen.getByText('read-only')).toBeInTheDocument();
+    expect(screen.getByText('editable')).toBeInTheDocument();
+    expect(mockList).toHaveBeenCalledWith('api');
+  });
+
+  it('renders the service tabs and switches service on click', async () => {
+    mockList.mockResolvedValue([]);
+    renderWithProviders(makeTestRouter('/_app/config/tls'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'osctrl-tls' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('tab', { name: 'osctrl-api' })).toBeInTheDocument();
+    expect(mockList).toHaveBeenCalledWith('tls');
+  });
+
+  it('shows empty state when no sections are returned', async () => {
+    mockList.mockResolvedValue([]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('No service config for api.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when the API fails', async () => {
+    const { ApiError } = await import('$/api/client');
+    mockList.mockRejectedValue(new ApiError('Internal error', 500));
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Retry')).toBeInTheDocument();
+  });
+
+  it('pretty-prints JSON values in the editor', async () => {
+    mockList.mockResolvedValue([
+      makeSection({ Value: '{"type":"stdout","alwaysLog":true}' }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      const editor = screen.getByTestId('monaco-editor');
+      const value = editor.getAttribute('data-value') ?? '';
+      // Pretty-printed JSON should contain newlines and indentation.
+      expect(value).toContain('\n');
+      expect(value).toContain('"type": "stdout"');
+    });
+  });
+
+  it('renders raw value when it is not valid JSON', async () => {
+    mockList.mockResolvedValue([
+      makeSection({ Value: 'not-json' }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      const editor = screen.getByTestId('monaco-editor');
+      expect(editor.getAttribute('data-value')).toBe('not-json');
+    });
+  });
+});

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -1,0 +1,216 @@
+import { usePageTitle } from '$/lib/usePageTitle';
+import { useParams, useNavigate, Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { listServiceConfig, type ServiceConfig } from '$/api/service-config';
+import { AuthError } from '$/api/client';
+import { cn } from '$/lib/cn';
+import { Skeleton } from '$/components/data/Skeleton';
+import { EmptyState } from '$/components/data/EmptyState';
+import { CodeEditor } from '$/components/forms/CodeEditor';
+import { formatRelative } from '$/lib/time';
+
+const SERVICES = ['api', 'tls'] as const;
+type Service = (typeof SERVICES)[number];
+
+export function ServiceConfigPage() {
+  usePageTitle('Service Config');
+  const params = useParams({ strict: false });
+  const navigate = useNavigate();
+  const serviceParam = (params as { service?: string }).service ?? 'api';
+  const service: Service = (SERVICES as readonly string[]).includes(serviceParam)
+    ? (serviceParam as Service)
+    : 'api';
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['service-config', service],
+    queryFn: () => listServiceConfig(service),
+    staleTime: 30_000,
+  });
+
+  if (isError && error instanceof AuthError) {
+    void navigate({ to: '/login' });
+    return null;
+  }
+
+  const sections = data ?? [];
+  const loading = isLoading;
+  const fetching = isFetching;
+  const hasError = isError;
+  const pageError = error;
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Toolbar row */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border)] flex-wrap">
+        <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">
+          Service Config
+        </h1>
+        {fetching && !loading && (
+          <span
+            aria-live="polite"
+            aria-label="Refreshing data"
+            className="ml-auto text-[10px] text-[color:var(--text-3)] font-mono-tabular"
+          >
+            refreshing…
+          </span>
+        )}
+      </div>
+
+      {/* Service tabs — same underline TabButton pattern as SettingsPage */}
+      <div
+        role="tablist"
+        aria-label="Service config service tabs"
+        className="flex items-center gap-1 px-2 border-b border-[color:var(--border)] overflow-x-auto"
+      >
+        {SERVICES.map((s) => (
+          <Link
+            key={s}
+            to="/_app/config/$service"
+            params={{ service: s }}
+            role="tab"
+            aria-selected={s === service}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-3 pt-2 pb-1.5 text-xs whitespace-nowrap',
+              'border-b-2 transition-colors',
+              'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+              s === service
+                ? 'border-[color:var(--signal)] text-[color:var(--text-1)] font-semibold'
+                : 'border-transparent text-[color:var(--text-3)] hover:text-[color:var(--text-1)]',
+            )}
+          >
+            osctrl-{s}
+          </Link>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-auto min-h-0 p-4">
+        {loading && (
+          <div className="space-y-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 w-full" />
+            ))}
+          </div>
+        )}
+
+        {hasError && !loading && (
+          <EmptyState
+            icon={
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 8v4M12 16h.01" />
+              </svg>
+            }
+            title={pageError instanceof Error ? pageError.message : 'Failed to load service config'}
+            action={
+              <button
+                type="button"
+                onClick={() => void refetch()}
+                className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors"
+              >
+                Retry
+              </button>
+            }
+          />
+        )}
+
+        {!loading && !hasError && sections.length === 0 && (
+          <EmptyState
+            icon={
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            }
+            title={`No service config for ${service}.`}
+          />
+        )}
+
+        {!loading && !hasError && sections.length > 0 && (
+          <div className="space-y-3">
+            {sections.map((s) => (
+              <ConfigSectionCard key={s.ID} section={s} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConfigSectionCard({ section }: { section: ServiceConfig }) {
+  // Pretty-print the JSON so the Monaco viewer gets syntax-highlighted,
+  // folded, scrollable content instead of a single long line.
+  let prettyValue = section.Value;
+  try {
+    prettyValue = JSON.stringify(JSON.parse(section.Value), null, 2);
+  } catch {
+    // not JSON — show raw
+  }
+
+  return (
+    <section
+      className="border border-[color:var(--border)] rounded-md overflow-hidden bg-[color:var(--bg-1)]"
+      aria-labelledby={`config-${section.Name}-heading`}
+    >
+      <header className="flex items-center gap-3 px-3 py-2 bg-[color:var(--bg-0)] border-b border-[color:var(--border)]">
+        <h2
+          id={`config-${section.Name}-heading`}
+          className="font-display text-sm font-semibold text-[color:var(--text-1)] font-mono-tabular"
+        >
+          {section.Name}
+        </h2>
+        <span
+          className={cn(
+            'px-1.5 py-0.5 rounded text-[10px] font-mono-tabular',
+            section.Source === 'db'
+              ? 'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)]'
+              : 'bg-[color:var(--bg-2)] text-[color:var(--text-3)]',
+          )}
+          title={section.Source === 'db' ? 'Edited via database' : 'Seeded from YAML file'}
+        >
+          {section.Source}
+        </span>
+        <span
+          className={cn(
+            'px-1.5 py-0.5 rounded text-[10px] font-mono-tabular',
+            section.Editable
+              ? 'bg-[rgba(var(--signal-r),var(--signal-g),var(--signal-b),0.12)] text-[color:var(--signal)]'
+              : 'bg-[color:var(--bg-2)] text-[color:var(--text-3)]',
+          )}
+        >
+          {section.Editable ? 'editable' : 'read-only'}
+        </span>
+        {section.Info && (
+          <p className="text-[10px] text-[color:var(--text-3)] truncate flex-1">
+            {section.Info}
+          </p>
+        )}
+        {!section.Info && <div className="flex-1" />}
+        <span
+          className="text-[10px] tnum text-[color:var(--text-3)] whitespace-nowrap"
+          title={section.UpdatedAt}
+        >
+          updated {formatRelative(section.UpdatedAt)}
+        </span>
+      </header>
+
+      <div className="p-3">
+        <CodeEditor
+          value={prettyValue}
+          language="json"
+          readOnly
+          height="200px"
+          aria-label={`Configuration section ${section.Name}`}
+        />
+      </div>
+    </section>
+  );
+}
+
+export default ServiceConfigPage;

--- a/frontend/src/features/settings/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/SettingsPage.test.tsx
@@ -14,14 +14,11 @@ import { SettingsPage } from './SettingsPage';
 import type { SettingValue } from '$/api/settings';
 
 const mockList = vi.fn<(service: string) => Promise<SettingValue[]>>();
-const mockListJSON = vi.fn<(service: string) => Promise<SettingValue[]>>();
 const mockPatch = vi.fn();
 
 vi.mock('$/api/settings', () => ({
   listServiceSettings: (service: string) => mockList(service),
   patchSetting: (...args: unknown[]) => mockPatch(...args),
-  listAllSettings: vi.fn(),
-  listServiceJSONSettings: (service: string) => mockListJSON(service),
 }));
 
 vi.mock('$/api/client', () => ({
@@ -47,7 +44,6 @@ function makeSetting(overrides: Partial<SettingValue> = {}): SettingValue {
     Name: 'service_metrics',
     Service: 'api',
     EnvironmentID: 0,
-    JSON: false,
     Type: 'boolean',
     String: '',
     Boolean: false,
@@ -55,18 +51,6 @@ function makeSetting(overrides: Partial<SettingValue> = {}): SettingValue {
     Info: 'Metrics endpoint',
     ...overrides,
   };
-}
-
-function makeJSONSetting(overrides: Partial<SettingValue> = {}): SettingValue {
-  return makeSetting({
-    ID: 100,
-    Name: 'json_listener',
-    JSON: true,
-    Type: 'string',
-    String: '0.0.0.0',
-    Info: '',
-    ...overrides,
-  });
 }
 
 function makeTestRouter(initialPath = '/_app/settings/api') {
@@ -108,28 +92,20 @@ function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
 describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockListJSON.mockResolvedValue([]);
   });
 
-  it('renders api flag parameters and editable stored settings', async () => {
+  it('renders editable stored settings', async () => {
     mockList.mockResolvedValue([
       makeSetting(),
       makeSetting({ ID: 2, Name: 'refresh_settings', Type: 'integer', Integer: 30 }),
     ]);
-    mockListJSON.mockResolvedValue([
-      makeJSONSetting(),
-      makeJSONSetting({ ID: 101, Name: 'json_port', String: '9000' }),
-    ]);
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByText('json_listener')).toBeInTheDocument();
+      expect(screen.getByText('service_metrics')).toBeInTheDocument();
     });
-    expect(screen.getByText('json_port')).toBeInTheDocument();
-    expect(screen.getByText('service_metrics')).toBeInTheDocument();
     expect(screen.getByText('refresh_settings')).toBeInTheDocument();
     expect(mockList).toHaveBeenCalledWith('api');
-    expect(mockListJSON).toHaveBeenCalledWith('api');
   });
 
   it('does not expose osctrl-admin in the settings tabs', async () => {
@@ -143,22 +119,17 @@ describe('SettingsPage', () => {
     expect(screen.queryByRole('tab', { name: 'osctrl-admin' })).not.toBeInTheDocument();
   });
 
-  it('shows flag parameters and editable settings for tls when they are available', async () => {
+  it('shows settings for tls when they are available', async () => {
     mockList.mockResolvedValue([
       makeSetting({ ID: 2, Name: 'accelerated_seconds', Service: 'tls', Type: 'integer', Integer: 5 }),
-    ]);
-    mockListJSON.mockResolvedValue([
-      makeJSONSetting({ ID: 1, Name: 'json_carver', Service: 'tls', String: 'db' }),
     ]);
 
     renderWithProviders(makeTestRouter('/_app/settings/tls'));
 
     await waitFor(() => {
-      expect(screen.getByText('json_carver')).toBeInTheDocument();
+      expect(screen.getByText('accelerated_seconds')).toBeInTheDocument();
     });
-    expect(screen.getByText('accelerated_seconds')).toBeInTheDocument();
     expect(mockList).toHaveBeenCalledWith('tls');
-    expect(mockListJSON).toHaveBeenCalledWith('tls');
   });
 
   it('shows empty state when no settings exist', async () => {

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -4,7 +4,6 @@ import { useParams, useNavigate, Link } from '@tanstack/react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   listServiceSettings,
-  listServiceJSONSettings,
   patchSetting,
   type SettingValue,
   type SettingType,
@@ -47,23 +46,8 @@ export function SettingsPage() {
     queryFn: () => listServiceSettings(service),
     staleTime: 30_000,
   });
-  const {
-    data: configData,
-    isLoading: isConfigLoading,
-    isFetching: isConfigFetching,
-    isError: isConfigError,
-    error: configError,
-    refetch: refetchConfig,
-  } = useQuery({
-    queryKey: ['settings', service, 'json'],
-    queryFn: () => listServiceJSONSettings(service),
-    staleTime: 30_000,
-  });
 
-  if (
-    (isError && error instanceof AuthError) ||
-    (isConfigError && configError instanceof AuthError)
-  ) {
+  if (isError && error instanceof AuthError) {
     void navigate({ to: '/login' });
     return null;
   }
@@ -71,11 +55,10 @@ export function SettingsPage() {
   const items = (data ?? []).filter(
     (setting) => !HIDDEN_SETTINGS_BY_SERVICE[service]?.has(setting.Name),
   );
-  const flagParameters = configData ?? [];
-  const loading = isLoading || isConfigLoading;
-  const fetching = isFetching || isConfigFetching;
-  const hasError = isError || isConfigError;
-  const pageError = error ?? configError;
+  const loading = isLoading;
+  const fetching = isFetching;
+  const hasError = isError;
+  const pageError = error;
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -148,7 +131,6 @@ export function SettingsPage() {
                 type="button"
                 onClick={() => {
                   void refetch();
-                  void refetchConfig();
                 }}
                 className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors"
               >
@@ -158,7 +140,7 @@ export function SettingsPage() {
           />
         )}
 
-        {!loading && !hasError && items.length === 0 && flagParameters.length === 0 && (
+        {!loading && !hasError && items.length === 0 && (
           <EmptyState
             icon={
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -169,80 +151,27 @@ export function SettingsPage() {
           />
         )}
 
-        {!loading && !hasError && (items.length > 0 || flagParameters.length > 0) && (
-          <div className="space-y-4">
-            {flagParameters.length > 0 && (
-              <SettingsTable title="Flag Parameters" settings={flagParameters} />
-            )}
-            {items.length > 0 && (
-              <section aria-labelledby="settings-updatable-heading" className="space-y-2">
-                <h2
-                  id="settings-updatable-heading"
-                  className="font-display text-sm font-semibold text-[color:var(--text-1)]"
-                >
-                  Settings
-                </h2>
-                {items.map((s) => (
-                  <SettingRow
-                    key={s.ID}
-                    setting={s}
-                    service={service}
-                    onSaved={() => qc.invalidateQueries({ queryKey: ['settings', service] })}
-                  />
-                ))}
-              </section>
-            )}
-          </div>
+        {!loading && !hasError && items.length > 0 && (
+          <section aria-labelledby="settings-updatable-heading" className="space-y-2">
+            <h2
+              id="settings-updatable-heading"
+              className="font-display text-sm font-semibold text-[color:var(--text-1)]"
+            >
+              Settings
+            </h2>
+            {items.map((s) => (
+              <SettingRow
+                key={s.ID}
+                setting={s}
+                service={service}
+                onSaved={() => qc.invalidateQueries({ queryKey: ['settings', service] })}
+              />
+            ))}
+          </section>
         )}
       </div>
     </div>
   );
-}
-
-function SettingsTable({ title, settings }: { title: string; settings: SettingValue[] }) {
-  return (
-    <section
-      aria-labelledby={`settings-${title.toLowerCase()}-heading`}
-      className="border border-[color:var(--border)] rounded-md overflow-hidden bg-[color:var(--bg-1)]"
-    >
-      <header className="px-3 py-2 bg-[color:var(--bg-0)] border-b border-[color:var(--border)]">
-        <h2
-          id={`settings-${title.toLowerCase()}-heading`}
-          className="font-display text-sm font-semibold text-[color:var(--text-1)]"
-        >
-          {title}
-        </h2>
-      </header>
-      <div className="overflow-x-auto">
-        <table className="w-full text-left text-xs">
-          <thead className="text-[10px] uppercase tracking-[0.08em] text-[color:var(--text-3)]">
-            <tr>
-              <th className="px-3 py-2 font-medium">Name</th>
-              <th className="px-3 py-2 font-medium">Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {settings.map((setting) => (
-              <tr key={setting.ID} className="border-t border-[color:var(--border)]">
-                <td className="px-3 py-2 font-mono-tabular text-[color:var(--text-1)]">
-                  {setting.Name}
-                </td>
-                <td className="px-3 py-2 font-mono-tabular text-[color:var(--text-2)]">
-                  {settingValue(setting)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </section>
-  );
-}
-
-function settingValue(setting: SettingValue) {
-  if (setting.Type === 'boolean') return setting.Boolean ? 'true' : 'false';
-  if (setting.Type === 'integer') return String(setting.Integer);
-  return setting.String;
 }
 
 function SettingRow({

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -23,6 +23,7 @@ import { usersRoute } from './routes/_app/users'
 import { profileRoute } from './routes/_app/profile'
 import { environmentsRoute } from './routes/_app/environments'
 import { settingsServiceRoute } from './routes/_app/settings.$service'
+import { serviceConfigRoute } from './routes/_app/config.$service'
 import { auditRoute } from './routes/_app/audit'
 import { devComponentsRoute } from './routes/dev.components'
 
@@ -36,6 +37,7 @@ const routeTree = rootRoute.addChildren([
     profileRoute,
     environmentsRoute,
     settingsServiceRoute,
+    serviceConfigRoute,
     auditRoute,
     envRoute.addChildren([
       envIndexRoute,

--- a/frontend/src/routes/_app/config.$service.tsx
+++ b/frontend/src/routes/_app/config.$service.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { appRoute } from './route';
+import { ServiceConfigPage } from '$/features/service-config/ServiceConfigPage';
+
+export const serviceConfigRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: 'config/$service',
+  component: ServiceConfigPage,
+});


### PR DESCRIPTION
Follow up for #950 

## Summary

Adds a read-only frontend view for the database-backed service configuration, completing phase 1 of the service config design.

### Problem

Phase 1 backend (PR #N) introduced `pkg/serviceconfig` with YAML→DB seeding and three read-only GET endpoints, but the frontend had no way to display the persisted configuration sections. Operators could not inspect the seeded logger, carver, SAML, OIDC, metrics, TLS, or debug sections from the UI.

### Changes

**API client** (`frontend/src/api/service-config.ts`)
- `ServiceConfig` interface matching the Go `pkg/serviceconfig.ServiceConfig` wire shape.
- `listAllServiceConfig`, `listServiceConfig`, `getServiceConfig` — typed wrappers over the three GET endpoints.

**ServiceConfigPage** (`frontend/src/features/service-config/ServiceConfigPage.tsx`)
- Reuses the existing `api`/`tls` tab pattern from `SettingsPage`.
- Each section renders as a card with:
  - Section name, `source` badge (`yaml`/`db`), `editable`/`read-only` badge, info text, and relative timestamp.
  - JSON viewer using the existing lazy-loaded `CodeEditor` in read-only mode, with pretty-printing so the content is syntax-highlighted, foldable, and scrollable.
- Skeleton loading state, error state with retry, and empty state — matching existing component conventions.

**Route** (`frontend/src/routes/_app/config.$service.tsx`)
- `/_app/config/$service` registered in the router.

**Navigation** (`frontend/src/components/chrome/SideNav.tsx`)
- New "Service Config" nav item below "Settings", active when the path is under `/_app/config`.

**Tests** (`frontend/src/features/service-config/ServiceConfigPage.test.tsx`)
- 6 tests covering: section rendering with badges, service tab switching, empty state, error state with retry, JSON pretty-printing, and raw-value passthrough for non-JSON.
- Monaco editor mocked per the existing `CodeEditor.test.tsx` pattern.

### Validation

- `npm run check` — TypeScript typecheck clean
- `npm test` — 34 test files / 197 tests pass (191 existing + 6 new)
- `go build ./...` — backend still builds clean

### Phase 1 status

Phase 1 is now fully complete: YAML → DB seeding, read-only API, and read-only frontend view. The next step is phase 2 — the PUT handler for editable sections plus frontend editing.