### PR TITLE
Ability to write modified service configuration values to YAML

### DIFF
--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -88,6 +88,11 @@ type HandlersApi struct {
 	// process manager restarts the service and picks up DB-edited
 	// config. nil means the apply endpoint returns 503.
 	RestartCh chan<- struct{}
+	// ConfigPersist, when wired via WithConfigPersist, writes this
+	// service's DB-edited config sections back to its own YAML file. It
+	// lives in main because the YAML loader does. nil means the persist
+	// endpoint returns 503 for osctrl-api.
+	ConfigPersist func() error
 }
 
 type HandlersOption func(*HandlersApi)
@@ -297,6 +302,12 @@ func WithDBHealth(hl backend.DegradedReader) HandlersOption {
 func WithRestartCh(ch chan<- struct{}) HandlersOption {
 	return func(h *HandlersApi) {
 		h.RestartCh = ch
+	}
+}
+
+func WithConfigPersist(fn func() error) HandlersOption {
+	return func(h *HandlersApi) {
+		h.ConfigPersist = fn
 	}
 }
 

--- a/cmd/api/handlers/service_config.go
+++ b/cmd/api/handlers/service_config.go
@@ -328,6 +328,191 @@ func (h *HandlersApi) ServiceConfigApplyHandler(w http.ResponseWriter, r *http.R
 	}
 }
 
