### PR TITLE
Updated `fake_news_go` tool to simulate load

### DIFF
--- a/tools/fake_news_go/README.md
+++ b/tools/fake_news_go/README.md
@@ -23,14 +23,40 @@ It keeps the terminal workflow of the original `fake_news.py`, but adds a struct
 - `--env`: environment UUID
 - `--secret`: enroll secret for `osctrl-tls`
 - `--mode`: `steady` or `sweep`
-- `--display-mode`: `quiet`, `summary`, `verbose`, `dashboard`, or `json`
+- `--nodes` or `-n`: number of simulated nodes per environment (default 5)
+- `--status`: interval in seconds for status requests (default 60)
+- `--result`: interval in seconds for result requests (default 60)
+- `--config`: interval in seconds for config requests (default 45)
+- `--query`: interval in seconds for query requests (default 30)
+- `--enroll-delay`: delay in milliseconds between each node enrollment to avoid rate limiting (default 0)
+- `--posture-level`: simulate security posture data: `none`, `good`, `moderate`, or `poor` (default `none`)
+- `--display-mode` or `--output-mode`: `quiet`, `summary`, `verbose`, `dashboard`, or `json`
+- `--verbose` or `-v`: enable verbose output
+- `--insecure`: skip TLS certificate verification
+- `--summary-interval`: interval in seconds for summary reports (default 30)
 - `--error-threshold`: stop sweep when error rate exceeds this ratio
 - `--p95-threshold`: stop sweep when p95 exceeds this duration
 - `--sweep-start-nodes`, `--sweep-step-nodes`, `--sweep-stages`
 - `--settle`, `--sample`
-- `--state`: persisted node state file
+- `--osquery-binary`: path to `osqueryi` binary (default `osqueryi`)
+- `--state`: persisted node state file (default `fake_news_state.json`)
 
 The harness now simulates distributed query results internally and does not require a local `osqueryi` binary for query-write traffic.
+
+### `--posture-level`
+
+Sends fake security posture data to the TLS `/write` endpoint on startup and every 24 hours. The level controls what kind of data is generated:
+
+| Level | Description |
+|-------|-------------|
+| `none` | No posture data sent (default) |
+| `good` | Healthy node: few packages, few users, encrypted disk, only safe ports, all standard SUID binaries, many patches — scores green/low risk |
+| `moderate` | Some issues: more packages, more users, possibly unencrypted disk, more listening ports, some non-standard SUID binaries — scores yellow/medium risk |
+| `poor` | At-risk node: many packages, many users, unencrypted disk, risky ports (telnet, FTP, RDP), many non-standard SUID binaries, few patches — scores red/high risk |
+
+### `--enroll-delay`
+
+Adds a delay (in milliseconds) between each node enrollment. This avoids triggering rate limits on the TLS enroll endpoint when enrolling large numbers of nodes. For example, `--enroll-delay 200` spaces enrollments 200ms apart, so 100 nodes enroll over ~20 seconds instead of all at once.
 
 Default runtime files:
 
@@ -83,6 +109,31 @@ go run ./tools/fake_news_go \
   --env YOUR_ENV_UUID \
   --secret YOUR_SECRET \
   --nodes 50 \
