### PR TITLE
Implementation of `service_commands` to issue service restarts in `osctrl-tls` from `osctrl-api`

### DIFF
--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/posture"
 	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
 	"github.com/jmpsec/osctrl/pkg/serviceconfig"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
@@ -46,6 +47,7 @@ type HandlersApi struct {
 	Carves          *carves.Carves
 	Settings        *settings.Settings
 	ServiceConfig   *serviceconfig.ServiceConfigManager
+	ServiceCommands *servicecommands.Manager
 	Activity        activityReader
 	GeoIP           *geoip.GeoIPResolver
 	Posture         *posture.PostureManager
@@ -168,6 +170,12 @@ func WithSettings(settings *settings.Settings) HandlersOption {
 func WithServiceConfig(mgr *serviceconfig.ServiceConfigManager) HandlersOption {
 	return func(h *HandlersApi) {
 		h.ServiceConfig = mgr
+	}
+}
+
+func WithServiceCommands(mgr *servicecommands.Manager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.ServiceCommands = mgr
 	}
 }
 

--- a/cmd/api/handlers/service_config.go
+++ b/cmd/api/handlers/service_config.go
@@ -4,10 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
 	"github.com/jmpsec/osctrl/pkg/serviceconfig"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
@@ -15,6 +19,8 @@ import (
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
+
+const serviceCommandTTL = 2 * time.Minute
 
 // ServiceConfigHandler - GET Handler for all service config sections
 // @Summary List all service config sections
@@ -275,17 +281,98 @@ func (h *HandlersApi) ServiceConfigApplyHandler(w http.ResponseWriter, r *http.R
 		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		return
 	}
-	if h.RestartCh == nil {
-		apiErrorResponse(w, "restart not available", http.StatusServiceUnavailable, nil)
+	var body types.ServiceConfigApplyRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+			return
+		}
+	}
+	service := body.Service
+	if service == "" {
+		service = config.ServiceAPI
+	}
+	switch service {
+	case config.ServiceAPI:
+		if h.RestartCh == nil {
+			apiErrorResponse(w, "restart not available", http.StatusServiceUnavailable, nil)
+			return
+		}
+		h.AuditLog.SettingsAction(ctx[ctxUser], "apply service-config api restart", strings.Split(r.RemoteAddr, ":")[0])
+		log.Info().Msgf("Service config apply triggered by %s — initiating API restart", ctx[ctxUser])
+		utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusAccepted, types.ServiceConfigApplyResponse{
+			Service: config.ServiceAPI,
+			Message: "Restart triggered. osctrl-api will restart shortly to apply config changes.",
+		})
+		h.RestartCh <- struct{}{}
+	case config.ServiceTLS:
+		if h.ServiceCommands == nil {
+			apiErrorResponse(w, "service commands not available", http.StatusServiceUnavailable, nil)
+			return
+		}
+		cmd, err := h.ServiceCommands.RequestRestart(config.ServiceTLS, ctx[ctxUser], strings.Split(r.RemoteAddr, ":")[0], serviceCommandTTL)
+		if err != nil {
+			apiErrorResponse(w, "error requesting tls restart", http.StatusInternalServerError, err)
+			return
+		}
+		h.AuditLog.SettingsAction(ctx[ctxUser], fmt.Sprintf("apply service-config tls restart command %s", cmd.CommandID), strings.Split(r.RemoteAddr, ":")[0])
+		log.Info().Str("command", cmd.CommandID).Msgf("TLS restart requested by %s", ctx[ctxUser])
+		resp := serviceCommandResponse(cmd)
+		utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusAccepted, types.ServiceConfigApplyResponse{
+			Service: config.ServiceTLS,
+			Message: "Restart requested. osctrl-tls will restart after consuming the service command.",
+			Command: &resp,
+		})
+	default:
+		apiErrorResponse(w, "invalid service", http.StatusBadRequest, nil)
+	}
+}
+
+// ServiceCommandHandler — GET /api/v1/service-config/commands/{command_id}
+func (h *HandlersApi) ServiceCommandHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
 		return
 	}