+// ServiceConfigStatusHandler — GET /api/v1/service-config/status/{service}
+//
+// Reports whether the service has config sections edited in the database that
+// the YAML file on disk does not have, and whether the service's own process
+// can write that file. The SPA uses this to decide whether to offer the
+// "Write to disk" action and whether it has to be disabled.
+//
+// The writability answer comes from the row the service itself reported at
+// boot: osctrl-tls runs in its own process (usually its own container), so
+// this process cannot check the TLS config file directly.
+//
+// @Summary Service config file status
+// @Description Reports unsaved DB changes and config file writability for a service.
+// @Tags service-config
+// @Produce json
+// @Param service path string true "Service name"
+// @Success 200 {object} types.ServiceConfigStatusResponse
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/service-config/status/{service} [get]
+func (h *HandlersApi) ServiceConfigStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	if h.ServiceConfig == nil {
+		apiErrorResponse(w, "service config not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	service := r.PathValue("service")
+	if !h.ServiceConfig.VerifyService(service) {
+		apiErrorResponse(w, "invalid service", http.StatusBadRequest, nil)
+		return
+	}
+	pending, err := h.ServiceConfig.HasPendingChanges(service, serviceconfig.NoEnvironmentID)
+	if err != nil {
+		apiErrorResponse(w, "error checking pending changes", http.StatusInternalServerError, err)
+		return
+	}
+	resp := types.ServiceConfigStatusResponse{
+		Service:        service,
+		PendingChanges: pending,
+	}
+	status, err := h.ServiceConfig.GetFileStatus(service)
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		// The service has not booted since this feature shipped, so it has
+		// never reported its file. Treat as not writable rather than
+		// guessing — the operator sees why and can restart it.
+		resp.FileReason = "service has not reported its configuration file yet"
+	case err != nil:
+		apiErrorResponse(w, "error getting config file status", http.StatusInternalServerError, err)
+		return
+	default:
+		resp.FilePath = status.Path
+		resp.FileWritable = status.Writable
+		resp.FileReason = status.Reason
+		resp.CheckedAt = status.CheckedAt
+	}
+	h.AuditLog.Visit(ctx[ctxUser], r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, resp)
+}
+
+// ServiceConfigPersistHandler — POST /api/v1/service-config/persist
+//
+// Writes the DB-edited config sections back to the service's YAML file so the
+// changes survive a redeploy that starts from the file. It does not restart
+// anything: applying the changes to the running process remains the separate
+// apply endpoint.
+//
+// osctrl-api writes its own file inline. osctrl-tls cannot be written from
+// here — it is a different process with a different config volume — so the
+// write is queued as a service command that the TLS process consumes on its
+// next poll, exactly like a restart request.
+//
+// @Summary Write config changes to disk
+// @Description Persists DB-edited config sections back to the service's YAML file.
+// @Tags service-config
+// @Accept json
+// @Produce json
+// @Param request body types.ServiceConfigPersistRequest false "Request body"
+// @Success 200 {object} types.ServiceConfigPersistResponse "Written"
+// @Success 202 {object} types.ServiceConfigPersistResponse "Write queued"
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 409 {object} types.ApiErrorResponse "Config file not writable"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Failure 503 {object} types.ApiErrorResponse "Service unavailable"
+// @Security ApiKeyAuth
+// @Router /api/v1/service-config/persist [post]
+func (h *HandlersApi) ServiceConfigPersistHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", ctx[ctxUser]))
+		return
+	}
+	if h.ServiceConfig == nil {
+		apiErrorResponse(w, "service config not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	var body types.ServiceConfigPersistRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+			return
+		}
+	}
+	service := body.Service
+	if service == "" {
+		service = config.ServiceAPI
+	}
+	if !h.ServiceConfig.VerifyService(service) {
+		apiErrorResponse(w, "invalid service", http.StatusBadRequest, nil)
+		return
+	}
+	ipAddress := strings.Split(r.RemoteAddr, ":")[0]
+	// Fail on the writability the target service reported at boot before
+	// attempting anything, so the operator gets the real reason — a missing
+	// file, bad permissions, or a service configured from environment
+	// variables with no file at all — instead of a load error later.
+	fileStatus, err := h.ServiceConfig.GetFileStatus(service)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErrorResponse(w, fmt.Sprintf("osctrl-%s has not reported its configuration file yet", service), http.StatusConflict, err)
+			return
+		}
+		apiErrorResponse(w, "error getting config file status", http.StatusInternalServerError, err)
+		return
+	}
+	if !fileStatus.Writable {
+		apiErrorResponse(w, fmt.Sprintf("%s: %s", serviceconfig.ErrConfigFileNotWritable, fileStatus.Reason), http.StatusConflict, nil)
+		return
+	}
+	switch service {
+	case config.ServiceAPI:
+		if h.ConfigPersist == nil {
+			apiErrorResponse(w, "persist not available", http.StatusServiceUnavailable, nil)
+			return
+		}
+		if err := h.ConfigPersist(); err != nil {
+			if errors.Is(err, serviceconfig.ErrConfigFileNotWritable) {
+				apiErrorResponse(w, err.Error(), http.StatusConflict, err)
+				return
+			}
+			apiErrorResponse(w, "error writing config file", http.StatusInternalServerError, err)
+			return
+		}
+		h.AuditLog.SettingsAction(ctx[ctxUser], "persist service-config api to file", ipAddress)
+		log.Info().Msgf("Service config persisted to file by %s", ctx[ctxUser])
+		utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ServiceConfigPersistResponse{
+			Service: config.ServiceAPI,
+			Message: "Configuration written to disk.",
+		})
+	case config.ServiceTLS:
+		if h.ServiceCommands == nil {
+			apiErrorResponse(w, "service commands not available", http.StatusServiceUnavailable, nil)
+			return
+		}
+		cmd, err := h.ServiceCommands.Request(config.ServiceTLS, servicecommands.ActionPersistConfig, ctx[ctxUser], ipAddress, serviceCommandTTL)
+		if err != nil {
+			apiErrorResponse(w, "error requesting tls config persist", http.StatusInternalServerError, err)
+			return
+		}
+		h.AuditLog.SettingsAction(ctx[ctxUser], fmt.Sprintf("persist service-config tls command %s", cmd.CommandID), ipAddress)
+		log.Info().Str("command", cmd.CommandID).Msgf("TLS config persist requested by %s", ctx[ctxUser])
+		resp := serviceCommandResponse(cmd)
+		utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusAccepted, types.ServiceConfigPersistResponse{
+			Service: config.ServiceTLS,
+			Message: "Write requested. osctrl-tls will write its configuration file after consuming the service command.",
+			Command: &resp,
+		})
+	}
+}
+
 // ServiceCommandHandler — GET /api/v1/service-config/commands/{command_id}
 func (h *HandlersApi) ServiceCommandHandler(w http.ResponseWriter, r *http.Request) {
 	if h.DebugHTTPConfig.EnableHTTP {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -396,6 +396,11 @@ func osctrlAPIService() {
 	if err := serviceConfigMgr.Resolve(config.ServiceAPI, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error resolving service config - %v", err)
 	}
+	// Report whether this process can write its own config file. Only this
+	// process can know — osctrl-tls runs elsewhere and reports its own.
+	if err := serviceConfigMgr.ReportFile(config.ServiceAPI, flagParams.ConfigFilePath()); err != nil {
+		log.Err(err).Msg("Error reporting service config file status")
+	}
 	if flagParams.RateLimits == nil {
 		flagParams.RateLimits = config.DefaultRateLimitsPtr()
 	}
@@ -453,6 +458,17 @@ func osctrlAPIService() {
 	// restarts the service with the DB-edited config.
 	restartCh := make(chan struct{}, 1)
 
+	// Persisting this service's config file happens in this process — the
+	// YAML loader lives here, and no other service can reach the file.
+	persistConfig := func() error {
+		path := flagParams.ConfigFilePath()
+		loaded, err := loadYAMLConfiguration(path)
+		if err != nil {
+			return fmt.Errorf("reload %s: %w", path, err)
+		}
+		return serviceConfigMgr.PersistToFile(config.ServiceAPI, path, loadedYAMLToServiceParams(loaded, path), settings.NoEnvironmentID)
+	}
+
 	handlersApi = handlers.CreateHandlersApi(
 		handlers.WithDB(db.Conn),
 		handlers.WithLogReader(logReader),
@@ -468,6 +484,7 @@ func osctrlAPIService() {
 		handlers.WithSettings(settingsmgr),
 		handlers.WithServiceConfig(serviceConfigMgr),
 		handlers.WithServiceCommands(serviceCommandMgr),
+		handlers.WithConfigPersist(persistConfig),
 		handlers.WithActivityReader(activity.NewRedisStore(redis.Client, activity.DefaultPrefix, activity.DefaultRetentionDays, 8*24*time.Hour)),
 		handlers.WithGeoIP(geoIPResolver),
 		handlers.WithPosture(posturemgr),
@@ -935,6 +952,12 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"GET "+_apiPath(apiServiceConfigPath)+"/{service}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigServiceHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	// Literal-prefixed like /commands/{command_id}: "{service}/status" would
+	// conflict with it — neither pattern is more specific than the other, and
+	// ServeMux panics at registration.
+	muxAPI.Handle(
+		"GET "+_apiPath(apiServiceConfigPath)+"/status/{service}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigStatusHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	muxAPI.Handle(
 		"GET "+_apiPath(apiServiceConfigPath)+"/{service}/{section}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigSectionHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
@@ -944,6 +967,11 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"POST "+_apiPath(apiServiceConfigPath)+"/apply",
 		restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
+	// Persist writes a file rather than restarting anything, but it is the
+	// same class of privileged, disk-touching operation — same limiter.
+	muxAPI.Handle(
+		"POST "+_apiPath(apiServiceConfigPath)+"/persist",
+		restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigPersistHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
 	// API: audit log
 	if flagParams.Service.AuditLog {
 		muxAPI.Handle(

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -274,6 +274,11 @@ func osctrlService() {
 	if err := serviceConfigMgr.Resolve(config.ServiceTLS, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error resolving service config - %v", err)
 	}
+	// Report whether this process can write its own config file. Only this
+	// process can know — osctrl-api runs elsewhere and cannot stat it.
+	if err := serviceConfigMgr.ReportFile(config.ServiceTLS, flagParams.ConfigFilePath()); err != nil {
+		log.Err(err).Msg("Error reporting service config file status")
+	}
 	if flagParams.RateLimits == nil {
 		flagParams.RateLimits = config.DefaultRateLimitsPtr()
 	}
@@ -460,7 +465,7 @@ func osctrlService() {
 		srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
 	}
 	watchCtx, stopCommandWatcher := context.WithCancel(context.Background())
-	go watchServiceCommands(watchCtx, serviceCommandMgr, auditLog, restartCh)
+	go watchServiceCommands(watchCtx, serviceCommandMgr, serviceConfigMgr, auditLog, restartCh)
 	serverErr := make(chan error, 1)
 	go func() {
 		log.Info().Msgf("%s v%s - HTTP%s listening %s", serviceName, buildVersion, map[bool]string{true: "S", false: ""}[flagParams.TLS.Termination], serviceListener)
@@ -484,7 +489,7 @@ func osctrlService() {
 	}
 }
 
-func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, auditLog *auditlog.AuditLogManager, restartCh chan<- struct{}) {
+func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfgMgr *serviceconfig.ServiceConfigManager, auditLog *auditlog.AuditLogManager, restartCh chan<- struct{}) {
 	ticker := time.NewTicker(serviceCommandPollInterval)
 	defer ticker.Stop()
 	for {
@@ -500,12 +505,40 @@ func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, aud
 			if !ok {
 				continue
 			}
-			auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls restart command %s consumed", cmd.CommandID), "local")
-			log.Info().Str("command", cmd.CommandID).Msg("Consumed TLS restart command")
-			restartCh <- struct{}{}
-			return
+			switch cmd.Action {
+			case servicecommands.ActionRestart:
+				auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls restart command %s consumed", cmd.CommandID), "local")
+				log.Info().Str("command", cmd.CommandID).Msg("Consumed TLS restart command")
+				restartCh <- struct{}{}
+				return
+			case servicecommands.ActionPersistConfig:
+				// Writing the file does not affect the running process,
+				// so keep polling instead of exiting.
+				if err := persistConfigToFile(cfgMgr); err != nil {
+					log.Err(err).Str("command", cmd.CommandID).Msg("error persisting TLS config to file")
+					auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls persist-config command %s failed: %v", cmd.CommandID, err), "local")
+					continue
+				}
+				auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls persist-config command %s consumed", cmd.CommandID), "local")
+				log.Info().Str("command", cmd.CommandID).Msg("Persisted TLS config to file")
+			default:
+				log.Warn().Str("command", cmd.CommandID).Msgf("Ignoring unknown TLS service command action %q", cmd.Action)
+			}
 		}
 	}
+}
+
+// persistConfigToFile reloads the YAML file from disk, overlays the DB-edited
+// sections and writes the result back. Reloading rather than reusing the live
+// flagParams keeps the running service's configuration untouched — the
+// operator's edits still only take effect on restart.
+func persistConfigToFile(cfgMgr *serviceconfig.ServiceConfigManager) error {
+	path := flagParams.ConfigFilePath()
+	loaded, err := loadYAMLConfiguration(path)
+	if err != nil {
+		return fmt.Errorf("reload %s: %w", path, err)
+	}
+	return cfgMgr.PersistToFile(config.ServiceTLS, path, loadedYAMLToServiceParams(loaded, path), settings.NoEnvironmentID)
 }
 
 // Action to run when no flags are provided to run checks and prepare data

--- a/frontend/src/api/service-config.ts
+++ b/frontend/src/api/service-config.ts
@@ -98,6 +98,43 @@ export function applyServiceConfig(service = 'api'): Promise<ServiceConfigApplyR
   });
 }
 
+export interface ServiceConfigStatus {
+  service: string;
+  /** Sections edited in the DB that the YAML file on disk does not have. */
+  pending_changes: boolean;
+  file_path: string;
+  /** Whether the service's own process can write its config file. */
+  file_writable: boolean;
+  /** Why the file cannot be written, when file_writable is false. */
+  file_reason?: string;
+  checked_at?: string;
+}
+
+/** GET /api/v1/service-config/status/{service} — unsaved changes + file writability. */
+export function getServiceConfigStatus(service: string): Promise<ServiceConfigStatus> {
+  return apiFetch<ServiceConfigStatus>(
+    `/api/v1/service-config/status/${encodeURIComponent(service)}`,
+  );
+}
+
+export interface ServiceConfigPersistResponse {
+  message: string;
+  service?: string;
+  /** Present for osctrl-tls, which performs the write in its own process. */
+  command?: ServiceCommand;
+}
+
+/** POST /api/v1/service-config/persist — write DB changes back to the YAML file. */
+export function persistServiceConfig(
+  service = 'api',
+): Promise<ServiceConfigPersistResponse> {
+  return apiFetch<ServiceConfigPersistResponse>('/api/v1/service-config/persist', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ service }),
+  });
+}
+
 /** GET /api/v1/service-config/commands/{command_id} — command restart status. */
 export function getServiceCommand(commandID: string): Promise<ServiceCommand> {
   return apiFetch<ServiceCommand>(

--- a/frontend/src/features/service-config/ServiceConfigPage.test.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.test.tsx
@@ -11,18 +11,22 @@ import {
   Outlet,
 } from '@tanstack/react-router';
 import { ServiceConfigPage } from './ServiceConfigPage';
-import type { ServiceCommand, ServiceConfig } from '$/api/service-config';
+import type { ServiceCommand, ServiceConfig, ServiceConfigStatus } from '$/api/service-config';
 
 const mockList = vi.fn<(service: string) => Promise<ServiceConfig[]>>();
 const mockUpdate = vi.fn();
 const mockApply = vi.fn();
 const mockGetCommand = vi.fn<(commandID: string) => Promise<ServiceCommand>>();
+const mockStatus = vi.fn<(service: string) => Promise<ServiceConfigStatus>>();
+const mockPersist = vi.fn();
 
 vi.mock('$/api/service-config', () => ({
   listServiceConfig: (service: string) => mockList(service),
   updateServiceConfig: (...args: unknown[]) => mockUpdate(...args),
   applyServiceConfig: (service: string) => mockApply(service),
   getServiceCommand: (commandID: string) => mockGetCommand(commandID),
+  getServiceConfigStatus: (service: string) => mockStatus(service),
+  persistServiceConfig: (service: string) => mockPersist(service),
 }));
 
 vi.mock('$/api/client', () => ({
@@ -96,6 +100,12 @@ function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
 describe('ServiceConfigPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockStatus.mockResolvedValue({
+      service: 'api',
+      pending_changes: true,
+      file_path: '/etc/osctrl/api.yml',
+      file_writable: true,
+    });
   });
 
   it('renders service config sections with their names and badges', async () => {
@@ -461,6 +471,103 @@ describe('ServiceConfigPage', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Apply & Restart/i })).toBeInTheDocument();
+    });
+  });
+
+  it('does not show Write to Disk button when nothing is pending', async () => {
+    mockList.mockResolvedValue([makeSection({ Source: 'yaml' })]);
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByText('logger')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /Write to Disk/i })).not.toBeInTheDocument();
+  });
+
+  it('calls persistServiceConfig when Write to Disk is clicked', async () => {
+    const user = userEvent.setup();
+    mockList.mockResolvedValue([makeSection({ Source: 'db', Name: 'debug', Editable: true })]);
+    mockPersist.mockResolvedValue({ message: 'Configuration written to disk.' });
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Write to Disk/i })).toBeEnabled();
+    });
+    await user.click(screen.getByRole('button', { name: /Write to Disk/i }));
+
+    await waitFor(() => {
+      expect(mockPersist).toHaveBeenCalledWith('api');
+    });
+    // Writing must not restart anything — that stays a separate action.
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+
+  it('keeps offering Apply & Restart after writing to disk', async () => {
+    const user = userEvent.setup();
+    // After the write the backend flips every section back to source=yaml,
+    // so the page must not conclude there is nothing left to restart for.
+    mockList
+      .mockResolvedValueOnce([makeSection({ Source: 'db', Name: 'debug', Editable: true })])
+      .mockResolvedValue([makeSection({ Source: 'yaml', Name: 'debug', Editable: true })]);
+    mockPersist.mockResolvedValue({ message: 'Configuration written to disk.' });
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Write to Disk/i })).toBeEnabled();
+    });
+    await user.click(screen.getByRole('button', { name: /Write to Disk/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Write to Disk/i })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /Apply & Restart/i })).toBeInTheDocument();
+  });
+
+  it('disables Write to Disk with the reason when the file is not writable', async () => {
+    mockList.mockResolvedValue([makeSection({ Source: 'db', Name: 'debug', Editable: true })]);
+    mockStatus.mockResolvedValue({
+      service: 'api',
+      pending_changes: true,
+      file_path: '/etc/osctrl/api.yml',
+      file_writable: false,
+      file_reason: 'open /etc/osctrl/api.yml: permission denied',
+    });
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Cannot Write to Disk/i })).toBeDisabled();
+    });
+    expect(screen.getByRole('button', { name: /Cannot Write to Disk/i })).toHaveAttribute(
+      'title',
+      expect.stringContaining('permission denied'),
+    );
+    // A disabled button is not focusable, so the tooltip alone would never
+    // reach a keyboard user — the reason has to be on screen.
+    expect(
+      screen.getByText('(open /etc/osctrl/api.yml: permission denied)'),
+    ).toBeInTheDocument();
+  });
+
+  it('stays quiet rather than flashing red while the status is loading', async () => {
+    mockList.mockResolvedValue([makeSection({ Source: 'db', Name: 'debug', Editable: true })]);
+    mockStatus.mockRejectedValue(new Error('boom'));
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Write to Disk/i })).toBeDisabled();
+    });
+    expect(
+      screen.queryByRole('button', { name: /Cannot Write to Disk/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps Write to Disk disabled when the status is unavailable', async () => {
+    mockList.mockResolvedValue([makeSection({ Source: 'db', Name: 'debug', Editable: true })]);
+    mockStatus.mockRejectedValue(new Error('boom'));
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Write to Disk/i })).toBeDisabled();
     });
   });
 

