### PR TITLE
Rate limits in `osctrl-tls` and `osctrl-api` are now configurable

### DIFF
--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // osctrl-api reads its config either from flags/env vars or from a YAML
@@ -136,5 +137,50 @@ saml:
 	}
 	if !cfg.SAML.ForceAuthn {
 		t.Error("SAML.ForceAuthn = false, want true when the key is omitted")
+	}
+}
+
+func TestLoadedYAMLCarriesRateLimits(t *testing.T) {
+	const body = `
+service:
+  auth: jwt
+db:
+  type: postgres
+redis:
+  host: 127.0.0.1
+rateLimits:
+  login:
+    burst: 7
+    period: 1m
+    evictAfter: 10m
+    retryAfter: 23
+  preAuth:
+    burst: 60
+    period: 1m
+    evictAfter: 10m
+    retryAfter: 60
+  serviceConfigApply:
+    burst: 3
+    period: 10m
+    evictAfter: 30m
+    retryAfter: 60
+`
+	cfg, err := loadYAMLConfiguration(writeTempConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration: %v", err)
+	}
+	params := loadedYAMLToServiceParams(cfg, "api.yml")
+
+	if params.RateLimits == nil {
+		t.Fatal("RateLimits params are nil")
+	}
+	if got := params.RateLimits.Login.Burst; got != 7 {
+		t.Fatalf("login burst = %d, want 7", got)
+	}
+	if got := params.RateLimits.Login.Period; got != time.Minute {
+		t.Fatalf("login period = %s, want 1m", got)
+	}
+	if got := params.RateLimits.Login.RetryAfter; got != 23 {
+		t.Fatalf("login retryAfter = %d, want 23", got)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -174,6 +174,11 @@ func loadYAMLConfiguration(file string) (config.APIConfiguration, error) {
 	if !validAuth[cfg.Service.Auth] {
 		return cfg, fmt.Errorf("invalid auth method: '%s'", cfg.Service.Auth)
 	}
+	if cfg.RateLimits != nil {
+		if err := config.ValidateRateLimits(*cfg.RateLimits, "login", "preAuth", "serviceConfigApply"); err != nil {
+			return cfg, err
+		}
+	}
 	// No errors!
 	return cfg, nil
 }
@@ -205,7 +210,8 @@ func init() {
 			S3:    &config.S3Carver{},
 			Local: &config.LocalCarver{},
 		},
-		Debug: &config.YAMLConfigurationDebug{},
+		Debug:      &config.YAMLConfigurationDebug{},
+		RateLimits: config.DefaultRateLimitsPtr(),
 	}
 	// Initialize CLI flags using the config package
 	flags = config.InitAPIFlags(flagParams)
@@ -388,6 +394,12 @@ func osctrlAPIService() {
 	if err := serviceConfigMgr.Resolve(config.ServiceAPI, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error resolving service config - %v", err)
 	}
+	if flagParams.RateLimits == nil {
+		flagParams.RateLimits = config.DefaultRateLimitsPtr()
+	}
+	if err := config.ValidateRateLimits(*flagParams.RateLimits, "login", "preAuth", "serviceConfigApply"); err != nil {
+		log.Fatal().Msgf("Invalid rate limit configuration - %v", err)
+	}
 	// Initialize audit log manager
 	if flagParams.Service.AuditLog {
 		log.Info().Msg("Initialize audit log")
@@ -486,12 +498,12 @@ func osctrlAPIService() {
 	muxAPI.HandleFunc("GET "+_apiPath(checksNoAuthPath), handlersApi.CheckHandlerNoAuth)
 
 	// ///////////////////////// UNAUTHENTICATED
-	// Login is the only password-acceptance surface on the API. Cap to
-	// 10 attempts per IP per minute (token-bucket; bursts of 10, refill
-	// at 1/6s) and 429 the rest. Rejections are audit-logged inside the
-	// LoginHandler / RateLimit middleware so SoC tooling sees the spray.
+	// Login is the only password-acceptance surface on the API. By default
+	// it is capped to 10 attempts per IP per minute and 429s the rest.
+	// Rejections are audit-logged inside the LoginHandler / RateLimit
+	// middleware so SoC tooling sees the spray.
 	//
-	loginLimiter := ratelimit.New(10, time.Minute, 10*time.Minute)
+	loginLimiter := ratelimit.NewFromConfig(flagParams.RateLimits.Login)
 	loginRateLimit := loginLimiter.HTTPMiddleware(ratelimit.KeyByIP, func(r *http.Request, key string) {
 		handlersApi.AuditLog.FailedLogin("", utils.GetIP(r), "rate limit exceeded")
 	})
@@ -500,11 +512,11 @@ func osctrlAPIService() {
 	// Read-only pre-auth endpoints (env list for the login picker).
 	// The env list is the one piece of data the login page legitimately
 	// needs before the user has a session, so it stays pre-auth —
-	// rate-limited at 60/min/IP to block low-effort scanning probes.
+	// rate-limited at 60/min/IP by default to block low-effort scanning probes.
 	// React strict-mode / browser reloads easily exceed 10/min during
 	// normal use, so the preAuth budget is more permissive than the
 	// credential-spray budget on /login.
-	preAuthLimiter := ratelimit.New(60, time.Minute, 10*time.Minute)
+	preAuthLimiter := ratelimit.NewFromConfig(flagParams.RateLimits.PreAuth)
 	preAuthRateLimit := preAuthLimiter.HTTPMiddleware(ratelimit.KeyByIP, nil)
 	muxAPI.Handle("GET "+_apiPath(apiLoginPath)+"/environments", preAuthRateLimit(http.HandlerFunc(handlersApi.LoginEnvironmentsHandler)))
 	// Auth-methods discovery: the SPA polls this to decide whether to
@@ -903,11 +915,11 @@ func osctrlAPIService() {
 		"PATCH "+_apiPath(apiSettingsPath)+"/{service}/{name}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingPatchHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// API: service config (phase 1 read + phase 2 editable PUT + apply)
-	// Rate-limit the restart endpoint to 3 per 10 minutes per IP — strict
-	// enough to prevent brute-forcing restarts, generous enough for an
-	// operator to retry after a failed restart. Rejections are audit-logged
-	// so SoC tooling sees attempted abuse.
-	restartLimiter := ratelimit.New(3, 10*time.Minute, 30*time.Minute)
+	// Rate-limit the restart endpoint to 3 per 10 minutes per IP by default
+	// — strict enough to prevent brute-forcing restarts, generous enough
+	// for an operator to retry after a failed restart. Rejections are
+	// audit-logged so SoC tooling sees attempted abuse.
+	restartLimiter := ratelimit.NewFromConfig(flagParams.RateLimits.ServiceConfigApply)
 	restartRateLimit := restartLimiter.HTTPMiddleware(ratelimit.KeyByIP, func(r *http.Request, key string) {
 		handlersApi.AuditLog.SettingsAction("", fmt.Sprintf("service-config apply rate limit exceeded from %s", key), utils.GetIP(r))
 	})

--- a/cmd/api/utils.go
+++ b/cmd/api/utils.go
@@ -17,6 +17,7 @@ func loadedYAMLToServiceParams(yml config.APIConfiguration, loadedFile string) *
 		Service:           &yml.Service,
 		DB:                &yml.DB,
 		Redis:             &yml.Redis,
+		RateLimits:        config.DefaultRateLimitsPtr(),
 	}
 	// Optional sections — only set when the YAML provided them.
 	if yml.Osquery != nil {
@@ -42,6 +43,9 @@ func loadedYAMLToServiceParams(yml config.APIConfiguration, loadedFile string) *
 	}
 	if yml.Debug != nil {
 		params.Debug = yml.Debug
+	}
+	if yml.RateLimits != nil {
+		params.RateLimits = yml.RateLimits
 	}
 	return params
 }

--- a/cmd/tls/config_test.go
+++ b/cmd/tls/config_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeTempTLSConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tls.yml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	return path
+}
+
+func TestLoadedYAMLCarriesRateLimits(t *testing.T) {
+	const body = `
+service:
+  auth: none
+db:
+  type: postgres
+redis:
+  host: 127.0.0.1
+rateLimits:
+  enroll:
+    burst: 9
+    period: 2m
+    evictAfter: 12m
+    retryAfter: 45
+`
+	cfg, err := loadYAMLConfiguration(writeTempTLSConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration: %v", err)
+	}
+	params := loadedYAMLToServiceParams(cfg, "tls.yml")
+
+	if params.RateLimits == nil {
+		t.Fatal("RateLimits params are nil")
+	}
+	if got := params.RateLimits.Enroll.Burst; got != 9 {
+		t.Fatalf("enroll burst = %d, want 9", got)
+	}
+	if got := params.RateLimits.Enroll.Period; got != 2*time.Minute {
+		t.Fatalf("enroll period = %s, want 2m", got)
+	}
+	if got := params.RateLimits.Enroll.RetryAfter; got != 45 {
+		t.Fatalf("enroll retryAfter = %d, want 45", got)
+	}
+}

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -134,7 +134,8 @@ func init() {
 			S3:    &config.S3Carver{},
 			Local: &config.LocalCarver{},
 		},
-		Debug: &config.YAMLConfigurationDebug{},
+		Debug:      &config.YAMLConfigurationDebug{},
+		RateLimits: config.DefaultRateLimitsPtr(),
 	}
 	// Initialize CLI flags using the config package
 	flags = config.InitTLSFlags(flagParams)
@@ -269,6 +270,12 @@ func osctrlService() {
 	if err := serviceConfigMgr.Resolve(config.ServiceTLS, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error resolving service config - %v", err)
 	}
+	if flagParams.RateLimits == nil {
+		flagParams.RateLimits = config.DefaultRateLimitsPtr()
+	}
+	if err := config.ValidateRateLimits(*flagParams.RateLimits, "enroll"); err != nil {
+		log.Fatal().Msgf("Invalid rate limit configuration - %v", err)
+	}
 	settingsCacheTTL := time.Duration(settingsmgr.RefreshSettings(config.ServiceTLS)) * time.Second
 	if settingsCacheTTL <= 0 {
 		settingsCacheTTL = time.Duration(defaultRefresh) * time.Second
@@ -323,9 +330,9 @@ func osctrlService() {
 	if err != nil {
 		log.Fatal().Msgf("error initializing audit log manager: %v", err)
 	}
-	// Per-IP rate limit on /enroll. Bursts of 20 per minute, idle eviction
-	// after 10 minutes.
-	enrollLimiter := ratelimit.New(20, time.Minute, 10*time.Minute)
+	// Per-IP rate limit on /enroll. Defaults to bursts of 20 per minute,
+	// idle eviction after 10 minutes.
+	enrollLimiter := ratelimit.NewFromConfig(flagParams.RateLimits.Enroll)
 
 	// Initialize TLS handlers before router
 	log.Info().Msg("Initializing handlers")

--- a/cmd/tls/utils.go
+++ b/cmd/tls/utils.go
@@ -14,6 +14,7 @@ func loadedYAMLToServiceParams(yml config.TLSConfiguration, loadedFile string) *
 		Service:           &yml.Service,
 		DB:                &yml.DB,
 		Redis:             &yml.Redis,
+		RateLimits:        config.DefaultRateLimitsPtr(),
 	}
 	// Optional sections — only set when the YAML provided them.
 	if yml.BatchWriter != nil {
@@ -42,6 +43,9 @@ func loadedYAMLToServiceParams(yml config.TLSConfiguration, loadedFile string) *
 	}
 	if yml.Debug != nil {
 		params.Debug = yml.Debug
+	}
+	if yml.RateLimits != nil {
+		params.RateLimits = yml.RateLimits
 	}
 	return params
 }

--- a/deploy/config/api.yml
+++ b/deploy/config/api.yml
@@ -78,6 +78,33 @@ redis:
   db: 0
   connRetry: 10
 
+# HTTP request rate limits. Values match the built-in defaults.
+rateLimits:
+  login:
+    burst: 10
+    period: 1m
+    evictAfter: 10m
+    retryAfter: 60
+    maxBuckets: 0
+  preAuth:
+    burst: 60
+    period: 1m
+    evictAfter: 10m
+    retryAfter: 60
+    maxBuckets: 0
+  serviceConfigApply:
+    burst: 3
+    period: 10m
+    evictAfter: 30m
+    retryAfter: 60
+    maxBuckets: 0
+  enroll:
+    burst: 20
+    period: 1m
+    evictAfter: 10m
+    retryAfter: 60
+    maxBuckets: 0
+
 # Osquery nodes configuration
 osquery:
   version: 5.23.1

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -78,6 +78,33 @@ redis:
   db: 0
   connRetry: 10
 
+# HTTP request rate limits. Values match the built-in defaults.
+rateLimits:
+  login:
+    burst: 10
+    period: 1m
+    evictAfter: 10m
+    retryAfter: 60
+    maxBuckets: 0
+  preAuth:
+    burst: 60
+    period: 1m
+    evictAfter: 10m
+    retryAfter: 60
+    maxBuckets: 0
+  serviceConfigApply:
+    burst: 3
+    period: 10m
+    evictAfter: 30m
+    retryAfter: 60
+    maxBuckets: 0
+  enroll:
+    burst: 20
+    period: 1m
+    evictAfter: 10m
+    retryAfter: 60
+    maxBuckets: 0
+
 # Osquery nodes configuration
 osquery:
   version: 5.23.1

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -71,6 +71,8 @@ type ServiceParameters struct {
 	Carver *YAMLConfigurationCarver
 	// Debug configuration values
 	Debug *YAMLConfigurationDebug
+	// Rate limit configuration values
+	RateLimits *YAMLConfigurationRateLimits
 }
 
 // initAuthFlag returns the per-service `--auth` flag with the given
@@ -112,6 +114,7 @@ func InitTLSFlags(params *ServiceParameters) []cli.Flag {
 	allFlags = append(allFlags, initOsctrldFlags(params)...)
 	allFlags = append(allFlags, initOsqueryFlags(params)...)
 	allFlags = append(allFlags, initCarverFlags(params)...)
+	allFlags = append(allFlags, initRateLimitFlags(params, ServiceTLS)...)
 	allFlags = append(allFlags, initS3LoggingFlags(params)...)
 	allFlags = append(allFlags, initKafkaFlags(params)...)
 	allFlags = append(allFlags, initDebugFlags(params, ServiceTLS)...)
@@ -155,6 +158,7 @@ func InitAPIFlags(params *ServiceParameters) []cli.Flag {
 	allFlags = append(allFlags, initSAMLFlags(params)...)
 	allFlags = append(allFlags, initOsqueryFlags(params)...)
 	allFlags = append(allFlags, initCarverFlags(params)...)
+	allFlags = append(allFlags, initRateLimitFlags(params, ServiceAPI)...)
 	allFlags = append(allFlags, initDebugFlags(params, ServiceAPI)...)
 	allFlags = append(allFlags, &cli.BoolFlag{
 		Name:        "db-health-check",
@@ -596,6 +600,64 @@ func initCarverFlags(params *ServiceParameters) []cli.Flag {
 			Usage:       "Local directory to store carved files",
 			Sources:     cli.EnvVars("CARVER_LOCAL_DIR"),
 			Destination: &params.Carver.Local.CarvesDir,
+		},
+	}
+}
+
+// initRateLimitFlags initializes request rate-limit flags. Only currently
+// rate-limited surfaces are exposed.
+func initRateLimitFlags(params *ServiceParameters, service string) []cli.Flag {
+	if params.RateLimits == nil {
+		params.RateLimits = DefaultRateLimitsPtr()
+	}
+	if service == ServiceTLS {
+		return rateLimitFlags("enroll", "RATE_LIMIT_ENROLL", &params.RateLimits.Enroll)
+	}
+	return append(
+		append(
+			rateLimitFlags("login", "RATE_LIMIT_LOGIN", &params.RateLimits.Login),
+			rateLimitFlags("pre-auth", "RATE_LIMIT_PRE_AUTH", &params.RateLimits.PreAuth)...,
+		),
+		rateLimitFlags("service-config-apply", "RATE_LIMIT_SERVICE_CONFIG_APPLY", &params.RateLimits.ServiceConfigApply)...,
+	)
+}
+
+func rateLimitFlags(name, envPrefix string, cfg *YAMLConfigurationRateLimit) []cli.Flag {
+	return []cli.Flag{
+		&cli.IntFlag{
+			Name:        "rate-limit-" + name + "-burst",
+			Value:       cfg.Burst,
+			Usage:       "Maximum burst for the " + name + " rate limiter",
+			Sources:     cli.EnvVars(envPrefix + "_BURST"),
+			Destination: &cfg.Burst,
+		},
+		&cli.DurationFlag{
+			Name:        "rate-limit-" + name + "-period",
+			Value:       cfg.Period,
+			Usage:       "Refill period for the " + name + " rate limiter",
+			Sources:     cli.EnvVars(envPrefix + "_PERIOD"),
+			Destination: &cfg.Period,
+		},
+		&cli.DurationFlag{
+			Name:        "rate-limit-" + name + "-evict-after",
+			Value:       cfg.EvictAfter,
+			Usage:       "Idle bucket eviction window for the " + name + " rate limiter",
+			Sources:     cli.EnvVars(envPrefix + "_EVICT_AFTER"),
+			Destination: &cfg.EvictAfter,
+		},
+		&cli.IntFlag{
+			Name:        "rate-limit-" + name + "-retry-after",
+			Value:       cfg.RetryAfter,
+			Usage:       "Retry-After seconds returned by the " + name + " rate limiter",
+			Sources:     cli.EnvVars(envPrefix + "_RETRY_AFTER"),
+			Destination: &cfg.RetryAfter,
+		},
+		&cli.IntFlag{
+			Name:        "rate-limit-" + name + "-max-buckets",
+			Value:       cfg.MaxBuckets,
+			Usage:       "Maximum per-key buckets for the " + name + " rate limiter; 0 uses the default",
+			Sources:     cli.EnvVars(envPrefix + "_MAX_BUCKETS"),
+			Destination: &cfg.MaxBuckets,
 		},
 	}
 }

--- a/pkg/config/flags_test.go
+++ b/pkg/config/flags_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/urfave/cli/v3"
 )
@@ -81,5 +82,34 @@ func TestOsqueryFileExplorerFlagDefaultsOff(t *testing.T) {
 	}
 	if fileExplorerFlag.Destination != &params.Osquery.FileExplorer {
 		t.Fatalf("osquery-file-explorer flag destination does not wire Osquery.FileExplorer")
+	}
+}
+
+func TestRateLimitFlagsWireDefaults(t *testing.T) {
+	params := &ServiceParameters{}
+	flags := initRateLimitFlags(params, ServiceAPI)
+
+	if params.RateLimits == nil {
+		t.Fatal("rate limits were not initialized")
+	}
+	if params.RateLimits.Login.Burst != 10 {
+		t.Fatalf("login burst default: got %d want 10", params.RateLimits.Login.Burst)
+	}
+	if params.RateLimits.ServiceConfigApply.Period != 10*time.Minute {
+		t.Fatalf("service-config apply period default: got %s want 10m", params.RateLimits.ServiceConfigApply.Period)
+	}
+
+	var loginBurst *cli.IntFlag
+	for _, flag := range flags {
+		if f, ok := flag.(*cli.IntFlag); ok && f.Name == "rate-limit-login-burst" {
+			loginBurst = f
+			break
+		}
+	}
+	if loginBurst == nil {
+		t.Fatal("missing login burst rate-limit flag")
+	}
+	if loginBurst.Destination != &params.RateLimits.Login.Burst {
+		t.Fatal("login burst flag destination does not wire RateLimits.Login.Burst")
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -74,15 +74,16 @@ type TLSConfiguration struct {
 	Redis   YAMLConfigurationRedis   `mapstructure:"redis"`
 	// Optional sections — nil when absent from the YAML file. The service
 	// boot code and serviceconfig.Resolve handle nil gracefully.
-	BatchWriter     *YAMLConfigurationWriter    `mapstructure:"batchWriter"`
-	Osquery         *YAMLConfigurationOsquery   `mapstructure:"osquery"`
-	ConfigEndpoints *YAMLConfigurationEndpoints `mapstructure:"configEndpoints"`
-	Osctrld         *YAMLConfigurationOsctrld   `mapstructure:"osctrld"`
-	Metrics         *YAMLConfigurationMetrics   `mapstructure:"metrics"`
-	TLS             *YAMLConfigurationTLS       `mapstructure:"tls"`
-	Logger          *YAMLConfigurationLogger    `mapstructure:"logger"`
-	Carver          *YAMLConfigurationCarver    `mapstructure:"carver"`
-	Debug           *YAMLConfigurationDebug     `mapstructure:"debug"`
+	BatchWriter     *YAMLConfigurationWriter     `mapstructure:"batchWriter"`
+	Osquery         *YAMLConfigurationOsquery    `mapstructure:"osquery"`
+	ConfigEndpoints *YAMLConfigurationEndpoints  `mapstructure:"configEndpoints"`
+	Osctrld         *YAMLConfigurationOsctrld    `mapstructure:"osctrld"`
+	Metrics         *YAMLConfigurationMetrics    `mapstructure:"metrics"`
+	TLS             *YAMLConfigurationTLS        `mapstructure:"tls"`
+	Logger          *YAMLConfigurationLogger     `mapstructure:"logger"`
+	Carver          *YAMLConfigurationCarver     `mapstructure:"carver"`
+	Debug           *YAMLConfigurationDebug      `mapstructure:"debug"`
+	RateLimits      *YAMLConfigurationRateLimits `mapstructure:"rateLimits"`
 }
 
 // APIConfiguration to hold osctrl-api configuration values. Required sections
@@ -92,14 +93,15 @@ type APIConfiguration struct {
 	DB      YAMLConfigurationDB      `mapstructure:"db"`
 	Redis   YAMLConfigurationRedis   `mapstructure:"redis"`
 	// Optional sections — nil when absent from the YAML file.
-	Osquery *YAMLConfigurationOsquery `mapstructure:"osquery"`
-	SAML    *YAMLConfigurationSAML    `mapstructure:"saml"`
-	OIDC    *YAMLConfigurationOIDC    `mapstructure:"oidc"`
-	JWT     *YAMLConfigurationJWT     `mapstructure:"jwt"`
-	TLS     *YAMLConfigurationTLS     `mapstructure:"tls"`
-	Logger  *YAMLConfigurationLogger  `mapstructure:"logger"`
-	Carver  *YAMLConfigurationCarver  `mapstructure:"carver"`
-	Debug   *YAMLConfigurationDebug   `mapstructure:"debug"`
+	Osquery    *YAMLConfigurationOsquery    `mapstructure:"osquery"`
+	SAML       *YAMLConfigurationSAML       `mapstructure:"saml"`
+	OIDC       *YAMLConfigurationOIDC       `mapstructure:"oidc"`
+	JWT        *YAMLConfigurationJWT        `mapstructure:"jwt"`
+	TLS        *YAMLConfigurationTLS        `mapstructure:"tls"`
+	Logger     *YAMLConfigurationLogger     `mapstructure:"logger"`
+	Carver     *YAMLConfigurationCarver     `mapstructure:"carver"`
+	Debug      *YAMLConfigurationDebug      `mapstructure:"debug"`
+	RateLimits *YAMLConfigurationRateLimits `mapstructure:"rateLimits"`
 }
 
 // YAMLConfigurationService to hold the service configuration values
@@ -245,6 +247,23 @@ type YAMLConfigurationDebug struct {
 	// log, queryRead, queryWrite, carveInit) can match; pre-enroll /
 	// no-node endpoints are skipped while a filter is set.
 	TargetHostIdentifier string `yaml:"hostIdentifier"`
+}
+
+// YAMLConfigurationRateLimit holds one token-bucket rate limit.
+type YAMLConfigurationRateLimit struct {
+	Burst      int           `yaml:"burst" mapstructure:"burst"`
+	Period     time.Duration `yaml:"period" mapstructure:"period"`
+	EvictAfter time.Duration `yaml:"evictAfter" mapstructure:"evictAfter"`
+	RetryAfter int           `yaml:"retryAfter" mapstructure:"retryAfter"`
+	MaxBuckets int           `yaml:"maxBuckets" mapstructure:"maxBuckets"`
+}
+
+// YAMLConfigurationRateLimits holds service request-throttle settings.
+type YAMLConfigurationRateLimits struct {
+	Login              YAMLConfigurationRateLimit `yaml:"login" mapstructure:"login"`
+	PreAuth            YAMLConfigurationRateLimit `yaml:"preAuth" mapstructure:"preAuth"`
+	ServiceConfigApply YAMLConfigurationRateLimit `yaml:"serviceConfigApply" mapstructure:"serviceConfigApply"`
+	Enroll             YAMLConfigurationRateLimit `yaml:"enroll" mapstructure:"enroll"`
 }
 
 // YAMLConfigurationWriter to hold the DB batch writer configuration values

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // Valid values for authentication in configuration
 var validAuth = map[string]bool{
@@ -29,6 +32,87 @@ var validCarver = map[string]bool{
 	CarverS3:    true,
 }
 
+const maxRateLimitBurst = 100000
+
+// DefaultRateLimits returns the existing hardcoded HTTP rate-limit defaults.
+func DefaultRateLimits() YAMLConfigurationRateLimits {
+	return YAMLConfigurationRateLimits{
+		Login: YAMLConfigurationRateLimit{
+			Burst:      10,
+			Period:     time.Minute,
+			EvictAfter: 10 * time.Minute,
+			RetryAfter: 60,
+		},
+		PreAuth: YAMLConfigurationRateLimit{
+			Burst:      60,
+			Period:     time.Minute,
+			EvictAfter: 10 * time.Minute,
+			RetryAfter: 60,
+		},
+		ServiceConfigApply: YAMLConfigurationRateLimit{
+			Burst:      3,
+			Period:     10 * time.Minute,
+			EvictAfter: 30 * time.Minute,
+			RetryAfter: 60,
+		},
+		Enroll: YAMLConfigurationRateLimit{
+			Burst:      20,
+			Period:     time.Minute,
+			EvictAfter: 10 * time.Minute,
+			RetryAfter: 60,
+		},
+	}
+}
+
+// DefaultRateLimitsPtr returns DefaultRateLimits as a pointer for optional
+// config sections.
+func DefaultRateLimitsPtr() *YAMLConfigurationRateLimits {
+	defaults := DefaultRateLimits()
+	return &defaults
+}
+
+// ValidateRateLimits validates named rate-limit entries.
+func ValidateRateLimits(cfg YAMLConfigurationRateLimits, names ...string) error {
+	limits := map[string]YAMLConfigurationRateLimit{
+		"login":              cfg.Login,
+		"preAuth":            cfg.PreAuth,
+		"serviceConfigApply": cfg.ServiceConfigApply,
+		"enroll":             cfg.Enroll,
+	}
+	for _, name := range names {
+		limit, ok := limits[name]
+		if !ok {
+			return fmt.Errorf("unknown rate limit %q", name)
+		}
+		if err := validateRateLimit(name, limit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRateLimit(name string, limit YAMLConfigurationRateLimit) error {
+	if limit.Burst <= 0 {
+		return fmt.Errorf("%s burst must be greater than 0", name)
+	}
+	if limit.Burst > maxRateLimitBurst {
+		return fmt.Errorf("%s burst must be <= %d", name, maxRateLimitBurst)
+	}
+	if limit.Period <= 0 {
+		return fmt.Errorf("%s period must be greater than 0", name)
+	}
+	if limit.EvictAfter < limit.Period {
+		return fmt.Errorf("%s evictAfter must be greater than or equal to period", name)
+	}
+	if limit.RetryAfter < 0 {
+		return fmt.Errorf("%s retryAfter must be >= 0", name)
+	}
+	if limit.MaxBuckets < 0 {
+		return fmt.Errorf("%s maxBuckets must be >= 0", name)
+	}
+	return nil
+}
+
 // Helper to validate the TLS configuration values
 func ValidateTLSConfigValues(cfg TLSConfiguration) error {
 	// Check if values are valid
@@ -49,6 +133,11 @@ func ValidateTLSConfigValues(cfg TLSConfiguration) error {
 	if cfg.Carver != nil {
 		if !validCarver[cfg.Carver.Type] {
 			return fmt.Errorf("invalid carver method: %s", cfg.Carver.Type)
+		}
+	}
+	if cfg.RateLimits != nil {
+		if err := ValidateRateLimits(*cfg.RateLimits, "enroll"); err != nil {
+			return err
 		}
 	}
 	// No errors!

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+)
 
 func TestValidateTLSConfigValuesAcceptsKafkaAndMultipleLoggers(t *testing.T) {
 	err := ValidateTLSConfigValues(TLSConfiguration{
@@ -21,5 +25,30 @@ func TestValidateTLSConfigValuesRejectsInvalidMultipleLogger(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("expected invalid logger type to fail validation")
+	}
+}
+
+func TestValidateRateLimitsRejectsInvalidValues(t *testing.T) {
+	cfg := YAMLConfigurationRateLimits{
+		Enroll: YAMLConfigurationRateLimit{
+			Burst:      0,
+			Period:     time.Minute,
+			EvictAfter: time.Minute,
+			RetryAfter: 60,
+		},
+	}
+
+	err := ValidateRateLimits(cfg, "enroll")
+	if err == nil {
+		t.Fatal("expected invalid rate limit to fail validation")
+	}
+	if !strings.Contains(err.Error(), "enroll burst must be greater than 0") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRateLimitsAcceptsDefaults(t *testing.T) {
+	if err := ValidateRateLimits(DefaultRateLimits(), "login", "preAuth", "serviceConfigApply", "enroll"); err != nil {
+		t.Fatalf("default rate limits should validate: %v", err)
 	}
 }

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -8,9 +8,11 @@ package ratelimit
 
 import (
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"golang.org/x/time/rate"
 )
@@ -35,6 +37,7 @@ type Limiter struct {
 	maxBuckets    int
 	rate          rate.Limit
 	burst         int
+	retryAfter    int
 	evictAfter    time.Duration
 	lastEviction  time.Time
 	evictInterval time.Duration
@@ -58,12 +61,31 @@ func New(burst int, per, evictAfter time.Duration) *Limiter {
 
 // NewWithCap is New with an explicit ceiling on the per-key map size.
 func NewWithCap(burst int, per, evictAfter time.Duration, maxBuckets int) *Limiter {
+	return newWithRetryAfter(burst, per, evictAfter, maxBuckets, 60)
+}
+
+// NewFromConfig returns a Limiter from service configuration values.
+func NewFromConfig(cfg config.YAMLConfigurationRateLimit) *Limiter {
+	maxBuckets := cfg.MaxBuckets
+	if maxBuckets <= 0 {
+		maxBuckets = DefaultMaxBuckets
+	}
+	return newWithRetryAfter(cfg.Burst, cfg.Period, cfg.EvictAfter, maxBuckets, cfg.RetryAfter)
+}
+
+func newWithRetryAfter(burst int, per, evictAfter time.Duration, maxBuckets, retryAfter int) *Limiter {
 	interval := evictAfter / 2
 	if interval <= 0 {
 		interval = time.Second
 	}
 	if maxBuckets <= 0 {
 		maxBuckets = DefaultMaxBuckets
+	}
+	if burst <= 0 {
+		burst = 1
+	}
+	if per <= 0 {
+		per = time.Minute
 	}
 	r := rate.Every(per / time.Duration(burst))
 	return &Limiter{
@@ -72,6 +94,7 @@ func NewWithCap(burst int, per, evictAfter time.Duration, maxBuckets int) *Limit
 		maxBuckets:    maxBuckets,
 		rate:          r,
 		burst:         burst,
+		retryAfter:    retryAfter,
 		evictAfter:    evictAfter,
 		evictInterval: interval,
 	}
@@ -128,7 +151,7 @@ func (l *Limiter) HTTPMiddleware(keyFn func(*http.Request) string, onReject func
 				if onReject != nil {
 					onReject(r, key)
 				}
-				w.Header().Set("Retry-After", "60")
+				w.Header().Set("Retry-After", strconv.Itoa(l.retryAfter))
 				http.Error(w, "too many requests", http.StatusTooManyRequests)
 				return
 			}

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
 )
 
 // TestAllowBurst verifies a Limiter allows up to `burst` calls in a single
@@ -63,6 +65,26 @@ func TestHTTPMiddleware429s(t *testing.T) {
 	}
 	if rejected != 1 {
 		t.Fatalf("onReject calls: got %d, want 1", rejected)
+	}
+}
+
+func TestNewFromConfigUsesRetryAfter(t *testing.T) {
+	l := NewFromConfig(config.YAMLConfigurationRateLimit{
+		Burst:      1,
+		Period:     time.Second,
+		EvictAfter: time.Minute,
+		RetryAfter: 17,
+	})
+	h := l.HTTPMiddleware(func(r *http.Request) string { return "fixed" }, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/login", nil))
+	second := httptest.NewRecorder()
+	h.ServeHTTP(second, httptest.NewRequest("POST", "/login", nil))
+
+	if got := second.Header().Get("Retry-After"); got != "17" {
+		t.Fatalf("Retry-After = %q, want 17", got)
 	}
 }
 

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -81,6 +81,7 @@ var SectionRegistry = map[string][]SectionSpec{
 		{"logger", false, "Log sinks — may contain credentials (future: editable)"},
 		{"carver", false, "File carver configuration — may contain credentials"},
 		{"debug", true, "HTTP debug dump settings"},
+		{"rateLimits", true, "HTTP request rate limits"},
 	},
 	config.ServiceAPI: {
 		{"service", true, "Core service listener, port, log level, auth mode"},
@@ -94,6 +95,7 @@ var SectionRegistry = map[string][]SectionSpec{
 		{"logger", false, "Log sinks — may contain credentials (future: editable)"},
 		{"carver", false, "File carver configuration — may contain credentials"},
 		{"debug", true, "HTTP debug dump settings"},
+		{"rateLimits", true, "HTTP request rate limits"},
 	},
 }
 
@@ -292,6 +294,10 @@ func applySection(cfg *config.ServiceParameters, name, value string) (bool, erro
 		if cfg.Debug != nil {
 			return true, json.Unmarshal([]byte(value), cfg.Debug)
 		}
+	case "rateLimits":
+		if cfg.RateLimits != nil {
+			return true, json.Unmarshal([]byte(value), cfg.RateLimits)
+		}
 	case "batchWriter":
 		if cfg.BatchWriter != nil {
 			return true, json.Unmarshal([]byte(value), cfg.BatchWriter)
@@ -342,6 +348,19 @@ func (m *ServiceConfigManager) UpdateSection(service, name, value string, envID 
 	// Validate that the new value is valid JSON.
 	if !json.Valid([]byte(value)) {
 		return ServiceConfig{}, fmt.Errorf("value is not valid JSON")
+	}
+	if name == "rateLimits" {
+		var limits config.YAMLConfigurationRateLimits
+		if err := json.Unmarshal([]byte(value), &limits); err != nil {
+			return ServiceConfig{}, fmt.Errorf("unmarshal rateLimits: %w", err)
+		}
+		names := []string{"enroll"}
+		if service == config.ServiceAPI {
+			names = []string{"login", "preAuth", "serviceConfigApply"}
+		}
+		if err := config.ValidateRateLimits(limits, names...); err != nil {
+			return ServiceConfig{}, err
+		}
 	}
 	existing, err := m.GetSection(service, name, envID)
 	if err != nil {
@@ -407,6 +426,11 @@ func sectionValues(service string, cfg *config.ServiceParameters) (map[string]st
 	}
 	if cfg.Debug != nil {
 		if err := add("debug", cfg.Debug); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.RateLimits != nil {
+		if err := add("rateLimits", cfg.RateLimits); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/serviceconfig/serviceconfig_test.go
+++ b/pkg/serviceconfig/serviceconfig_test.go
@@ -3,6 +3,7 @@ package serviceconfig
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,6 +50,9 @@ func testTLSParams() *config.ServiceParameters {
 		Logger:  &config.YAMLConfigurationLogger{Type: config.LoggingDB, LoggerDBSame: true},
 		Carver:  &config.YAMLConfigurationCarver{Type: config.CarverLocal, Local: &config.LocalCarver{CarvesDir: "/carves"}},
 		Debug:   &config.YAMLConfigurationDebug{EnableHTTP: false},
+		RateLimits: &config.YAMLConfigurationRateLimits{
+			Enroll: config.YAMLConfigurationRateLimit{Burst: 20, Period: time.Minute, EvictAfter: 10 * time.Minute, RetryAfter: 60},
+		},
 		BatchWriter: &config.YAMLConfigurationWriter{
 			WriterBatchSize:  50,
 			WriterBufferSize: 2000,
@@ -83,6 +87,11 @@ func testAPIParams() *config.ServiceParameters {
 		},
 		Carver: &config.YAMLConfigurationCarver{Type: config.CarverDB},
 		Debug:  &config.YAMLConfigurationDebug{EnableHTTP: false},
+		RateLimits: &config.YAMLConfigurationRateLimits{
+			Login:              config.YAMLConfigurationRateLimit{Burst: 10, Period: time.Minute, EvictAfter: 10 * time.Minute, RetryAfter: 60},
+			PreAuth:            config.YAMLConfigurationRateLimit{Burst: 60, Period: time.Minute, EvictAfter: 10 * time.Minute, RetryAfter: 60},
+			ServiceConfigApply: config.YAMLConfigurationRateLimit{Burst: 3, Period: 10 * time.Minute, EvictAfter: 30 * time.Minute, RetryAfter: 60},
+		},
 	}
 }
 
@@ -196,6 +205,7 @@ func TestSeed_ServiceSpecificSections(t *testing.T) {
 	assert.Contains(t, apiNames, "saml")
 	assert.Contains(t, apiNames, "oidc")
 	assert.Contains(t, apiNames, "jwt")
+	assert.Contains(t, apiNames, "rateLimits")
 	assert.NotContains(t, apiNames, "batchWriter")
 	assert.NotContains(t, apiNames, "metrics")
 	assert.NotContains(t, apiNames, "osctrld")
@@ -204,6 +214,7 @@ func TestSeed_ServiceSpecificSections(t *testing.T) {
 	assert.Contains(t, tlsNames, "configEndpoints")
 	assert.Contains(t, tlsNames, "osctrld")
 	assert.Contains(t, tlsNames, "metrics")
+	assert.Contains(t, tlsNames, "rateLimits")
 	assert.NotContains(t, tlsNames, "saml")
 	assert.NotContains(t, tlsNames, "oidc")
 	assert.NotContains(t, tlsNames, "jwt")
@@ -411,6 +422,8 @@ func TestIsEditable(t *testing.T) {
 	assert.True(t, m.IsEditable(config.ServiceAPI, "debug"))
 	assert.False(t, m.IsEditable(config.ServiceTLS, "db"))
 	assert.False(t, m.IsEditable(config.ServiceTLS, "logger"))
+	assert.True(t, m.IsEditable(config.ServiceTLS, "rateLimits"))
+	assert.True(t, m.IsEditable(config.ServiceAPI, "rateLimits"))
 	assert.False(t, m.IsEditable(config.ServiceTLS, "nonexistent"))
 	assert.False(t, m.IsEditable("bogus", "debug"))
 }
@@ -575,6 +588,20 @@ func TestResolve_MultipleDBEdits(t *testing.T) {
 	assert.True(t, cfg.Debug.EnableHTTP)
 	assert.Equal(t, "5.12.2", cfg.Osquery.Version)
 	assert.Equal(t, "./data/5.12.2.json", cfg.Osquery.TablesFile)
+}
+
+func TestResolve_RateLimitsSection_OverridesYAML(t *testing.T) {
+	db := setupTestDB(t)
+	m := &ServiceConfigManager{DB: db}
+	cfg := testAPIParams()
+	require.NoError(t, m.Seed(config.ServiceAPI, cfg, 0))
+
+	_, err := m.UpdateSection(config.ServiceAPI, "rateLimits", `{"login":{"burst":7,"period":60000000000,"evictAfter":600000000000,"retryAfter":23},"preAuth":{"burst":60,"period":60000000000,"evictAfter":600000000000,"retryAfter":60},"serviceConfigApply":{"burst":3,"period":600000000000,"evictAfter":1800000000000,"retryAfter":60},"enroll":{"burst":20,"period":60000000000,"evictAfter":600000000000,"retryAfter":60}}`, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Resolve(config.ServiceAPI, cfg, 0))
+	assert.Equal(t, 7, cfg.RateLimits.Login.Burst)
+	assert.Equal(t, 23, cfg.RateLimits.Login.RetryAfter)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Added configurable HTTP rate limits for `osctrl-api` and `osctrl-tls`.
- Replaced hardcoded limiter construction for API login, pre-auth, service-config apply, and TLS enroll paths with config-backed values.
- Added a new editable `rateLimits` service-config section for both API and TLS.
- Made `Retry-After` configurable in the shared rate-limit middleware.
- Updated example API/TLS YAML configs with defaults matching the previous hardcoded behavior.
