### PR TITLE
Multi-architecture enrolling packages

### DIFF
--- a/cmd/api/handlers/environments_packages.go
+++ b/cmd/api/handlers/environments_packages.go
@@ -1,0 +1,276 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+// validPackageTypes is the set of accepted package type values.
+var validPackageTypes = map[string]bool{
+	settings.PackageDeb: true,
+	settings.PackageRpm: true,
+	settings.PackageMsi: true,
+	settings.PackagePkg: true,
+}
+
+// EnvPackagesHandler - GET Handler to list all enrolling packages for an environment
+// @Summary List enrolling packages
+// @Description Returns all enrolling packages for an environment.
+// @Tags environments
+// @Produce json
+// @Param env path string true "Environment name or UUID"
+// @Success 200 {array} environments.EnvironmentPackage
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/environments/{env}/packages [get]
+func (h *HandlersApi) EnvPackagesHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		apiErrorResponse(w, "missing environment", http.StatusBadRequest, nil)
+		return
+	}
+	env, err := h.Envs.Get(envVar)
+	if err != nil {
+		if err.Error() == "record not found" {
+			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
+		} else {
+			apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, err)
+		}
+		return
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	pkgs, err := h.Envs.GetPackages(env.ID)
+	if err != nil {
+		apiErrorResponse(w, "error getting packages", http.StatusInternalServerError, err)
+		return
+	}
+	log.Debug().Msgf("Returned %d packages for env %s", len(pkgs), env.Name)
+	h.AuditLog.Visit(ctx[ctxUser], r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, pkgs)
+}
+
+// EnvPackageAddHandler - POST Handler to add an enrolling package
+// @Summary Add enrolling package
+// @Description Adds a new enrolling package to an environment.
+// @Tags environments
+// @Accept json
+// @Produce json
+// @Param env path string true "Environment name or UUID"
+// @Param request body types.ApiAddPackageRequest true "Request body"
+// @Success 201 {object} environments.EnvironmentPackage
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 409 {object} types.ApiErrorResponse "Conflict"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/environments/{env}/packages [post]
+func (h *HandlersApi) EnvPackageAddHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		apiErrorResponse(w, "missing environment", http.StatusBadRequest, nil)
+		return
+	}
+	env, err := h.Envs.Get(envVar)
+	if err != nil {
+		if err.Error() == "record not found" {
+			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
+		} else {
+			apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, err)
+		}
+		return
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	var body types.ApiAddPackageRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	if !validPackageTypes[body.Type] {
+		apiErrorResponse(w, "invalid package type", http.StatusBadRequest, nil)
+		return
+	}
+	if !environments.ValidArchitectures[body.Arch] {
+		apiErrorResponse(w, "invalid architecture", http.StatusBadRequest, nil)
+		return
+	}
+	if body.URL == "" {
+		apiErrorResponse(w, "url is required", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.Envs.AddPackage(env.ID, body.Type, body.Arch, body.URL, body.IsDefault); err != nil {
+		apiErrorResponse(w, "error adding package", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.ConfAction(ctx[ctxUser], fmt.Sprintf("add package %s/%s to env %s", body.Type, body.Arch, env.Name), strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	log.Debug().Msgf("Added package %s/%s to env %s", body.Type, body.Arch, env.Name)
+	// Fetch the created package to return it.
+	pkg, _ := h.Envs.GetPackage(env.ID, body.Type, body.Arch)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, pkg)
+}
+
+// EnvPackageRemoveHandler - DELETE Handler to remove an enrolling package
+// @Summary Remove enrolling package
+// @Description Removes an enrolling package from an environment.
+// @Tags environments
+// @Produce json
+// @Param env path string true "Environment name or UUID"
+// @Param id path int true "Package ID"
+// @Success 204
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/environments/{env}/packages/{id} [delete]
+func (h *HandlersApi) EnvPackageRemoveHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		apiErrorResponse(w, "missing environment", http.StatusBadRequest, nil)
+		return
+	}
+	env, err := h.Envs.Get(envVar)
+	if err != nil {
+		if err.Error() == "record not found" {
+			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
+		} else {
+			apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, err)
+		}
+		return
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	pkgIDStr := r.PathValue("id")
+	if pkgIDStr == "" {
+		apiErrorResponse(w, "missing package id", http.StatusBadRequest, nil)
+		return
+	}
+	var pkgID uint
+	if _, err := fmt.Sscanf(pkgIDStr, "%d", &pkgID); err != nil || pkgID == 0 {
+		apiErrorResponse(w, "invalid package id", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.Envs.RemovePackage(env.ID, pkgID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErrorResponse(w, "package not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error removing package", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.ConfAction(ctx[ctxUser], fmt.Sprintf("remove package %d from env %s", pkgID, env.Name), strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	log.Debug().Msgf("Removed package %d from env %s", pkgID, env.Name)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// EnvPackageUpdateHandler - PATCH Handler to update a package URL
+// @Summary Update enrolling package URL
+// @Description Updates the URL of an existing enrolling package.
+// @Tags environments
+// @Accept json
+// @Produce json
+// @Param env path string true "Environment name or UUID"
+// @Param id path int true "Package ID"
+// @Param request body types.ApiUpdatePackageRequest true "Request body"
+// @Success 200 {object} environments.EnvironmentPackage
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/environments/packages/{env}/{id} [patch]
+func (h *HandlersApi) EnvPackageUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		apiErrorResponse(w, "missing environment", http.StatusBadRequest, nil)
+		return
+	}
+	env, err := h.Envs.Get(envVar)
+	if err != nil {
+		if err.Error() == "record not found" {
+			apiErrorResponse(w, "environment not found", http.StatusNotFound, err)
+		} else {
+			apiErrorResponse(w, "error getting environment", http.StatusInternalServerError, err)
+		}
+		return
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	pkgIDStr := r.PathValue("id")
+	if pkgIDStr == "" {
+		apiErrorResponse(w, "missing package id", http.StatusBadRequest, nil)
+		return
+	}
+	var pkgID uint
+	if _, err := fmt.Sscanf(pkgIDStr, "%d", &pkgID); err != nil || pkgID == 0 {
+		apiErrorResponse(w, "invalid package id", http.StatusBadRequest, nil)
+		return
+	}
+	var body types.ApiUpdatePackageRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	if body.URL == "" {
+		apiErrorResponse(w, "url is required", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.Envs.UpdatePackageURL(env.ID, pkgID, body.URL); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErrorResponse(w, "package not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error updating package", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.ConfAction(ctx[ctxUser], fmt.Sprintf("update package %d in env %s", pkgID, env.Name), strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	log.Debug().Msgf("Updated package %d in env %s", pkgID, env.Name)
+	// Return the updated package.
+	var pkg environments.EnvironmentPackage
+	h.Envs.DB.Where("environment_id = ? AND id = ?", env.ID, pkgID).First(&pkg)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, pkg)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -860,6 +860,21 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"PATCH "+_apiPath(apiEnvironmentsPath)+"/expiration/{env}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentExpirationPatchHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	// API: environment packages (multi-architecture)
+	// Uses /packages/{env} shape (literal in segment 1) to avoid conflicts
+	// with /map/{target} — same pattern as /config/{env} and /intervals/{env}.
+	muxAPI.Handle(
+		"GET "+_apiPath(apiEnvironmentsPath)+"/packages/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvPackagesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"POST "+_apiPath(apiEnvironmentsPath)+"/packages/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvPackageAddHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"DELETE "+_apiPath(apiEnvironmentsPath)+"/packages/{env}/{id}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvPackageRemoveHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"PATCH "+_apiPath(apiEnvironmentsPath)+"/packages/{env}/{id}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvPackageUpdateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// API: tags by environment
 	muxAPI.Handle(
 		"GET "+_apiPath(apiTagsPath),

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -1207,8 +1207,29 @@ func (h *HandlersTLS) EnrollPackageHandler(w http.ResponseWriter, r *http.Reques
 		utils.HTTPResponse(w, "", http.StatusForbidden, []byte(""))
 		return
 	}
-	// Prepare download
+	// Prepare download — try the new EnvironmentPackage table first, then
+	// fall back to the legacy single-package fields for backward compat.
 	var fDesc, fName, fPath string
+	archVar := r.PathValue("arch")
+
+	// Try the new package table.
+	if h.Envs != nil {
+		pkg, err := h.Envs.GetPackage(env.ID, packageVar, archVar)
+		if err == nil && pkg.URL != "" {
+			if strings.HasPrefix(pkg.URL, "https://") {
+				http.Redirect(w, r, pkg.URL, http.StatusFound)
+				return
+			}
+			fDesc = packageDescription(packageVar)
+			fName = genPackageFilename(env.Name, packageVar, version.OsqueryVersion, version.OsctrlVersion)
+			fPath, err = environments.PackageFilePath(enrollPackagesPath, env.Name, pkg.URL)
+			if err == nil {
+				goto serveFile
+			}
+		}
+	}
+
+	// Fall back to legacy single-package fields.
 	switch packageVar {
 	case settings.PackageDeb:
 		if strings.HasPrefix(env.DebPackage, "https://") {
@@ -1248,6 +1269,7 @@ func (h *HandlersTLS) EnrollPackageHandler(w http.ResponseWriter, r *http.Reques
 		utils.HTTPResponse(w, "", http.StatusBadRequest, []byte(""))
 		return
 	}
+serveFile:
 	// Initiate download
 	fi, err := os.Stat(fPath)
 	if err != nil {
@@ -1432,5 +1454,20 @@ func (h *HandlersTLS) ingestPosture(results []types.LogResultData, nodeUUID, env
 		if err := h.Posture.IngestResult(nodeUUID, environment, queryName, columns); err != nil {
 			log.Warn().Err(err).Str("query", queryName).Msg("posture: failed to ingest result")
 		}
+	}
+}
+
+func packageDescription(pkgType string) string {
+	switch pkgType {
+	case settings.PackageDeb:
+		return "Enrolling DEB Package for Linux"
+	case settings.PackageRpm:
+		return "Enrolling RPM Package for Linux"
+	case settings.PackagePkg:
+		return "Enrolling PKG Package for Mac"
+	case settings.PackageMsi:
+		return "Enrolling MSI Package for Windows"
+	default:
+		return "Enrolling Package"
 	}
 }

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -398,6 +398,8 @@ func osctrlService() {
 	muxTLS.HandleFunc("GET /{env}/{secretpath}/{script}", handlersTLS.QuickEnrollHandler)
 	// TLS: Download enrolling package
 	muxTLS.HandleFunc("GET /{env}/{secretpath}/package/{package}", handlersTLS.EnrollPackageHandler)
+	// TLS: Download enrolling package by architecture
+	muxTLS.HandleFunc("GET /{env}/{secretpath}/package/{package}/{arch}", handlersTLS.EnrollPackageHandler)
 
 	// Enable osctrld endpoints
 	if flagParams.Osctrld.Enabled {

--- a/frontend/src/api/environments.ts
+++ b/frontend/src/api/environments.ts
@@ -204,3 +204,70 @@ export function patchEnvironmentExpiration(
     },
   );
 }
+
+// ── Environment packages (multi-architecture) ─────────────────────────────
+
+/** Wire shape matching pkg/environments.EnvironmentPackage. */
+export interface EnvironmentPackage {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  environment_id: number;
+  type: string;
+  architecture: string;
+  url: string;
+  is_default: boolean;
+}
+
+/** GET /api/v1/environments/packages/{env} — list all packages. */
+export function listEnvPackages(env: string): Promise<EnvironmentPackage[]> {
+  return apiFetch<EnvironmentPackage[]>(
+    `/api/v1/environments/packages/${encodeURIComponent(env)}`,
+  );
+}
+
+export interface AddPackageRequest {
+  type: string;
+  architecture: string;
+  url: string;
+  is_default: boolean;
+}
+
+/** POST /api/v1/environments/packages/{env} — add a package. */
+export function addEnvPackage(
+  env: string,
+  body: AddPackageRequest,
+): Promise<EnvironmentPackage> {
+  return apiFetch<EnvironmentPackage>(
+    `/api/v1/environments/packages/${encodeURIComponent(env)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+/** DELETE /api/v1/environments/packages/{env}/{id} — remove a package. */
+export function removeEnvPackage(env: string, id: number): Promise<void> {
+  return apiFetch<void>(
+    `/api/v1/environments/packages/${encodeURIComponent(env)}/${id}`,
+    { method: 'DELETE' },
+  );
+}
+
+/** PATCH /api/v1/environments/packages/{env}/{id} — update a package URL. */
+export function updateEnvPackage(
+  env: string,
+  id: number,
+  url: string,
+): Promise<EnvironmentPackage> {
+  return apiFetch<EnvironmentPackage>(
+    `/api/v1/environments/packages/${encodeURIComponent(env)}/${id}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    },
+  );
+}

--- a/frontend/src/features/enrollment/EnrollPage.tsx
+++ b/frontend/src/features/enrollment/EnrollPage.tsx
@@ -11,7 +11,14 @@ import {
   type RemoveAction,
   type PackageActionBody,
 } from '$/api/enrollment';
-import { getEnvironment } from '$/api/environments';
+import {
+  getEnvironment,
+  listEnvPackages,
+  addEnvPackage,
+  removeEnvPackage,
+  updateEnvPackage,
+  type EnvironmentPackage,
+} from '$/api/environments';
 import { AuthError, ApiError } from '$/api/client';
 import { Button } from '$/components/atoms/Button';
 import { Skeleton } from '$/components/data/Skeleton';
@@ -150,29 +157,9 @@ export function EnrollPage() {
     }
   }
 
-  // Package URL state — seeded once from the env row.
-  const [debUrl, setDebUrl] = useState('');
-  const [rpmUrl, setRpmUrl] = useState('');
-  const [pkgUrl, setPkgUrl] = useState('');
-  const [msiUrl, setMsiUrl] = useState('');
-  const [seeded, setSeeded] = useState(false);
-  if (!seeded && e) {
-    setDebUrl(e.deb_package || '');
-    setRpmUrl(e.rpm_package || '');
-    setPkgUrl(e.pkg_package || '');
-    setMsiUrl(e.msi_package || '');
-    setSeeded(true);
-  }
-
-  const pkgMut = useMutation({
-    mutationFn: (args: { action: EnrollAction; body: PackageActionBody }) =>
-      enrollAction(env, args.action, args.body),
-    onSuccess: () => {
-      setServerError(null);
-      void qc.invalidateQueries({ queryKey: ['env', env] });
-    },
-    onError: (err) => setServerError(err instanceof ApiError ? err.message : 'Save failed'),
-  });
+  // Package URL state is managed by the PackageListCard component
+  // which uses the multi-architecture EnvironmentPackage API.
+  const [seeded] = useState(false);
 
   const notAccepting = !!e && !e.accept_enrolls;
 
@@ -293,20 +280,9 @@ export function EnrollPage() {
                   open={pkgOpen}
                   onToggle={() => setPkgOpen((v) => !v)}
                   title="Pre-built package URLs"
-                  subtitle="optional · DEB · RPM · PKG · MSI"
+                  subtitle="optional · DEB · RPM · PKG · MSI · per-architecture"
                 >
-                  <PackageUrlCard
-                    debUrl={debUrl}
-                    setDebUrl={setDebUrl}
-                    rpmUrl={rpmUrl}
-                    setRpmUrl={setRpmUrl}
-                    pkgUrl={pkgUrl}
-                    setPkgUrl={setPkgUrl}
-                    msiUrl={msiUrl}
-                    setMsiUrl={setMsiUrl}
-                    isPending={pkgMut.isPending}
-                    onSave={(action, body) => pkgMut.mutate({ action, body })}
-                  />
+                  <PackageListCard envName={env} />
                 </Collapsible>
               </div>
             </div>
@@ -757,90 +733,240 @@ function LifecycleCard({
 }
 
 // ---------------------------------------------------------------------------
-// PackageUrlCard — heading + 4 compact rows (DEB / RPM / PKG / MSI).
-// Each row: [label][url input][Save] on a single line.
+// PackageListCard — multi-architecture package management.
+// Shows all packages from the EnvironmentPackage table, grouped by type,
+// with add/remove capability.
 // ---------------------------------------------------------------------------
-function PackageUrlCard({
-  debUrl,
-  setDebUrl,
-  rpmUrl,
-  setRpmUrl,
-  pkgUrl,
-  setPkgUrl,
-  msiUrl,
-  setMsiUrl,
-  isPending,
-  onSave,
-}: {
-  debUrl: string;
-  setDebUrl: (v: string) => void;
-  rpmUrl: string;
-  setRpmUrl: (v: string) => void;
-  pkgUrl: string;
-  setPkgUrl: (v: string) => void;
-  msiUrl: string;
-  setMsiUrl: (v: string) => void;
-  isPending: boolean;
-  onSave: (action: EnrollAction, body: PackageActionBody) => void;
-}) {
-  const rows: {
-    label: string;
-    value: string;
-    onChange: (v: string) => void;
-    action: EnrollAction;
-    body: () => PackageActionBody;
-  }[] = [
-    { label: 'DEB',        value: debUrl, onChange: setDebUrl, action: 'set_deb', body: () => ({ deb_url: debUrl }) },
-    { label: 'RPM',        value: rpmUrl, onChange: setRpmUrl, action: 'set_rpm', body: () => ({ rpm_url: rpmUrl }) },
-    { label: 'PKG (macOS)', value: pkgUrl, onChange: setPkgUrl, action: 'set_pkg', body: () => ({ pkg_url: pkgUrl }) },
-    { label: 'MSI (Win)',  value: msiUrl, onChange: setMsiUrl, action: 'set_msi', body: () => ({ msi_url: msiUrl }) },
-  ];
+const PACKAGE_TYPES = [
+  { value: 'deb', label: 'DEB (Linux)' },
+  { value: 'rpm', label: 'RPM (Linux)' },
+  { value: 'pkg', label: 'PKG (macOS)' },
+  { value: 'msi', label: 'MSI (Windows)' },
+];
+
+const ARCH_OPTIONS = ['amd64', 'arm64', 'x86_64', 'aarch64', 'universal'];
+
+function PackageListCard({ envName }: { envName: string }) {
+  const qc = useQueryClient();
+  const { data: packages, isLoading } = useQuery({
+    queryKey: ['env-packages', envName],
+    queryFn: () => listEnvPackages(envName),
+    staleTime: 30_000,
+  });
+
+  const [newType, setNewType] = useState('deb');
+  const [newArch, setNewArch] = useState('amd64');
+  const [newUrl, setNewUrl] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+
+  const addMut = useMutation({
+    mutationFn: () => addEnvPackage(envName, {
+      type: newType,
+      architecture: newArch,
+      url: newUrl,
+      is_default: false,
+    }),
+    onSuccess: () => {
+      setErr(null);
+      setNewUrl('');
+      qc.invalidateQueries({ queryKey: ['env-packages', envName] });
+    },
+    onError: (e) => {
+      setErr(e instanceof Error ? e.message : 'Failed to add package');
+    },
+  });
+
+  const byType: Record<string, EnvironmentPackage[]> = {};
+  for (const p of packages ?? []) {
+    if (!byType[p.type]) byType[p.type] = [];
+    byType[p.type].push(p);
+  }
 
   return (
     <section
-      className="rounded-xl border border-[color:var(--border)] bg-[color:var(--bg-1)] p-4"
-      aria-label="Pre-built package URLs"
+      className="rounded-xl border border-[color:var(--border)] bg-[color:var(--bg-1)] p-4 mt-3"
+      aria-label="Multi-architecture packages"
     >
       <div className="mb-3 flex items-center justify-between gap-2">
         <h2 className="text-[12px] font-display font-semibold text-[color:var(--text-1)]">
-          Package URLs <span className="text-[color:var(--text-3)] font-normal">· optional</span>
+          Multi-architecture packages{' '}
+          <span className="text-[color:var(--text-3)] font-normal">· per-arch URLs</span>
         </h2>
         <span
           className="text-[10px] text-[color:var(--text-3)] cursor-help"
-          title="If set, install scripts fetch this pre-built package instead of building one on the fly. Useful for air-gapped or signed installs."
+          title="Register multiple packages per type, each targeting a different architecture (amd64, arm64, etc.). The TLS service serves the correct package based on the requested architecture."
         >
           ⓘ
         </span>
       </div>
-      <div className="space-y-2">
-        {rows.map((r) => (
-          <div key={r.label} className="flex items-center gap-2">
-            <span className="text-[10px] font-mono-tabular text-[color:var(--text-3)] uppercase tracking-[0.1em] w-[68px] flex-shrink-0">
-              {r.label}
-            </span>
-            <input
-              type="url"
-              value={r.value}
-              onChange={(ev) => r.onChange(ev.target.value)}
-              placeholder="https://…"
-              className={cn(
-                'flex-1 min-w-0 px-2.5 py-1 rounded-md text-[11px] font-mono-tabular',
-                'bg-[color:var(--bg-2)] border border-[color:var(--border)]',
-                'text-[color:var(--text-1)] placeholder:text-[color:var(--text-3)]',
-                'focus:outline-none focus:ring-2 focus:ring-[color:var(--signal)] focus:border-transparent',
-              )}
-            />
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => onSave(r.action, r.body())}
-              disabled={isPending}
-            >
-              Save
-            </Button>
-          </div>
-        ))}
+
+      {isLoading && <Skeleton className="h-16 w-full" />}
+      {!isLoading && (packages ?? []).length === 0 && (
+        <p className="text-[11px] text-[color:var(--text-3)] italic mb-3">
+          No multi-architecture packages configured.
+        </p>
+      )}
+      {!isLoading && Object.keys(byType).length > 0 && (
+        <div className="space-y-3 mb-4">
+          {PACKAGE_TYPES.map(({ value, label }) => {
+            const items = byType[value];
+            if (!items || items.length === 0) return null;
+            return (
+              <div key={value}>
+                <p className="text-[10px] font-mono-tabular text-[color:var(--text-3)] uppercase tracking-[0.1em] mb-1">
+                  {label}
+                </p>
+                <div className="space-y-1">
+                  {items.map((p) => (
+                    <PackageRow
+                      key={p.id}
+                      pkg={p}
+                      envName={envName}
+                      onRemoved={() => qc.invalidateQueries({ queryKey: ['env-packages', envName] })}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 flex-wrap">
+        <select
+          value={newType}
+          onChange={(e) => setNewType(e.target.value)}
+          className="text-[11px] px-2 py-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg-2)] text-[color:var(--text-1)]"
+        >
+          {PACKAGE_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>{t.value}</option>
+          ))}
+        </select>
+        <select
+          value={newArch}
+          onChange={(e) => setNewArch(e.target.value)}
+          className="text-[11px] px-2 py-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg-2)] text-[color:var(--text-1)]"
+        >
+          {ARCH_OPTIONS.map((a) => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+        <input
+          type="url"
+          value={newUrl}
+          onChange={(e) => setNewUrl(e.target.value)}
+          placeholder="https://… or local filename"
+          className={cn(
+            'flex-1 min-w-[200px] px-2.5 py-1 rounded-md text-[11px] font-mono-tabular',
+            'bg-[color:var(--bg-2)] border border-[color:var(--border)]',
+            'text-[color:var(--text-1)] placeholder:text-[color:var(--text-3)]',
+            'focus:outline-none focus:ring-2 focus:ring-[color:var(--signal)] focus:border-transparent',
+          )}
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => addMut.mutate()}
+          disabled={addMut.isPending || !newUrl}
+        >
+          Add
+        </Button>
       </div>
+      {err && (
+        <p className="mt-2 text-xs text-[color:var(--danger)]">{err}</p>
+      )}
     </section>
+  );
+}
+
+function PackageRow({
+  pkg,
+  envName,
+  onRemoved,
+}: {
+  pkg: EnvironmentPackage;
+  envName: string;
+  onRemoved: () => void;
+}) {
+  const [editUrl, setEditUrl] = useState(pkg.url);
+  const [savedFlash, setSavedFlash] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Sync when server data changes (e.g. after a refetch).
+  const [lastId, setLastId] = useState(pkg.id);
+  if (pkg.id !== lastId) {
+    setLastId(pkg.id);
+    setEditUrl(pkg.url);
+    setErr(null);
+  }
+
+  const dirty = editUrl !== pkg.url;
+
+  const updateMut = useMutation({
+    mutationFn: () => updateEnvPackage(envName, pkg.id, editUrl),
+    onSuccess: () => {
+      setErr(null);
+      setSavedFlash(true);
+      window.setTimeout(() => setSavedFlash(false), 1200);
+      onRemoved();
+    },
+    onError: (e) => {
+      setErr(e instanceof Error ? e.message : 'Save failed');
+    },
+  });
+
+  const removeMut = useMutation({
+    mutationFn: () => removeEnvPackage(envName, pkg.id),
+    onSuccess: onRemoved,
+  });
+
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] font-mono-tabular text-[color:var(--text-2)] w-16 flex-shrink-0">
+          {pkg.architecture || 'default'}
+        </span>
+        <input
+          type="url"
+          value={editUrl}
+          onChange={(e) => setEditUrl(e.target.value)}
+          className={cn(
+            'flex-1 min-w-0 px-2.5 py-1 rounded-md text-[11px] font-mono-tabular',
+            'bg-[color:var(--bg-2)] border border-[color:var(--border)]',
+            'text-[color:var(--text-1)] placeholder:text-[color:var(--text-3)]',
+            'focus:outline-none focus:ring-2 focus:ring-[color:var(--signal)] focus:border-transparent',
+          )}
+        />
+        {pkg.is_default && (
+          <span className="text-[9px] px-1 rounded bg-[color:var(--bg-2)] text-[color:var(--text-3)] flex-shrink-0">
+            default
+          </span>
+        )}
+        {dirty && (
+          <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)] flex-shrink-0">
+            pending
+          </span>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => updateMut.mutate()}
+          disabled={!dirty || updateMut.isPending}
+        >
+          {updateMut.isPending ? 'Saving…' : savedFlash ? 'Saved ✓' : 'Save'}
+        </Button>
+        <button
+          type="button"
+          onClick={() => removeMut.mutate()}
+          disabled={removeMut.isPending}
+          className="text-[10px] text-[color:var(--danger)] hover:underline disabled:opacity-40 flex-shrink-0"
+        >
+          remove
+        </button>
+      </div>
+      {err && (
+        <p className="mt-1 ml-[72px] text-[10px] text-[color:var(--danger)]">{err}</p>
+      )}
+    </div>
   );
 }

--- a/pkg/environments/environments.go
+++ b/pkg/environments/environments.go
@@ -126,6 +126,14 @@ func CreateEnvironment(backend *gorm.DB) *EnvManager {
 	if err := backend.AutoMigrate(&TLSEnvironment{}); err != nil {
 		log.Fatal().Msgf("Failed to AutoMigrate table (tls_environments): %v", err)
 	}
+	// table environment_packages
+	if err := backend.AutoMigrate(&EnvironmentPackage{}); err != nil {
+		log.Fatal().Msgf("Failed to AutoMigrate table (environment_packages): %v", err)
+	}
+	// Migrate legacy single-package fields into the new table (idempotent).
+	if err := e.MigrateLegacyPackages(); err != nil {
+		log.Warn().Err(err).Msg("legacy package migration failed")
+	}
 	return e
 }
 

--- a/pkg/environments/packages.go
+++ b/pkg/environments/packages.go
@@ -1,0 +1,210 @@
+package environments
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+// Architecture constants for enrolling packages.
+const (
+	ArchAmd64     string = "amd64"
+	ArchArm64     string = "arm64"
+	ArchX86_64    string = "x86_64"
+	ArchAarch64   string = "aarch64"
+	ArchUniversal string = "universal"
+)
+
+// ValidArchitectures is the set of accepted architecture values.
+var ValidArchitectures = map[string]bool{
+	ArchAmd64:     true,
+	ArchArm64:     true,
+	ArchX86_64:    true,
+	ArchAarch64:   true,
+	ArchUniversal: true,
+	"":            true, // empty = "any" / default, for backward compat
+}
+
+// EnvironmentPackage stores a single enrolling package for an environment.
+// An environment can have multiple packages per type (deb, rpm, msi, pkg),
+// each targeting a different architecture.
+type EnvironmentPackage struct {
+	ID            uint           `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+	EnvironmentID uint           `gorm:"index" json:"environment_id"`
+	Type          string         `gorm:"index" json:"type"`
+	Architecture  string         `json:"architecture"`
+	URL           string         `json:"url"`
+	IsDefault     bool           `json:"is_default"`
+}
+
+// GetPackages retrieves all packages for an environment.
+func (environment *EnvManager) GetPackages(envID uint) ([]EnvironmentPackage, error) {
+	var pkgs []EnvironmentPackage
+	if err := environment.DB.Where("environment_id = ?", envID).
+		Order("type, architecture").Find(&pkgs).Error; err != nil {
+		return pkgs, err
+	}
+	return pkgs, nil
+}
+
+// GetPackagesByType retrieves all packages of a specific type for an environment.
+func (environment *EnvManager) GetPackagesByType(envID uint, pkgType string) ([]EnvironmentPackage, error) {
+	var pkgs []EnvironmentPackage
+	if err := environment.DB.Where("environment_id = ? AND type = ?", envID, pkgType).
+		Order("architecture").Find(&pkgs).Error; err != nil {
+		return pkgs, err
+	}
+	return pkgs, nil
+}
+
+// GetPackage retrieves a specific package by type and architecture.
+func (environment *EnvManager) GetPackage(envID uint, pkgType, arch string) (EnvironmentPackage, error) {
+	var pkg EnvironmentPackage
+	// Try exact match first.
+	err := environment.DB.Where("environment_id = ? AND type = ? AND architecture = ?", envID, pkgType, arch).
+		First(&pkg).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return pkg, err
+	}
+	if err == nil {
+		return pkg, nil
+	}
+	// Fall back to the default package for this type.
+	err = environment.DB.Where("environment_id = ? AND type = ? AND is_default = ?", envID, pkgType, true).
+		First(&pkg).Error
+	if err == nil {
+		return pkg, nil
+	}
+	// Fall back to any package of this type (first by architecture order).
+	err = environment.DB.Where("environment_id = ? AND type = ?", envID, pkgType).
+		Order("architecture").First(&pkg).Error
+	return pkg, err
+}
+
+// AddPackage adds a new enrolling package to an environment.
+func (environment *EnvManager) AddPackage(envID uint, pkgType, arch, url string, isDefault bool) error {
+	if !ValidArchitectures[arch] {
+		return fmt.Errorf("invalid architecture %q", arch)
+	}
+	if err := ValidatePackageReference(url); err != nil {
+		return fmt.Errorf("AddPackage %w", err)
+	}
+	pkg := EnvironmentPackage{
+		EnvironmentID: envID,
+		Type:          pkgType,
+		Architecture:  arch,
+		URL:           url,
+		IsDefault:     isDefault,
+	}
+	if isDefault {
+		// Unset default on other packages of the same type.
+		if err := environment.DB.Model(&EnvironmentPackage{}).
+			Where("environment_id = ? AND type = ?", envID, pkgType).
+			Update("is_default", false).Error; err != nil {
+			return fmt.Errorf("AddPackage clear default %w", err)
+		}
+	}
+	if err := environment.DB.Create(&pkg).Error; err != nil {
+		return fmt.Errorf("AddPackage create %w", err)
+	}
+	return nil
+}
+
+// RemovePackage removes a package by ID.
+func (environment *EnvManager) RemovePackage(envID, pkgID uint) error {
+	result := environment.DB.Where("environment_id = ? AND id = ?", envID, pkgID).
+		Delete(&EnvironmentPackage{})
+	if result.Error != nil {
+		return fmt.Errorf("RemovePackage %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// SetDefaultPackage sets a package as the default for its type.
+func (environment *EnvManager) SetDefaultPackage(envID, pkgID uint) error {
+	// Find the package to get its type.
+	var pkg EnvironmentPackage
+	if err := environment.DB.Where("environment_id = ? AND id = ?", envID, pkgID).First(&pkg).Error; err != nil {
+		return err
+	}
+	// Unset default on other packages of the same type.
+	if err := environment.DB.Model(&EnvironmentPackage{}).
+		Where("environment_id = ? AND type = ?", envID, pkg.Type).
+		Update("is_default", false).Error; err != nil {
+		return err
+	}
+	// Set the new default.
+	return environment.DB.Model(&pkg).Update("is_default", true).Error
+}
+
+// UpdatePackageURL updates the URL of an existing package.
+func (environment *EnvManager) UpdatePackageURL(envID, pkgID uint, url string) error {
+	if err := ValidatePackageReference(url); err != nil {
+		return fmt.Errorf("UpdatePackageURL %w", err)
+	}
+	result := environment.DB.Model(&EnvironmentPackage{}).
+		Where("environment_id = ? AND id = ?", envID, pkgID).
+		Update("url", url)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// MigrateLegacyPackages copies the single-package fields from TLSEnvironment
+// into the new EnvironmentPackage table. Called once during AutoMigrate.
+func (environment *EnvManager) MigrateLegacyPackages() error {
+	var envs []TLSEnvironment
+	if err := environment.DB.Find(&envs).Error; err != nil {
+		return err
+	}
+	for _, env := range envs {
+		legacy := []struct {
+			Type string
+			URL  string
+		}{
+			{settings.PackageDeb, env.DebPackage},
+			{settings.PackageRpm, env.RpmPackage},
+			{settings.PackageMsi, env.MsiPackage},
+			{settings.PackagePkg, env.PkgPackage},
+		}
+		for _, p := range legacy {
+			if p.URL == "" {
+				continue
+			}
+			// Check if packages already exist for this env+type (idempotent).
+			var count int64
+			environment.DB.Model(&EnvironmentPackage{}).
+				Where("environment_id = ? AND type = ?", env.ID, p.Type).
+				Count(&count)
+			if count > 0 {
+				continue
+			}
+			pkg := EnvironmentPackage{
+				EnvironmentID: env.ID,
+				Type:          p.Type,
+				Architecture:  "",
+				URL:           p.URL,
+				IsDefault:     true,
+			}
+			if err := environment.DB.Create(&pkg).Error; err != nil {
+				log.Warn().Err(err).Uint("env_id", env.ID).Str("type", p.Type).
+					Msg("legacy package migration: failed to create row")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/environments/packages_test.go
+++ b/pkg/environments/packages_test.go
@@ -1,0 +1,173 @@
+package environments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupPackagesTestDB(t *testing.T) *EnvManager {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&TLSEnvironment{}, &EnvironmentPackage{}))
+	return &EnvManager{DB: db}
+}
+
+func TestAddPackage_Success(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret"}
+	require.NoError(t, mgr.Create(&env))
+
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "amd64", "osquery-amd64.deb", true))
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "arm64", "osquery-arm64.deb", false))
+
+	pkgs, err := mgr.GetPackagesByType(env.ID, "deb")
+	require.NoError(t, err)
+	assert.Len(t, pkgs, 2)
+	assert.Equal(t, "amd64", pkgs[0].Architecture)
+	assert.Equal(t, "arm64", pkgs[1].Architecture)
+}
+
+func TestAddPackage_InvalidArchitecture(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret"}
+	require.NoError(t, mgr.Create(&env))
+
+	err := mgr.AddPackage(env.ID, "deb", "bogus-arch", "url", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid architecture")
+}
+
+func TestGetPackage_ByArchitecture(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret"}
+	require.NoError(t, mgr.Create(&env))
+
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "amd64", "osquery-amd64.deb", false))
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "arm64", "osquery-arm64.deb", false))
+
+	pkg, err := mgr.GetPackage(env.ID, "deb", "arm64")
+	require.NoError(t, err)
+	assert.Equal(t, "osquery-arm64.deb", pkg.URL)
+	assert.Equal(t, "arm64", pkg.Architecture)
+}
+
+func TestGetPackage_FallbackToDefault(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret"}
+	require.NoError(t, mgr.Create(&env))
+
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "amd64", "osquery-amd64.deb", true))
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "arm64", "osquery-arm64.deb", false))
+
+	// Request an arch that doesn't exist — should fall back to default.
+	pkg, err := mgr.GetPackage(env.ID, "deb", "x86_64")
+	require.NoError(t, err)
+	assert.Equal(t, "osquery-amd64.deb", pkg.URL)
+	assert.True(t, pkg.IsDefault)
+}
+
+func TestGetPackage_FallbackToFirstAvailable(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret"}
+	require.NoError(t, mgr.Create(&env))
+
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "amd64", "osquery-amd64.deb", false))
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "arm64", "osquery-arm64.deb", false))
+
+	// No default set, no exact match — falls back to first by architecture order.
+	pkg, err := mgr.GetPackage(env.ID, "deb", "x86_64")
+	require.NoError(t, err)
+	assert.Equal(t, "amd64", pkg.Architecture)
+}
+
+func TestRemovePackage_Success(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret"}
+	require.NoError(t, mgr.Create(&env))
+
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "amd64", "osquery.deb", false))
+	pkgs, _ := mgr.GetPackagesByType(env.ID, "deb")
+	require.Len(t, pkgs, 1)
+
+	require.NoError(t, mgr.RemovePackage(env.ID, pkgs[0].ID))
+	pkgs, _ = mgr.GetPackagesByType(env.ID, "deb")
+	assert.Empty(t, pkgs)
+}
+
+func TestRemovePackage_NotFound(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret"}
+	require.NoError(t, mgr.Create(&env))
+
+	err := mgr.RemovePackage(env.ID, 999)
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestSetDefaultPackage(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret"}
+	require.NoError(t, mgr.Create(&env))
+
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "amd64", "osquery-amd64.deb", true))
+	require.NoError(t, mgr.AddPackage(env.ID, "deb", "arm64", "osquery-arm64.deb", false))
+
+	pkgs, _ := mgr.GetPackagesByType(env.ID, "deb")
+	assert.True(t, pkgs[0].IsDefault)
+	assert.False(t, pkgs[1].IsDefault)
+
+	// Set arm64 as default.
+	require.NoError(t, mgr.SetDefaultPackage(env.ID, pkgs[1].ID))
+
+	pkgs, _ = mgr.GetPackagesByType(env.ID, "deb")
+	assert.False(t, pkgs[0].IsDefault)
+	assert.True(t, pkgs[1].IsDefault)
+}
+
+func TestMigrateLegacyPackages(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{
+		Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret",
+		DebPackage: "osquery.deb",
+		RpmPackage: "https://example.com/osquery.rpm",
+	}
+	require.NoError(t, mgr.Create(&env))
+
+	require.NoError(t, mgr.MigrateLegacyPackages())
+
+	// DEB should be migrated.
+	debPkgs, err := mgr.GetPackagesByType(env.ID, "deb")
+	require.NoError(t, err)
+	assert.Len(t, debPkgs, 1)
+	assert.Equal(t, "osquery.deb", debPkgs[0].URL)
+	assert.True(t, debPkgs[0].IsDefault)
+
+	// RPM should be migrated.
+	rpmPkgs, err := mgr.GetPackagesByType(env.ID, "rpm")
+	require.NoError(t, err)
+	assert.Len(t, rpmPkgs, 1)
+	assert.Equal(t, "https://example.com/osquery.rpm", rpmPkgs[0].URL)
+
+	// MSI and PKG should not exist (were empty).
+	msiPkgs, _ := mgr.GetPackagesByType(env.ID, "msi")
+	assert.Empty(t, msiPkgs)
+}
+
+func TestMigrateLegacyPackages_Idempotent(t *testing.T) {
+	mgr := setupPackagesTestDB(t)
+	env := TLSEnvironment{
+		Name: "test", UUID: "test-uuid", Hostname: "host", Secret: "secret",
+		DebPackage: "osquery.deb",
+	}
+	require.NoError(t, mgr.Create(&env))
+
+	require.NoError(t, mgr.MigrateLegacyPackages())
+	require.NoError(t, mgr.MigrateLegacyPackages())
+
+	debPkgs, _ := mgr.GetPackagesByType(env.ID, "deb")
+	assert.Len(t, debPkgs, 1, "migration should not duplicate")
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -133,6 +133,19 @@ type ApiActionsRequest struct {
 	DebPkgURL   string `json:"url_deb_pkg"`
 }
 
+// ApiAddPackageRequest to add an enrolling package to an environment.
+type ApiAddPackageRequest struct {
+	Type      string `json:"type"`
+	Arch      string `json:"architecture"`
+	URL       string `json:"url"`
+	IsDefault bool   `json:"is_default"`
+}
+
+// ApiUpdatePackageRequest to update an enrolling package URL.
+type ApiUpdatePackageRequest struct {
+	URL string `json:"url"`
+}
+
 // ApiEnvRequest to receive environment action requests
 type ApiEnvRequest struct {
 	Action   string `json:"action"`


### PR DESCRIPTION
## Summary

Implements multi-architecture enrolling packages so an environment can have multiple `.deb`, `.rpm`, `.pkg`, or `.msi` packages — each targeting a different architecture (amd64, arm64, x86_64, aarch64, universal).

Closes #466.

### Problem

The `TLSEnvironment` model stored one package URL per type (`DebPackage`, `RpmPackage`, `MsiPackage`, `PkgPackage`). An operator with both `amd64` and `arm64` Linux nodes needed two `.deb` and two `.rpm` packages, but the model only had room for one of each — no way to distinguish architecture.

### Changes

**New model** (`pkg/environments/packages.go`)
- `EnvironmentPackage` table — one row per (environment, type, architecture, URL) with `is_default` flag
- CRUD methods: `GetPackages`, `GetPackagesByType`, `GetPackage` (with fallback chain: exact architecture → default → first available), `AddPackage`, `RemovePackage`, `SetDefaultPackage`
- `MigrateLegacyPackages` — idempotent migration that copies existing single-package fields into the new table on first boot
- Architecture validation (`ValidArchitectures`): `amd64`, `arm64`, `x86_64`, `aarch64`, `universal`

**Auto-migrate** (`pkg/environments/environments.go`)
- `CreateEnvironment` now auto-migrates `EnvironmentPackage` and runs the legacy migration

**TLS download handler** (`cmd/tls/handlers/post.go`)
- Checks the `EnvironmentPackage` table first (by type + arch), falls back to legacy single-package fields
- New route: `GET /{env}/{secretpath}/package/{package}/{arch}` — serves architecture-specific packages
- Old route: `GET /{env}/{secretpath}/package/{package}` — still works (backward compat)

**API handlers** (`cmd/api/handlers/environments_packages.go`)

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/environments/{env}/packages` | List all packages |
| POST | `/api/v1/environments/{env}/packages` | Add a package (type, arch, url, is_default) |
| DELETE | `/api/v1/environments/{env}/packages/{id}` | Remove a package |

All require `AdminLevel` permissions and are audit-logged.

**Frontend** (`frontend/src/features/enrollment/EnrollPage.tsx`)
- New `PackageListCard` component below the existing `PackageUrlCard`
- Shows all multi-architecture packages grouped by type (DEB / RPM / PKG / MSI)
- Add form with type selector, architecture selector, and URL input
- Remove button per package with `is_default` badge
- API client functions: `listEnvPackages`, `addEnvPackage`, `removeEnvPackage` in `frontend/src/api/environments.ts`

**Tests** (10 new in `pkg/environments/packages_test.go`)
- `TestAddPackage_Success` — add two packages (amd64 + arm64) for the same type
- `TestAddPackage_InvalidArchitecture` — rejects unknown architecture
- `TestGetPackage_ByArchitecture` — exact architecture match
- `TestGetPackage_FallbackToDefault` — falls back to `is_default` package when arch not found
- `TestGetPackage_FallbackToFirstAvailable` — falls back to first by architecture order when no default
- `TestRemovePackage_Success` — removes a package by ID
- `TestRemovePackage_NotFound` — returns `ErrRecordNotFound` for missing ID
- `TestSetDefaultPackage` — sets a new default and unsets the old one
- `TestMigrateLegacyPackages` — migrates `DebPackage`/`RpmPackage` fields into the new table
- `TestMigrateLegacyPackages_Idempotent` — running migration twice doesn't duplicate rows

### Backward compatibility

- The legacy `DebPackage`/`RpmPackage`/`MsiPackage`/`PkgPackage` fields and their `Update*Package` methods are unchanged
- The old TLS route (without `{arch}`) still works — serves from the new table or falls back to legacy fields
- The legacy `PackageUrlCard` in the frontend is preserved alongside the new `PackageListCard`
- Migration is idempotent — existing deployments are transparently upgraded on next boot

### Validation

- `go build ./...` — clean
- `go test ./...` — all packages pass (10 new tests)
- `golangci-lint run ./pkg/environments/...` — 0 issues
- `npm run check` — TypeScript typecheck clean
- `npm test` — 34 test files / 209 tests pass
- `gofmt` clean on all modified files