### PR TITLE
Consume service configuration values from the DB stored ones

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -382,6 +382,10 @@ func osctrlAPIService() {
 	if err := serviceConfigMgr.Seed(config.ServiceAPI, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error seeding service config - %v", err)
 	}
+	log.Info().Msg("Resolving service config from DB")
+	if err := serviceConfigMgr.Resolve(config.ServiceAPI, flagParams, settings.NoEnvironmentID); err != nil {
+		log.Fatal().Msgf("Error resolving service config - %v", err)
+	}
 	// Initialize audit log manager
 	if flagParams.Service.AuditLog {
 		log.Info().Msg("Initialize audit log")

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -263,6 +263,10 @@ func osctrlService() {
 	if err := serviceConfigMgr.Seed(config.ServiceTLS, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error seeding service config - %v", err)
 	}
+	log.Info().Msg("Resolving service config from DB")
+	if err := serviceConfigMgr.Resolve(config.ServiceTLS, flagParams, settings.NoEnvironmentID); err != nil {
+		log.Fatal().Msgf("Error resolving service config - %v", err)
+	}
 	settingsCacheTTL := time.Duration(settingsmgr.RefreshSettings(config.ServiceTLS)) * time.Second
 	if settingsCacheTTL <= 0 {
 		settingsCacheTTL = time.Duration(defaultRefresh) * time.Second

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -216,6 +216,79 @@ func (m *ServiceConfigManager) GetAll(envID uint) ([]ServiceConfig, error) {
 	return values, nil
 }
 
+// Resolve applies DB-edited sections back into ServiceParameters so the
+// service uses the operator's DB values at runtime instead of the YAML
+// defaults. For each section with source=db, the JSON value is unmarshaled
+// into the matching ServiceParameters field, overriding the YAML value.
+// Sections with source=yaml are skipped — the YAML value is already in
+// ServiceParameters from the initial load.
+//
+// This is the core of phase 3: the YAML file bootstraps the config, the DB
+// overrides it for sections the operator has edited through the API.
+func (m *ServiceConfigManager) Resolve(service string, cfg *config.ServiceParameters, envID uint) error {
+	if !m.VerifyService(service) {
+		return fmt.Errorf("unknown service %q", service)
+	}
+	if cfg == nil {
+		return fmt.Errorf("nil ServiceParameters for %s", service)
+	}
+	sections, err := m.GetAllByService(service, envID)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", service, err)
+	}
+	for _, sc := range sections {
+		// Only DB-edited rows override the YAML defaults.
+		if sc.Source != SourceDB {
+			continue
+		}
+		if err := applySection(cfg, sc.Name, sc.Value); err != nil {
+			return fmt.Errorf("resolve %s/%s: %w", service, sc.Name, err)
+		}
+		log.Debug().Msgf("Resolved service config %s/%s from DB (source=db)", service, sc.Name)
+	}
+	return nil
+}
+
+// applySection unmarshals a JSON section value into the matching field on
+// ServiceParameters. Unknown sections are silently skipped.
+func applySection(cfg *config.ServiceParameters, name, value string) error {
+	switch name {
+	case "service":
+		return json.Unmarshal([]byte(value), cfg.Service)
+	case "db":
+		return json.Unmarshal([]byte(value), cfg.DB)
+	case "redis":
+		return json.Unmarshal([]byte(value), cfg.Redis)
+	case "osquery":
+		return json.Unmarshal([]byte(value), cfg.Osquery)
+	case "tls":
+		return json.Unmarshal([]byte(value), cfg.TLS)
+	case "logger":
+		return json.Unmarshal([]byte(value), cfg.Logger)
+	case "carver":
+		return json.Unmarshal([]byte(value), cfg.Carver)
+	case "debug":
+		return json.Unmarshal([]byte(value), cfg.Debug)
+	case "batchWriter":
+		return json.Unmarshal([]byte(value), cfg.BatchWriter)
+	case "configEndpoints":
+		return json.Unmarshal([]byte(value), cfg.ConfigEndpoints)
+	case "osctrld":
+		return json.Unmarshal([]byte(value), cfg.Osctrld)
+	case "metrics":
+		return json.Unmarshal([]byte(value), cfg.Metrics)
+	case "saml":
+		return json.Unmarshal([]byte(value), cfg.SAML)
+	case "oidc":
+		return json.Unmarshal([]byte(value), cfg.OIDC)
+	case "jwt":
+		return json.Unmarshal([]byte(value), cfg.JWT)
+	default:
+		// Unknown section — skip silently.
+		return nil
+	}
+}
+
 // ErrSectionNotEditable is returned when UpdateSection is called on a section
 // that is not marked editable in the registry.
 var ErrSectionNotEditable = fmt.Errorf("section is not editable")

--- a/pkg/serviceconfig/serviceconfig_test.go
+++ b/pkg/serviceconfig/serviceconfig_test.go
@@ -435,3 +435,144 @@ func TestUpdateSection_SeedDoesNotClobber(t *testing.T) {
 	assert.Equal(t, newValue, sc.Value)
 	assert.Equal(t, SourceDB, sc.Source)
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Resolve — phase 3 DB-first consumption
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Resolve must be a no-op when no sections have source=db — the YAML
+// values in ServiceParameters must be unchanged.
+func TestResolve_NoDBEdits_KeepsYAMLValues(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+	originalPort := cfg.Service.Port
+	originalListener := cfg.Service.Listener
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+	require.NoError(t, m.Resolve(config.ServiceTLS, cfg, 0))
+
+	assert.Equal(t, originalPort, cfg.Service.Port)
+	assert.Equal(t, originalListener, cfg.Service.Listener)
+}
+
+// Resolve must override ServiceParameters fields when a section has
+// source=db.
+func TestResolve_DBEditedSection_OverridesYAML(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	// Edit the debug section via the API (flips source to db).
+	newDebug := `{"enableHttp":true,"httpFile":"/tmp/debug.log","showBody":true}`
+	_, err := m.UpdateSection(config.ServiceTLS, "debug", newDebug, 0)
+	require.NoError(t, err)
+
+	// Resolve must apply the DB value to cfg.Debug.
+	require.NoError(t, m.Resolve(config.ServiceTLS, cfg, 0))
+	assert.True(t, cfg.Debug.EnableHTTP)
+	assert.Equal(t, "/tmp/debug.log", cfg.Debug.HTTPFile)
+	assert.True(t, cfg.Debug.ShowBody)
+}
+
+// Resolve must override the service section (listener, port, host) when it
+// has been edited via the DB.
+func TestResolve_ServiceSection_OverridesYAML(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	// Edit the service section via the API.
+	newService := `{"listener":"127.0.0.1","port":9999,"host":"db.example.com","logLevel":"debug","logFormat":"json","auth":"none","auditLog":true,"postureEnabled":false,"postureQueryPrefix":"","trustedProxies":"","dbHealthCheck":false,"dbHealthInterval":0,"dbHealthThreshold":0,"geoipDBPath":""}`
+	_, err := m.UpdateSection(config.ServiceTLS, "service", newService, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Resolve(config.ServiceTLS, cfg, 0))
+	assert.Equal(t, "127.0.0.1", cfg.Service.Listener)
+	assert.Equal(t, 9999, cfg.Service.Port)
+	assert.Equal(t, "db.example.com", cfg.Service.Host)
+	assert.Equal(t, "debug", cfg.Service.LogLevel)
+	assert.True(t, cfg.Service.AuditLog)
+}
+
+// Resolve must not override YAML values for sections with source=yaml.
+func TestResolve_YAMLSourceSectionsAreSkipped(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+	originalDBHost := cfg.DB.Host
+
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+	// db section is source=yaml (not editable, never edited).
+	require.NoError(t, m.Resolve(config.ServiceTLS, cfg, 0))
+
+	// DB host must still be the YAML value.
+	assert.Equal(t, originalDBHost, cfg.DB.Host)
+}
+
+// Resolve must reject an unknown service.
+func TestResolve_UnknownService(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	err := m.Resolve("bogus", testTLSParams(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown service")
+}
+
+// Resolve must reject a nil config.
+func TestResolve_NilConfig(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	err := m.Resolve(config.ServiceTLS, nil, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil ServiceParameters")
+}
+
+// Resolve + Seed + Update + Resolve round-trip: edit a section via the API,
+// re-seed (which doesn't clobber), resolve, and verify the DB value wins
+// over the YAML value.
+func TestResolve_FullRoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+
+	// Boot 1: seed from YAML, no DB edits, resolve is a no-op.
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+	require.NoError(t, m.Resolve(config.ServiceTLS, cfg, 0))
+	assert.False(t, cfg.Debug.EnableHTTP) // YAML default
+
+	// Operator edits debug via the API.
+	_, err := m.UpdateSection(config.ServiceTLS, "debug", `{"enableHttp":true,"httpFile":"/tmp/x.log","showBody":false}`, 0)
+	require.NoError(t, err)
+
+	// Boot 2: re-seed (doesn't clobber DB edit), then resolve.
+	cfg2 := testTLSParams() // fresh YAML load
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg2, 0))
+	require.NoError(t, m.Resolve(config.ServiceTLS, cfg2, 0))
+
+	// The DB value must win over the YAML default.
+	assert.True(t, cfg2.Debug.EnableHTTP)
+	assert.Equal(t, "/tmp/x.log", cfg2.Debug.HTTPFile)
+	assert.False(t, cfg2.Debug.ShowBody)
+}
+
+// Resolve must handle multiple DB-edited sections simultaneously.
+func TestResolve_MultipleDBEdits(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testTLSParams()
+	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
+
+	// Edit multiple sections.
+	_, err := m.UpdateSection(config.ServiceTLS, "debug", `{"enableHttp":true,"httpFile":"/tmp/a.log","showBody":false,"hostIdentifier":""}`, 0)
+	require.NoError(t, err)
+	_, err = m.UpdateSection(config.ServiceTLS, "osquery", `{"version":"5.12.2","tablesFile":"./data/5.12.2.json","logger":true,"config":true,"query":true,"carve":true,"accelerated":false,"fileExplorer":false,"readOnly":false}`, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Resolve(config.ServiceTLS, cfg, 0))
+	assert.True(t, cfg.Debug.EnableHTTP)
+	assert.Equal(t, "5.12.2", cfg.Osquery.Version)
+	assert.Equal(t, "./data/5.12.2.json", cfg.Osquery.TablesFile)
+}


### PR DESCRIPTION
## Summary

Makes services consume DB-edited configuration at startup, so changes made through the API actually affect runtime behavior. This is phase 3 of the service config design.

### Problem

Phases 1 and 2 persisted YAML config sections to the DB and allowed editing via the API, but the DB was still just a mirror. Services loaded config from YAML into `ServiceParameters` and used it directly — DB edits had no runtime effect. An operator could change `debug.enableHttp` to `true` in the frontend, but the service kept using the YAML value on the next boot.

### Changes

**`pkg/serviceconfig` — `Resolve` method**

`Resolve(service, cfg, envID)` reads all sections for a service from the DB and, for any section with `source=db`, unmarshals the JSON value into the matching `ServiceParameters` field — overriding the YAML default. Sections with `source=yaml` are skipped (the YAML value is already in `ServiceParameters` from the initial load).

The `applySection` helper maps each section name to its `ServiceParameters` field and does the `json.Unmarshal`. All 15 sections are handled (`service`, `db`, `redis`, `osquery`, `tls`, `logger`, `carver`, `debug`, `batchWriter`, `configEndpoints`, `osctrld`, `metrics`, `saml`, `oidc`, `jwt`).

**Startup wiring**

Both services now call `Resolve` right after `Seed`:
- `cmd/tls/main.go`: `Seed` → `Resolve` — DB-edited sections override YAML defaults in `flagParams` before any downstream consumer reads them.
- `cmd/api/main.go`: same flow for the API service.

The startup flow is now: load YAML → seed to DB (create-if-missing) → resolve DB overrides back into `ServiceParameters`. Every downstream consumer of `flagParams` (logger, carver, metrics, TLS, handlers, etc.) gets the resolved values.

**Tests** (8 new in `pkg/serviceconfig/serviceconfig_test.go`)
- `TestResolve_NoDBEdits_KeepsYAMLValues` — no-op when nothing is DB-edited.
- `TestResolve_DBEditedSection_OverridesYAML` — debug section override.
- `TestResolve_ServiceSection_OverridesYAML` — service section override (listener, port, host, log level, audit log).
- `TestResolve_YAMLSourceSectionsAreSkipped` — source=yaml sections are not touched.
- `TestResolve_UnknownService` — rejects unknown service.
- `TestResolve_NilConfig` — rejects nil config.
- `TestResolve_FullRoundTrip` — seed → edit → re-seed → resolve: DB value wins over fresh YAML.
- `TestResolve_MultipleDBEdits` — multiple sections resolved simultaneously.

### Validation

- `go build ./...` — clean
- `go test ./...` — all packages pass (8 new tests in `pkg/serviceconfig`)
- `golangci-lint run ./pkg/serviceconfig/...` — 0 issues
- `gofmt` clean on all modified files

### How it works end-to-end

1. **First boot**: YAML loads into `ServiceParameters` → `Seed` creates DB rows with `source=yaml` → `Resolve` finds nothing to override (all `source=yaml`) → service uses YAML values.
2. **Operator edits `debug` in the frontend**: `UpdateSection` flips `source=db` and stores the new JSON.
3. **Next boot**: YAML loads into `ServiceParameters` → `Seed` doesn't clobber the `source=db` row (create-if-missing) → `Resolve` sees `source=db`, unmarshals the DB value into `cfg.Debug` → service uses the DB-edited value.

### Security notes

- `Resolve` applies **all** sections with `source=db`, including non-editable ones like `db` and `redis`. This is intentional: non-editable sections can only get `source=db` through direct DB access (operator/automation), not through the API. The `Editable` flag gates the API write path; `Resolve` trusts any row the operator put in the DB.
- The YAML file remains the bootstrap — if the DB is empty or the table is dropped, the service falls back to pure YAML behavior.