### PR TITLE
Add editable capabilities to frontend for service config values

### DIFF
--- a/frontend/src/api/service-config.ts
+++ b/frontend/src/api/service-config.ts
@@ -1,10 +1,11 @@
 /**
  * Service config API client.
  *
- * Read-only access to the service_config table, which mirrors the structured
- * YAML configuration sections (logger, carver, SAML, OIDC, metrics, TLS, …)
- * per service into the database. Each section is stored as a JSON-encoded
- * blob. Phase 1 is read-only; phase 2 will add a PUT for editable sections.
+ * Access to the service_config table, which mirrors the structured YAML
+ * configuration sections (logger, carver, SAML, OIDC, metrics, TLS, …) per
+ * service into the database. Each section is stored as a JSON-encoded blob.
+ * Read endpoints are available for all sections; editable sections can be
+ * updated via PUT.
  */
 import { apiFetch } from './client';
 
@@ -42,5 +43,27 @@ export function getServiceConfig(
 ): Promise<ServiceConfig> {
   return apiFetch<ServiceConfig>(
     `/api/v1/service-config/${encodeURIComponent(service)}/${encodeURIComponent(section)}`,
+  );
+}
+
+/** Body shape for PUT /api/v1/service-config/{service}/{section}. */
+export interface ServiceConfigUpdateRequest {
+  /** Raw JSON object representing the new section contents. */
+  value: unknown;
+}
+
+/** PUT /api/v1/service-config/{service}/{section} — update an editable section. */
+export function updateServiceConfig(
+  service: string,
+  section: string,
+  body: ServiceConfigUpdateRequest,
+): Promise<ServiceConfig> {
+  return apiFetch<ServiceConfig>(
+    `/api/v1/service-config/${encodeURIComponent(service)}/${encodeURIComponent(section)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
   );
 }

--- a/frontend/src/features/service-config/ServiceConfigPage.test.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   createMemoryHistory,
@@ -13,9 +14,11 @@ import { ServiceConfigPage } from './ServiceConfigPage';
 import type { ServiceConfig } from '$/api/service-config';
 
 const mockList = vi.fn<(service: string) => Promise<ServiceConfig[]>>();
+const mockUpdate = vi.fn();
 
 vi.mock('$/api/service-config', () => ({
   listServiceConfig: (service: string) => mockList(service),
+  updateServiceConfig: (...args: unknown[]) => mockUpdate(...args),
 }));
 
 vi.mock('$/api/client', () => ({
@@ -33,11 +36,20 @@ vi.mock('$/api/client', () => ({
   },
 }));
 
-// Monaco Editor is lazy-loaded and not available in jsdom.
+// Monaco Editor is lazy-loaded and not available in jsdom. Capture the
+// onChange callback so tests can simulate edits.
+let lastEditorOnChange: ((v: string | undefined) => void) | null = null;
 vi.mock('@monaco-editor/react', () => ({
-  Editor: ({ value }: { value: string }) => (
-    <div data-testid="monaco-editor" data-value={value} />
-  ),
+  Editor: ({ value, onChange }: { value: string; onChange?: (v: string | undefined) => void }) => {
+    lastEditorOnChange = onChange ?? null;
+    return (
+      <div
+        data-testid="monaco-editor"
+        data-value={value}
+        data-readonly={onChange === undefined}
+      />
+    );
+  },
 }));
 
 function makeSection(overrides: Partial<ServiceConfig> = {}): ServiceConfig {
@@ -96,6 +108,7 @@ function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
 describe('ServiceConfigPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    lastEditorOnChange = null;
   });
 
   it('renders service config sections with their names and badges', async () => {
@@ -163,7 +176,6 @@ describe('ServiceConfigPage', () => {
     await waitFor(() => {
       const editor = screen.getByTestId('monaco-editor');
       const value = editor.getAttribute('data-value') ?? '';
-      // Pretty-printed JSON should contain newlines and indentation.
       expect(value).toContain('\n');
       expect(value).toContain('"type": "stdout"');
     });
@@ -178,6 +190,114 @@ describe('ServiceConfigPage', () => {
     await waitFor(() => {
       const editor = screen.getByTestId('monaco-editor');
       expect(editor.getAttribute('data-value')).toBe('not-json');
+    });
+  });
+
+  it('does not show Edit button for read-only sections', async () => {
+    mockList.mockResolvedValue([makeSection({ Editable: false })]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('logger')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+  });
+
+  it('shows Edit button for editable sections', async () => {
+    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('debug')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+  });
+
+  it('enters edit mode and shows Save/Cancel when Edit is clicked', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    // Editor should now be writable (onChange is wired).
+    expect(lastEditorOnChange).not.toBeNull();
+  });
+
+  it('calls updateServiceConfig when Save is clicked after editing', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
+    mockUpdate.mockResolvedValue(makeSection({ Value: '{"enableHttp":true}', Source: 'db' }));
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    // Simulate an edit in the Monaco editor.
+    expect(lastEditorOnChange).not.toBeNull();
+    await act(async () => {
+      lastEditorOnChange!('{\n  "enableHttp": true\n}');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+    const args = mockUpdate.mock.calls[0] as [string, string, { value: unknown }];
+    expect(args[0]).toBe('api');
+    expect(args[1]).toBe('debug');
+    expect(args[2].value).toEqual({ enableHttp: true });
+  });
+
+  it('cancels editing and restores the original value', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    await act(async () => {
+      lastEditorOnChange!('{\n  "enableHttp": true\n}');
+    });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    // Back to read-only, Edit button visible again.
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    // Editor shows the original pretty-printed value.
+    const editor = screen.getByTestId('monaco-editor');
+    expect(editor.getAttribute('data-value')).toContain('"type": "stdout"');
+  });
+
+  it('shows an error when the PUT returns 409 (not editable)', async () => {
+    const user = userEvent.setup();
+    const { ApiError } = await import('$/api/client');
+    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
+    mockUpdate.mockRejectedValue(new ApiError('section is not editable', 409));
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await act(async () => {
+      lastEditorOnChange!('{\n  "enableHttp": true\n}');
+    });
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Section is not editable.')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -1,8 +1,13 @@
+import { useState, useEffect } from 'react';
 import { usePageTitle } from '$/lib/usePageTitle';
 import { useParams, useNavigate, Link } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
-import { listServiceConfig, type ServiceConfig } from '$/api/service-config';
-import { AuthError } from '$/api/client';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  listServiceConfig,
+  updateServiceConfig,
+  type ServiceConfig,
+} from '$/api/service-config';
+import { AuthError, ApiError } from '$/api/client';
 import { cn } from '$/lib/cn';
 import { Skeleton } from '$/components/data/Skeleton';
 import { EmptyState } from '$/components/data/EmptyState';
@@ -21,6 +26,7 @@ export function ServiceConfigPage() {
     ? (serviceParam as Service)
     : 'api';
 
+  const qc = useQueryClient();
   const {
     data,
     isLoading,
@@ -134,7 +140,12 @@ export function ServiceConfigPage() {
         {!loading && !hasError && sections.length > 0 && (
           <div className="space-y-3">
             {sections.map((s) => (
-              <ConfigSectionCard key={s.ID} section={s} />
+              <ConfigSectionCard
+                key={s.ID}
+                section={s}
+                service={service}
+                onSaved={() => qc.invalidateQueries({ queryKey: ['service-config', service] })}
+              />
             ))}
           </div>
         )}
@@ -143,14 +154,81 @@ export function ServiceConfigPage() {
   );
 }
 
-function ConfigSectionCard({ section }: { section: ServiceConfig }) {
-  // Pretty-print the JSON so the Monaco viewer gets syntax-highlighted,
-  // folded, scrollable content instead of a single long line.
-  let prettyValue = section.Value;
+function prettyPrint(value: string): string {
   try {
-    prettyValue = JSON.stringify(JSON.parse(section.Value), null, 2);
+    return JSON.stringify(JSON.parse(value), null, 2);
   } catch {
-    // not JSON — show raw
+    return value;
+  }
+}
+
+function ConfigSectionCard({
+  section,
+  service,
+  onSaved,
+}: {
+  section: ServiceConfig;
+  service: string;
+  onSaved: () => void;
+}) {
+  const storedPretty = prettyPrint(section.Value);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(storedPretty);
+  const [savedFlash, setSavedFlash] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Reset draft when the section value changes externally (e.g. after a
+  // refetch invalidates the query and new data arrives), but only when not
+  // actively editing so we don't clobber unsaved changes.
+  useEffect(() => {
+    if (!editing) {
+      setDraft(storedPretty);
+    }
+  }, [storedPretty, editing]);
+
+  const dirty = editing && draft !== storedPretty;
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      // Parse the draft so we send a raw JSON object, not a pre-serialized
+      // string. The backend expects { "value": {...} }.
+      const parsed = JSON.parse(draft);
+      return updateServiceConfig(service, section.Name, { value: parsed });
+    },
+    onSuccess: () => {
+      setErr(null);
+      setEditing(false);
+      setSavedFlash(true);
+      window.setTimeout(() => setSavedFlash(false), 1200);
+      onSaved();
+    },
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        window.location.href = '/login';
+        return;
+      }
+      if (e instanceof ApiError && e.status === 409) {
+        setErr('Section is not editable.');
+        return;
+      }
+      if (e instanceof ApiError && e.status === 400) {
+        setErr('Invalid JSON value.');
+        return;
+      }
+      setErr(e instanceof Error ? e.message : 'Save failed');
+    },
+  });
+
+  function handleCancel() {
+    setEditing(false);
+    setDraft(storedPretty);
+    setErr(null);
+  }
+
+  function handleEdit() {
+    setEditing(true);
+    setDraft(storedPretty);
+    setErr(null);
   }
 
   return (
@@ -192,22 +270,70 @@ function ConfigSectionCard({ section }: { section: ServiceConfig }) {
           </p>
         )}
         {!section.Info && <div className="flex-1" />}
+        {dirty && (
+          <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)]">
+            pending
+          </span>
+        )}
         <span
           className="text-[10px] tnum text-[color:var(--text-3)] whitespace-nowrap"
           title={section.UpdatedAt}
         >
           updated {formatRelative(section.UpdatedAt)}
         </span>
+        {section.Editable && !editing && (
+          <button
+            type="button"
+            onClick={handleEdit}
+            className="text-[10px] px-2 py-0.5 rounded font-medium border border-[color:var(--border)] text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)] transition-colors"
+          >
+            Edit
+          </button>
+        )}
+        {editing && (
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              disabled={!dirty || mutation.isPending}
+              onClick={() => mutation.mutate()}
+              className={cn(
+                'text-[10px] px-2 py-0.5 rounded font-medium',
+                'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
+                'disabled:opacity-40 disabled:cursor-not-allowed',
+              )}
+            >
+              {mutation.isPending ? 'Saving…' : savedFlash ? 'Saved ✓' : 'Save'}
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={mutation.isPending}
+              className="text-[10px] px-2 py-0.5 rounded font-medium border border-[color:var(--border)] text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
       </header>
 
       <div className="p-3">
         <CodeEditor
-          value={prettyValue}
+          value={editing ? draft : storedPretty}
+          onChange={editing ? (v) => setDraft(v ?? '') : undefined}
           language="json"
-          readOnly
+          readOnly={!editing}
           height="200px"
           aria-label={`Configuration section ${section.Name}`}
         />
+
+        {err && (
+          <p
+            role="alert"
+            className="mt-2 text-xs text-[color:var(--danger)] bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)] px-3 py-1.5 rounded-md"
+          >
+            {err}
+          </p>
+        )}
       </div>
     </section>
   );

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -64,34 +64,35 @@ type SectionSpec struct {
 
 // SectionRegistry maps each service to the sections it owns. The order
 // of the slice defines the display order in the frontend. Sections marked
-// Editable=false (db, redis, and other connection / secret-bearing sections)
-// can never be written through the API.
+// Editable=false (db, redis, tls, saml, oidc, jwt, and other
+// connection / secret / auth-bearing sections) can never be written through
+// the API.
 var SectionRegistry = map[string][]SectionSpec{
 	config.ServiceTLS: {
-		{"service", false, "Core service listener, port, log level, auth mode"},
+		{"service", true, "Core service listener, port, log level, auth mode"},
 		{"db", false, "Backend connection — not DB-editable"},
-		{"batchWriter", false, "DB batch writer tuning"},
+		{"batchWriter", true, "DB batch writer tuning"},
 		{"redis", false, "Redis connection — not DB-editable"},
-		{"osquery", false, "osquery feature toggles"},
-		{"configEndpoints", false, "Config endpoint fan-out targets"},
-		{"osctrld", false, "osctrld integration"},
-		{"metrics", false, "Prometheus metrics endpoint"},
-		{"tls", false, "TLS termination certificate/key paths"},
-		{"logger", false, "Log sinks (future: editable)"},
-		{"carver", false, "File carver configuration"},
+		{"osquery", true, "osquery feature toggles"},
+		{"configEndpoints", false, "Config endpoint fan-out targets — contains secrets"},
+		{"osctrld", true, "osctrld integration"},
+		{"metrics", true, "Prometheus metrics endpoint"},
+		{"tls", false, "TLS termination certificate/key paths — not DB-editable"},
+		{"logger", false, "Log sinks — may contain credentials (future: editable)"},
+		{"carver", false, "File carver configuration — may contain credentials"},
 		{"debug", true, "HTTP debug dump settings"},
 	},
 	config.ServiceAPI: {
-		{"service", false, "Core service listener, port, log level, auth mode"},
+		{"service", true, "Core service listener, port, log level, auth mode"},
 		{"db", false, "Backend connection — not DB-editable"},
 		{"redis", false, "Redis connection — not DB-editable"},
-		{"osquery", false, "osquery tables and feature toggles"},
-		{"saml", false, "SAML federated login configuration"},
-		{"oidc", false, "OIDC federated login configuration"},
-		{"jwt", false, "JWT signing configuration"},
-		{"tls", false, "TLS termination certificate/key paths"},
-		{"logger", false, "Log sinks (future: editable)"},
-		{"carver", false, "File carver configuration"},
+		{"osquery", true, "osquery tables and feature toggles"},
+		{"saml", false, "SAML federated login configuration — not DB-editable"},
+		{"oidc", false, "OIDC federated login configuration — not DB-editable"},
+		{"jwt", false, "JWT signing configuration — not DB-editable"},
+		{"tls", false, "TLS termination certificate/key paths — not DB-editable"},
+		{"logger", false, "Log sinks — may contain credentials (future: editable)"},
+		{"carver", false, "File carver configuration — may contain credentials"},
 		{"debug", true, "HTTP debug dump settings"},
 	},
 }
@@ -170,6 +171,18 @@ func (m *ServiceConfigManager) Seed(service string, cfg *config.ServiceParameter
 		// supports.
 		if err := m.DB.Clauses(clause.OnConflict{DoNothing: true}).Create(&entry).Error; err != nil {
 			return fmt.Errorf("seed %s/%s: %w", service, spec.Name, err)
+		}
+		// Sync registry metadata (Editable, Info) to existing rows. These
+		// are schema-level flags controlled by the code, not operator data,
+		// so they must always reflect the current registry — even for rows
+		// that already existed from a previous boot with different flags.
+		if err := m.DB.Model(&ServiceConfig{}).
+			Where("service = ? AND name = ? AND environment_id = ?", service, spec.Name, envID).
+			Updates(map[string]any{
+				"editable": spec.Editable,
+				"info":     spec.Info,
+			}).Error; err != nil {
+			return fmt.Errorf("sync metadata %s/%s: %w", service, spec.Name, err)
 		}
 	}
 	log.Debug().Msgf("Seeded service config for %s (%d sections)", service, len(SectionRegistry[service]))

--- a/pkg/serviceconfig/serviceconfig_test.go
+++ b/pkg/serviceconfig/serviceconfig_test.go
@@ -298,6 +298,55 @@ func sectionNames(rows []ServiceConfig) map[string]bool {
 	return out
 }
 
+// Seed must sync the Editable flag from the registry to existing rows.
+// This is the regression for the bug where rows seeded before a section was
+// marked editable kept the stale Editable=false, so the frontend never
+// showed the Edit button even though the registry said it was editable.
+func TestSeed_SyncsEditableFlagToExistingRows(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+
+	// Seed with all sections non-editable by temporarily swapping the
+	// registry. We can't easily swap the global, so instead we manually
+	// insert rows with Editable=false and then re-seed — the sync should
+	// flip the debug row's Editable to true.
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	// Force the debug row's Editable to false (simulating a stale row
+	// from before debug was marked editable).
+	require.NoError(t, db.Model(&ServiceConfig{}).
+		Where("service = ? AND name = ?", config.ServiceTLS, "debug").
+		Update("editable", false).Error)
+
+	// Re-seed — the sync must flip Editable back to true.
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	sc, err := m.GetSection(config.ServiceTLS, "debug", 0)
+	require.NoError(t, err)
+	assert.True(t, sc.Editable, "Seed must sync Editable=true for debug section to existing rows")
+}
+
+// Seed must sync the Info text from the registry to existing rows.
+func TestSeed_SyncsInfoToExistingRows(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	// Corrupt the info on the service row.
+	require.NoError(t, db.Model(&ServiceConfig{}).
+		Where("service = ? AND name = ?", config.ServiceTLS, "service").
+		Update("info", "stale info").Error)
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	sc, err := m.GetSection(config.ServiceTLS, "service", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "Core service listener, port, log level, auth mode", sc.Info)
+}
+
 // UpdateSection must update the value and flip source to "db" for an editable
 // section.
 func TestUpdateSection_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the service config feature so that editable sections can actually be edited from the frontend, and expands the set of editable sections beyond just `debug`.

### Problem

Two issues prevented editing:

1. **Only `debug` was editable** — `service`, `osquery`, `osctrld`, `batchWriter`, and `metrics` were all marked `Editable=false` in the registry, so the frontend never showed Edit buttons for them.
2. **Stale `Editable` flag in existing DB rows** — `Seed` used `ON CONFLICT DO NOTHING`, so rows created before a section was marked editable kept `Editable=false` forever. The GET endpoints returned the stale DB flag, and the frontend used that flag to decide whether to show the Edit button — so even after updating the registry, existing deployments never saw the Edit button until the table was manually wiped.

### Changes

**Expanded editable sections** (`pkg/serviceconfig/serviceconfig.go`)

| Section | TLS | API | Why |
|---------|-----|-----|-----|
| `service` | ✅ | ✅ | Listener, port, log level, host |
| `osquery` | ✅ | ✅ | Feature toggles |
| `osctrld` | ✅ | — | osctrl integration toggle |
| `batchWriter` | ✅ | — | Batch tuning |
| `metrics` | ✅ | — | Prometheus endpoint |
| `debug` | ✅ | ✅ | HTTP debug dump |

Non-editable (secrets/credentials/auth/file paths): `db`, `redis`, `tls`, `saml`, `oidc`, `jwt`, `configEndpoints`, `logger`, `carver`.

**Metadata sync on boot** (`pkg/serviceconfig/serviceconfig.go`)

`Seed` now syncs the `Editable` and `Info` fields from the `SectionRegistry` to existing rows after the create-if-missing step. These are schema-level flags controlled by the code, not operator data, so they must always reflect the current registry — even for rows seeded by a previous boot with different flags. The `Value` and `Source` fields are never touched by the sync, preserving the create-if-missing guarantee for operator-edited content.

**Tests** (2 new in `pkg/serviceconfig/serviceconfig_test.go`)
- `TestSeed_SyncsEditableFlagToExistingRows` — verifies that re-seeding flips a stale `Editable=false` row to `Editable=true` when the registry says it's editable.
- `TestSeed_SyncsInfoToExistingRows` — verifies that re-seeding updates stale `Info` text on existing rows.

### Validation

- `go build ./...` — clean
- `go test ./...` — all packages pass
- `golangci-lint run ./pkg/serviceconfig/...` — 0 issues

### Security notes

- The sync only touches `Editable` and `Info` — never `Value` or `Source`, so DB-edited content is preserved.
- Connection/secret/auth sections (`db`, `redis`, `tls`, `saml`, `oidc`, `jwt`, `configEndpoints`, `logger`, `carver`) remain non-editable and can never be written through the API.