--- a/frontend/src/features/service-config/ServiceConfigPage.tsx
+++ b/frontend/src/features/service-config/ServiceConfigPage.tsx
@@ -8,6 +8,8 @@ import {
   updateServiceConfig,
   applyServiceConfig,
   getServiceCommand,
+  getServiceConfigStatus,
+  persistServiceConfig,
   type ServiceConfig,
 } from '$/api/service-config';
 import { AuthError, ApiError } from '$/api/client';
@@ -437,6 +439,16 @@ export function ServiceConfigPage() {
   const [showApplyConfirm, setShowApplyConfirm] = useState(false);
   const [restarting, setRestarting] = useState(false);
   const [restartStatus, setRestartStatus] = useState<string | null>(null);
+  const [persisting, setPersisting] = useState(false);
+  const [persistFlash, setPersistFlash] = useState(false);
+  // Writing to disk flips every section back to source=yaml, which would
+  // otherwise hide Apply & Restart — leaving the changes on disk but never
+  // picked up by the running service. Keep offering the restart once we have
+  // written in this session.
+  // ponytail: session-local, so a page reload forgets it. Recording the
+  // service's boot time and comparing it against section UpdatedAt would
+  // survive reloads, if operators hit this.
+  const [persistedThisSession, setPersistedThisSession] = useState(false);
   const qc = useQueryClient();
   const {
     data,
@@ -448,6 +460,14 @@ export function ServiceConfigPage() {
   } = useQuery({
     queryKey: ['service-config', service],
     queryFn: () => listServiceConfig(service),
+    staleTime: 30_000,
+  });
+
+  // Whether the service's own process can write its config file. Only that
+  // process can know — osctrl-tls runs elsewhere and reports it at boot.
+  const { data: fileStatus } = useQuery({
+    queryKey: ['service-config-status', service],
+    queryFn: () => getServiceConfigStatus(service),
     staleTime: 30_000,
   });
 
@@ -463,6 +483,61 @@ export function ServiceConfigPage() {
   const pageError = error;
 
   const hasPendingChanges = sections.some((s) => s.Source === 'db');
+  // Only shout when the service actually reported it cannot write. While the
+  // status is still loading or failed to load, fileStatus is undefined — the
+  // button stays disabled but stays quiet rather than flashing red.
+  const cannotWrite = fileStatus?.file_writable === false;
+
+  // Writing the file does not touch the running service, so there is no
+  // restart to wait on. osctrl-api writes inline and returns done; osctrl-tls
+  // returns a queued command it consumes on its next poll, so watch the
+  // status endpoint until the pending changes clear.
+  const persistMutation = useMutation({
+    mutationFn: () => persistServiceConfig(service),
+    onSuccess: (resp) => {
+      setApplyErr(null);
+      const done = () => {
+        setPersisting(false);
+        setPersistFlash(true);
+        setPersistedThisSession(true);
+        setTimeout(() => setPersistFlash(false), 3000);
+        qc.invalidateQueries({ queryKey: ['service-config', service] });
+        qc.invalidateQueries({ queryKey: ['service-config-status', service] });
+      };
+      if (!resp.command) {
+        done();
+        return;
+      }
+      setPersisting(true);
+      let timeout: ReturnType<typeof setTimeout>;
+      const poll = setInterval(() => {
+        getServiceConfigStatus(service)
+          .then((status) => {
+            if (!status.pending_changes) {
+              clearInterval(poll);
+              clearTimeout(timeout);
+              done();
+            }
+          })
+          .catch(() => {});
+      }, 2000);
+      timeout = setTimeout(() => {
+        clearInterval(poll);
+        setPersisting(false);
+        setApplyErr(`osctrl-${service} did not write its configuration file within 60 seconds.`);
+      }, 60_000);
+    },
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        window.location.href = '/login';
+        return;
+      }
+      setPersisting(false);
+      setApplyErr(e instanceof Error ? e.message : 'Write to disk failed');
+    },
+  });
+
+  const writeBusy = persisting || persistMutation.isPending;
 
   const applyMutation = useMutation({
     mutationFn: () => applyServiceConfig(service),
@@ -470,6 +545,8 @@ export function ServiceConfigPage() {
       setApplyErr(null);
       setApplyFlash(true);
       setRestarting(true);
+      // The restart makes the config live, so nothing is left to apply.
+      setPersistedThisSession(false);
       setRestartStatus(resp.command?.status ?? null);
       if (service === 'tls' && resp.command?.command_id) {
         const commandID = resp.command.command_id;
@@ -533,7 +610,7 @@ export function ServiceConfigPage() {
         <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">
           Service Config
         </h1>
-        {hasPendingChanges && !loading && !hasError && !restarting && (
+        {(hasPendingChanges || persistedThisSession) && !loading && !hasError && !restarting && (
           <button
             type="button"
             disabled={applyMutation.isPending}
@@ -547,6 +624,44 @@ export function ServiceConfigPage() {
           >
             {applyMutation.isPending ? 'Restarting…' : applyFlash ? 'Restart triggered ✓' : 'Apply & Restart'}
           </button>
+        )}
+        {hasPendingChanges && !loading && !hasError && !restarting && (
+          <>
+            <button
+              type="button"
+              disabled={!fileStatus?.file_writable || writeBusy}
+              title={
+                fileStatus?.file_writable
+                  ? `Write these changes to ${fileStatus.file_path} so they survive a redeploy`
+                  : `Cannot write the configuration file${fileStatus?.file_reason ? `: ${fileStatus.file_reason}` : ''}`
+              }
+              onClick={() => persistMutation.mutate()}
+              className={cn(
+                'px-3 py-1 text-xs font-medium rounded transition-colors',
+                cannotWrite
+                  ? 'bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.12)] text-[color:var(--danger)] cursor-not-allowed'
+                  : !fileStatus?.file_writable || writeBusy
+                    ? 'bg-[color:var(--bg-3)] text-[color:var(--text-3)] cursor-not-allowed'
+                    : 'bg-[color:var(--bg-3)] text-[color:var(--text-2)] hover:bg-[color:var(--bg-4)]',
+              )}
+            >
+              {cannotWrite
+                ? 'Cannot Write to Disk ✕'
+                : writeBusy
+                  ? 'Writing…'
+                  : persistFlash
+                    ? 'Written to disk ✓'
+                    : 'Write to Disk'}
+            </button>
+            {cannotWrite && (
+              <span
+                aria-live="polite"
+                className="text-xs text-[color:var(--danger)]"
+              >
+                ({fileStatus?.file_reason || 'configuration file is not writable'})
+              </span>
+            )}
+          </>
         )}
         {restarting && (
           <span
@@ -1528,6 +1643,12 @@ function ApplyConfirmDialog({
           <p className="text-[10px] uppercase tracking-[0.08em] text-[color:var(--text-3)] mb-2">
             Pending changes ({pendingSections.length})
           </p>
+          {pendingSections.length === 0 && (
+            <p className="text-xs text-[color:var(--text-3)]">
+              Already written to disk — restarting loads them from the
+              configuration file.
+            </p>
+          )}
           <ul className="space-y-1">
             {pendingSections.map((s) => (
               <li

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -5195,6 +5195,115 @@ paths:
       summary: Apply config changes and restart
       tags:
         - service-config
+  /api/v1/service-config/persist:
+    post:
+      description: Persists DB-edited config sections back to the service's YAML file.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/types.ServiceConfigPersistRequest"
+        description: Request body
+      responses:
+        "200":
+          description: Written
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ServiceConfigPersistResponse"
+        "202":
+          description: Write queued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ServiceConfigPersistResponse"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "409":
+          description: Config file not writable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "503":
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Write config changes to disk
+      tags:
+        - service-config
+  "/api/v1/service-config/status/{service}":
+    get:
+      description: Reports unsaved DB changes and config file writability for a service.
+      parameters:
+        - description: Service name
+          in: path
+          name: service
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ServiceConfigStatusResponse"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Service config file status
+      tags:
+        - service-config
   /api/v1/settings:
     get:
       description: Returns settings for all services.
@@ -8834,6 +8943,62 @@ components:
         query:
           type: string
         updated_at:
+          type: string
+      type: object
+    types.ServiceCommandResponse:
+      properties:
+        action:
+          type: string
+        command_id:
+          type: string
+        consumed_at:
+          type: string
+        consumed_by:
+          type: string
+        created_at:
+          type: string
+        expires_at:
+          type: string
+        recovered_at:
+          type: string
+        recovered_by:
+          type: string
+        requested_by:
+          type: string
+        requested_from:
+          type: string
+        status:
+          type: string
+        target_service:
+          type: string
+      type: object
+    types.ServiceConfigPersistRequest:
+      properties:
+        service:
+          type: string
+      type: object
+    types.ServiceConfigPersistResponse:
+      properties:
+        command:
+          $ref: "#/components/schemas/types.ServiceCommandResponse"
+        message:
+          type: string
+        service:
+          type: string
+      type: object
+    types.ServiceConfigStatusResponse:
+      properties:
+        checked_at:
+          type: string
+        file_path:
+          type: string
+        file_reason:
+          type: string
+        file_writable:
+          type: boolean
+        pending_changes:
+          type: boolean
+        service:
           type: string
       type: object
     types.ServiceConfigUpdateRequest:

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -9,6 +9,17 @@ import (
 	"go.yaml.in/yaml/v2"
 )
 
+// ConfigFilePath returns the YAML file this service was configured from, or
+// an empty string when it was configured by flags and environment variables
+// instead. ServiceConfigFile always holds the flag default, so it is not on
+// its own evidence that a file is in use.
+func (p *ServiceParameters) ConfigFilePath() string {
+	if !p.ConfigFlag {
+		return ""
+	}
+	return p.ServiceConfigFile
+}
+
 // Helper to generate an example TLS configuration file
 func GenerateTLSConfigFile(path string, cfg *ServiceParameters, overwrite bool) error {
 	cfgTLS := TLSConfiguration{
@@ -24,6 +35,7 @@ func GenerateTLSConfigFile(path string, cfg *ServiceParameters, overwrite bool) 
 		Logger:          cfg.Logger,
 		Carver:          cfg.Carver,
 		Debug:           cfg.Debug,
+		RateLimits:      cfg.RateLimits,
 	}
 	return GenerateGenericConfigFile(path, cfgTLS, overwrite)
 }
@@ -40,8 +52,9 @@ func GenerateAPIConfigFile(path string, cfg *ServiceParameters, overwrite bool) 
 		JWT:     cfg.JWT,
 		TLS:     cfg.TLS,
 		Logger:  cfg.Logger,
-		Carver:  cfg.Carver,
-		Debug:   cfg.Debug,
+		Carver:     cfg.Carver,
+		Debug:      cfg.Debug,
+		RateLimits: cfg.RateLimits,
 	}
 	return GenerateGenericConfigFile(path, cfgAPI, overwrite)
 }

--- a/pkg/servicecommands/servicecommands.go
+++ b/pkg/servicecommands/servicecommands.go
@@ -16,6 +16,10 @@ import (
 
 const (
 	ActionRestart = "restart"
+	// ActionPersistConfig asks a service to write its DB-edited config
+	// sections back to its own YAML file. Unlike a restart it does not
+	// change what the running process is using — only what is on disk.
+	ActionPersistConfig = "persist-config"
 
 	StatusPending   = "pending"
 	StatusConsumed  = "consumed"
@@ -25,7 +29,16 @@ const (
 
 var (
 	ErrInvalidTarget = errors.New("invalid service command target")
+	ErrInvalidAction = errors.New("invalid service command action")
 )
+
+// validActions is the allowlist of commands a service will act on. Anything
+// not listed here is rejected at request time, so a row in the table can
+// never name an action the consumer does not recognise.
+var validActions = map[string]struct{}{
+	ActionRestart:       {},
+	ActionPersistConfig: {},
+}
 
 // ServiceCommand is a one-shot control request for another osctrl service.
 type ServiceCommand struct {
@@ -70,8 +83,17 @@ func NewManager(db *gorm.DB) *Manager {
 }
 
 func (m *Manager) RequestRestart(targetService, requestedBy, requestedFrom string, ttl time.Duration) (ServiceCommand, error) {
+	return m.Request(targetService, ActionRestart, requestedBy, requestedFrom, ttl)
+}
+
+// Request enqueues a one-shot command for a service to consume on its next
+// poll.
+func (m *Manager) Request(targetService, action, requestedBy, requestedFrom string, ttl time.Duration) (ServiceCommand, error) {
 	if targetService != config.ServiceTLS {
 		return ServiceCommand{}, ErrInvalidTarget
+	}
+	if _, ok := validActions[action]; !ok {
+		return ServiceCommand{}, ErrInvalidAction
 	}
 	if ttl <= 0 {
 		return ServiceCommand{}, fmt.Errorf("ttl must be positive")
@@ -83,7 +105,7 @@ func (m *Manager) RequestRestart(targetService, requestedBy, requestedFrom strin
 	cmd := ServiceCommand{
 		CommandID:     commandID,
 		TargetService: targetService,
-		Action:        ActionRestart,
+		Action:        action,
 		RequestedBy:   requestedBy,
 		RequestedFrom: requestedFrom,
 		ExpiresAt:     time.Now().Add(ttl),
@@ -102,6 +124,9 @@ func (m *Manager) Get(commandID string) (ServiceCommand, error) {
 	return cmd, nil
 }
 
+// ConsumeNext claims the oldest pending command for the service, whatever its
+// action. The caller dispatches on cmd.Action — actions are allowlisted at
+// request time, so anything returned here is one the consumer knows.
 func (m *Manager) ConsumeNext(targetService, consumedBy string, now time.Time) (ServiceCommand, bool, error) {
 	if targetService != config.ServiceTLS {
 		return ServiceCommand{}, false, ErrInvalidTarget
@@ -110,7 +135,7 @@ func (m *Manager) ConsumeNext(targetService, consumedBy string, now time.Time) (
 	err := m.DB.Transaction(func(tx *gorm.DB) error {
 		var cmd ServiceCommand
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("target_service = ? AND action = ? AND consumed_at IS NULL AND expires_at > ?", targetService, ActionRestart, now).
+			Where("target_service = ? AND consumed_at IS NULL AND expires_at > ?", targetService, now).
 			Order("created_at ASC").
 			Limit(1).
 			Find(&cmd).Error

--- a/pkg/serviceconfig/filestatus.go
+++ b/pkg/serviceconfig/filestatus.go
@@ -1,0 +1,143 @@
+package serviceconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ErrConfigFileNotWritable is returned when a persist is attempted against a
+// configuration file the service process cannot write.
+var ErrConfigFileNotWritable = errors.New("configuration file is not writable")
+
+// ConfigFileStatus records where a service's YAML configuration file lives
+// and whether the process running that service can write to it.
+//
+// Each service reports its own row at boot. It cannot be reported centrally:
+// osctrl-tls and osctrl-api run as separate processes, usually in separate
+// containers with separate config volumes, so the API service can neither
+// stat nor write the TLS service's file. The database is the only channel
+// through which that fact travels — the same reason restarts are requested
+// through pkg/servicecommands rather than performed directly.
+type ConfigFileStatus struct {
+	gorm.Model
+	Service   string `gorm:"uniqueIndex"`
+	Path      string
+	Writable  bool
+	Reason    string
+	CheckedAt time.Time
+}
+
+// CheckWritable reports whether the current process can write the given
+// configuration file, and a human-readable reason when it cannot.
+//
+// The check opens the file for writing without O_CREATE or O_TRUNC: that
+// tests the permission the persist actually needs without touching the
+// contents, and it is accurate where reasoning about mode bits, uid/gid and
+// ACLs separately would not be.
+func CheckWritable(path string) (bool, string) {
+	if path == "" {
+		return false, "service was not started from a configuration file"
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return false, err.Error()
+	}
+	_ = f.Close()
+	return true, ""
+}
+
+// ReportFile records this service's configuration file path and whether the
+// running process can write it. Services call this at boot, alongside Seed.
+func (m *ServiceConfigManager) ReportFile(service, path string) error {
+	if !m.VerifyService(service) {
+		return fmt.Errorf("unknown service %q", service)
+	}
+	writable, reason := CheckWritable(path)
+	status := ConfigFileStatus{
+		Service:   service,
+		Path:      path,
+		Writable:  writable,
+		Reason:    reason,
+		CheckedAt: time.Now(),
+	}
+	if err := m.DB.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "service"}},
+		DoUpdates: clause.AssignmentColumns([]string{"path", "writable", "reason", "checked_at", "updated_at"}),
+	}).Create(&status).Error; err != nil {
+		return fmt.Errorf("report config file for %s: %w", service, err)
+	}
+	log.Debug().Msgf("Reported config file for %s: %s (writable=%t)", service, path, writable)
+	return nil
+}
+
+// GetFileStatus retrieves the reported configuration file status of a service.
+func (m *ServiceConfigManager) GetFileStatus(service string) (ConfigFileStatus, error) {
+	var status ConfigFileStatus
+	if err := m.DB.Where("service = ?", service).First(&status).Error; err != nil {
+		return ConfigFileStatus{}, err
+	}
+	return status, nil
+}
+
+// HasPendingChanges reports whether any section of the service has been edited
+// through the API and therefore no longer matches the YAML file on disk. A
+// row with source=db is by definition a change the file does not have.
+func (m *ServiceConfigManager) HasPendingChanges(service string, envID uint) (bool, error) {
+	var count int64
+	if err := m.DB.Model(&ServiceConfig{}).
+		Where("service = ? AND environment_id = ? AND source = ?", service, envID, SourceDB).
+		Count(&count).Error; err != nil {
+		return false, fmt.Errorf("count pending changes for %s: %w", service, err)
+	}
+	return count > 0, nil
+}
+
+// PersistToFile writes the effective configuration — the YAML file with the
+// DB-edited sections overlaid — back to disk, then marks every section as
+// being in sync with the file again.
+//
+// cfg must be a FRESH load of the YAML file, never the running service's live
+// ServiceParameters: Resolve mutates what it is given, so passing the live
+// struct would apply the operator's pending edits to the running service
+// without the restart they are supposed to go through.
+func (m *ServiceConfigManager) PersistToFile(service, path string, cfg *config.ServiceParameters, envID uint) error {
+	if !m.VerifyService(service) {
+		return fmt.Errorf("unknown service %q", service)
+	}
+	if cfg == nil {
+		return fmt.Errorf("nil ServiceParameters for %s", service)
+	}
+	if writable, reason := CheckWritable(path); !writable {
+		return fmt.Errorf("%w: %s", ErrConfigFileNotWritable, reason)
+	}
+	if err := m.Resolve(service, cfg, envID); err != nil {
+		return fmt.Errorf("resolve before persist: %w", err)
+	}
+	var err error
+	switch service {
+	case config.ServiceTLS:
+		err = config.GenerateTLSConfigFile(path, cfg, true)
+	case config.ServiceAPI:
+		err = config.GenerateAPIConfigFile(path, cfg, true)
+	}
+	if err != nil {
+		return fmt.Errorf("write config file %s: %w", path, err)
+	}
+	// The file now matches the database, so every section is once again
+	// sourced from YAML. Without this the UI would keep offering to write
+	// changes that are already on disk.
+	if err := m.DB.Model(&ServiceConfig{}).
+		Where("service = ? AND environment_id = ? AND source = ?", service, envID, SourceDB).
+		Update("source", SourceYAML).Error; err != nil {
+		return fmt.Errorf("reset source after persist %s: %w", service, err)
+	}
+	log.Info().Msgf("Persisted service config for %s to %s", service, path)
+	return m.ReportFile(service, path)
+}

--- a/pkg/serviceconfig/filestatus_test.go
+++ b/pkg/serviceconfig/filestatus_test.go
@@ -1,0 +1,163 @@
+package serviceconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+)
+
+// setupFileTestDB mirrors setupTestDB but also migrates ConfigFileStatus.
+func setupFileTestDB(t *testing.T) *ServiceConfigManager {
+	t.Helper()
+	db := setupTestDB(t)
+	require.NoError(t, db.AutoMigrate(&ConfigFileStatus{}), "Failed to migrate file status schema")
+	return &ServiceConfigManager{DB: db}
+}
+
+func TestCheckWritable(t *testing.T) {
+	dir := t.TempDir()
+	writable := filepath.Join(dir, "tls.yml")
+	require.NoError(t, os.WriteFile(writable, []byte("service: {}\n"), 0o644))
+
+	ok, reason := CheckWritable(writable)
+	assert.True(t, ok)
+	assert.Empty(t, reason)
+
+	readOnly := filepath.Join(dir, "readonly.yml")
+	require.NoError(t, os.WriteFile(readOnly, []byte("service: {}\n"), 0o400))
+	if os.Geteuid() == 0 {
+		t.Log("running as root — skipping the read-only assertion, root ignores mode bits")
+	} else {
+		ok, reason = CheckWritable(readOnly)
+		assert.False(t, ok)
+		assert.Contains(t, reason, "permission denied")
+	}
+
+	ok, reason = CheckWritable(filepath.Join(dir, "missing.yml"))
+	assert.False(t, ok)
+	assert.NotEmpty(t, reason)
+
+	ok, reason = CheckWritable("")
+	assert.False(t, ok)
+	assert.Contains(t, reason, "not started from a configuration file")
+}
+
+func TestReportFileUpserts(t *testing.T) {
+	m := setupFileTestDB(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tls.yml")
+	require.NoError(t, os.WriteFile(path, []byte("service: {}\n"), 0o644))
+
+	require.NoError(t, m.ReportFile(config.ServiceTLS, path))
+	status, err := m.GetFileStatus(config.ServiceTLS)
+	require.NoError(t, err)
+	assert.Equal(t, path, status.Path)
+	assert.True(t, status.Writable)
+
+	// A second boot must update the existing row, not add another.
+	require.NoError(t, m.ReportFile(config.ServiceTLS, ""))
+	status, err = m.GetFileStatus(config.ServiceTLS)
+	require.NoError(t, err)
+	assert.False(t, status.Writable)
+	assert.NotEmpty(t, status.Reason)
+
+	var count int64
+	require.NoError(t, m.DB.Model(&ConfigFileStatus{}).Where("service = ?", config.ServiceTLS).Count(&count).Error)
+	assert.EqualValues(t, 1, count)
+
+	assert.Error(t, m.ReportFile("nonsense", path))
+}
+
+func TestHasPendingChanges(t *testing.T) {
+	m := setupFileTestDB(t)
+	require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), NoEnvironmentID))
+
+	pending, err := m.HasPendingChanges(config.ServiceTLS, NoEnvironmentID)
+	require.NoError(t, err)
+	assert.False(t, pending, "freshly seeded config is identical to the file")
+
+	_, err = m.UpdateSection(config.ServiceTLS, "debug", `{"enableHttp":true,"showBody":false}`, NoEnvironmentID)
+	require.NoError(t, err)
+
+	pending, err = m.HasPendingChanges(config.ServiceTLS, NoEnvironmentID)
+	require.NoError(t, err)
+	assert.True(t, pending, "a db-sourced section is a change the file does not have")
+
+	// Another service must not see the TLS edit.
+	pending, err = m.HasPendingChanges(config.ServiceAPI, NoEnvironmentID)
+	require.NoError(t, err)
+	assert.False(t, pending)
+}
+
+func TestPersistToFile(t *testing.T) {
+	m := setupFileTestDB(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tls.yml")
+
+	params := testTLSParams()
+	require.NoError(t, m.Seed(config.ServiceTLS, params, NoEnvironmentID))
+	// Write a starting file so the config has something on disk to replace.
+	require.NoError(t, config.GenerateTLSConfigFile(path, params, true))
+
+	_, err := m.UpdateSection(config.ServiceTLS, "debug", `{"enableHttp":true,"showBody":true}`, NoEnvironmentID)
+	require.NoError(t, err)
+
+	// A fresh struct, as the services pass in: persisting must not depend on
+	// the caller having already resolved anything.
+	require.NoError(t, m.PersistToFile(config.ServiceTLS, path, testTLSParams(), NoEnvironmentID))
+
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "enableHttp: true", "db edit should be on disk")
+	// Sections the operator never touched must survive the round trip —
+	// persisting must not silently drop parts of the live config file.
+	assert.Contains(t, string(written), "writerBatchSize: 50")
+	assert.Contains(t, string(written), "enroll:", "rateLimits must not be dropped")
+
+	// Once written, nothing is pending — otherwise the UI would keep
+	// offering to write changes that are already on disk.
+	pending, err := m.HasPendingChanges(config.ServiceTLS, NoEnvironmentID)
+	require.NoError(t, err)
+	assert.False(t, pending)
+
+	section, err := m.GetSection(config.ServiceTLS, "debug", NoEnvironmentID)
+	require.NoError(t, err)
+	assert.Equal(t, SourceYAML, section.Source)
+	var debug config.YAMLConfigurationDebug
+	require.NoError(t, json.Unmarshal([]byte(section.Value), &debug))
+	assert.True(t, debug.EnableHTTP, "the edited value must survive the source flip")
+}
+
+func TestPersistToFileNotWritable(t *testing.T) {
+	m := setupFileTestDB(t)
+	require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), NoEnvironmentID))
+
+	err := m.PersistToFile(config.ServiceTLS, filepath.Join(t.TempDir(), "missing.yml"), testTLSParams(), NoEnvironmentID)
+	assert.ErrorIs(t, err, ErrConfigFileNotWritable)
+}
+
+// TestPersistToFileLeavesLiveConfigAlone guards the reason PersistToFile takes
+// a config argument at all: Resolve mutates what it is given, so a service
+// passing its live ServiceParameters would silently apply pending edits to
+// itself without the restart they are meant to go through.
+func TestPersistToFileLeavesLiveConfigAlone(t *testing.T) {
+	m := setupFileTestDB(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tls.yml")
+
+	live := testTLSParams()
+	require.NoError(t, m.Seed(config.ServiceTLS, live, NoEnvironmentID))
+	require.NoError(t, config.GenerateTLSConfigFile(path, live, true))
+
+	_, err := m.UpdateSection(config.ServiceTLS, "debug", `{"enableHttp":true,"showBody":true}`, NoEnvironmentID)
+	require.NoError(t, err)
+	require.NoError(t, m.PersistToFile(config.ServiceTLS, path, testTLSParams(), NoEnvironmentID))
+
+	assert.False(t, live.Debug.EnableHTTP, "the running service's config must be untouched")
+}

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -106,6 +106,9 @@ func NewServiceConfigManager(backend *gorm.DB) *ServiceConfigManager {
 	if err := backend.AutoMigrate(&ServiceConfig{}); err != nil {
 		log.Fatal().Msgf("Failed to AutoMigrate table (service_config): %v", err)
 	}
+	if err := backend.AutoMigrate(&ConfigFileStatus{}); err != nil {
+		log.Fatal().Msgf("Failed to AutoMigrate table (config_file_statuses): %v", err)
+	}
 	return m
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -551,6 +551,35 @@ type ServiceConfigApplyResponse struct {
 	Command *ServiceCommandResponse `json:"command,omitempty"`
 }
 
+// ServiceConfigStatusResponse is the body of GET
+// /api/v1/service-config/{service}/status. It tells the SPA whether the
+// service has DB edits that the YAML file on disk does not have
+// (PendingChanges), and whether that service's process could write them out
+// if asked (FileWritable, with FileReason explaining a refusal).
+type ServiceConfigStatusResponse struct {
+	Service        string    `json:"service"`
+	PendingChanges bool      `json:"pending_changes"`
+	FilePath       string    `json:"file_path"`
+	FileWritable   bool      `json:"file_writable"`
+	FileReason     string    `json:"file_reason,omitempty"`
+	CheckedAt      time.Time `json:"checked_at"`
+}
+
+// ServiceConfigPersistRequest is the optional body for POST
+// /api/v1/service-config/persist. Empty service defaults to osctrl-api.
+type ServiceConfigPersistRequest struct {
+	Service string `json:"service,omitempty"`
+}
+
+// ServiceConfigPersistResponse is returned by the persist endpoint. For
+// osctrl-tls the write is performed asynchronously by the TLS process, so
+// Command carries the queued command to poll.
+type ServiceConfigPersistResponse struct {
+	Message string                  `json:"message"`
+	Service string                  `json:"service"`
+	Command *ServiceCommandResponse `json:"command,omitempty"`
+}
+
 // TLSEnvironmentView is the low-privilege projection of an environment.
 // UserLevel operators (env scope) need basic env metadata so the SPA can
 // render its env switcher / dashboard / table chrome — but they MUST NOT


### PR DESCRIPTION
## Summary

Adds a "Write to Disk" action so DB-edited service configuration survives a redeploy, not just a restart.

Previously, editing config through the API/SPA only ever wrote to the database — `Apply & Restart` picked up those edits into the running process, but a fresh deploy that reloads from the YAML file on disk would silently lose them. This closes that gap without changing how `Apply & Restart` works.

### Backend
- **`pkg/serviceconfig/filestatus.go`** (new): `ConfigFileStatus` table + `ReportFile`/`GetFileStatus`/`HasPendingChanges`/`PersistToFile`. Each service reports at boot whether its own process can write its config file (`CheckWritable` opens for write, no `O_CREATE`/`O_TRUNC`, to test the exact permission needed). `PersistToFile` overlays DB-edited sections onto a **freshly loaded** copy of the YAML (never the live running config, so writing to disk never affects the running process ahead of a restart), writes it, then flips affected rows back to `source=yaml`.
- **New endpoints**: `GET /api/v1/service-config/status/{service}` (pending changes + file writability) and `POST /api/v1/service-config/persist` (perform the write). Both admin-gated and rate-limited alongside `apply`.
- **osctrl-api** persists inline (same process owns the YAML loader). **osctrl-tls** cannot be written from osctrl-api's process, so the persist request is queued through `pkg/servicecommands` (extended with a generic `Request`/`ActionPersistConfig` alongside the existing restart action) and consumed by the TLS process's existing command-poll loop, which no longer exits after handling a command — persisting doesn't restart, so it keeps polling.
- `pkg/config/utils.go`: `ServiceParameters.ConfigFilePath()` returns the file path only when the service was actually started with `-config` (vs. flags/env vars); `GenerateTLSConfigFile`/`GenerateAPIConfigFile` now also carry `RateLimits` through.

### Frontend
- `ServiceConfigPage`: new "Write to Disk" button next to "Apply & Restart", driven by the status endpoint. Disabled quietly while status is loading (avoids a false-red flash), disabled with a visible reason when the target file isn't writable. Polls status after a queued (TLS) persist since it completes asynchronously.
- Tracks `persistedThisSession` (session-local, not persisted) so `Apply & Restart` stays available after a write flips sections back to `source=yaml` — otherwise the operator could write to disk but lose the ability to also restart in the same session.

### Docs
- `osctrl-api.yaml` regenerated with the two new paths/schemas.

**Not done / deliberately deferred:** `persistedThisSession` is in-memory only, so a page reload after writing-to-disk-without-restarting forgets that a restart is still worth offering — noted in code as a `ponytail:` comment; fix would be comparing service boot time against section `UpdatedAt` if this turns out to matter in practice.