### PR TITLE
Replace raw JSON editors with structured form UI for service config

### DIFF
--- a/frontend/src/features/service-config/ServiceConfigPage.test.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.test.tsx
@@ -335,6 +335,24 @@ describe('ServiceConfigPage', () => {
     expect(screen.getByText('secret123')).toBeInTheDocument();
   });
 
+  it('shows "empty" when revealing an empty sensitive field', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: false,
+        Name: 'redis',
+        Value: '{"Host":"redis-server","Password":""}',
+      }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('●●●●●●')).toBeInTheDocument();
+    });
+    await user.click(screen.getByTitle('Reveal'));
+    expect(screen.getByText('empty')).toBeInTheDocument();
+  });
+
   it('renders string arrays as tag chips in read-only sections', async () => {
     mockList.mockResolvedValue([
       makeSection({

--- a/frontend/src/features/service-config/ServiceConfigPage.test.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.test.tsx
@@ -175,6 +175,7 @@ describe('ServiceConfigPage', () => {
   });
 
   it('renders read-only values for non-editable sections', async () => {
+    const user = userEvent.setup();
     mockList.mockResolvedValue([
       makeSection({
         Editable: false,
@@ -188,6 +189,8 @@ describe('ServiceConfigPage', () => {
     await waitFor(() => {
       expect(screen.getByText('db')).toBeInTheDocument();
     });
+    // Read-only sections are collapsed by default — expand by clicking header
+    await user.click(screen.getByText('db'));
     // Read-only sections show values as text, not inputs
     expect(screen.getByText('osctrl-postgres')).toBeInTheDocument();
     expect(screen.getByText('5432')).toBeInTheDocument();
@@ -299,6 +302,7 @@ describe('ServiceConfigPage', () => {
   });
 
   it('masks sensitive fields in read-only sections', async () => {
+    const user = userEvent.setup();
     mockList.mockResolvedValue([
       makeSection({
         Editable: false,
@@ -311,6 +315,8 @@ describe('ServiceConfigPage', () => {
     await waitFor(() => {
       expect(screen.getByText('db')).toBeInTheDocument();
     });
+    // Expand the collapsed read-only section
+    await user.click(screen.getByText('db'));
     // Password should be masked
     expect(screen.getByText('●●●●●●')).toBeInTheDocument();
     // The actual value should not be visible
@@ -329,8 +335,10 @@ describe('ServiceConfigPage', () => {
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByText('●●●●●●')).toBeInTheDocument();
+      expect(screen.getByText('db')).toBeInTheDocument();
     });
+    await user.click(screen.getByText('db'));
+    expect(screen.getByText('●●●●●●')).toBeInTheDocument();
     await user.click(screen.getByTitle('Reveal'));
     expect(screen.getByText('secret123')).toBeInTheDocument();
   });
@@ -347,13 +355,16 @@ describe('ServiceConfigPage', () => {
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByText('●●●●●●')).toBeInTheDocument();
+      expect(screen.getByText('redis')).toBeInTheDocument();
     });
+    await user.click(screen.getByText('redis'));
+    expect(screen.getByText('●●●●●●')).toBeInTheDocument();
     await user.click(screen.getByTitle('Reveal'));
     expect(screen.getByText('empty')).toBeInTheDocument();
   });
 
   it('renders string arrays as tag chips in read-only sections', async () => {
+    const user = userEvent.setup();
     mockList.mockResolvedValue([
       makeSection({
         Editable: false,
@@ -366,6 +377,7 @@ describe('ServiceConfigPage', () => {
     await waitFor(() => {
       expect(screen.getByText('oidc')).toBeInTheDocument();
     });
+    await user.click(screen.getByText('oidc'));
     expect(screen.getByText('openid')).toBeInTheDocument();
     expect(screen.getByText('profile')).toBeInTheDocument();
     expect(screen.getByText('email')).toBeInTheDocument();

--- a/frontend/src/features/service-config/ServiceConfigPage.test.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.test.tsx
@@ -38,22 +38,6 @@ vi.mock('$/api/client', () => ({
   },
 }));
 
-// Monaco Editor is lazy-loaded and not available in jsdom. Capture the
-// onChange callback so tests can simulate edits.
-let lastEditorOnChange: ((v: string | undefined) => void) | null = null;
-vi.mock('@monaco-editor/react', () => ({
-  Editor: ({ value, onChange }: { value: string; onChange?: (v: string | undefined) => void }) => {
-    lastEditorOnChange = onChange ?? null;
-    return (
-      <div
-        data-testid="monaco-editor"
-        data-value={value}
-        data-readonly={onChange === undefined}
-      />
-    );
-  },
-}));
-
 function makeSection(overrides: Partial<ServiceConfig> = {}): ServiceConfig {
   return {
     ID: 1,
@@ -110,7 +94,6 @@ function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
 describe('ServiceConfigPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    lastEditorOnChange = null;
   });
 
   it('renders service config sections with their names and badges', async () => {
@@ -169,85 +152,90 @@ describe('ServiceConfigPage', () => {
     expect(screen.getByText('Retry')).toBeInTheDocument();
   });
 
-  it('pretty-prints JSON values in the editor', async () => {
+  it('renders structured form fields for editable sections', async () => {
     mockList.mockResolvedValue([
-      makeSection({ Value: '{"type":"stdout","alwaysLog":true}' }),
+      makeSection({
+        Editable: true,
+        Name: 'debug',
+        Value: '{"enableHttp":false,"httpFile":"/tmp/debug.log","showBody":true}',
+        Info: 'HTTP debug dump settings',
+      }),
     ]);
-    renderWithProviders(makeTestRouter());
-
-    await waitFor(() => {
-      const editor = screen.getByTestId('monaco-editor');
-      const value = editor.getAttribute('data-value') ?? '';
-      expect(value).toContain('\n');
-      expect(value).toContain('"type": "stdout"');
-    });
-  });
-
-  it('renders raw value when it is not valid JSON', async () => {
-    mockList.mockResolvedValue([
-      makeSection({ Value: 'not-json' }),
-    ]);
-    renderWithProviders(makeTestRouter());
-
-    await waitFor(() => {
-      const editor = screen.getByTestId('monaco-editor');
-      expect(editor.getAttribute('data-value')).toBe('not-json');
-    });
-  });
-
-  it('does not show Edit button for read-only sections', async () => {
-    mockList.mockResolvedValue([makeSection({ Editable: false })]);
-    renderWithProviders(makeTestRouter());
-
-    await waitFor(() => {
-      expect(screen.getByText('logger')).toBeInTheDocument();
-    });
-    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
-  });
-
-  it('shows Edit button for editable sections', async () => {
-    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
       expect(screen.getByText('debug')).toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    // Boolean fields render as toggle switches
+    expect(screen.getAllByRole('switch').length).toBeGreaterThanOrEqual(1);
+    // String fields render as text inputs
+    expect(screen.getByDisplayValue('/tmp/debug.log')).toBeInTheDocument();
+    // Save button is present but disabled (no changes yet)
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
-  it('enters edit mode and shows Save/Cancel when Edit is clicked', async () => {
-    const user = userEvent.setup();
-    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
+  it('renders read-only values for non-editable sections', async () => {
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: false,
+        Name: 'db',
+        Value: '{"Host":"osctrl-postgres","Port":5432}',
+        Info: 'Backend connection',
+      }),
+    ]);
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      expect(screen.getByText('db')).toBeInTheDocument();
     });
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    // Read-only sections show values as text, not inputs
+    expect(screen.getByText('osctrl-postgres')).toBeInTheDocument();
+    expect(screen.getByText('5432')).toBeInTheDocument();
+    // No Save button for read-only sections
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
 
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-    // Editor should now be writable (onChange is wired).
-    expect(lastEditorOnChange).not.toBeNull();
+  it('enables Save button when a field is modified', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: true,
+        Name: 'debug',
+        Value: '{"enableHttp":false,"httpFile":"/tmp/debug.log"}',
+      }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('/tmp/debug.log')).toBeInTheDocument();
+    });
+    const input = screen.getByDisplayValue('/tmp/debug.log');
+    await user.clear(input);
+    await user.type(input, '/var/log/debug.log');
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
   });
 
   it('calls updateServiceConfig when Save is clicked after editing', async () => {
     const user = userEvent.setup();
-    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
-    mockUpdate.mockResolvedValue(makeSection({ Value: '{"enableHttp":true}', Source: 'db' }));
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: true,
+        Name: 'debug',
+        Value: '{"enableHttp":false,"httpFile":"/tmp/debug.log"}',
+      }),
+    ]);
+    mockUpdate.mockResolvedValue(
+      makeSection({ Value: '{"enableHttp":false,"httpFile":"/var/log/debug.log"}', Source: 'db' }),
+    );
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      expect(screen.getByDisplayValue('/tmp/debug.log')).toBeInTheDocument();
     });
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
-
-    // Simulate an edit in the Monaco editor.
-    expect(lastEditorOnChange).not.toBeNull();
-    await act(async () => {
-      lastEditorOnChange!('{\n  "enableHttp": true\n}');
-    });
-
+    const input = screen.getByDisplayValue('/tmp/debug.log');
+    await user.clear(input);
+    await user.type(input, '/var/log/debug.log');
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
@@ -256,51 +244,113 @@ describe('ServiceConfigPage', () => {
     const args = mockUpdate.mock.calls[0] as [string, string, { value: unknown }];
     expect(args[0]).toBe('api');
     expect(args[1]).toBe('debug');
-    expect(args[2].value).toEqual({ enableHttp: true });
-  });
-
-  it('cancels editing and restores the original value', async () => {
-    const user = userEvent.setup();
-    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
-    renderWithProviders(makeTestRouter());
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
-    });
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
-
-    await act(async () => {
-      lastEditorOnChange!('{\n  "enableHttp": true\n}');
-    });
-    await user.click(screen.getByRole('button', { name: 'Cancel' }));
-
-    // Back to read-only, Edit button visible again.
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
-    // Editor shows the original pretty-printed value.
-    const editor = screen.getByTestId('monaco-editor');
-    expect(editor.getAttribute('data-value')).toContain('"type": "stdout"');
+    expect(args[2].value).toEqual({ enableHttp: false, httpFile: '/var/log/debug.log' });
   });
 
   it('shows an error when the PUT returns 409 (not editable)', async () => {
     const user = userEvent.setup();
     const { ApiError } = await import('$/api/client');
-    mockList.mockResolvedValue([makeSection({ Editable: true, Name: 'debug' })]);
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: true,
+        Name: 'debug',
+        Value: '{"enableHttp":false,"httpFile":"/tmp/debug.log"}',
+      }),
+    ]);
     mockUpdate.mockRejectedValue(new ApiError('section is not editable', 409));
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      expect(screen.getByDisplayValue('/tmp/debug.log')).toBeInTheDocument();
     });
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
-    await act(async () => {
-      lastEditorOnChange!('{\n  "enableHttp": true\n}');
-    });
+    const input = screen.getByDisplayValue('/tmp/debug.log');
+    await user.clear(input);
+    await user.type(input, '/changed');
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(screen.getByText('Section is not editable.')).toBeInTheDocument();
     });
+  });
+
+  it('renders boolean toggle switches that can be toggled', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: true,
+        Name: 'debug',
+        Value: '{"enableHttp":false,"showBody":true}',
+      }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('debug')).toBeInTheDocument();
+    });
+    const switches = screen.getAllByRole('switch');
+    expect(switches).toHaveLength(2);
+    // First switch (enableHttp) should be off
+    expect(switches[0]).toHaveAttribute('aria-checked', 'false');
+    // Toggle it on
+    await user.click(switches[0]);
+    expect(switches[0]).toHaveAttribute('aria-checked', 'true');
+    // Save should now be enabled
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('masks sensitive fields in read-only sections', async () => {
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: false,
+        Name: 'db',
+        Value: '{"Host":"localhost","Password":"secret123"}',
+      }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('db')).toBeInTheDocument();
+    });
+    // Password should be masked
+    expect(screen.getByText('●●●●●●')).toBeInTheDocument();
+    // The actual value should not be visible
+    expect(screen.queryByText('secret123')).not.toBeInTheDocument();
+  });
+
+  it('reveals masked sensitive fields when the eye button is clicked', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: false,
+        Name: 'db',
+        Value: '{"Host":"localhost","Password":"secret123"}',
+      }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('●●●●●●')).toBeInTheDocument();
+    });
+    await user.click(screen.getByTitle('Reveal'));
+    expect(screen.getByText('secret123')).toBeInTheDocument();
+  });
+
+  it('renders string arrays as tag chips in read-only sections', async () => {
+    mockList.mockResolvedValue([
+      makeSection({
+        Editable: false,
+        Name: 'oidc',
+        Value: '{"Scopes":["openid","profile","email"]}',
+      }),
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('oidc')).toBeInTheDocument();
+    });
+    expect(screen.getByText('openid')).toBeInTheDocument();
+    expect(screen.getByText('profile')).toBeInTheDocument();
+    expect(screen.getByText('email')).toBeInTheDocument();
   });
 
   it('does not show Apply & Restart button when no sections have source=db', async () => {
@@ -333,7 +383,6 @@ describe('ServiceConfigPage', () => {
     });
     await user.click(screen.getByRole('button', { name: /Apply & Restart/i }));
 
-    // Confirmation dialog appears.
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
@@ -363,7 +412,6 @@ describe('ServiceConfigPage', () => {
     });
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    // Dialog closes, apply not called.
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -649,10 +649,16 @@ function FieldHelpIcon({ fieldKey }: { fieldKey: string }) {
 
   if (!help) return null;
 
+  const TOOLTIP_W = 260;
+  const EDGE_PAD = 8;
+
   const show = () => {
     const rect = ref.current?.getBoundingClientRect();
     if (rect) {
-      setPos({ x: rect.left + rect.width / 2, y: rect.top });
+      const centerX = rect.left + rect.width / 2;
+      const minLeft = EDGE_PAD + TOOLTIP_W / 2;
+      const maxLeft = window.innerWidth - EDGE_PAD - TOOLTIP_W / 2;
+      setPos({ x: Math.max(minLeft, Math.min(maxLeft, centerX)), y: rect.top });
     }
   };
 
@@ -678,10 +684,11 @@ function FieldHelpIcon({ fieldKey }: { fieldKey: string }) {
       </svg>
       {pos && createPortal(
         <span
-          className="fixed px-3 py-2 text-[11px] leading-relaxed text-[color:var(--text-1)] bg-[color:var(--bg-0)] border border-[color:var(--border)] rounded-md shadow-lg w-[260px] pointer-events-none"
+          className="fixed px-3 py-2 text-[11px] leading-relaxed text-[color:var(--text-1)] bg-[color:var(--bg-0)] border border-[color:var(--border)] rounded-md shadow-lg pointer-events-none"
           style={{
             left: `${pos.x}px`,
             top: `${pos.y}px`,
+            width: TOOLTIP_W,
             transform: 'translate(-50%, -100%) translateY(-8px)',
             zIndex: 9999,
           }}

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -36,6 +36,58 @@ function isSensitive(key: string): boolean {
   return SENSITIVE_KEYS.has(key);
 }
 
+const FIELD_HELP: Record<string, string> = {
+  GeoIPDBPath: 'Path to a MaxMind GeoLite2-Country .mmdb file. When set, the API resolves node IPs to country codes. When empty, the feature is disabled.',
+  PostureEnabled: 'Controls whether the security & compliance posture system is active. When false (default), the entire posture subsystem is disabled.',
+  PostureQueryPrefix: 'Prefix that identifies scheduled queries whose result logs are ingested as node posture data. Only used when PostureEnabled is true.',
+  TrustedProxies: 'Comma-separated CIDRs whose X-Real-IP / X-Forwarded-For headers are honored. Empty → forwarding headers ignored, RemoteAddr used.',
+  DBHealthCheck: 'Enables background DB liveness monitor. Pings DB every DBHealthInterval seconds; after DBHealthThreshold failures, switches to stale-serve mode.',
+  DBHealthInterval: 'Seconds between DB health pings. Only used when DBHealthCheck is true.',
+  DBHealthThreshold: 'Consecutive DB ping failures before switching to stale-serve mode.',
+  Type: 'Database type: postgres, mysql, or sqlite.',
+  SSLMode: 'PostgreSQL SSL mode (e.g. disable, require, verify-full).',
+  FilePath: 'File path for SQLite database.',
+  ConnRetry: 'Number of connection retry attempts on startup.',
+  MaxIdleConns: 'Maximum idle connections in the pool.',
+  MaxOpenConns: 'Maximum open connections to the database.',
+  ConnMaxLifetime: 'Maximum lifetime of a connection in seconds.',
+  ConnectionString: 'Full Redis connection string. When set, overrides Host/Port/Password.',
+  EnableHTTP: 'When true, dumps HTTP requests to the debug file.',
+  HTTPFile: 'File path where HTTP debug dumps are written.',
+  ShowBody: 'Include request/response body in the debug dump.',
+  TargetHostIdentifier: 'Restrict debug dump to a specific node UUID or host_identifier (case-insensitive). Empty dumps all requests.',
+  Enabled: 'Enable or disable this feature.',
+  EntityID: 'SP entity identifier — what the IdP knows this service by. Conventionally the metadata URL.',
+  ACSURL: 'Assertion Consumer Service URL where the IdP POSTs the SAMLResponse. Must match IdP registration.',
+  UsernameAttribute: 'SAML attribute whose value becomes the osctrl username. Empty uses NameID verbatim.',
+  SigningCertPath: 'PEM file path to SP signing certificate. Both cert and key must be set to enable request signing.',
+  SigningKeyPath: 'PEM file path to SP signing RSA private key.',
+  ForceAuthn: 'When true (default), forces re-authentication at the IdP on every login.',
+  JITProvision: 'Automatically create osctrl user accounts on first federated login.',
+  IssuerURL: 'OIDC provider issuer URL (e.g. https://accounts.google.com).',
+  ClientID: 'OAuth2 client ID registered with the OIDC provider.',
+  ClientSecret: 'OAuth2 client secret.',
+  RedirectURL: 'OAuth2 callback URL — must match provider configuration.',
+  Scopes: 'OIDC scopes to request (e.g. openid, profile, email).',
+  UsernameClaim: 'JWT claim to use as the osctrl username.',
+  GroupsClaim: 'JWT claim containing group memberships.',
+  RequiredGroups: 'Groups a user must belong to for access.',
+  UsePKCE: 'Use Proof Key for Code Exchange for added security.',
+  JWTSecret: 'Secret key used to sign JWT tokens.',
+  HoursToExpire: 'JWT token lifetime in hours.',
+  WriterBatchSize: 'Number of records per batch write.',
+  WriterTimeout: 'Timeout for batch write operations.',
+  WriterBufferSize: 'Buffer size for the batch writer queue.',
+  Termination: 'Enable TLS/SSL termination at the service.',
+  CertificateFile: 'Path to the TLS certificate file.',
+  KeyFile: 'Path to the TLS private key file.',
+  LoggerDBSame: 'Use the same DB connection for logging (no separate logger DB).',
+  AlwaysLog: 'Always log, even when no logger backend is configured.',
+  Environment: 'Target osctrl environment name.',
+  Secret: 'Enrollment secret for this endpoint.',
+  IntegrityCheck: 'Verify config integrity before pushing.',
+};
+
 type FieldType = 'boolean' | 'number' | 'string' | 'string[]' | 'object' | 'null';
 
 function inferType(value: unknown): FieldType {
@@ -564,8 +616,9 @@ function ConfigSectionCard({
                     key={key}
                     className="flex items-center gap-2.5 px-3 py-2 rounded-md bg-[color:var(--bg-2)] border border-[color:var(--border)] hover:border-[color:var(--border-strong)] transition-colors"
                   >
-                    <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular flex-1">
+                    <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular flex-1 flex items-center gap-1.5">
                       {key}
+                      <FieldHelpIcon fieldKey={key} />
                     </span>
                     <ToggleSwitch
                       checked={draft[key] as boolean}
@@ -593,6 +646,31 @@ function ConfigSectionCard({
   );
 }
 
+function FieldHelpIcon({ fieldKey }: { fieldKey: string }) {
+  const help = FIELD_HELP[fieldKey];
+  if (!help) return null;
+  return (
+    <span className="group relative shrink-0">
+      <svg
+        className="w-3.5 h-3.5 text-[color:var(--text-3)] hover:text-[color:var(--signal)] cursor-help transition-colors"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </svg>
+      <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 text-[11px] leading-relaxed text-[color:var(--text-1)] bg-[color:var(--bg-0)] border border-[color:var(--border)] rounded-md shadow-lg w-[260px] opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-50">
+        {help}
+      </span>
+    </span>
+  );
+}
+
 function FieldRow({
   fieldKey,
   dirty,
@@ -611,6 +689,7 @@ function FieldRow({
     >
       <div className="flex items-center gap-2 w-[200px] min-w-[200px] shrink-0">
         <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular">{fieldKey}</span>
+        <FieldHelpIcon fieldKey={fieldKey} />
       </div>
       <div className="flex-1 flex items-center min-w-0">
         {children}
@@ -637,6 +716,7 @@ function ReadOnlyFieldRow({
       <div className="flex items-center min-h-[44px] px-3.5 gap-3 border-b border-[color:var(--border)] last:border-b-0">
         <div className="flex items-center gap-2 w-[200px] min-w-[200px] shrink-0">
           <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular">{fieldKey}</span>
+          <FieldHelpIcon fieldKey={fieldKey} />
         </div>
         <div className="flex-1 flex items-center min-w-0 gap-1.5 flex-wrap py-1.5">
           {arr.length === 0 ? (
@@ -664,12 +744,15 @@ function ReadOnlyFieldRow({
     <div className="flex items-center min-h-[44px] px-3.5 gap-3 border-b border-[color:var(--border)] last:border-b-0">
       <div className="flex items-center gap-2 w-[200px] min-w-[200px] shrink-0">
         <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular">{fieldKey}</span>
+        <FieldHelpIcon fieldKey={fieldKey} />
       </div>
       <div className="flex-1 flex items-center min-w-0">
         {sensitive ? (
           <div className="flex items-center gap-1.5">
             <span className="text-xs text-[color:var(--text-2)] font-mono-tabular">
-              {revealed ? displayValue : '●●●●●●'}
+              {revealed
+                ? (displayValue || <span className="text-[color:var(--text-3)] italic">empty</span>)
+                : '●●●●●●'}
             </span>
             <button
               type="button"

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { usePageTitle } from '$/lib/usePageTitle';
 import { useParams, useNavigate, Link } from '@tanstack/react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -12,12 +12,50 @@ import { AuthError, ApiError } from '$/api/client';
 import { cn } from '$/lib/cn';
 import { Skeleton } from '$/components/data/Skeleton';
 import { EmptyState } from '$/components/data/EmptyState';
-import { CodeEditor } from '$/components/forms/CodeEditor';
 import { ModalShell } from '$/components/feedback/ModalShell';
 import { formatRelative } from '$/lib/time';
 
 const SERVICES = ['api', 'tls'] as const;
 type Service = (typeof SERVICES)[number];
+
+const SENSITIVE_KEYS = new Set([
+  'Password',
+  'password',
+  'Secret',
+  'secret',
+  'JWTSecret',
+  'jwtSecret',
+  'ClientSecret',
+  'clientSecret',
+  'SecretAccessKey',
+  'secretAccessKey',
+  'secretKey',
+]);
+
+function isSensitive(key: string): boolean {
+  return SENSITIVE_KEYS.has(key);
+}
+
+type FieldType = 'boolean' | 'number' | 'string' | 'string[]' | 'object' | 'null';
+
+function inferType(value: unknown): FieldType {
+  if (value === null || value === undefined) return 'null';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'number') return 'number';
+  if (Array.isArray(value) && value.every((v) => typeof v === 'string')) return 'string[]';
+  if (typeof value === 'object') return 'object';
+  return 'string';
+}
+
+function parseConfigValue(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch { /* fall through */ }
+  return {};
+}
 
 export function ServiceConfigPage() {
   usePageTitle('Service Config');
@@ -57,9 +95,6 @@ export function ServiceConfigPage() {
   const hasError = isError;
   const pageError = error;
 
-  // An "Apply & Restart" is relevant when any section has source=db (meaning
-  // the operator has edited it through the API and the change is pending a
-  // restart to take effect).
   const hasPendingChanges = sections.some((s) => s.Source === 'db');
 
   const applyMutation = useMutation({
@@ -67,9 +102,6 @@ export function ServiceConfigPage() {
     onSuccess: () => {
       setApplyErr(null);
       setApplyFlash(true);
-      // Poll until the service comes back up, then refetch the config.
-      // The service restarts with exit code 1, so the API is briefly
-      // unavailable. We poll every 2 seconds until a request succeeds.
       setRestarting(true);
       const poll = setInterval(() => {
         listServiceConfig(service)
@@ -79,11 +111,8 @@ export function ServiceConfigPage() {
             setApplyFlash(false);
             qc.invalidateQueries({ queryKey: ['service-config', service] });
           })
-          .catch(() => {
-            // Service still restarting — keep polling.
-          });
+          .catch(() => {});
       }, 2000);
-      // Safety: stop polling after 60 seconds.
       setTimeout(() => {
         clearInterval(poll);
         setRestarting(false);
@@ -100,7 +129,6 @@ export function ServiceConfigPage() {
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      {/* Toolbar row */}
       <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border)] flex-wrap">
         <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">
           Service Config
@@ -117,7 +145,7 @@ export function ServiceConfigPage() {
                 : 'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)] hover:bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.2)]',
             )}
           >
-            {applyMutation.isPending ? 'Restarting…' : applyFlash ? 'Restart triggered ✓' : 'Apply \u0026 Restart'}
+            {applyMutation.isPending ? 'Restarting…' : applyFlash ? 'Restart triggered ✓' : 'Apply & Restart'}
           </button>
         )}
         {restarting && (
@@ -142,7 +170,6 @@ export function ServiceConfigPage() {
         )}
       </div>
 
-      {/* Service tabs — same underline TabButton pattern as SettingsPage */}
       <div
         role="tablist"
         aria-label="Service config service tabs"
@@ -239,14 +266,6 @@ export function ServiceConfigPage() {
   );
 }
 
-function prettyPrint(value: string): string {
-  try {
-    return JSON.stringify(JSON.parse(value), null, 2);
-  } catch {
-    return value;
-  }
-}
-
 function ConfigSectionCard({
   section,
   service,
@@ -256,33 +275,36 @@ function ConfigSectionCard({
   service: string;
   onSaved: () => void;
 }) {
-  const storedPretty = prettyPrint(section.Value);
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(storedPretty);
+  const originalFields = useMemo(() => parseConfigValue(section.Value), [section.Value]);
+  const [draft, setDraft] = useState<Record<string, unknown>>(() => ({ ...originalFields }));
+  const [collapsed, setCollapsed] = useState(!section.Editable);
   const [savedFlash, setSavedFlash] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  // Reset draft when the section value changes externally (e.g. after a
-  // refetch invalidates the query and new data arrives), but only when not
-  // actively editing so we don't clobber unsaved changes.
   useEffect(() => {
-    if (!editing) {
-      setDraft(storedPretty);
-    }
-  }, [storedPretty, editing]);
+    setDraft({ ...parseConfigValue(section.Value) });
+  }, [section.Value]);
 
-  const dirty = editing && draft !== storedPretty;
+  const dirtyKeys = useMemo(() => {
+    const keys: string[] = [];
+    for (const key of Object.keys(originalFields)) {
+      if (JSON.stringify(originalFields[key]) !== JSON.stringify(draft[key])) {
+        keys.push(key);
+      }
+    }
+    return keys;
+  }, [originalFields, draft]);
+
+  const dirty = dirtyKeys.length > 0;
+
+  const updateField = useCallback((key: string, value: unknown) => {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  }, []);
 
   const mutation = useMutation({
-    mutationFn: () => {
-      // Parse the draft so we send a raw JSON object, not a pre-serialized
-      // string. The backend expects { "value": {...} }.
-      const parsed = JSON.parse(draft);
-      return updateServiceConfig(service, section.Name, { value: parsed });
-    },
+    mutationFn: () => updateServiceConfig(service, section.Name, { value: draft }),
     onSuccess: () => {
       setErr(null);
-      setEditing(false);
       setSavedFlash(true);
       window.setTimeout(() => setSavedFlash(false), 1200);
       onSaved();
@@ -297,31 +319,33 @@ function ConfigSectionCard({
         return;
       }
       if (e instanceof ApiError && e.status === 400) {
-        setErr('Invalid JSON value.');
+        setErr('Invalid value.');
         return;
       }
       setErr(e instanceof Error ? e.message : 'Save failed');
     },
   });
 
-  function handleCancel() {
-    setEditing(false);
-    setDraft(storedPretty);
-    setErr(null);
-  }
+  const fieldEntries = Object.entries(originalFields);
 
-  function handleEdit() {
-    setEditing(true);
-    setDraft(storedPretty);
-    setErr(null);
-  }
+  const booleanFields = section.Editable
+    ? fieldEntries.filter(([, v]) => typeof v === 'boolean')
+    : [];
+  const nonBooleanFields = section.Editable
+    ? fieldEntries.filter(([, v]) => typeof v !== 'boolean')
+    : fieldEntries;
+
+  const hasManyBooleans = booleanFields.length >= 3;
 
   return (
     <section
       className="border border-[color:var(--border)] rounded-md overflow-hidden bg-[color:var(--bg-1)]"
       aria-labelledby={`config-${section.Name}-heading`}
     >
-      <header className="flex items-center gap-3 px-3 py-2 bg-[color:var(--bg-0)] border-b border-[color:var(--border)]">
+      <header
+        className="flex items-center gap-3 px-3 py-2 bg-[color:var(--bg-0)] border-b border-[color:var(--border)] cursor-pointer select-none hover:bg-[color-mix(in_srgb,var(--bg-0)_85%,var(--bg-3))]"
+        onClick={() => setCollapsed((c) => !c)}
+      >
         <h2
           id={`config-${section.Name}-heading`}
           className="font-display text-sm font-semibold text-[color:var(--text-1)] font-mono-tabular"
@@ -349,78 +373,374 @@ function ConfigSectionCard({
         >
           {section.Editable ? 'editable' : 'read-only'}
         </span>
+        {dirty && (
+          <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)]">
+            {dirtyKeys.length} {dirtyKeys.length === 1 ? 'change' : 'changes'}
+          </span>
+        )}
         {section.Info && (
           <p className="text-[10px] text-[color:var(--text-3)] truncate flex-1">
             {section.Info}
           </p>
         )}
         {!section.Info && <div className="flex-1" />}
-        {dirty && (
-          <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)]">
-            pending
-          </span>
-        )}
         <span
           className="text-[10px] tnum text-[color:var(--text-3)] whitespace-nowrap"
           title={section.UpdatedAt}
         >
           updated {formatRelative(section.UpdatedAt)}
         </span>
-        {section.Editable && !editing && (
+        {section.Editable && (
           <button
             type="button"
-            onClick={handleEdit}
-            className="text-[10px] px-2 py-0.5 rounded font-medium border border-[color:var(--border)] text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)] transition-colors"
+            disabled={!dirty || mutation.isPending}
+            onClick={(e) => {
+              e.stopPropagation();
+              mutation.mutate();
+            }}
+            className={cn(
+              'text-[10px] px-2 py-0.5 rounded font-medium',
+              'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
+              'disabled:opacity-40 disabled:cursor-not-allowed',
+            )}
           >
-            Edit
+            {mutation.isPending ? 'Saving…' : savedFlash ? 'Saved ✓' : 'Save'}
           </button>
         )}
-        {editing && (
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              disabled={!dirty || mutation.isPending}
-              onClick={() => mutation.mutate()}
-              className={cn(
-                'text-[10px] px-2 py-0.5 rounded font-medium',
-                'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
-                'disabled:opacity-40 disabled:cursor-not-allowed',
-              )}
-            >
-              {mutation.isPending ? 'Saving…' : savedFlash ? 'Saved ✓' : 'Save'}
-            </button>
-            <button
-              type="button"
-              onClick={handleCancel}
-              disabled={mutation.isPending}
-              className="text-[10px] px-2 py-0.5 rounded font-medium border border-[color:var(--border)] text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              Cancel
-            </button>
-          </div>
-        )}
+        <svg
+          className={cn(
+            'w-4 h-4 text-[color:var(--text-3)] transition-transform duration-200 shrink-0',
+            !collapsed && 'rotate-180',
+          )}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
       </header>
 
-      <div className="p-3">
-        <CodeEditor
-          value={editing ? draft : storedPretty}
-          onChange={editing ? (v) => setDraft(v ?? '') : undefined}
-          language="json"
-          readOnly={!editing}
-          height="200px"
-          aria-label={`Configuration section ${section.Name}`}
-        />
+      <div
+        className={cn(
+          'transition-[max-height,opacity] duration-250 overflow-hidden',
+          collapsed ? 'max-h-0 opacity-0' : 'max-h-[4000px] opacity-100',
+        )}
+      >
+        {/* Regular fields */}
+        {(hasManyBooleans ? nonBooleanFields : fieldEntries).map(([key]) => {
+          const originalValue = originalFields[key];
+          const currentValue = draft[key];
+          const type = inferType(originalValue);
+
+          if (type === 'null') {
+            return (
+              <FieldRow key={key} fieldKey={key} dirty={dirtyKeys.includes(key)}>
+                <span className="text-xs text-[color:var(--text-3)] font-mono-tabular italic">null</span>
+              </FieldRow>
+            );
+          }
+
+          if (type === 'string[]') {
+            const arr = currentValue as string[];
+            if (!section.Editable) {
+              return (
+                <ReadOnlyFieldRow key={key} fieldKey={key} value={originalValue} type={type} />
+              );
+            }
+            return (
+              <FieldRow key={key} fieldKey={key} dirty={dirtyKeys.includes(key)}>
+                <input
+                  type="text"
+                  value={arr.join(', ')}
+                  onChange={(e) => {
+                    const parts = e.target.value.split(',').map((s) => s.trim()).filter(Boolean);
+                    updateField(key, parts);
+                  }}
+                  placeholder="comma-separated values"
+                  className={cn(
+                    'w-full px-3 py-1.5 text-xs rounded-md border',
+                    'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular',
+                    'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+                    'placeholder:text-[color:var(--text-3)] placeholder:italic',
+                    dirtyKeys.includes(key)
+                      ? 'border-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.5)]'
+                      : 'border-[color:var(--border)]',
+                  )}
+                />
+              </FieldRow>
+            );
+          }
+
+          if (type === 'object') {
+            return (
+              <FieldRow key={key} fieldKey={key} dirty={dirtyKeys.includes(key)}>
+                <span className="text-xs text-[color:var(--text-3)] font-mono-tabular italic">
+                  {JSON.stringify(currentValue)}
+                </span>
+              </FieldRow>
+            );
+          }
+
+          if (!section.Editable) {
+            return (
+              <ReadOnlyFieldRow
+                key={key}
+                fieldKey={key}
+                value={originalValue}
+                type={type}
+              />
+            );
+          }
+
+          if (type === 'boolean' && !hasManyBooleans) {
+            return (
+              <FieldRow key={key} fieldKey={key} dirty={dirtyKeys.includes(key)}>
+                <ToggleSwitch
+                  checked={currentValue as boolean}
+                  onChange={(v) => updateField(key, v)}
+                />
+              </FieldRow>
+            );
+          }
+
+          if (type === 'number') {
+            return (
+              <FieldRow key={key} fieldKey={key} dirty={dirtyKeys.includes(key)}>
+                <input
+                  type="number"
+                  value={currentValue as number}
+                  onChange={(e) => {
+                    const v = Number(e.target.value);
+                    if (!Number.isNaN(v)) updateField(key, v);
+                  }}
+                  className={cn(
+                    'max-w-[120px] px-3 py-1.5 text-xs rounded-md border',
+                    'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular',
+                    'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+                    dirtyKeys.includes(key)
+                      ? 'border-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.5)]'
+                      : 'border-[color:var(--border)]',
+                  )}
+                />
+              </FieldRow>
+            );
+          }
+
+          return (
+            <FieldRow key={key} fieldKey={key} dirty={dirtyKeys.includes(key)}>
+              <input
+                type="text"
+                value={currentValue as string}
+                onChange={(e) => updateField(key, e.target.value)}
+                placeholder={currentValue === '' ? 'not set' : undefined}
+                className={cn(
+                  'w-full px-3 py-1.5 text-xs rounded-md border',
+                  'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular',
+                  'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+                  'placeholder:text-[color:var(--text-3)] placeholder:italic',
+                  dirtyKeys.includes(key)
+                    ? 'border-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.5)]'
+                    : 'border-[color:var(--border)]',
+                )}
+              />
+            </FieldRow>
+          );
+        })}
+
+        {/* Compact boolean grid for sections with many boolean flags */}
+        {hasManyBooleans && booleanFields.length > 0 && (
+          <>
+            <div className="h-px bg-[color:var(--border)]" />
+            <div className="px-3.5 py-3">
+              <p className="text-[11px] font-semibold text-[color:var(--text-3)] uppercase tracking-[0.06em] mb-2.5 font-mono-tabular">
+                Feature Toggles
+              </p>
+              <div className="grid grid-cols-2 gap-2">
+                {booleanFields.map(([key]) => (
+                  <div
+                    key={key}
+                    className="flex items-center gap-2.5 px-3 py-2 rounded-md bg-[color:var(--bg-2)] border border-[color:var(--border)] hover:border-[color:var(--border-strong)] transition-colors"
+                  >
+                    <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular flex-1">
+                      {key}
+                    </span>
+                    <ToggleSwitch
+                      checked={draft[key] as boolean}
+                      onChange={(v) => updateField(key, v)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
 
         {err && (
-          <p
-            role="alert"
-            className="mt-2 text-xs text-[color:var(--danger)] bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)] px-3 py-1.5 rounded-md"
-          >
-            {err}
-          </p>
+          <div className="px-3 pb-3">
+            <p
+              role="alert"
+              className="text-xs text-[color:var(--danger)] bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)] px-3 py-1.5 rounded-md"
+            >
+              {err}
+            </p>
+          </div>
         )}
       </div>
     </section>
+  );
+}
+
+function FieldRow({
+  fieldKey,
+  dirty,
+  children,
+}: {
+  fieldKey: string;
+  dirty: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-center min-h-[44px] px-3.5 gap-3 border-b border-[color:var(--border)] last:border-b-0',
+        dirty && 'border-l-[3px] border-l-[color:var(--warning)] pl-[11px] bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.03)]',
+      )}
+    >
+      <div className="flex items-center gap-2 w-[200px] min-w-[200px] shrink-0">
+        <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular">{fieldKey}</span>
+      </div>
+      <div className="flex-1 flex items-center min-w-0">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function ReadOnlyFieldRow({
+  fieldKey,
+  value,
+  type,
+}: {
+  fieldKey: string;
+  value: unknown;
+  type: FieldType;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const sensitive = isSensitive(fieldKey);
+
+  if (type === 'string[]') {
+    const arr = Array.isArray(value) ? (value as string[]) : [];
+    return (
+      <div className="flex items-center min-h-[44px] px-3.5 gap-3 border-b border-[color:var(--border)] last:border-b-0">
+        <div className="flex items-center gap-2 w-[200px] min-w-[200px] shrink-0">
+          <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular">{fieldKey}</span>
+        </div>
+        <div className="flex-1 flex items-center min-w-0 gap-1.5 flex-wrap py-1.5">
+          {arr.length === 0 ? (
+            <span className="text-xs text-[color:var(--text-3)] font-mono-tabular italic">empty</span>
+          ) : (
+            arr.map((item, i) => (
+              <span
+                key={i}
+                className="px-1.5 py-0.5 rounded text-[11px] font-mono-tabular bg-[color:var(--bg-2)] text-[color:var(--text-2)] border border-[color:var(--border)]"
+              >
+                {item}
+              </span>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const displayValue = type === 'boolean'
+    ? (value ? 'true' : 'false')
+    : String(value ?? '');
+
+  return (
+    <div className="flex items-center min-h-[44px] px-3.5 gap-3 border-b border-[color:var(--border)] last:border-b-0">
+      <div className="flex items-center gap-2 w-[200px] min-w-[200px] shrink-0">
+        <span className="text-xs font-medium text-[color:var(--text-1)] font-mono-tabular">{fieldKey}</span>
+      </div>
+      <div className="flex-1 flex items-center min-w-0">
+        {sensitive ? (
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-[color:var(--text-2)] font-mono-tabular">
+              {revealed ? displayValue : '●●●●●●'}
+            </span>
+            <button
+              type="button"
+              onClick={() => setRevealed((r) => !r)}
+              className="inline-flex items-center justify-center w-7 h-7 rounded border border-[color:var(--border)] bg-[color:var(--bg-2)] text-[color:var(--text-3)] hover:text-[color:var(--text-1)] hover:border-[color:var(--border-strong)] transition-colors shrink-0"
+              title={revealed ? 'Hide' : 'Reveal'}
+            >
+              {revealed ? (
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                  <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                  <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+                  <line x1="1" y1="1" x2="23" y2="23" />
+                </svg>
+              ) : (
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              )}
+            </button>
+          </div>
+        ) : (
+          <span className="text-xs text-[color:var(--text-2)] font-mono-tabular py-1.5">
+            {displayValue || <span className="text-[color:var(--text-3)] italic">empty</span>}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ToggleSwitch({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={cn(
+          'relative w-9 h-5 rounded-full border transition-colors shrink-0',
+          checked
+            ? 'bg-[color:var(--signal-deep)] border-[color:var(--signal)]'
+            : 'bg-[color:var(--bg-3)] border-[color:var(--border)]',
+        )}
+      >
+        <span
+          className={cn(
+            'absolute top-0.5 left-0.5 w-3.5 h-3.5 rounded-full transition-transform',
+            checked
+              ? 'translate-x-4 bg-[color:var(--signal)]'
+              : 'translate-x-0 bg-[color:var(--text-3)]',
+          )}
+        />
+      </button>
+      <span
+        className={cn(
+          'text-[11px]',
+          checked ? 'text-[color:var(--signal)]' : 'text-[color:var(--text-3)]',
+        )}
+      >
+        {checked ? 'enabled' : 'disabled'}
+      </span>
+    </div>
   );
 }
 

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -38,6 +38,14 @@ function isSensitive(key: string): boolean {
 }
 
 const FIELD_HELP: Record<string, string> = {
+  // Service
+  Listener: 'Network interface to bind to (e.g. 0.0.0.0 for all interfaces, 127.0.0.1 for localhost only).',
+  Port: 'TCP port the service listens on.',
+  Host: 'Hostname or IP address (context-dependent: service host, database host, Redis host, etc.).',
+  LogLevel: 'Minimum log level: debug, info, warn, or error.',
+  LogFormat: 'Log output format: console (human-readable) or json (structured).',
+  Auth: 'Authentication backend: none, json, db, saml, jwt, oauth, or oidc.',
+  AuditLog: 'When enabled, records admin actions to an audit trail.',
   GeoIPDBPath: 'Path to a MaxMind GeoLite2-Country .mmdb file. When set, the API resolves node IPs to country codes. When empty, the feature is disabled.',
   PostureEnabled: 'Controls whether the security & compliance posture system is active. When false (default), the entire posture subsystem is disabled.',
   PostureQueryPrefix: 'Prefix that identifies scheduled queries whose result logs are ingested as node posture data. Only used when PostureEnabled is true.',
@@ -45,26 +53,64 @@ const FIELD_HELP: Record<string, string> = {
   DBHealthCheck: 'Enables background DB liveness monitor. Pings DB every DBHealthInterval seconds; after DBHealthThreshold failures, switches to stale-serve mode.',
   DBHealthInterval: 'Seconds between DB health pings. Only used when DBHealthCheck is true.',
   DBHealthThreshold: 'Consecutive DB ping failures before switching to stale-serve mode.',
-  Type: 'Database type: postgres, mysql, or sqlite.',
+  // DB
+  Type: 'Backend type (e.g. postgres, mysql, sqlite for databases; stdout, db, s3, etc. for loggers).',
+  Name: 'Database name to connect to.',
+  Username: 'Database username for authentication.',
+  Password: 'Database password or service secret.',
   SSLMode: 'PostgreSQL SSL mode (e.g. disable, require, verify-full).',
-  FilePath: 'File path for SQLite database.',
+  FilePath: 'File path (SQLite database or local log file).',
   ConnRetry: 'Number of connection retry attempts on startup.',
   MaxIdleConns: 'Maximum idle connections in the pool.',
   MaxOpenConns: 'Maximum open connections to the database.',
   ConnMaxLifetime: 'Maximum lifetime of a connection in seconds.',
+  // Redis
   ConnectionString: 'Full Redis connection string. When set, overrides Host/Port/Password.',
+  DB: 'Redis database index (0–15).',
+  // Osquery
+  Version: 'Expected osquery version string.',
+  TablesFile: 'Path to the osquery tables JSON definition file.',
+  Logger: 'Enable osquery result log collection.',
+  Config: 'Enable osquery configuration distribution.',
+  Query: 'Enable on-demand distributed query support.',
+  Carve: 'Enable file carve collection from nodes.',
+  Accelerated: 'Allow accelerated check-in intervals for nodes.',
+  FileExplorer: 'Enable the file explorer feature for nodes.',
+  ReadOnly: 'Run in read-only mode (no writes to osquery nodes).',
+  // Metrics
+  Enabled: 'Enable or disable this feature.',
+  // Debug
   EnableHTTP: 'When true, dumps HTTP requests to the debug file.',
   HTTPFile: 'File path where HTTP debug dumps are written.',
   ShowBody: 'Include request/response body in the debug dump.',
   TargetHostIdentifier: 'Restrict debug dump to a specific node UUID or host_identifier (case-insensitive). Empty dumps all requests.',
-  Enabled: 'Enable or disable this feature.',
+  // TLS
+  Termination: 'Enable TLS/SSL termination at the service.',
+  CertificateFile: 'Path to the TLS certificate file.',
+  KeyFile: 'Path to the TLS private key file.',
+  // JWT
+  JWTSecret: 'Secret key used to sign JWT tokens.',
+  HoursToExpire: 'JWT token lifetime in hours.',
+  // BatchWriter
+  WriterBatchSize: 'Number of records per batch write.',
+  WriterTimeout: 'Timeout for batch write operations.',
+  WriterBufferSize: 'Buffer size for the batch writer queue.',
+  // SAML
   EntityID: 'SP entity identifier — what the IdP knows this service by. Conventionally the metadata URL.',
   ACSURL: 'Assertion Consumer Service URL where the IdP POSTs the SAMLResponse. Must match IdP registration.',
+  CertPath: 'Path to the SAML SP certificate file.',
+  KeyPath: 'Path to the SAML SP private key file.',
+  MetaDataURL: 'IdP metadata URL for automatic SAML configuration.',
+  RootURL: 'Root URL of the application (used to build SAML endpoints).',
+  LoginURL: 'URL to redirect users for SAML login.',
+  LogoutURL: 'URL to redirect users after SAML logout.',
   UsernameAttribute: 'SAML attribute whose value becomes the osctrl username. Empty uses NameID verbatim.',
   SigningCertPath: 'PEM file path to SP signing certificate. Both cert and key must be set to enable request signing.',
   SigningKeyPath: 'PEM file path to SP signing RSA private key.',
   ForceAuthn: 'When true (default), forces re-authentication at the IdP on every login.',
+  SPInitiated: 'Enable SP-initiated SAML login flow.',
   JITProvision: 'Automatically create osctrl user accounts on first federated login.',
+  // OIDC
   IssuerURL: 'OIDC provider issuer URL (e.g. https://accounts.google.com).',
   ClientID: 'OAuth2 client ID registered with the OIDC provider.',
   ClientSecret: 'OAuth2 client secret.',
@@ -74,19 +120,55 @@ const FIELD_HELP: Record<string, string> = {
   GroupsClaim: 'JWT claim containing group memberships.',
   RequiredGroups: 'Groups a user must belong to for access.',
   UsePKCE: 'Use Proof Key for Code Exchange for added security.',
-  JWTSecret: 'Secret key used to sign JWT tokens.',
-  HoursToExpire: 'JWT token lifetime in hours.',
-  WriterBatchSize: 'Number of records per batch write.',
-  WriterTimeout: 'Timeout for batch write operations.',
-  WriterBufferSize: 'Buffer size for the batch writer queue.',
-  Termination: 'Enable TLS/SSL termination at the service.',
-  CertificateFile: 'Path to the TLS certificate file.',
-  KeyFile: 'Path to the TLS private key file.',
+  // Logger
+  Types: 'Logger backends to use (e.g. stdout, db, s3, graylog, splunk, logstash, kinesis, kafka, elastic).',
   LoggerDBSame: 'Use the same DB connection for logging (no separate logger DB).',
   AlwaysLog: 'Always log, even when no logger backend is configured.',
+  // ConfigEndpoints
   Environment: 'Target osctrl environment name.',
   Secret: 'Enrollment secret for this endpoint.',
   IntegrityCheck: 'Verify config integrity before pushing.',
+  // S3 (logger/carver)
+  Bucket: 'S3 bucket name for storage.',
+  Region: 'AWS region for the S3 bucket or Kinesis stream.',
+  AccessKey: 'AWS access key ID.',
+  SecretAccessKey: 'AWS secret access key.',
+  // Local carver
+  CarvesDir: 'Local directory to store carved files.',
+  // Kinesis
+  Stream: 'Kinesis stream name.',
+  Endpoint: 'Custom Kinesis endpoint URL (for localstack or VPC endpoints).',
+  AccessKeyID: 'AWS access key ID for Kinesis.',
+  SessionToken: 'AWS session token (for temporary credentials).',
+  // Kafka
+  BootstrapServer: 'Kafka bootstrap server address (host:port).',
+  SSLCALocation: 'Path to SSL CA certificate for Kafka TLS.',
+  ConnectionTimeout: 'Kafka connection timeout duration.',
+  Topic: 'Kafka topic to publish logs to.',
+  SASL: 'Kafka SASL authentication configuration.',
+  Mechanism: 'SASL mechanism (e.g. PLAIN, SCRAM-SHA-256).',
+  // Graylog
+  URL: 'Graylog or Splunk API endpoint URL.',
+  Queries: 'Graylog stream/index for query logs.',
+  Status: 'Graylog stream/index for status logs.',
+  Results: 'Graylog stream/index for result logs.',
+  // Elastic
+  IndexPrefix: 'Elasticsearch index name prefix.',
+  DateSeparator: 'Date separator in index names (e.g. "." for YYYY.MM.DD).',
+  IndexSeparator: 'Separator between prefix and date (e.g. "-" for prefix-YYYY.MM.DD).',
+  // Splunk
+  Token: 'Splunk HEC (HTTP Event Collector) token.',
+  Index: 'Splunk index to write events to.',
+  // Logstash
+  Protocol: 'Network protocol for Logstash connection (tcp or udp).',
+  Path: 'URL path for Logstash HTTP input.',
+  // Local logger
+  MaxSize: 'Maximum log file size in megabytes before rotation.',
+  MaxBackups: 'Maximum number of old log files to retain.',
+  MaxAge: 'Maximum days to retain old log files.',
+  Compress: 'Compress rotated log files with gzip.',
+  // Osctrld
+  // (uses Enabled, already defined above)
 };
 
 type FieldType = 'boolean' | 'number' | 'string' | 'string[]' | 'object' | 'null';
@@ -100,14 +182,25 @@ function inferType(value: unknown): FieldType {
   return 'string';
 }
 
-function parseConfigValue(raw: string): Record<string, unknown> {
+type ParsedConfig =
+  | { kind: 'object'; fields: Record<string, unknown> }
+  | { kind: 'array'; items: Record<string, unknown>[] };
+
+function parseConfigValue(raw: string): ParsedConfig {
   try {
     const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
+    if (Array.isArray(parsed)) {
+      const items = parsed.filter(
+        (item): item is Record<string, unknown> =>
+          item && typeof item === 'object' && !Array.isArray(item),
+      );
+      return { kind: 'array', items };
+    }
+    if (parsed && typeof parsed === 'object') {
+      return { kind: 'object', fields: parsed as Record<string, unknown> };
     }
   } catch { /* fall through */ }
-  return {};
+  return { kind: 'object', fields: {} };
 }
 
 export function ServiceConfigPage() {
@@ -328,14 +421,18 @@ function ConfigSectionCard({
   service: string;
   onSaved: () => void;
 }) {
-  const originalFields = useMemo(() => parseConfigValue(section.Value), [section.Value]);
+  const parsed = useMemo(() => parseConfigValue(section.Value), [section.Value]);
+  const isArray = parsed.kind === 'array';
+  const originalFields = isArray ? {} as Record<string, unknown> : parsed.fields;
+  const arrayItems = isArray ? parsed.items : [];
   const [draft, setDraft] = useState<Record<string, unknown>>(() => ({ ...originalFields }));
   const [collapsed, setCollapsed] = useState(!section.Editable);
   const [savedFlash, setSavedFlash] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
-    setDraft({ ...parseConfigValue(section.Value) });
+    const p = parseConfigValue(section.Value);
+    setDraft(p.kind === 'object' ? { ...p.fields } : {});
   }, [section.Value]);
 
   const dirtyKeys = useMemo(() => {
@@ -477,8 +574,31 @@ function ConfigSectionCard({
       </header>
 
       {!collapsed && <div>
-        {/* Regular fields */}
-        {(hasManyBooleans ? nonBooleanFields : fieldEntries).map(([key]) => {
+        {/* Array-type sections (e.g. configEndpoints) */}
+        {isArray && (
+          arrayItems.length === 0 ? (
+            <div className="px-3.5 py-4 text-xs text-[color:var(--text-3)] italic">No items configured.</div>
+          ) : (
+            arrayItems.map((item, idx) => (
+              <div key={idx} className="border-b border-[color:var(--border)] last:border-b-0">
+                <div className="px-3.5 py-1.5 bg-[color:var(--bg-0)]">
+                  <span className="text-[10px] font-semibold text-[color:var(--text-3)] uppercase tracking-[0.06em] font-mono-tabular">
+                    #{idx + 1}
+                  </span>
+                </div>
+                {Object.entries(item).map(([key, value]) => {
+                  const type = inferType(value);
+                  return (
+                    <ReadOnlyFieldRow key={key} fieldKey={key} value={value} type={type} />
+                  );
+                })}
+              </div>
+            ))
+          )
+        )}
+
+        {/* Regular object fields */}
+        {!isArray && (hasManyBooleans ? nonBooleanFields : fieldEntries).map(([key]) => {
           const originalValue = originalFields[key];
           const currentValue = draft[key];
           const type = inferType(originalValue);
@@ -599,7 +719,7 @@ function ConfigSectionCard({
         })}
 
         {/* Compact boolean grid for sections with many boolean flags */}
-        {hasManyBooleans && booleanFields.length > 0 && (
+        {!isArray && hasManyBooleans && booleanFields.length > 0 && (
           <>
             <div className="h-px bg-[color:var(--border)]" />
             <div className="px-3.5 py-3">
@@ -645,20 +765,27 @@ function ConfigSectionCard({
 function FieldHelpIcon({ fieldKey }: { fieldKey: string }) {
   const help = FIELD_HELP[fieldKey];
   const ref = useRef<HTMLSpanElement>(null);
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const [pos, setPos] = useState<{ x: number; y: number; flip: boolean } | null>(null);
 
   if (!help) return null;
 
   const TOOLTIP_W = 260;
   const EDGE_PAD = 8;
+  const GAP = 6;
 
   const show = () => {
     const rect = ref.current?.getBoundingClientRect();
     if (rect) {
-      const centerX = rect.left + rect.width / 2;
-      const minLeft = EDGE_PAD + TOOLTIP_W / 2;
-      const maxLeft = window.innerWidth - EDGE_PAD - TOOLTIP_W / 2;
-      setPos({ x: Math.max(minLeft, Math.min(maxLeft, centerX)), y: rect.top });
+      let left = rect.right + 8;
+      const rightEdge = left + TOOLTIP_W;
+      if (rightEdge > window.innerWidth - EDGE_PAD) {
+        left = window.innerWidth - EDGE_PAD - TOOLTIP_W;
+      }
+      setPos({
+        x: left,
+        y: rect.top + rect.height / 2,
+        flip: false,
+      });
     }
   };
 
@@ -689,7 +816,7 @@ function FieldHelpIcon({ fieldKey }: { fieldKey: string }) {
             left: `${pos.x}px`,
             top: `${pos.y}px`,
             width: TOOLTIP_W,
-            transform: 'translate(-50%, -100%) translateY(-8px)',
+            transform: 'translateY(-50%)',
             zIndex: 9999,
           }}
         >

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -391,11 +391,11 @@ function ConfigSectionCard({
 
   return (
     <section
-      className="border border-[color:var(--border)] rounded-md overflow-hidden bg-[color:var(--bg-1)]"
+      className="border border-[color:var(--border)] rounded-md bg-[color:var(--bg-1)]"
       aria-labelledby={`config-${section.Name}-heading`}
     >
       <header
-        className="flex items-center gap-3 px-3 py-2 bg-[color:var(--bg-0)] border-b border-[color:var(--border)] cursor-pointer select-none hover:bg-[color-mix(in_srgb,var(--bg-0)_85%,var(--bg-3))]"
+        className="flex items-center gap-3 px-3 py-2 bg-[color:var(--bg-0)] border-b border-[color:var(--border)] cursor-pointer select-none hover:bg-[color-mix(in_srgb,var(--bg-0)_85%,var(--bg-3))] rounded-t-[5px]"
         onClick={() => setCollapsed((c) => !c)}
       >
         <h2

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { usePageTitle } from '$/lib/usePageTitle';
 import { useParams, useNavigate, Link } from '@tanstack/react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -643,9 +644,25 @@ function ConfigSectionCard({
 
 function FieldHelpIcon({ fieldKey }: { fieldKey: string }) {
   const help = FIELD_HELP[fieldKey];
+  const ref = useRef<HTMLSpanElement>(null);
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+
   if (!help) return null;
+
+  const show = () => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (rect) {
+      setPos({ x: rect.left + rect.width / 2, y: rect.top });
+    }
+  };
+
   return (
-    <span className="group relative shrink-0">
+    <span
+      ref={ref}
+      className="shrink-0"
+      onMouseEnter={show}
+      onMouseLeave={() => setPos(null)}
+    >
       <svg
         className="w-3.5 h-3.5 text-[color:var(--text-3)] hover:text-[color:var(--signal)] cursor-help transition-colors"
         viewBox="0 0 24 24"
@@ -659,9 +676,20 @@ function FieldHelpIcon({ fieldKey }: { fieldKey: string }) {
         <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
         <line x1="12" y1="17" x2="12.01" y2="17" />
       </svg>
-      <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 text-[11px] leading-relaxed text-[color:var(--text-1)] bg-[color:var(--bg-0)] border border-[color:var(--border)] rounded-md shadow-lg w-[260px] opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-50">
-        {help}
-      </span>
+      {pos && createPortal(
+        <span
+          className="fixed px-3 py-2 text-[11px] leading-relaxed text-[color:var(--text-1)] bg-[color:var(--bg-0)] border border-[color:var(--border)] rounded-md shadow-lg w-[260px] pointer-events-none"
+          style={{
+            left: `${pos.x}px`,
+            top: `${pos.y}px`,
+            transform: 'translate(-50%, -100%) translateY(-8px)',
+            zIndex: 9999,
+          }}
+        >
+          {help}
+        </span>,
+        document.body,
+      )}
     </span>
   );
 }

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -475,12 +475,7 @@ function ConfigSectionCard({
         </svg>
       </header>
 
-      <div
-        className={cn(
-          'transition-[max-height,opacity] duration-250 overflow-hidden',
-          collapsed ? 'max-h-0 opacity-0' : 'max-h-[4000px] opacity-100',
-        )}
-      >
+      {!collapsed && <div>
         {/* Regular fields */}
         {(hasManyBooleans ? nonBooleanFields : fieldEntries).map(([key]) => {
           const originalValue = originalFields[key];
@@ -641,7 +636,7 @@ function ConfigSectionCard({
             </p>
           </div>
         )}
-      </div>
+      </div>}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Redesigns the Service Config page (`/_app/config/$service`) to use per-field form controls instead of raw Monaco JSON code editors
- Renders type-appropriate inputs for each config field: text inputs for strings, number inputs for integers, toggle switches for booleans, comma-separated inputs for string arrays, and masked values with reveal buttons for sensitive fields (passwords, secrets, keys)
- Sections with 3+ boolean flags (e.g. osquery feature toggles) use a compact 2-column toggle grid
- Collapsible sections with chevron toggle — editable sections default open, read-only sections default closed
- Per-field dirty tracking with yellow left-border highlight on changed rows and a change count badge on section headers
- All Go config struct field types are accounted for: `string`, `int`, `bool`, `[]string`, `time.Duration`, and nested objects
- Preserves the existing Apply & Restart flow, confirmation dialog, service tabs, and all backend API contracts unchanged

### Before
Raw JSON code editor per section — requires manual JSON editing to change config values.

### After
Structured form fields matching the UX pattern of the Settings page — individual inputs per field with inline save.

## Test plan

- [ ] Navigate to `/_app/config/api` and verify all sections render with structured form fields
- [ ] Navigate to `/_app/config/tls` and verify TLS-specific sections (batchWriter, osctrld, metrics) render correctly
- [ ] Edit a field in an editable section (e.g. service port), verify dirty state indicators appear
- [ ] Click Save on a dirty section, verify it persists and the source badge changes to "db"
- [ ] Verify "Apply & Restart" button appears after saving, confirm dialog works, and service restarts successfully
- [ ] Verify read-only sections (db, redis, jwt, tls, saml, oidc) show values but no input controls
- [ ] Verify sensitive fields (Password, JWTSecret, ClientSecret) are masked with a reveal toggle
- [ ] Verify OIDC scopes/requiredGroups render as tag chips (string arrays)
- [ ] Verify osquery section shows feature toggles in a compact 2-column boolean grid
- [ ] Collapse and expand sections, verify state persists during the session