+  --display-mode dashboard
+```
+
+Enroll 100 nodes slowly (200ms apart) with good posture data:
+
+```bash
+go run ./tools/fake_news_go \
+  --tls-url http://localhost:9000 \
+  --env YOUR_ENV_UUID \
+  --secret YOUR_SECRET \
+  --nodes 100 \
+  --enroll-delay 200 \
+  --posture-level good \
+  --display-mode dashboard
+```
+
+Enroll 50 nodes with poor posture (unencrypted disk, risky ports, many users):
+
+```bash
+go run ./tools/fake_news_go \
+  --tls-url http://localhost:9000 \
+  --env YOUR_ENV_UUID \
+  --secret YOUR_SECRET \
+  --nodes 50 \
+  --posture-level poor \
   --display-mode dashboard
 ```
 

--- a/tools/fake_news_go/fake_news.go
+++ b/tools/fake_news_go/fake_news.go
@@ -26,6 +26,7 @@ import (
 	internalrunner "github.com/jmpsec/osctrl/tools/fake_news_go/internal/runner"
 	internaltransport "github.com/jmpsec/osctrl/tools/fake_news_go/internal/transport"
 	internaltui "github.com/jmpsec/osctrl/tools/fake_news_go/internal/tui"
+	internalworkload "github.com/jmpsec/osctrl/tools/fake_news_go/internal/workload"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -266,6 +267,8 @@ type FakeNewsConfig struct {
 	OutputMode      OutputMode
 	SummaryInterval int
 	StateFile       string
+	PostureLevel    string
+	EnrollDelay     int
 }
 
 type runtimeTarget struct {
@@ -927,6 +930,44 @@ func queryWrite(client *HTTPClient, node *Node, queryName string, query interfac
 	}
 }
 
+// sendPostureData sends fake posture query results to the TLS write endpoint
+// once on startup, then every 24 hours. The posture level (good/moderate/poor)
+// controls the kind of data generated — e.g. "poor" produces more users, more
+// listening ports, unencrypted disks, and suspicious cron jobs.
+func sendPostureData(ctx context.Context, client *HTTPClient, node *Node, urls map[string]string, config FakeNewsConfig) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano() + int64(node.Identifier[len(node.Identifier)-1])))
+	level := internalworkload.PostureLevel(config.PostureLevel)
+
+	sendOnce := func() {
+		results := internalworkload.GeneratePostureResults(level, r)
+		for queryName, rows := range results {
+			data := generateQueryWriteRequest(*node, queryName, rows)
+			headers := map[string]string{"X-Real-IP": node.IP}
+			code, _, err := client.Post(urls["write"], data, headers)
+			success := err == nil && code == 200
+			logOperationWithURL(QueryWriteOp, node.Name, urls["write"], 0, success, config)
+			if config.OutputMode == VerboseMode {
+				fmt.Printf("Posture data sent: %s (%d rows) for node %s\n", queryName, len(rows), node.Name)
+			}
+		}
+	}
+
+	// Send immediately on startup.
+	sendOnce()
+
+	// Then every 24 hours.
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sendOnce()
+		}
+	}
+}
+
 // loadNodesFromFile loads nodes from a JSON file
 func loadNodesFromFile(filename string) ([]Node, error) {
 	data, err := os.ReadFile(filename)
@@ -1132,10 +1173,9 @@ func (gs *GlobalStats) GetNodeCounts() (int, int) {
 func printSummary() {
 	uptime := globalStats.GetUptime()
 
-	fmt.Printf("\n%s\n", strings.Repeat("=", 80))
-	fmt.Printf("FAKE NEWS GENERATOR - PERFORMANCE SUMMARY\n")
-	fmt.Printf("Uptime: %s\n", uptime.Round(time.Second))
-	fmt.Printf("%s\n", strings.Repeat("=", 80))
+	fmt.Printf("\n%s\n", strings.Repeat("=", 90))
+	fmt.Printf("  FAKE NEWS GENERATOR — PERFORMANCE SUMMARY  (uptime %s)\n", uptime.Round(time.Second))
+	fmt.Printf("%s\n\n", strings.Repeat("=", 90))
 
 	operations := []struct {
 		name string
@@ -1149,37 +1189,44 @@ func printSummary() {
 		{"Query Write", QueryWriteOp},
 	}
 
+	fmt.Printf("  %-14s %10s %10s %10s %10s %10s %10s %10s\n",
+		"Operation", "Count", "Success%", "Min(ms)", "Avg(ms)", "Max(ms)", "P95(ms)", "P99(ms)")
+	fmt.Printf("  %s\n", strings.Repeat("-", 86))
+
 	for _, op := range operations {
 		stats := globalStats.GetOperationStats(op.op)
 		min, max, avg, p95, p99, count, success, _ := stats.GetStats()
 
 		if count > 0 {
 			successRate := float64(success) / float64(count) * 100
-			fmt.Printf("%-12s | Count: %6d | Success: %5.1f%% | Min: %4dms | Avg: %4dms | Max: %4dms | P95: %4dms | P99: %4dms\n",
+			fmt.Printf("  %-14s %10d %9.1f%% %10d %10d %10d %10d %10d\n",
 				op.name, count, successRate, min.Milliseconds(), avg.Milliseconds(), max.Milliseconds(), p95.Milliseconds(), p99.Milliseconds())
+		} else {
+			fmt.Printf("  %-14s %10d %10s %10s %10s %10s %10s %10s\n",
+				op.name, 0, "-", "-", "-", "-", "-", "-")
 		}
 	}
 
-	// Print URL statistics
-	fmt.Printf("%s\n", strings.Repeat("=", 80))
-	fmt.Printf("URL STATISTICS - ABSOLUTE NUMBERS\n")
-	fmt.Printf("%s\n", strings.Repeat("=", 80))
+	fmt.Printf("\n  %s\n", strings.Repeat("=", 86))
+	fmt.Printf("  URL STATISTICS\n")
+	fmt.Printf("  %s\n\n", strings.Repeat("-", 86))
 
 	urlStats := globalStats.GetURLStats()
 	if len(urlStats) > 0 {
-		fmt.Printf("%-50s | %8s | %8s | %8s | %8s\n", "URL", "Total", "Success", "Failed", "Success%")
-		fmt.Printf("%s\n", strings.Repeat("-", 80))
-
+		fmt.Printf("  %-55s %8s %8s %8s %9s\n", "URL", "Total", "Success", "Failed", "Success%")
+		fmt.Printf("  %s\n", strings.Repeat("-", 86))
 		for url, stats := range urlStats {
 			_, _, _, _, _, count, success, fail := stats.GetStats()
 			if count > 0 {
 				successRate := float64(success) / float64(count) * 100
-				fmt.Printf("%-50s | %8d | %8d | %8d | %7.1f%%\n",
-					url, count, success, fail, successRate)
+				if len(url) > 55 {
+					url = "..." + url[len(url)-52:]
+				}
+				fmt.Printf("  %-55s %8d %8d %8d %8.1f%%\n", url, count, success, fail, successRate)
 			}
 		}
 	}
-	fmt.Printf("%s\n\n", strings.Repeat("=", 80))
+	fmt.Printf("\n%s\n\n", strings.Repeat("=", 90))
 }
 
 // printDashboard prints a real-time dashboard
@@ -1189,7 +1236,7 @@ func printDashboard() {
 
 	uptime := globalStats.GetUptime()
 
-	fmt.Printf("FAKE NEWS GENERATOR - REAL-TIME DASHBOARD\n")
+	fmt.Printf("FAKE NEWS GENERATOR — REAL-TIME DASHBOARD\n")
 	fmt.Printf("Uptime: %s | Last Update: %s\n", uptime.Round(time.Second), time.Now().Format("15:04:05"))
 	fmt.Printf("%s\n", strings.Repeat("-", 100))
 
@@ -1205,9 +1252,9 @@ func printDashboard() {
 		{"Query Write", QueryWriteOp},
 	}
 
-	fmt.Printf("%-12s | %8s | %8s | %8s | %8s | %8s | %8s | %8s\n",
+	fmt.Printf("  %-14s %10s %10s %10s %10s %10s %10s %10s\n",
 		"Operation", "Count", "Success%", "Min(ms)", "Avg(ms)", "Max(ms)", "P95(ms)", "P99(ms)")
-	fmt.Printf("%s\n", strings.Repeat("-", 100))
+	fmt.Printf("  %s\n", strings.Repeat("-", 96))
 
 	for _, op := range operations {
 		stats := globalStats.GetOperationStats(op.op)
@@ -1215,20 +1262,20 @@ func printDashboard() {
 
 		if count > 0 {
 			successRate := float64(success) / float64(count) * 100
-			fmt.Printf("%-12s | %8d | %7.1f%% | %8d | %8d | %8d | %8d | %8d\n",
+			fmt.Printf("  %-14s %10d %9.1f%% %10d %10d %10d %10d %10d\n",
 				op.name, count, successRate, min.Milliseconds(), avg.Milliseconds(), max.Milliseconds(), p95.Milliseconds(), p99.Milliseconds())
 		} else {
-			fmt.Printf("%-12s | %8d | %7s | %8s | %8s | %8s | %8s | %8s\n",
+			fmt.Printf("  %-14s %10d %10s %10s %10s %10s %10s %10s\n",
 				op.name, 0, "-", "-", "-", "-", "-", "-")
 		}
 	}
-	fmt.Printf("%s\n", strings.Repeat("-", 100))
+	fmt.Printf("  %s\n\n", strings.Repeat("-", 96))
 
-	// Print URL statistics section
-	fmt.Printf("\nURL STATISTICS - ABSOLUTE NUMBERS\n")
-	fmt.Printf("%s\n", strings.Repeat("-", 100))
-	fmt.Printf("%-50s | %8s | %8s | %8s | %8s\n", "URL", "Total", "Success", "Failed", "Success%")
-	fmt.Printf("%s\n", strings.Repeat("-", 100))
+	// URL statistics
+	fmt.Printf("URL STATISTICS\n")
+	fmt.Printf("  %s\n", strings.Repeat("-", 96))
+	fmt.Printf("  %-55s %8s %8s %8s %9s\n", "URL", "Total", "Success", "Failed", "Success%")
+	fmt.Printf("  %s\n", strings.Repeat("-", 96))
 
 	urlStats := globalStats.GetURLStats()
 	if len(urlStats) > 0 {
@@ -1236,14 +1283,16 @@ func printDashboard() {
 			_, _, _, _, _, count, success, fail := stats.GetStats()
 			if count > 0 {
 				successRate := float64(success) / float64(count) * 100
-				fmt.Printf("%-50s | %8d | %8d | %8d | %7.1f%%\n",
-					url, count, success, fail, successRate)
+				if len(url) > 55 {
+					url = "..." + url[len(url)-52:]
+				}
+				fmt.Printf("  %-55s %8d %8d %8d %8.1f%%\n", url, count, success, fail, successRate)
 			}
 		}
 	} else {
-		fmt.Printf("%-50s | %8s | %8s | %8s | %8s\n", "No data yet", "-", "-", "-", "-")
+		fmt.Printf("  %-55s %8s %8s %8s %9s\n", "No data yet", "-", "-", "-", "-")
 	}
-	fmt.Printf("%s\n", strings.Repeat("-", 100))
+	fmt.Printf("  %s\n", strings.Repeat("-", 96))
 }
 
 // printJSONStats prints statistics in JSON format
@@ -1640,6 +1689,9 @@ func enrollNodes(client *HTTPClient, nodes []Node, secret string, urls map[strin
 			nodes[idx].Key = key
 			mu.Unlock()
 		}(i)
+		if config.EnrollDelay > 0 {
+			time.Sleep(time.Duration(config.EnrollDelay) * time.Millisecond)
+		}
 	}
 	wg.Wait()
 }
@@ -1662,6 +1714,9 @@ func startTraffic(ctx context.Context, client *HTTPClient, nodes []Node, urls ma
 			time.Duration(config.ConfigInterval)*time.Second, &mutex, config)
 		go queryRead(ctx, client, &nodes[i], urls, config.Secret,
 			time.Duration(config.QueryInterval)*time.Second, &mutex, config, writeSem)
+		if config.PostureLevel != "" {
+			go sendPostureData(ctx, client, &nodes[i], urls, config)
+		}
 	}
 }
 
@@ -1799,6 +1854,7 @@ func run() error {
 		Insecure:        parsedConfig.Insecure,
 		SummaryInterval: parsedConfig.SummaryInterval,
 		StateFile:       parsedConfig.StateFile,
+		PostureLevel:    parsedConfig.PostureLevel,
 	}
 
 	osqueryRunner = internalosquery.NewDefault(parsedConfig.OSQueryBinary)

--- a/tools/fake_news_go/internal/config/config.go
+++ b/tools/fake_news_go/internal/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	Insecure        bool
 	OutputMode      string
 	SummaryInterval int
+	PostureLevel    string
+	EnrollDelay     int
 }
 
 func (c Config) Validate() error {
@@ -135,6 +137,8 @@ func Parse(args []string) (Config, error) {
 	fs.StringVar(&outputModeValue, "mode-output", "summary", "output mode: quiet, summary, verbose, dashboard, json")
 	fs.StringVar(&outputModeValue, "display-mode", "summary", "output mode: quiet, summary, verbose, dashboard, json")
 	fs.IntVar(&cfg.SummaryInterval, "summary-interval", 30, "interval in seconds for summary reports")
+	fs.StringVar(&cfg.PostureLevel, "posture-level", "", "simulate posture data: none, good, moderate, poor")
+	fs.IntVar(&cfg.EnrollDelay, "enroll-delay", 0, "delay in milliseconds between each node enrollment to avoid rate limiting")
 
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err

--- a/tools/fake_news_go/internal/workload/posture.go
+++ b/tools/fake_news_go/internal/workload/posture.go
@@ -1,0 +1,247 @@
+package workload
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// PostureLevel controls the kind of fake posture data generated.
+type PostureLevel string
+
+const (
+	PostureLevelNone     PostureLevel = ""
+	PostureLevelGood     PostureLevel = "good"
+	PostureLevelModerate PostureLevel = "moderate"
+	PostureLevelPoor     PostureLevel = "poor"
+)
+
+// PostureQueryPrefix mirrors pkg/posture.DefaultQueryPrefix.
+const PostureQueryPrefix = "osctrl:posture:"
+
+// PostureQuery is a fake posture query definition.
+type PostureQuery struct {
+	Name     string
+	Columns  []string
+	Generate func(level PostureLevel, r *rand.Rand) []map[string]interface{}
+}
+
+// PostureQueries defines the set of posture queries the tool will send.
+// Category names match what pkg/posture/scoring.go expects so the scoring
+// engine evaluates them correctly.
+var PostureQueries = []PostureQuery{
+	{
+		Name:    "packages_deb",
+		Columns: []string{"name", "version", "revision", "repo"},
+		Generate: func(level PostureLevel, r *rand.Rand) []map[string]interface{} {
+			count := 0
+			switch level {
+			case PostureLevelGood:
+				count = r.Intn(20) + 40
+			case PostureLevelModerate:
+				count = r.Intn(30) + 80
+			case PostureLevelPoor:
+				count = r.Intn(50) + 150
+			}
+			results := make([]map[string]interface{}, 0, count)
+			for i := 0; i < count; i++ {
+				results = append(results, map[string]interface{}{
+					"name":     fmt.Sprintf("package-%d", i),
+					"version":  fmt.Sprintf("%d.%d.%d", r.Intn(5), r.Intn(20), r.Intn(10)),
+					"revision": "1",
+					"repo":     "main",
+				})
+			}
+			return results
+		},
+	},
+	{
+		Name:    "users",
+		Columns: []string{"username", "uid", "gid", "shell"},
+		Generate: func(level PostureLevel, r *rand.Rand) []map[string]interface{} {
+			// Good: few users, no extra root. Poor: many users, maybe extra root.
+			count := 0
+			extraRoot := 0
+			switch level {
+			case PostureLevelGood:
+				count = r.Intn(2) + 2
+			case PostureLevelModerate:
+				count = r.Intn(5) + 5
+			case PostureLevelPoor:
+				count = r.Intn(10) + 20
+				extraRoot = r.Intn(2)
+			}
+			shells := []string{"/bin/bash", "/bin/sh", "/bin/zsh"}
+			nologinShells := []string{"/usr/sbin/nologin", "/bin/false"}
+			results := make([]map[string]interface{}, 0, count)
+			// Always include root first
+			results = append(results, map[string]interface{}{
+				"username": "root", "uid": 0, "gid": 0, "shell": "/bin/bash",
+			})
+			for i := 0; i < extraRoot; i++ {
+				results = append(results, map[string]interface{}{
+					"username": fmt.Sprintf("root%d", i), "uid": 0, "gid": 0, "shell": "/bin/bash",
+				})
+			}
+			for i := 0; i < count; i++ {
+				shell := shells[r.Intn(len(shells))]
+				if level == PostureLevelGood && r.Intn(3) == 0 {
+					shell = nologinShells[r.Intn(len(nologinShells))]
+				}
+				results = append(results, map[string]interface{}{
+					"username": fmt.Sprintf("user%d", i),
+					"uid":      1000 + i,
+					"gid":      1000 + i,
+					"shell":    shell,
+				})
+			}
+			return results
+		},
+	},
+	{
+		Name:    "disk_encryption",
+		Columns: []string{"name", "encrypted", "type"},
+		Generate: func(level PostureLevel, r *rand.Rand) []map[string]interface{} {
+			// Good: all encrypted. Poor: unencrypted.
+			encrypted := "1"
+			if level == PostureLevelPoor {
+				encrypted = "0"
+			} else if level == PostureLevelModerate && r.Intn(2) == 0 {
+				encrypted = "0"
+			}
+			return []map[string]interface{}{
+				{"name": "/dev/sda1", "encrypted": encrypted, "type": "LUKS1"},
+			}
+		},
+	},
+	{
+		Name:    "listening_ports",
+		Columns: []string{"pid", "port", "protocol", "address"},
+		Generate: func(level PostureLevel, r *rand.Rand) []map[string]interface{} {
+			count := 0
+			switch level {
+			case PostureLevelGood:
+				count = r.Intn(3) + 2
+			case PostureLevelModerate:
+				count = r.Intn(10) + 10
+			case PostureLevelPoor:
+				count = r.Intn(20) + 30
+			}
+			// Good: only safe ports (22, 443). Poor: include risky ports (23, 21, 3389).
+			safePorts := []int{22, 443, 80}
+			riskyPorts := []int{23, 21, 3389, 445, 161}
+			results := make([]map[string]interface{}, 0, count)
+			for i := 0; i < count; i++ {
+				port := 0
+				if level == PostureLevelPoor && r.Intn(3) == 0 {
+					port = riskyPorts[r.Intn(len(riskyPorts))]
+				} else {
+					port = safePorts[r.Intn(len(safePorts))]
+				}
+				results = append(results, map[string]interface{}{
+					"pid":      r.Intn(50000),
+					"port":     port,
+					"protocol": []string{"tcp", "udp"}[r.Intn(2)],
+					"address":  "0.0.0.0",
+				})
+			}
+			return results
+		},
+	},
+	{
+		Name:    "suid_binaries",
+		Columns: []string{"path", "permissions", "username", "groupname"},
+		Generate: func(level PostureLevel, r *rand.Rand) []map[string]interface{} {
+			// Standard SUID binaries that the scoring engine accepts.
+			standardSUID := []string{
+				"/usr/bin/sudo", "/usr/bin/passwd", "/usr/bin/su",
+				"/usr/bin/chsh", "/usr/bin/chfn", "/usr/bin/newgrp",
+				"/usr/bin/mount", "/usr/bin/umount",
+			}
+			// Non-standard SUID that triggers a warning.
+			nonStandardSUID := []string{
+				"/tmp/custom_suid", "/opt/app/escalate", "/home/user/runme",
+				"/var/lib/helper", "/usr/local/bin/elevate",
+			}
+
+			count := 0
+			nonStandardCount := 0
+			switch level {
+			case PostureLevelGood:
+				count = r.Intn(3) + 5
+				nonStandardCount = 0
+			case PostureLevelModerate:
+				count = r.Intn(5) + 8
+				nonStandardCount = r.Intn(3)
+			case PostureLevelPoor:
+				count = r.Intn(5) + 10
+				nonStandardCount = r.Intn(3) + 5
+			}
+
+			results := make([]map[string]interface{}, 0, count)
+			for i := 0; i < count && i < len(standardSUID); i++ {
+				results = append(results, map[string]interface{}{
+					"path":        standardSUID[i],
+					"permissions": "4755",
+					"username":    "root",
+					"groupname":   "root",
+				})
+			}
+			for i := 0; i < nonStandardCount && i < len(nonStandardSUID); i++ {
+				results = append(results, map[string]interface{}{
+					"path":        nonStandardSUID[i],
+					"permissions": "4755",
+					"username":    "root",
+					"groupname":   "root",
+				})
+			}
+			return results
+		},
+	},
+	{
+		Name:    "patches",
+		Columns: []string{"name", "version"},
+		Generate: func(level PostureLevel, r *rand.Rand) []map[string]interface{} {
+			// Good: many patches. Poor: few or none.
+			count := 0
+			switch level {
+			case PostureLevelGood:
+				count = r.Intn(50) + 100
+			case PostureLevelModerate:
+				count = r.Intn(30) + 30
+			case PostureLevelPoor:
+				count = r.Intn(5)
+			}
+			results := make([]map[string]interface{}, 0, count)
+			for i := 0; i < count; i++ {
+				results = append(results, map[string]interface{}{
+					"name":    fmt.Sprintf("patch-%d", i),
+					"version": fmt.Sprintf("KB%d", 500000+r.Intn(999999)),
+				})
+			}
+			return results
+		},
+	},
+}
+
+// GeneratePostureResults generates fake posture query results for all
+// categories at the given level. Returns a map of query-name → results.
+func GeneratePostureResults(level PostureLevel, r *rand.Rand) map[string][]map[string]interface{} {
+	if level == PostureLevelNone {
+		return nil
+	}
+	out := make(map[string][]map[string]interface{})
+	for _, q := range PostureQueries {
+		fullName := PostureQueryPrefix + q.Name
+		out[fullName] = q.Generate(level, r)
+	}
+	return out
+}
+
+// IsValidPostureLevel returns true if the given string is a valid posture level.
+func IsValidPostureLevel(s string) bool {
+	switch PostureLevel(s) {
+	case PostureLevelNone, PostureLevelGood, PostureLevelModerate, PostureLevelPoor:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Enhances `fake_news_go` with fake security posture data generation, slow enrollment to avoid rate limiting, and improved output formatting.

### Changes

**`--posture-level` flag** (`tools/fake_news_go/internal/workload/posture.go`, `internal/config/config.go`, `fake_news.go`)

Sends fake security posture data to the TLS `/write` endpoint on startup and every 24 hours. The level controls what kind of data is generated:

| Level | Description |
|-------|-------------|
| `none` | No posture data sent (default) |
| `good` | Healthy node: few packages, few users, encrypted disk, only safe ports, all standard SUID binaries, many patches — scores green/low risk |
| `moderate` | Some issues: more packages, more users, possibly unencrypted disk, more listening ports, some non-standard SUID binaries — scores yellow/medium risk |
| `poor` | At-risk node: many packages, many users, unencrypted disk, risky ports (telnet, FTP, RDP), many non-standard SUID binaries, few patches — scores red/high risk |

Six posture categories are generated, matching the scoring engine's expected category names: `packages_deb`, `users`, `disk_encryption`, `listening_ports`, `suid_binaries`, `patches`. The `good` level produces data where every scoring control passes — total score 0, risk level "low" (green).

**`--enroll-delay` flag** (`internal/config/config.go`, `fake_news.go`)

Adds a configurable delay (in milliseconds) between each node enrollment. This avoids triggering rate limits on the TLS enroll endpoint when enrolling large numbers of nodes. For example, `--enroll-delay 200` spaces enrollments 200ms apart, so 100 nodes enroll over ~20 seconds instead of all at once.

**Improved output formatting** (`fake_news.go`)

Rewrote `printSummary` and `printDashboard` with:
- Consistent right-aligned column widths (`%10d`, `%9.1f%%`) so columns line up regardless of value size
- Proper table headers matching the data below them
- URL truncation (55 chars with `...` prefix) so long URLs don't break the table layout
- Two-space indent on data rows for visual hierarchy
- Clean section headers and separator lines

**Updated README** (`tools/fake_news_go/README.md`)

- Documented all flags including `--posture-level`, `--enroll-delay`, `--nodes`, `--status`, `--result`, `--config`, `--query`, `--verbose`, `--insecure`, `--summary-interval`, `--osquery-binary`
- Added `--posture-level` section with level/description table
- Added `--enroll-delay` section explaining rate-limit avoidance
- Added examples for slow enrollment with good posture and poor posture
- Preserved all existing examples (steady, sweep, discovery, dashboard)

### Usage

```bash
# Enroll 100 nodes slowly (200ms apart) with good posture data (green)
go run ./tools/fake_news_go \
  --tls-url http://localhost:9000 \
  --env YOUR_ENV_UUID \
  --secret YOUR_SECRET \
  --nodes 100 \
  --enroll-delay 200 \
  --posture-level good \
  --display-mode dashboard

# Enroll 50 nodes with poor posture (red — unencrypted disk, risky ports)
go run ./tools/fake_news_go \
  --tls-url http://localhost:9000 \
  --env YOUR_ENV_UUID \
  --secret YOUR_SECRET \
  --nodes 50 \
  --posture-level poor \
  --display-mode dashboard
Validation
- go build ./tools/fake_news_go/... — clean
- go test ./tools/fake_news_go/... — all packages pass