-	h.AuditLog.SettingsAction(ctx[ctxUser], "apply service-config (restart)", strings.Split(r.RemoteAddr, ":")[0])
-	log.Info().Msgf("Service config apply triggered by %s — initiating graceful restart", ctx[ctxUser])
-	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusAccepted, map[string]string{
-		"message": "Restart triggered. The service will restart shortly to apply config changes.",
-	})
-	// Signal the main goroutine to shut down. The channel is buffered
-	// (cap 1) so this send completes immediately without blocking, and
-	// the handler returns so srv.Shutdown() can proceed.
-	h.RestartCh <- struct{}{}
+	if h.ServiceCommands == nil {
+		apiErrorResponse(w, "service commands not available", http.StatusServiceUnavailable, nil)
+		return
+	}
+	commandID := r.PathValue("command_id")
+	if commandID == "" {
+		apiErrorResponse(w, "missing command id", http.StatusBadRequest, nil)
+		return
+	}
+	cmd, err := h.ServiceCommands.Get(commandID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErrorResponse(w, "command not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error getting command", http.StatusInternalServerError, err)
+		return
+	}
+	resp := serviceCommandResponse(cmd)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, resp)
+}
+
+func serviceCommandResponse(cmd servicecommands.ServiceCommand) types.ServiceCommandResponse {
+	return types.ServiceCommandResponse{
+		CommandID:     cmd.CommandID,
+		TargetService: cmd.TargetService,
+		Action:        cmd.Action,
+		Status:        cmd.Status(time.Now()),
+		RequestedBy:   cmd.RequestedBy,
+		RequestedFrom: cmd.RequestedFrom,
+		CreatedAt:     cmd.CreatedAt,
+		ExpiresAt:     cmd.ExpiresAt,
+		ConsumedAt:    cmd.ConsumedAt,
+		ConsumedBy:    cmd.ConsumedBy,
+		RecoveredAt:   cmd.RecoveredAt,
+		RecoveredBy:   cmd.RecoveredBy,
+	}
 }

--- a/cmd/api/handlers/service_config_apply_test.go
+++ b/cmd/api/handlers/service_config_apply_test.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupServiceConfigApplyHandler(t *testing.T) (*HandlersApi, chan struct{}) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	userManager := users.CreateUserManager(db)
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "alice", Admin: true}))
+	auditLog, err := auditlog.CreateAuditLogManager(db, "osctrl-api", false)
+	require.NoError(t, err)
+	restartCh := make(chan struct{}, 1)
+	h := CreateHandlersApi(
+		WithUsers(userManager),
+		WithAuditLog(auditLog),
+		WithDebugHTTP(&config.YAMLConfigurationDebug{}),
+		WithRestartCh(restartCh),
+		WithServiceCommands(servicecommands.NewManager(db)),
+	)
+	return h, restartCh
+}
+
+func serviceConfigApplyRequest(t *testing.T, service string) *http.Request {
+	t.Helper()
+	body, err := json.Marshal(types.ServiceConfigApplyRequest{Service: service})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/service-config/apply", bytes.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:1234"
+	return req.WithContext(context.WithValue(req.Context(), ContextKey(contextAPI), ContextValue{ctxUser: "alice"}))
+}
+
+func TestServiceConfigApplyHandlerQueuesTLSRestart(t *testing.T) {
+	h, restartCh := setupServiceConfigApplyHandler(t)
+	req := serviceConfigApplyRequest(t, config.ServiceTLS)
+	rr := httptest.NewRecorder()
+
+	h.ServiceConfigApplyHandler(rr, req)
+
+	require.Equal(t, http.StatusAccepted, rr.Code)
+	select {
+	case <-restartCh:
+		t.Fatal("TLS apply must not restart osctrl-api")
+	default:
+	}
+	var resp types.ServiceConfigApplyResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, config.ServiceTLS, resp.Service)
+	require.NotNil(t, resp.Command)
+	require.Equal(t, servicecommands.StatusPending, resp.Command.Status)
+	require.NotEmpty(t, resp.Command.CommandID)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/posture"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/ratelimit"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
 	"github.com/jmpsec/osctrl/pkg/serviceconfig"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
@@ -387,6 +388,7 @@ func osctrlAPIService() {
 	}
 	log.Info().Msg("Seeding service config from YAML")
 	serviceConfigMgr := serviceconfig.NewServiceConfigManager(db.Conn)
+	serviceCommandMgr := servicecommands.NewManager(db.Conn)
 	if err := serviceConfigMgr.Seed(config.ServiceAPI, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error seeding service config - %v", err)
 	}
