### PR TITLE
Ability to update service configuration values using `osctrl-api`

### DIFF
--- a/cmd/api/handlers/service_config.go
+++ b/cmd/api/handlers/service_config.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/serviceconfig"
+	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -151,4 +153,94 @@ func (h *HandlersApi) ServiceConfigSectionHandler(w http.ResponseWriter, r *http
 	log.Debug().Msgf("Returned service config %s/%s", service, section)
 	h.AuditLog.Visit(ctx[ctxUser], r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, sc)
+}
+
+// ServiceConfigUpdateHandler — PUT /api/v1/service-config/{service}/{section}
+//
+// Replaces the JSON value of an editable service config section. Only
+// sections marked Editable=true in the SectionRegistry can be updated.
+// The source is flipped to "db" so subsequent boots won't clobber the
+// change. The body must be a JSON object with a "value" field containing
+// the new JSON-encoded section value.
+//
+// Body shape:
+//
+//	{ "value": {"enableHttp": true, "showBody": false} }
+//
+// @Summary Update service config section
+// @Description Replaces an editable service config section's JSON value.
+// @Tags service-config
+// @Accept json
+// @Produce json
+// @Param service path string true "Service name"
+// @Param section path string true "Section name"
+// @Param request body types.ServiceConfigUpdateRequest true "Request body"
+// @Success 200 {object} serviceconfig.ServiceConfig
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 409 {object} types.ApiErrorResponse "Conflict"
+// @Failure 429 {object} types.ApiErrorResponse "Too many requests"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Failure 503 {object} types.ApiErrorResponse "Service unavailable"
+// @Security ApiKeyAuth
+// @Router /api/v1/service-config/{service}/{section} [put]
+func (h *HandlersApi) ServiceConfigUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	if h.ServiceConfig == nil {
+		apiErrorResponse(w, "service config not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	service := r.PathValue("service")
+	if service == "" {
+		apiErrorResponse(w, "missing service", http.StatusBadRequest, nil)
+		return
+	}
+	if !h.ServiceConfig.VerifyService(service) {
+		apiErrorResponse(w, "invalid service", http.StatusBadRequest, nil)
+		return
+	}
+	section := r.PathValue("section")
+	if section == "" {
+		apiErrorResponse(w, "missing section", http.StatusBadRequest, nil)
+		return
+	}
+	if !h.ServiceConfig.VerifySection(service, section) {
+		apiErrorResponse(w, "invalid section", http.StatusBadRequest, nil)
+		return
+	}
+
+	var body types.ServiceConfigUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	if len(body.Value) == 0 {
+		apiErrorResponse(w, "missing value in request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	updated, err := h.ServiceConfig.UpdateSection(service, section, string(body.Value), serviceconfig.NoEnvironmentID)
+	if err != nil {
+		switch {
+		case errors.Is(err, serviceconfig.ErrSectionNotEditable):
+			apiErrorResponse(w, "section is not editable", http.StatusConflict, err)
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			apiErrorResponse(w, "section not found", http.StatusNotFound, err)
+		default:
+			apiErrorResponse(w, "error updating section", http.StatusInternalServerError, err)
+		}
+		return
+	}
+	h.AuditLog.SettingsAction(ctx[ctxUser], fmt.Sprintf("put service-config %s/%s", service, section), strings.Split(r.RemoteAddr, ":")[0])
+	log.Debug().Msgf("Updated service config %s/%s", service, section)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, updated)
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -874,7 +874,7 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"PATCH "+_apiPath(apiSettingsPath)+"/{service}/{name}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingPatchHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
-	// API: service config (read-only phase 1)
+	// API: service config (phase 1 read + phase 2 editable PUT)
 	muxAPI.Handle(
 		"GET "+_apiPath(apiServiceConfigPath),
 		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
@@ -884,6 +884,9 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"GET "+_apiPath(apiServiceConfigPath)+"/{service}/{section}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigSectionHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"PUT "+_apiPath(apiServiceConfigPath)+"/{service}/{section}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigUpdateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// API: audit log
 	if flagParams.Service.AuditLog {
 		muxAPI.Handle(

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -79,7 +79,7 @@ var SectionRegistry = map[string][]SectionSpec{
 		{"tls", false, "TLS termination certificate/key paths"},
 		{"logger", false, "Log sinks (future: editable)"},
 		{"carver", false, "File carver configuration"},
-		{"debug", false, "HTTP debug dump settings"},
+		{"debug", true, "HTTP debug dump settings"},
 	},
 	config.ServiceAPI: {
 		{"service", false, "Core service listener, port, log level, auth mode"},
@@ -92,7 +92,7 @@ var SectionRegistry = map[string][]SectionSpec{
 		{"tls", false, "TLS termination certificate/key paths"},
 		{"logger", false, "Log sinks (future: editable)"},
 		{"carver", false, "File carver configuration"},
-		{"debug", false, "HTTP debug dump settings"},
+		{"debug", true, "HTTP debug dump settings"},
 	},
 }
 
@@ -117,6 +117,16 @@ func (m *ServiceConfigManager) VerifySection(service, section string) bool {
 	for _, spec := range SectionRegistry[service] {
 		if spec.Name == section {
 			return true
+		}
+	}
+	return false
+}
+
+// IsEditable checks that the section is registered and marked editable.
+func (m *ServiceConfigManager) IsEditable(service, section string) bool {
+	for _, spec := range SectionRegistry[service] {
+		if spec.Name == section {
+			return spec.Editable
 		}
 	}
 	return false
@@ -191,6 +201,39 @@ func (m *ServiceConfigManager) GetAll(envID uint) ([]ServiceConfig, error) {
 		return values, err
 	}
 	return values, nil
+}
+
+// ErrSectionNotEditable is returned when UpdateSection is called on a section
+// that is not marked editable in the registry.
+var ErrSectionNotEditable = fmt.Errorf("section is not editable")
+
+// UpdateSection replaces the JSON value of an editable section. It validates
+// that the new value is valid JSON, that the section exists and is marked
+// editable, and flips the source to SourceDB so subsequent boots won't
+// clobber the change. Returns the updated row.
+func (m *ServiceConfigManager) UpdateSection(service, name, value string, envID uint) (ServiceConfig, error) {
+	if !m.VerifyService(service) {
+		return ServiceConfig{}, fmt.Errorf("unknown service %q", service)
+	}
+	if !m.IsEditable(service, name) {
+		return ServiceConfig{}, ErrSectionNotEditable
+	}
+	// Validate that the new value is valid JSON.
+	if !json.Valid([]byte(value)) {
+		return ServiceConfig{}, fmt.Errorf("value is not valid JSON")
+	}
+	existing, err := m.GetSection(service, name, envID)
+	if err != nil {
+		return ServiceConfig{}, fmt.Errorf("get section %s/%s: %w", service, name, err)
+	}
+	if err := m.DB.Model(&existing).Updates(map[string]any{
+		"value":  value,
+		"source": SourceDB,
+	}).Error; err != nil {
+		return ServiceConfig{}, fmt.Errorf("update %s/%s: %w", service, name, err)
+	}
+	log.Debug().Msgf("Updated service config %s/%s (source=db)", service, name)
+	return existing, nil
 }
 
 // sectionValues extracts each registered section from ServiceParameters and

--- a/pkg/serviceconfig/serviceconfig_test.go
+++ b/pkg/serviceconfig/serviceconfig_test.go
@@ -100,14 +100,17 @@ func TestSeed_CreatesAllSections(t *testing.T) {
 
 	// Every registered section name should be present.
 	names := make(map[string]bool, len(rows))
+	editableByRow := make(map[string]bool, len(rows))
 	for _, r := range rows {
 		names[r.Name] = true
+		editableByRow[r.Name] = r.Editable
 		assert.Equal(t, SourceYAML, r.Source)
-		assert.False(t, r.Editable) // phase 1 — none editable
 		assert.Equal(t, "json", r.Type)
 	}
 	for _, spec := range SectionRegistry[config.ServiceTLS] {
 		assert.True(t, names[spec.Name], "missing section %s", spec.Name)
+		assert.Equal(t, spec.Editable, editableByRow[spec.Name],
+			"editable flag mismatch for %s", spec.Name)
 	}
 }
 
@@ -293,4 +296,93 @@ func sectionNames(rows []ServiceConfig) map[string]bool {
 		out[r.Name] = true
 	}
 	return out
+}
+
+// UpdateSection must update the value and flip source to "db" for an editable
+// section.
+func TestUpdateSection_Success(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), 0))
+
+	newValue := `{"enableHttp":true,"httpFile":"/tmp/debug.log","showBody":true}`
+	updated, err := m.UpdateSection(config.ServiceTLS, "debug", newValue, 0)
+	require.NoError(t, err)
+	assert.Equal(t, newValue, updated.Value)
+	assert.Equal(t, SourceDB, updated.Source)
+}
+
+// UpdateSection must reject a non-editable section with ErrSectionNotEditable.
+func TestUpdateSection_NotEditable(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), 0))
+
+	_, err := m.UpdateSection(config.ServiceTLS, "db", `{"host":"x"}`, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSectionNotEditable)
+}
+
+// UpdateSection must reject invalid JSON.
+func TestUpdateSection_InvalidJSON(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), 0))
+
+	_, err := m.UpdateSection(config.ServiceTLS, "debug", "not-json", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+// UpdateSection must reject an unknown service.
+func TestUpdateSection_UnknownService(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	_, err := m.UpdateSection("bogus", "debug", `{}`, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown service")
+}
+
+// UpdateSection must reject a section that doesn't exist in the DB.
+func TestUpdateSection_SectionNotFound(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	// "debug" is editable but we haven't seeded — should fail on GetSection.
+	_, err := m.UpdateSection(config.ServiceTLS, "debug", `{}`, 0)
+	require.Error(t, err)
+}
+
+// IsEditable must return true for editable sections and false for
+// non-editable or unknown sections.
+func TestIsEditable(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+
+	assert.True(t, m.IsEditable(config.ServiceTLS, "debug"))
+	assert.True(t, m.IsEditable(config.ServiceAPI, "debug"))
+	assert.False(t, m.IsEditable(config.ServiceTLS, "db"))
+	assert.False(t, m.IsEditable(config.ServiceTLS, "logger"))
+	assert.False(t, m.IsEditable(config.ServiceTLS, "nonexistent"))
+	assert.False(t, m.IsEditable("bogus", "debug"))
+}
+
+// After UpdateSection flips source to "db", a subsequent Seed must not
+// overwrite the edited value.
+func TestUpdateSection_SeedDoesNotClobber(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	newValue := `{"enableHttp":true,"httpFile":"/tmp/x.log","showBody":false}`
+	_, err := m.UpdateSection(config.ServiceTLS, "debug", newValue, 0)
+	require.NoError(t, err)
+
+	// Re-seed — debug is create-if-missing so the DB value survives.
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	sc, err := m.GetSection(config.ServiceTLS, "debug", 0)
+	require.NoError(t, err)
+	assert.Equal(t, newValue, sc.Value)
+	assert.Equal(t, SourceDB, sc.Source)
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/queries"
@@ -501,6 +502,13 @@ type SettingPatchRequest struct {
 	String  *string `json:"string,omitempty"`
 	Boolean *bool   `json:"boolean,omitempty"`
 	Integer *int64  `json:"integer,omitempty"`
+}
+
+// ServiceConfigUpdateRequest is the body for PUT
+// /api/v1/service-config/{service}/{section}. Value is a raw JSON object
+// representing the new section contents.
+type ServiceConfigUpdateRequest struct {
+	Value json.RawMessage `json:"value"`
 }
 
 // TLSEnvironmentView is the low-privilege projection of an environment.


### PR DESCRIPTION
## Summary

Adds the ability to update editable service config sections through the API, implementing phase 2 of the service config design.

### Problem

Phase 1 introduced `pkg/serviceconfig` with YAML→DB seeding and read-only GET endpoints, but there was no way to modify the persisted configuration sections from the API. Operators had to edit the YAML file and restart the service to change any section.

### Changes

**`pkg/serviceconfig`**
- `UpdateSection(service, name, value, envID)` method — validates the section is editable, validates the new value is valid JSON, updates the `Value` field, and flips `Source` from `yaml` to `db` so subsequent boots won't clobber the change (the `Seed` create-if-missing semantics already protect DB-edited rows).
- `IsEditable(service, section)` helper — looks up the `Editable` flag from the `SectionRegistry`.
- `ErrSectionNotEditable` sentinel error for the handler to return a 409 Conflict.
- `debug` section marked `Editable: true` for both TLS and API services — a low-risk first editable section (HTTP debug dump settings).

**`pkg/types`**
- `ServiceConfigUpdateRequest` with `Value json.RawMessage` — the PUT body carries the new section contents as a raw JSON object.

**API handler** (`cmd/api/handlers/service_config.go`)
- `PUT /api/v1/service-config/{service}/{section}` — `ServiceConfigUpdateHandler`:
  - Requires `AdminLevel` + `NoEnvironment` permissions.
  - Validates service and section against the registry.
  - Decodes the request body, calls `UpdateSection`, and returns the updated row.
  - 409 Conflict for non-editable sections, 404 for missing sections, 400 for invalid body.
  - Audit-logged via `AuditLog.SettingsAction`.

**Route** registered in `cmd/api/main.go` alongside the existing GET routes.

**Tests** (7 new in `pkg/serviceconfig/serviceconfig_test.go`)
- `TestUpdateSection_Success` — updates an editable section, verifies value and source=db.
- `TestUpdateSection_NotEditable` — rejects a non-editable section with `ErrSectionNotEditable`.
- `TestUpdateSection_InvalidJSON` — rejects non-JSON values.
- `TestUpdateSection_UnknownService` — rejects unknown service.
- `TestUpdateSection_SectionNotFound` — rejects when section doesn't exist in DB.
- `TestIsEditable` — verifies the editable flag lookup.
- `TestUpdateSection_SeedDoesNotClobber` — verifies that re-seeding after an edit preserves the DB value and source.

### Validation

- `go build ./...` — clean
- `go test ./...` — all packages pass (17 new tests in `pkg/serviceconfig`)
- `golangci-lint run ./pkg/serviceconfig/...` — 0 issues
- `gofmt` clean on all modified files

### Security notes

- Connection/secret sections (`db`, `redis`) remain `editable=false` and can never be written through the API.
- The `Editable` flag is enforced both in the manager (`UpdateSection` checks `IsEditable`) and in the handler (returns 409 before reaching the manager).
- All writes are audit-logged via `SettingsAction`.