@@ -465,6 +467,7 @@ func osctrlAPIService() {
 		handlers.WithCarves(filecarves),
 		handlers.WithSettings(settingsmgr),
 		handlers.WithServiceConfig(serviceConfigMgr),
+		handlers.WithServiceCommands(serviceCommandMgr),
 		handlers.WithActivityReader(activity.NewRedisStore(redis.Client, activity.DefaultPrefix, activity.DefaultRetentionDays, 8*24*time.Hour)),
 		handlers.WithGeoIP(geoIPResolver),
 		handlers.WithPosture(posturemgr),
@@ -926,6 +929,9 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"GET "+_apiPath(apiServiceConfigPath),
 		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"GET "+_apiPath(apiServiceConfigPath)+"/commands/{command_id}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceCommandHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	muxAPI.Handle(
 		"GET "+_apiPath(apiServiceConfigPath)+"/{service}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigServiceHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/posture"
 	"github.com/jmpsec/osctrl/pkg/queries"
 	"github.com/jmpsec/osctrl/pkg/ratelimit"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
 	"github.com/jmpsec/osctrl/pkg/serviceconfig"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
@@ -55,7 +57,8 @@ const (
 	// Default accelerate interval in seconds
 	defaultAccelerate int = 5
 	// Default expiration of oneliners for enroll/expire
-	defaultOnelinerExpiration bool = true
+	defaultOnelinerExpiration  bool = true
+	serviceCommandPollInterval      = 5 * time.Second
 )
 
 // Build-time metadata (overridden via -ldflags "-X main.buildVersion=... -X main.buildCommit=... -X main.buildDate=...")
@@ -263,6 +266,7 @@ func osctrlService() {
 	}
 	log.Info().Msg("Seeding service config from YAML")
 	serviceConfigMgr := serviceconfig.NewServiceConfigManager(db.Conn)
+	serviceCommandMgr := servicecommands.NewManager(db.Conn)
 	if err := serviceConfigMgr.Seed(config.ServiceTLS, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error seeding service config - %v", err)
 	}
@@ -330,6 +334,13 @@ func osctrlService() {
 	if err != nil {
 		log.Fatal().Msgf("error initializing audit log manager: %v", err)
 	}
+	if n, err := serviceCommandMgr.MarkRecovered(config.ServiceTLS, serviceName, time.Now()); err != nil {
+		log.Err(err).Msg("error marking TLS service commands recovered")
+	} else if n > 0 {
+		auditLog.SettingsAction("", fmt.Sprintf("tls service recovered after %d restart command(s)", n), "local")
+		log.Info().Int64("commands", n).Msg("Marked TLS service command(s) recovered")
+	}
+	restartCh := make(chan struct{}, 1)
 	// Per-IP rate limit on /enroll. Defaults to bursts of 20 per minute,
 	// idle eviction after 10 minutes.
 	enrollLimiter := ratelimit.NewFromConfig(flagParams.RateLimits.Enroll)
@@ -429,9 +440,13 @@ func osctrlService() {
 
 	// ////////////////////////////// Everything is ready at this point!
 	serviceListener := flagParams.Service.Listener + ":" + strconv.Itoa(flagParams.Service.Port)
+	srv := &http.Server{
+		Addr:    serviceListener,
+		Handler: muxTLS,
+	}
 	if flagParams.TLS.Termination {
 		log.Info().Msg("TLS Termination is enabled")
-		cfg := &tls.Config{
+		srv.TLSConfig = &tls.Config{
 			MinVersion:               tls.VersionTLS12,
 			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 			PreferServerCipherSuites: true,
@@ -442,22 +457,53 @@ func osctrlService() {
 				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 			},
 		}
-		srv := &http.Server{
-			Addr:         serviceListener,
-			Handler:      muxTLS,
-			TLSConfig:    cfg,
-			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
-		}
-		log.Info().Msgf("%s v%s - HTTPS listening %s", serviceName, buildVersion, serviceListener)
+		srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
+	}
+	watchCtx, stopCommandWatcher := context.WithCancel(context.Background())
+	go watchServiceCommands(watchCtx, serviceCommandMgr, auditLog, restartCh)
+	serverErr := make(chan error, 1)
+	go func() {
+		log.Info().Msgf("%s v%s - HTTP%s listening %s", serviceName, buildVersion, map[bool]string{true: "S", false: ""}[flagParams.TLS.Termination], serviceListener)
 		log.Info().Msgf("%s - commit=%s - build date=%s", serviceName, buildCommit, buildDate)
-		if err := srv.ListenAndServeTLS(flagParams.TLS.CertificateFile, flagParams.TLS.KeyFile); err != nil {
-			log.Fatal().Msgf("ListenAndServeTLS: %v", err)
+		if flagParams.TLS.Termination {
+			serverErr <- srv.ListenAndServeTLS(flagParams.TLS.CertificateFile, flagParams.TLS.KeyFile)
+		} else {
+			serverErr <- srv.ListenAndServe()
 		}
-	} else {
-		log.Info().Msgf("%s v%s - HTTP listening %s", serviceName, buildVersion, serviceListener)
-		log.Info().Msgf("%s - commit=%s - build date=%s", serviceName, buildCommit, buildDate)
-		if err := http.ListenAndServe(serviceListener, muxTLS); err != nil {
+	}()
+	select {
+	case err := <-serverErr:
+		stopCommandWatcher()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatal().Msgf("ListenAndServe: %v", err)
+		}
+	case <-restartCh:
+		stopCommandWatcher()
+		log.Info().Msg("TLS service command consumed — exiting for restart")
+		os.Exit(1)
+	}
+}
+
+func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, auditLog *auditlog.AuditLogManager, restartCh chan<- struct{}) {
+	ticker := time.NewTicker(serviceCommandPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cmd, ok, err := mgr.ConsumeNext(config.ServiceTLS, serviceName, time.Now())
+			if err != nil {
+				log.Err(err).Msg("error checking TLS service commands")
+				continue
+			}
+			if !ok {
+				continue
+			}
+			auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls restart command %s consumed", cmd.CommandID), "local")
+			log.Info().Str("command", cmd.CommandID).Msg("Consumed TLS restart command")
+			restartCh <- struct{}{}
+			return
 		}
 	}
 }

--- a/deploy/docker/conf/dev/air/.air-osctrl-tls.toml
+++ b/deploy/docker/conf/dev/air/.air-osctrl-tls.toml
@@ -15,7 +15,12 @@ tmp_dir = "/tmp"
   exclude_regex = ["_test.go"]
   exclude_unchanged = false
   follow_symlink = false
-  full_bin = "cd /opt/osctrl && ./bin/osctrl-tls"
+  # Wrap in a restart loop so that when osctrl-tls exits with code 1
+  # (the "apply & restart" signal from the service-config endpoint),
+  # the binary is re-run immediately. Air itself doesn't restart on
+  # child exit — only on file changes — so the loop handles the restart
+  # case. Exit code 0 (clean shutdown) breaks the loop so air can rebuild.
+  full_bin = "cd /opt/osctrl && while ./bin/osctrl-tls; [ $? -eq 1 ]; do echo 'osctrl-tls exited with code 1 — restarting'; sleep 1; done"
   include_dir = []
   include_ext = ["go"]
   kill_delay = "0s"

--- a/frontend/src/api/service-config.ts
+++ b/frontend/src/api/service-config.ts
@@ -68,9 +68,39 @@ export function updateServiceConfig(
   );
 }
 
+export interface ServiceCommand {
+  command_id: string;
+  target_service: string;
+  action: string;
+  status: 'pending' | 'consumed' | 'recovered' | 'expired';
+  requested_by?: string;
+  requested_from?: string;
+  created_at?: string;
+  expires_at?: string;
+  consumed_at?: string;
+  consumed_by?: string;
+  recovered_at?: string;
+  recovered_by?: string;
+}
+
+export interface ServiceConfigApplyResponse {
+  message: string;
+  service?: string;
+  command?: ServiceCommand;
+}
+
 /** POST /api/v1/service-config/apply — trigger graceful restart to apply config changes. */
-export function applyServiceConfig(): Promise<{ message: string }> {
-  return apiFetch<{ message: string }>('/api/v1/service-config/apply', {
+export function applyServiceConfig(service = 'api'): Promise<ServiceConfigApplyResponse> {
+  return apiFetch<ServiceConfigApplyResponse>('/api/v1/service-config/apply', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ service }),
   });
+}
+
+/** GET /api/v1/service-config/commands/{command_id} — command restart status. */
+export function getServiceCommand(commandID: string): Promise<ServiceCommand> {
+  return apiFetch<ServiceCommand>(
+    `/api/v1/service-config/commands/${encodeURIComponent(commandID)}`,
+  );
 }

--- a/frontend/src/features/service-config/ServiceConfigPage.test.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.test.tsx
@@ -11,16 +11,18 @@ import {
   Outlet,
 } from '@tanstack/react-router';
 import { ServiceConfigPage } from './ServiceConfigPage';
-import type { ServiceConfig } from '$/api/service-config';
+import type { ServiceCommand, ServiceConfig } from '$/api/service-config';
 
 const mockList = vi.fn<(service: string) => Promise<ServiceConfig[]>>();
 const mockUpdate = vi.fn();
 const mockApply = vi.fn();
+const mockGetCommand = vi.fn<(commandID: string) => Promise<ServiceCommand>>();
 
 vi.mock('$/api/service-config', () => ({
   listServiceConfig: (service: string) => mockList(service),
   updateServiceConfig: (...args: unknown[]) => mockUpdate(...args),
-  applyServiceConfig: () => mockApply(),
+  applyServiceConfig: (service: string) => mockApply(service),
+  getServiceCommand: (commandID: string) => mockGetCommand(commandID),
 }));
 
 vi.mock('$/api/client', () => ({
@@ -483,6 +485,28 @@ describe('ServiceConfigPage', () => {
 
     await waitFor(() => {
       expect(mockApply).toHaveBeenCalledTimes(1);
+    });
+    expect(mockApply).toHaveBeenCalledWith('api');
+  });
+
+  it('passes tls to applyServiceConfig from the tls tab', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([makeSection({ Source: 'db', Name: 'debug', Editable: true, Service: 'tls' })]);
+    mockApply.mockResolvedValue({
+      message: 'Restart requested.',
+      service: 'tls',
+      command: { command_id: 'cmd-1', target_service: 'tls', action: 'restart', status: 'pending' },
+    });
+    renderWithProviders(makeTestRouter('/_app/config/tls'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Apply & Restart/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /Apply & Restart/i }));
+    await user.click(screen.getByRole('button', { name: 'Restart now' }));
+
+    await waitFor(() => {
+      expect(mockApply).toHaveBeenCalledWith('tls');
     });
   });
 

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -7,6 +7,7 @@ import {
   listServiceConfig,
   updateServiceConfig,
   applyServiceConfig,
+  getServiceCommand,
   type ServiceConfig,
 } from '$/api/service-config';
 import { AuthError, ApiError } from '$/api/client';
@@ -292,6 +293,7 @@ export function ServiceConfigPage() {
   const [applyFlash, setApplyFlash] = useState(false);
   const [showApplyConfirm, setShowApplyConfirm] = useState(false);
   const [restarting, setRestarting] = useState(false);
+  const [restartStatus, setRestartStatus] = useState<string | null>(null);
   const qc = useQueryClient();
   const {
     data,
@@ -320,17 +322,49 @@ export function ServiceConfigPage() {
   const hasPendingChanges = sections.some((s) => s.Source === 'db');
 
   const applyMutation = useMutation({
-    mutationFn: () => applyServiceConfig(),
-    onSuccess: () => {
+    mutationFn: () => applyServiceConfig(service),
+    onSuccess: (resp) => {
       setApplyErr(null);
       setApplyFlash(true);
       setRestarting(true);
+      setRestartStatus(resp.command?.status ?? null);
+      if (service === 'tls' && resp.command?.command_id) {
+        const commandID = resp.command.command_id;
+        let timeout: ReturnType<typeof setTimeout>;
+        const poll = setInterval(() => {
+          getServiceCommand(commandID)
+            .then((cmd) => {
+              setRestartStatus(cmd.status);
+              if (cmd.status === 'recovered') {
+                clearInterval(poll);
+                clearTimeout(timeout);
+                setRestarting(false);
+                setApplyFlash(false);
+                qc.invalidateQueries({ queryKey: ['service-config', service] });
+              }
+              if (cmd.status === 'expired') {
+                clearInterval(poll);
+                clearTimeout(timeout);
+                setRestarting(false);
+                setApplyErr('TLS restart command expired before osctrl-tls consumed it.');
+              }
+            })
+            .catch(() => {});
+        }, 2000);
+        timeout = setTimeout(() => {
+          clearInterval(poll);
+          setRestarting(false);
+          setApplyErr('TLS restart recovery was not confirmed within 60 seconds.');
+        }, 60_000);
+        return;
+      }
       const poll = setInterval(() => {
         listServiceConfig(service)
           .then(() => {
             clearInterval(poll);
             setRestarting(false);
             setApplyFlash(false);
+            setRestartStatus(null);
             qc.invalidateQueries({ queryKey: ['service-config', service] });
           })
           .catch(() => {});
@@ -345,6 +379,7 @@ export function ServiceConfigPage() {
         window.location.href = '/login';
         return;
       }
+      setRestartStatus(null);
       setApplyErr(e instanceof Error ? e.message : 'Apply failed');
     },
   });
@@ -375,7 +410,9 @@ export function ServiceConfigPage() {
             aria-live="polite"
             className="text-xs text-[color:var(--text-3)] font-mono-tabular"
           >
-            Restarting — waiting for service…
+            {service === 'tls' && restartStatus
+              ? `osctrl-tls restart ${restartStatus}…`
+              : `Restarting — waiting for osctrl-${service}…`}
           </span>
         )}
         {applyErr && (
@@ -475,6 +512,7 @@ export function ServiceConfigPage() {
 
       {showApplyConfirm && (
         <ApplyConfirmDialog
+          service={service}
           pendingSections={sections.filter((s) => s.Source === 'db')}
           isPending={applyMutation.isPending}
           onConfirm={() => {
@@ -1258,11 +1296,13 @@ function ToggleSwitch({
 export default ServiceConfigPage;
 
 function ApplyConfirmDialog({
+  service,
   pendingSections,
   isPending,
   onConfirm,
   onCancel,
 }: {
+  service: string;
   pendingSections: ServiceConfig[];
   isPending: boolean;
   onConfirm: () => void;
@@ -1277,7 +1317,7 @@ function ApplyConfirmDialog({
     >
       <div className="space-y-4">
         <p className="text-sm text-[color:var(--text-1)]">
-          This will restart the osctrl-api service to apply the following
+          This will restart the osctrl-{service} service to apply the following
           configuration changes. The service will be briefly unavailable.
         </p>
         <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-0)] p-3">

--- a/pkg/servicecommands/servicecommands.go
+++ b/pkg/servicecommands/servicecommands.go
@@ -1,0 +1,165 @@
+// Package servicecommands stores small, allowlisted service control requests.
+package servicecommands
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	ActionRestart = "restart"
+
+	StatusPending   = "pending"
+	StatusConsumed  = "consumed"
+	StatusRecovered = "recovered"
+	StatusExpired   = "expired"
+)
+
+var (
+	ErrInvalidTarget = errors.New("invalid service command target")
+)
+
+// ServiceCommand is a one-shot control request for another osctrl service.
+type ServiceCommand struct {
+	gorm.Model
+	CommandID     string `gorm:"uniqueIndex"`
+	TargetService string `gorm:"index:idx_service_commands_pending"`
+	Action        string `gorm:"index:idx_service_commands_pending"`
+	RequestedBy   string
+	RequestedFrom string
+	ConsumedAt    *time.Time `gorm:"index:idx_service_commands_pending"`
+	ConsumedBy    string
+	RecoveredAt   *time.Time
+	RecoveredBy   string
+	ExpiresAt     time.Time `gorm:"index:idx_service_commands_pending"`
+}
+
+// Status derives the operator-facing command status.
+func (c ServiceCommand) Status(now time.Time) string {
+	if c.RecoveredAt != nil {
+		return StatusRecovered
+	}
+	if c.ConsumedAt != nil {
+		return StatusConsumed
+	}
+	if !c.ExpiresAt.After(now) {
+		return StatusExpired
+	}
+	return StatusPending
+}
+
+// Manager manages service_commands.
+type Manager struct {
+	DB *gorm.DB
+}
+
+func NewManager(db *gorm.DB) *Manager {
+	m := &Manager{DB: db}
+	if err := db.AutoMigrate(&ServiceCommand{}); err != nil {
+		log.Fatal().Msgf("Failed to AutoMigrate table (service_commands): %v", err)
+	}
+	return m
+}
+
+func (m *Manager) RequestRestart(targetService, requestedBy, requestedFrom string, ttl time.Duration) (ServiceCommand, error) {
+	if targetService != config.ServiceTLS {
+		return ServiceCommand{}, ErrInvalidTarget
+	}
+	if ttl <= 0 {
+		return ServiceCommand{}, fmt.Errorf("ttl must be positive")
+	}
+	commandID, err := newCommandID()
+	if err != nil {
+		return ServiceCommand{}, err
+	}
+	cmd := ServiceCommand{
+		CommandID:     commandID,
+		TargetService: targetService,
+		Action:        ActionRestart,
+		RequestedBy:   requestedBy,
+		RequestedFrom: requestedFrom,
+		ExpiresAt:     time.Now().Add(ttl),
+	}
+	if err := m.DB.Create(&cmd).Error; err != nil {
+		return ServiceCommand{}, err
+	}
+	return cmd, nil
+}
+
+func (m *Manager) Get(commandID string) (ServiceCommand, error) {
+	var cmd ServiceCommand
+	if err := m.DB.Where("command_id = ?", commandID).First(&cmd).Error; err != nil {
+		return ServiceCommand{}, err
+	}
+	return cmd, nil
+}
+
+func (m *Manager) ConsumeNext(targetService, consumedBy string, now time.Time) (ServiceCommand, bool, error) {
+	if targetService != config.ServiceTLS {
+		return ServiceCommand{}, false, ErrInvalidTarget
+	}
+	var consumed ServiceCommand
+	err := m.DB.Transaction(func(tx *gorm.DB) error {
+		var cmd ServiceCommand
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("target_service = ? AND action = ? AND consumed_at IS NULL AND expires_at > ?", targetService, ActionRestart, now).
+			Order("created_at ASC").
+			Limit(1).
+			Find(&cmd).Error
+		if err != nil {
+			return err
+		}
+		if cmd.ID == 0 {
+			return nil
+		}
+		res := tx.Model(&ServiceCommand{}).
+			Where("id = ? AND consumed_at IS NULL AND expires_at > ?", cmd.ID, now).
+			Updates(map[string]any{
+				"consumed_at": &now,
+				"consumed_by": consumedBy,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return nil
+		}
+		consumed = cmd
+		consumed.ConsumedAt = &now
+		consumed.ConsumedBy = consumedBy
+		return nil
+	})
+	if err != nil {
+		return ServiceCommand{}, false, err
+	}
+	return consumed, consumed.ID != 0, nil
+}
+
+func (m *Manager) MarkRecovered(targetService, recoveredBy string, now time.Time) (int64, error) {
+	if targetService != config.ServiceTLS {
+		return 0, ErrInvalidTarget
+	}
+	res := m.DB.Model(&ServiceCommand{}).
+		Where("target_service = ? AND action = ? AND consumed_at IS NOT NULL AND recovered_at IS NULL", targetService, ActionRestart).
+		Updates(map[string]any{
+			"recovered_at": &now,
+			"recovered_by": recoveredBy,
+		})
+	return res.RowsAffected, res.Error
+}
+
+func newCommandID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/pkg/servicecommands/servicecommands_test.go
+++ b/pkg/servicecommands/servicecommands_test.go
@@ -1,0 +1,98 @@
+package servicecommands
+
+import (
+	"bytes"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupServiceCommandsDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&ServiceCommand{}))
+	return db
+}
+
+func TestRequestRestartCreatesPendingCommand(t *testing.T) {
+	m := &Manager{DB: setupServiceCommandsDB(t)}
+
+	cmd, err := m.RequestRestart(config.ServiceTLS, "alice", "127.0.0.1", time.Minute)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, cmd.CommandID)
+	require.Equal(t, config.ServiceTLS, cmd.TargetService)
+	require.Equal(t, ActionRestart, cmd.Action)
+	require.Equal(t, StatusPending, cmd.Status(time.Now()))
+}
+
+func TestConsumeNextConsumesCommandOnce(t *testing.T) {
+	m := &Manager{DB: setupServiceCommandsDB(t)}
+	created, err := m.RequestRestart(config.ServiceTLS, "alice", "127.0.0.1", time.Minute)
+	require.NoError(t, err)
+
+	consumed, ok, err := m.ConsumeNext(config.ServiceTLS, "osctrl-tls", time.Now())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, created.CommandID, consumed.CommandID)
+	require.Equal(t, StatusConsumed, consumed.Status(time.Now()))
+
+	_, ok, err = m.ConsumeNext(config.ServiceTLS, "osctrl-tls", time.Now())
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestConsumeNextSkipsExpiredCommands(t *testing.T) {
+	m := &Manager{DB: setupServiceCommandsDB(t)}
+	created, err := m.RequestRestart(config.ServiceTLS, "alice", "127.0.0.1", time.Nanosecond)
+	require.NoError(t, err)
+
+	now := created.ExpiresAt.Add(time.Second)
+	_, ok, err := m.ConsumeNext(config.ServiceTLS, "osctrl-tls", now)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	stored, err := m.Get(created.CommandID)
+	require.NoError(t, err)
+	require.Equal(t, StatusExpired, stored.Status(now))
+}
+
+func TestConsumeNextDoesNotLogRecordNotFoundWhenIdle(t *testing.T) {
+	var logs bytes.Buffer
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{
+		Logger: logger.New(log.New(&logs, "", 0), logger.Config{LogLevel: logger.Info}),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&ServiceCommand{}))
+	m := &Manager{DB: db}
+
+	_, ok, err := m.ConsumeNext(config.ServiceTLS, "osctrl-tls", time.Now())
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.NotContains(t, logs.String(), "record not found")
+}
+
+func TestMarkRecoveredUpdatesConsumedCommands(t *testing.T) {
+	m := &Manager{DB: setupServiceCommandsDB(t)}
+	created, err := m.RequestRestart(config.ServiceTLS, "alice", "127.0.0.1", time.Minute)
+	require.NoError(t, err)
+	_, ok, err := m.ConsumeNext(config.ServiceTLS, "osctrl-tls", time.Now())
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	n, err := m.MarkRecovered(config.ServiceTLS, "osctrl-tls", time.Now())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	stored, err := m.Get(created.CommandID)
+	require.NoError(t, err)
+	require.Equal(t, StatusRecovered, stored.Status(time.Now()))
+	require.NotNil(t, stored.RecoveredAt)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -524,6 +524,33 @@ type ServiceConfigUpdateRequest struct {
 	Value json.RawMessage `json:"value"`
 }
 
+// ServiceConfigApplyRequest is the optional body for POST
+// /api/v1/service-config/apply. Empty service defaults to osctrl-api.
+type ServiceConfigApplyRequest struct {
+	Service string `json:"service,omitempty"`
+}
+
+type ServiceCommandResponse struct {
+	CommandID     string     `json:"command_id"`
+	TargetService string     `json:"target_service"`
+	Action        string     `json:"action"`
+	Status        string     `json:"status"`
+	RequestedBy   string     `json:"requested_by"`
+	RequestedFrom string     `json:"requested_from"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ExpiresAt     time.Time  `json:"expires_at"`
+	ConsumedAt    *time.Time `json:"consumed_at,omitempty"`
+	ConsumedBy    string     `json:"consumed_by,omitempty"`
+	RecoveredAt   *time.Time `json:"recovered_at,omitempty"`
+	RecoveredBy   string     `json:"recovered_by,omitempty"`
+}
+
+type ServiceConfigApplyResponse struct {
+	Message string                  `json:"message"`
+	Service string                  `json:"service"`
+	Command *ServiceCommandResponse `json:"command,omitempty"`
+}
+
 // TLSEnvironmentView is the low-privilege projection of an environment.
 // UserLevel operators (env scope) need basic env metadata so the SPA can
 // render its env switcher / dashboard / table chrome — but they MUST NOT


### PR DESCRIPTION
## Summary

- Added a DB-backed `service_commands` system so `osctrl-api` can request an `osctrl-tls` restart without shell, Docker, SSH, or systemd privileges.
- Updated `POST /api/v1/service-config/apply` to be service-aware:
  - `api` keeps the existing local restart behavior.
  - `tls` creates a one-shot restart command for `osctrl-tls`.
- Added `GET /api/v1/service-config/commands/{command_id}` so restart command status can be polled.
- Updated `osctrl-tls` to poll for pending restart commands, consume them once, exit for supervisor restart, and mark consumed commands as recovered on startup.
- Updated the frontend service config view to apply restarts for the selected service and display TLS restart command status.
- Updated dev Air config so `osctrl-tls` restarts when it exits with code `1`.
- Suppressed noisy idle polling logs by avoiding GORM `record not found` logging when no service command exists.

## Security

- Restart commands are allowlisted to `target_service=tls` and `action=restart`.
- No host-level process control was added to `osctrl-api`.
- Restart apply remains protected by existing admin auth and rate limiting.
- Command lifecycle is auditable through requested, consumed, expired, and recovered states.

## Validation

- `GOCACHE=/tmp/osctrl-gocache go test ./pkg/servicecommands`
- `GOCACHE=/tmp/osctrl-gocache go test ./pkg/servicecommands ./cmd/tls`
- `GOCACHE=/tmp/osctrl-gocache go test ./pkg/servicecommands ./cmd/api/handlers ./cmd/api ./cmd/tls`
- `npm test`
- `npm run build`