### PR TITLE
DB-backed log sinks with hot reload capabilities per environment

### DIFF
--- a/cmd/api/handlers/features.go
+++ b/cmd/api/handlers/features.go
@@ -12,9 +12,13 @@ type FeaturesResponse struct {
 	// ServiceConfig gates the whole Service Config section in the SPA. When
 	// false the /api/v1/service-config routes are not registered at all.
 	ServiceConfig bool `json:"service_config"`
-	Accelerated   bool `json:"accelerated"`
-	Console       bool `json:"console"`
-	FileExplorer  bool `json:"file_explorer"`
+	// LogSinks gates the Log Sinks section in the SPA. Tied to the same
+	// flag as ServiceConfig — the log_sinks routes are registered
+	// alongside the service-config routes.
+	LogSinks     bool `json:"log_sinks"`
+	Accelerated  bool `json:"accelerated"`
+	Console      bool `json:"console"`
+	FileExplorer bool `json:"file_explorer"`
 }
 
 // FeaturesHandler — GET /api/v1/features.
@@ -25,6 +29,7 @@ func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, FeaturesResponse{
 		Posture:       h.PostureEnabled,
 		ServiceConfig: h.ServiceConfigEnabled,
+		LogSinks:      h.ServiceConfigEnabled,
 		Accelerated:   h.OsqueryValues.Accelerated,
 		Console:       h.OsqueryValues.Query && h.OsqueryValues.Console,
 		FileExplorer:  h.OsqueryValues.Query && h.OsqueryValues.FileExplorer,

--- a/cmd/api/handlers/features_test.go
+++ b/cmd/api/handlers/features_test.go
@@ -55,6 +55,9 @@ func TestFeaturesHandlerReportsServiceConfigEnabled(t *testing.T) {
 	if !on.ServiceConfig {
 		t.Fatalf("service config feature: got false want true")
 	}
+	if !on.LogSinks {
+		t.Fatalf("log_sinks feature: got false want true (shares the service-config gate)")
+	}
 }
 
 func TestFeaturesHandlerReportsPostureEnabled(t *testing.T) {

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/geoip"
 	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/logsinks"
 	"github.com/jmpsec/osctrl/pkg/mfa"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/posture"
@@ -48,9 +49,10 @@ type HandlersApi struct {
 	Carves        *carves.Carves
 	Settings      *settings.Settings
 	ServiceConfig *serviceconfig.ServiceConfigManager
-	// ServiceConfigEnabled mirrors service.serviceConfigEnabled. When false
-	// the service-config routes are never registered and the SPA hides the
-	// section; the rows are still seeded and resolved at every boot.
+	// LogSinks manages the log_sinks table when service-config is
+	// enabled. nil when ServiceConfigEnabled is false — the routes are
+	// not registered in that case.
+	LogSinks             *logsinks.LogSinksManager
 	ServiceConfigEnabled bool
 	ServiceCommands      *servicecommands.Manager
 	Activity             activityReader
@@ -187,6 +189,15 @@ func WithSettings(settings *settings.Settings) HandlersOption {
 func WithServiceConfig(mgr *serviceconfig.ServiceConfigManager) HandlersOption {
 	return func(h *HandlersApi) {
 		h.ServiceConfig = mgr
+	}
+}
+
+// WithLogSinks wires the log_sinks manager. Only meaningful when
+// ServiceConfigEnabled is also true; the routes are gated on that
+// flag in cmd/api/main.go.
+func WithLogSinks(mgr *logsinks.LogSinksManager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.LogSinks = mgr
 	}
 }
 

--- a/cmd/api/handlers/log_sinks.go
+++ b/cmd/api/handlers/log_sinks.go
@@ -79,7 +79,7 @@ func parseEnvFilter(r *http.Request) (*uint, error) {
 	if v == "" {
 		return nil, nil
 	}
-	n, err := strconv.ParseUint(v, 10, 64)
+	n, err := strconv.ParseUint(v, 10, strconv.IntSize)
 	if err != nil {
 		return nil, fmt.Errorf("invalid env id: %w", err)
 	}

--- a/cmd/api/handlers/log_sinks.go
+++ b/cmd/api/handlers/log_sinks.go
@@ -1,0 +1,487 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/logsinks"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+const logSinksCommandTTL = 2 * time.Minute
+
+// logSinkDTO is the JSON shape returned to the SPA. It mirrors
+// logsinks.LogSink but exposes Config as a json.RawMessage so the
+// client receives the decoded object (with secrets redacted unless
+// reveal=1 was passed) rather than a stringified blob. This keeps the
+// frontend form code trivial.
+type logSinkDTO struct {
+	ID            uint            `json:"id"`
+	CreatedAt     string          `json:"created_at"`
+	UpdatedAt     string          `json:"updated_at"`
+	Name          string          `json:"name"`
+	EnvironmentID uint            `json:"environment_id"`
+	Type          string          `json:"type"`
+	Enabled       bool            `json:"enabled"`
+	Order         int             `json:"order"`
+	Config        json.RawMessage `json:"config"`
+	Source        string          `json:"source"`
+	Info          string          `json:"info"`
+}
+
+func toLogSinkDTO(s logsinks.LogSink, reveal bool) logSinkDTO {
+	cfg := s.Config
+	if !reveal {
+		cfg = logsinks.RedactedConfig(s.Type, s.Config)
+	}
+	return logSinkDTO{
+		ID:            s.ID,
+		CreatedAt:     s.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:     s.UpdatedAt.Format(time.RFC3339),
+		Name:          s.Name,
+		EnvironmentID: s.EnvironmentID,
+		Type:          s.Type,
+		Enabled:       s.Enabled,
+		Order:         s.Order,
+		Config:        json.RawMessage(cfg),
+		Source:        s.Source,
+		Info:          s.Info,
+	}
+}
+
+func (h *HandlersApi) requireLogSinksAdmin(w http.ResponseWriter, r *http.Request) (string, bool) {
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use log-sinks API by user %s", ctx[ctxUser]))
+		return "", false
+	}
+	return ctx[ctxUser], true
+}
+
+func parseReveal(r *http.Request) bool {
+	return r.URL.Query().Get("reveal") == "1"
+}
+
+func parseEnvFilter(r *http.Request) (*uint, error) {
+	v := r.URL.Query().Get("env")
+	if v == "" {
+		return nil, nil
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid env id: %w", err)
+	}
+	e := uint(n)
+	return &e, nil
+}
+
+// LogSinksListHandler — GET /api/v1/log-sinks?env={id}&reveal={0|1}
+//
+// @Summary List log sinks
+// @Description Returns log sink rows, optionally filtered by environment. Secrets are redacted unless reveal=1 is passed by an admin.
+// @Tags log-sinks
+// @Produce json
+// @Param env query int false "Environment ID; omit to list all environments"
+// @Param reveal query int false "Pass 1 to include secret fields in the config (admin only)"
+// @Success 200 {array} logSinkDTO
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks [get]
+func (h *HandlersApi) LogSinksListHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireLogSinksAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.LogSinks == nil {
+		apiErrorResponse(w, "log sinks not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	envID, err := parseEnvFilter(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid env filter", http.StatusBadRequest, err)
+		return
+	}
+	rows, err := h.LogSinks.List(envID)
+	if err != nil {
+		apiErrorResponse(w, "error listing log sinks", http.StatusInternalServerError, err)
+		return
+	}
+	reveal := parseReveal(r)
+	out := make([]logSinkDTO, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toLogSinkDTO(row, reveal))
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, out)
+}
+
+// LogSinksTypesHandler — GET /api/v1/log-sinks/types
+//
+// @Summary List supported log sink types
+// @Description Returns the sink type registry: type, description, whether the config carries secrets, and which JSON keys hold them.
+// @Tags log-sinks
+// @Produce json
+// @Success 200 {array} types.LogSinkTypeSpec
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks/types [get]
+func (h *HandlersApi) LogSinksTypesHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	if _, ok := h.requireLogSinksAdmin(w, r); !ok {
+		return
+	}
+	specs := make([]types.LogSinkTypeSpec, 0, len(logsinks.Registry))
+	for _, typ := range logsinks.SupportedTypes() {
+		spec := logsinks.Registry[typ]
+		fields := make([]types.LogSinkFieldSpec, 0, len(spec.Fields))
+		for _, f := range spec.Fields {
+			fields = append(fields, types.LogSinkFieldSpec{
+				Name:        f.Name,
+				Label:       f.Label,
+				Type:        string(f.Type),
+				Required:    f.Required,
+				Secret:      f.Secret,
+				Placeholder: f.Placeholder,
+				Help:        f.Help,
+				Options:     f.Options,
+				Default:     f.Default,
+			})
+		}
+		specs = append(specs, types.LogSinkTypeSpec{
+			Type:         spec.Type,
+			Description:  spec.Description,
+			HasSecret:    spec.HasSecret,
+			SecretFields: spec.SecretFields,
+			Fields:       fields,
+		})
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, specs)
+}
+
+// LogSinksGetHandler — GET /api/v1/log-sinks/{id}?reveal={0|1}
+//
+// @Summary Get one log sink
+// @Description Returns a single log sink by ID. Secrets are redacted unless reveal=1 is passed by an admin.
+// @Tags log-sinks
+// @Produce json
+// @Param id path int true "Sink ID"
+// @Param reveal query int false "Pass 1 to include secret fields (admin only)"
+// @Success 200 {object} logSinkDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks/{id} [get]
+func (h *HandlersApi) LogSinksGetHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireLogSinksAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.LogSinks == nil {
+		apiErrorResponse(w, "log sinks not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	id, err := parseLogSinkID(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid sink id", http.StatusBadRequest, err)
+		return
+	}
+	row, err := h.LogSinks.Get(id)
+	if err != nil {
+		if errors.Is(err, logsinks.ErrSinkNotFound) {
+			apiErrorResponse(w, "log sink not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error getting log sink", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toLogSinkDTO(row, parseReveal(r)))
+}
+
+// LogSinksCreateHandler — POST /api/v1/log-sinks
+//
+// @Summary Create a log sink
+// @Description Creates a new log sink instance for the given environment (or global when environment_id is 0).
+// @Tags log-sinks
+// @Accept json
+// @Produce json
+// @Param request body types.LogSinkCreateRequest true "Request body"
+// @Success 201 {object} logSinkDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 409 {object} types.ApiErrorResponse "Conflict"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks [post]
+func (h *HandlersApi) LogSinksCreateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireLogSinksAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.LogSinks == nil {
+		apiErrorResponse(w, "log sinks not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	var body types.LogSinkCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	row, err := h.LogSinks.Create(body.Name, body.Type, body.Enabled, body.Order, string(body.Config), body.EnvironmentID, body.Info)
+	if err != nil {
+		respondLogSinksErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("created log sink %q (type %s, env %d)", row.Name, row.Type, row.EnvironmentID), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, toLogSinkDTO(row, true))
+}
+
+// LogSinksUpdateHandler — PUT /api/v1/log-sinks/{id}
+//
+// @Summary Update a log sink
+// @Description Replaces an existing log sink's mutable fields. A secret field set to "***" is merged from the previously stored value.
+// @Tags log-sinks
+// @Accept json
+// @Produce json
+// @Param id path int true "Sink ID"
+// @Param request body types.LogSinkUpdateRequest true "Request body"
+// @Success 200 {object} logSinkDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks/{id} [put]
+func (h *HandlersApi) LogSinksUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireLogSinksAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.LogSinks == nil {
+		apiErrorResponse(w, "log sinks not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	id, err := parseLogSinkID(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid sink id", http.StatusBadRequest, err)
+		return
+	}
+	var body types.LogSinkUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	prev, err := h.LogSinks.Get(id)
+	if err != nil {
+		if errors.Is(err, logsinks.ErrSinkNotFound) {
+			apiErrorResponse(w, "log sink not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error getting log sink", http.StatusInternalServerError, err)
+		return
+	}
+	merged, err := logsinks.MergeSecrets(prev.Type, prev.Config, string(body.Config))
+	if err != nil {
+		apiErrorResponse(w, "error merging sink secrets", http.StatusBadRequest, err)
+		return
+	}
+	row, err := h.LogSinks.Update(id, body.Name, body.Type, body.Enabled, body.Order, merged, body.Info)
+	if err != nil {
+		respondLogSinksErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("updated log sink %q (type %s, env %d)", row.Name, row.Type, row.EnvironmentID), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toLogSinkDTO(row, true))
+}
+
+// LogSinksDeleteHandler — DELETE /api/v1/log-sinks/{id}
+//
+// @Summary Delete a log sink
+// @Description Deletes a log sink by ID. Deletion takes effect on the next apply/reload.
+// @Tags log-sinks
+// @Produce json
+// @Param id path int true "Sink ID"
+// @Success 204 "No content"
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks/{id} [delete]
+func (h *HandlersApi) LogSinksDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireLogSinksAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.LogSinks == nil {
+		apiErrorResponse(w, "log sinks not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	id, err := parseLogSinkID(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid sink id", http.StatusBadRequest, err)
+		return
+	}
+	if err := h.LogSinks.Delete(id); err != nil {
+		if errors.Is(err, logsinks.ErrSinkNotFound) {
+			apiErrorResponse(w, "log sink not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error deleting log sink", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("deleted log sink %d", id), strings.Split(r.RemoteAddr, ":")[0])
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// LogSinksCloneHandler — POST /api/v1/log-sinks/clone
+//
+// @Summary Clone sinks from one environment to another
+// @Description Copies all log sinks from a source environment (use 0 for global) to a target environment. With overwrite=false returns 409 if the target already has sinks.
+// @Tags log-sinks
+// @Accept json
+// @Produce json
+// @Param request body types.LogSinkCloneRequest true "Request body"
+// @Success 200 {array} logSinkDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 409 {object} types.ApiErrorResponse "Target has sinks"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks/clone [post]
+func (h *HandlersApi) LogSinksCloneHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireLogSinksAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.LogSinks == nil {
+		apiErrorResponse(w, "log sinks not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	var body types.LogSinkCloneRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	cloned, err := h.LogSinks.CloneEnvironment(body.SourceEnvironmentID, body.TargetEnvironmentID, body.Overwrite)
+	if err != nil {
+		if errors.Is(err, logsinks.ErrTargetHasSinks) {
+			apiErrorResponse(w, "target environment already has log sinks", http.StatusConflict, err)
+			return
+		}
+		respondLogSinksErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("cloned log sinks env %d -> env %d (overwrite=%v)", body.SourceEnvironmentID, body.TargetEnvironmentID, body.Overwrite), strings.Split(r.RemoteAddr, ":")[0])
+	out := make([]logSinkDTO, 0, len(cloned))
+	for _, row := range cloned {
+		out = append(out, toLogSinkDTO(row, true))
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, out)
+}
+
+// LogSinksApplyHandler — POST /api/v1/log-sinks/apply
+//
+// @Summary Apply log sink changes (hot reload)
+// @Description Queues a reload-log-sinks service command for osctrl-tls. The TLS process rebuilds its per-environment exporter map from the log_sinks table and atomically swaps it in, closing the old sinks. In-flight logs to the old sinks may be dropped during the swap; no restart is required.
+// @Tags log-sinks
+// @Produce json
+// @Success 202 {object} types.ServiceConfigApplyResponse "Reload requested"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 503 {object} types.ApiErrorResponse "Service commands unavailable"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks/apply [post]
+func (h *HandlersApi) LogSinksApplyHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireLogSinksAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.ServiceCommands == nil {
+		apiErrorResponse(w, "service commands not available", http.StatusServiceUnavailable, nil)
+		return
+	}
+	cmd, err := h.ServiceCommands.Request(config.ServiceTLS, servicecommands.ActionReloadLogSinks, user, strings.Split(r.RemoteAddr, ":")[0], logSinksCommandTTL)
+	if err != nil {
+		apiErrorResponse(w, "error requesting tls log sinks reload", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("apply log-sinks reload command %s", cmd.CommandID), strings.Split(r.RemoteAddr, ":")[0])
+	log.Info().Str("command", cmd.CommandID).Msgf("TLS log sinks reload requested by %s", user)
+	resp := serviceCommandResponse(cmd)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusAccepted, types.ServiceConfigApplyResponse{
+		Service: config.ServiceTLS,
+		Message: "Reload requested. osctrl-tls will rebuild its log sink exporters after consuming the service command. In-flight logs to the old sinks may be dropped during the swap.",
+		Command: &resp,
+	})
+}
+
+func parseLogSinkID(r *http.Request) (uint, error) {
+	v := r.PathValue("id")
+	if v == "" {
+		return 0, fmt.Errorf("missing id")
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid id: %w", err)
+	}
+	return uint(n), nil
+}
+
+func respondLogSinksErr(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, logsinks.ErrInvalidSinkType):
+		apiErrorResponse(w, "invalid log sink type", http.StatusBadRequest, err)
+	case errors.Is(err, logsinks.ErrInvalidSinkConfig):
+		apiErrorResponse(w, "invalid log sink configuration", http.StatusBadRequest, err)
+	case errors.Is(err, logsinks.ErrSinkNotFound):
+		apiErrorResponse(w, "log sink not found", http.StatusNotFound, err)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		apiErrorResponse(w, "log sink not found", http.StatusNotFound, err)
+	default:
+		apiErrorResponse(w, "error", http.StatusInternalServerError, err)
+	}
+}

--- a/cmd/api/handlers/log_sinks.go
+++ b/cmd/api/handlers/log_sinks.go
@@ -464,7 +464,7 @@ func parseLogSinkID(r *http.Request) (uint, error) {
 	if v == "" {
 		return 0, fmt.Errorf("missing id")
 	}
-	n, err := strconv.ParseUint(v, 10, 64)
+	n, err := strconv.ParseUint(v, 10, strconv.IntSize)
 	if err != nil {
 		return 0, fmt.Errorf("invalid id: %w", err)
 	}

--- a/cmd/api/handlers/log_sinks_test.go
+++ b/cmd/api/handlers/log_sinks_test.go
@@ -1,0 +1,224 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/logsinks"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupLogSinksHandler(t *testing.T) *HandlersApi {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	if err := db.AutoMigrate(&logsinks.LogSink{}); err != nil {
+		t.Fatalf("automigrate log_sinks: %v", err)
+	}
+	userManager := users.CreateUserManager(db)
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "alice", Admin: true}))
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "bob"})) // non-admin
+	auditLog, err := auditlog.CreateAuditLogManager(db, "osctrl-api", false)
+	require.NoError(t, err)
+	h := CreateHandlersApi(
+		WithUsers(userManager),
+		WithAuditLog(auditLog),
+		WithDebugHTTP(&config.YAMLConfigurationDebug{}),
+		WithLogSinks(&logsinks.LogSinksManager{DB: db}),
+		WithServiceCommands(servicecommands.NewManager(db)),
+	)
+	return h
+}
+
+func logSinksCtx(user string) context.Context {
+	return context.WithValue(context.Background(), ContextKey(contextAPI), ContextValue{ctxUser: user})
+}
+
+func TestLogSinksListRejectsNonAdmin(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/log-sinks", nil).WithContext(logSinksCtx("bob"))
+	rr := httptest.NewRecorder()
+	h.LogSinksListHandler(rr, req)
+	require.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestLogSinksListRedactsSecretsByDefault(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	_, err := h.LogSinks.Create("prod-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"supersecret","host":"h","index":"i"}`, 0, "")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/log-sinks", nil).WithContext(logSinksCtx("alice"))
+	rr := httptest.NewRecorder()
+	h.LogSinksListHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var got []logSinkDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	var cfg map[string]any
+	require.NoError(t, json.Unmarshal(got[0].Config, &cfg))
+	require.Equal(t, "***", cfg["token"], "token must be redacted without reveal=1")
+	require.Equal(t, "http://x", cfg["url"])
+}
+
+func TestLogSinksListRevealsSecretsWithRevealFlag(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	_, err := h.LogSinks.Create("prod-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"supersecret","host":"h","index":"i"}`, 0, "")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/log-sinks?reveal=1", nil).WithContext(logSinksCtx("alice"))
+	rr := httptest.NewRecorder()
+	h.LogSinksListHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var got []logSinkDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	var cfg map[string]any
+	require.NoError(t, json.Unmarshal(got[0].Config, &cfg))
+	require.Equal(t, "supersecret", cfg["token"])
+}
+
+func TestLogSinksCreateAndRoundTrip(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	body, _ := json.Marshal(types.LogSinkCreateRequest{
+		Name: "s", Type: config.LoggingNone, Enabled: true, Order: 0,
+		Config: json.RawMessage(`{}`), EnvironmentID: 0,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/log-sinks", bytes.NewReader(body)).WithContext(logSinksCtx("alice"))
+	rr := httptest.NewRecorder()
+	h.LogSinksCreateHandler(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var dto logSinkDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &dto))
+	require.NotZero(t, dto.ID)
+	require.Equal(t, "s", dto.Name)
+	require.Equal(t, config.LoggingNone, dto.Type)
+}
+
+func TestLogSinksCreateRejectsInvalidType(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	body, _ := json.Marshal(types.LogSinkCreateRequest{
+		Name: "s", Type: "nope", Config: json.RawMessage(`{}`),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/log-sinks", bytes.NewReader(body)).WithContext(logSinksCtx("alice"))
+	rr := httptest.NewRecorder()
+	h.LogSinksCreateHandler(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestLogSinksUpdateMergesSecretPlaceholder(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	row, err := h.LogSinks.Create("s", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"real-secret","host":"h","index":"i"}`, 0, "")
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(types.LogSinkUpdateRequest{
+		Name: "s", Type: config.LoggingSplunk, Enabled: false, Order: 5,
+		Config: json.RawMessage(`{"url":"http://y","token":"***","host":"h2","index":"j"}`),
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/log-sinks/"+itoa(row.ID), bytes.NewReader(body)).WithContext(logSinksCtx("alice"))
+	req.SetPathValue("id", itoa(row.ID))
+	rr := httptest.NewRecorder()
+	h.LogSinksUpdateHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var dto logSinkDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &dto))
+	require.False(t, dto.Enabled)
+	var cfg map[string]any
+	require.NoError(t, json.Unmarshal(dto.Config, &cfg))
+	require.Equal(t, "real-secret", cfg["token"], "*** must be merged from previous value")
+	require.Equal(t, "http://y", cfg["url"], "non-secret field must be updated")
+}
+
+func TestLogSinksDelete(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	row, err := h.LogSinks.Create("s", config.LoggingNone, true, 0, `{}`, 0, "")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/log-sinks/"+itoa(row.ID), nil).WithContext(logSinksCtx("alice"))
+	req.SetPathValue("id", itoa(row.ID))
+	rr := httptest.NewRecorder()
+	h.LogSinksDeleteHandler(rr, req)
+	require.Equal(t, http.StatusNoContent, rr.Code)
+
+	// Second delete → 404.
+	req2 := httptest.NewRequest(http.MethodDelete, "/api/v1/log-sinks/"+itoa(row.ID), nil).WithContext(logSinksCtx("alice"))
+	req2.SetPathValue("id", itoa(row.ID))
+	rr2 := httptest.NewRecorder()
+	h.LogSinksDeleteHandler(rr2, req2)
+	require.Equal(t, http.StatusNotFound, rr2.Code)
+}
+
+func TestLogSinksClone(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	_, err := h.LogSinks.Create("g", config.LoggingNone, true, 0, `{}`, 0, "")
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(types.LogSinkCloneRequest{SourceEnvironmentID: 0, TargetEnvironmentID: 5, Overwrite: false})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/log-sinks/clone", bytes.NewReader(body)).WithContext(logSinksCtx("alice"))
+	rr := httptest.NewRecorder()
+	h.LogSinksCloneHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var got []logSinkDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	require.Equal(t, uint(5), got[0].EnvironmentID)
+
+	// Clone again without overwrite → 409. Fresh body, same request shape.
+	body2, _ := json.Marshal(types.LogSinkCloneRequest{SourceEnvironmentID: 0, TargetEnvironmentID: 5, Overwrite: false})
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/log-sinks/clone", bytes.NewReader(body2)).WithContext(logSinksCtx("alice"))
+	rr2 := httptest.NewRecorder()
+	h.LogSinksCloneHandler(rr2, req2)
+	require.Equal(t, http.StatusConflict, rr2.Code)
+}
+
+func TestLogSinksApplyQueuesReloadCommand(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/log-sinks/apply", nil).WithContext(logSinksCtx("alice"))
+	rr := httptest.NewRecorder()
+	h.LogSinksApplyHandler(rr, req)
+	require.Equal(t, http.StatusAccepted, rr.Code)
+	var resp types.ServiceConfigApplyResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, config.ServiceTLS, resp.Service)
+	require.NotNil(t, resp.Command)
+	require.Equal(t, "reload-log-sinks", resp.Command.Action)
+}
+
+func TestLogSinksTypesListed(t *testing.T) {
+	h := setupLogSinksHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/log-sinks/types", nil).WithContext(logSinksCtx("alice"))
+	rr := httptest.NewRecorder()
+	h.LogSinksTypesHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var got []types.LogSinkTypeSpec
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	require.NotEmpty(t, got)
+	// Splunk must be present and flagged as secret-bearing.
+	var splunk *types.LogSinkTypeSpec
+	for i := range got {
+		if got[i].Type == config.LoggingSplunk {
+			splunk = &got[i]
+		}
+	}
+	require.NotNil(t, splunk, "splunk type missing from registry response")
+	require.True(t, splunk.HasSecret)
+	require.Contains(t, splunk.SecretFields, "token")
+}
+
+func itoa(n uint) string {
+	return strconv.FormatUint(uint64(n), 10)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/geoip"
 	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/logsinks"
 	"github.com/jmpsec/osctrl/pkg/mfa"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/osquery"
@@ -104,6 +105,8 @@ const (
 	apiSettingsPath = "/settings"
 	// API service config path
 	apiServiceConfigPath = "/service-config"
+	// API log sinks path
+	apiLogSinksPath = "/log-sinks"
 	// API features path
 	apiFeaturesPath = "/features"
 	// API file explorer path
@@ -419,6 +422,12 @@ func osctrlAPIService() {
 	log.Info().Msg("Seeding service config from YAML")
 	serviceConfigMgr := serviceconfig.NewServiceConfigManager(db.Conn)
 	serviceCommandMgr := servicecommands.NewManager(db.Conn)
+	// Log sinks manager shares the service-config feature gate: when
+	// serviceConfigEnabled is false the routes are not registered and
+	// the SPA hides the section. The manager is still constructed so
+	// the table is migrated; rows can be edited directly in the DB or
+	// YAML and picked up on the next osctrl-tls boot/reload.
+	logSinksMgr := logsinks.NewLogSinksManager(db.Conn)
 	if err := serviceConfigMgr.Seed(config.ServiceAPI, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error seeding service config - %v", err)
 	}
@@ -516,6 +525,7 @@ func osctrlAPIService() {
 		handlers.WithCarves(filecarves),
 		handlers.WithSettings(settingsmgr),
 		handlers.WithServiceConfig(serviceConfigMgr),
+		handlers.WithLogSinks(logSinksMgr),
 		handlers.WithServiceConfigEnabled(flagParams.Service.ServiceConfigEnabled),
 		handlers.WithServiceCommands(serviceCommandMgr),
 		handlers.WithConfigPersist(persistConfig),
@@ -1021,6 +1031,35 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"POST "+_apiPath(apiServiceConfigPath)+"/persist",
 			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigPersistHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
+
+		// API: log sinks. Shares the service-config feature gate. The
+		// apply endpoint reuses the same restart limiter since a log
+		// sink reload is the same class of privileged, runtime-affecting
+		// operation as a service-config apply.
+		muxAPI.Handle(
+			"GET "+_apiPath(apiLogSinksPath),
+			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksListHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiLogSinksPath)+"/types",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksTypesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiLogSinksPath)+"/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksGetHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiLogSinksPath),
+			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksCreateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"PUT "+_apiPath(apiLogSinksPath)+"/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksUpdateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"DELETE "+_apiPath(apiLogSinksPath)+"/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksDeleteHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiLogSinksPath)+"/clone",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksCloneHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiLogSinksPath)+"/apply",
+			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
 	}
 	// API: multi-factor enrollment for the calling user
 	muxAPI.Handle(

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -357,7 +357,7 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 		// Process logs and update metadata
 		go func() {
 			start := time.Now()
-			results := h.Logs.ProcessLogs(t.Data, t.LogType, env.Name, utils.GetIP(r), len(body), env.DebugHTTP)
+			results := h.Logs.ProcessLogs(t.Data, t.LogType, env.ID, env.Name, utils.GetIP(r), len(body), env.DebugHTTP)
 			duration := time.Since(start).Seconds()
 			logProcessDuration.WithLabelValues(string(env.UUID), t.LogType).Observe(duration)
 			// Ingest posture data from result logs (if enabled)

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/logsinks"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/posture"
 	"github.com/jmpsec/osctrl/pkg/queries"
@@ -79,6 +80,7 @@ var (
 	queriesmgr           *queries.Queries
 	filecarves           *carves.Carves
 	loggerTLS            *logging.LoggerTLS
+	logSinksMgr          *logsinks.LogSinksManager
 	handlersTLS          *handlers.HandlersTLS
 	tagsmgr              *tags.TagManager
 	carvers3             *carves.CarverS3
@@ -311,11 +313,31 @@ func osctrlService() {
 	)
 	// Initialize service metrics
 	log.Info().Msg("Loading service metrics")
-	// Initialize TLS logger
-	log.Info().Msg("Loading TLS logger")
-	loggerTLS, err = logging.CreateLoggerTLS(*flagParams, settingsmgr, nodesmgr, queriesmgr)
+	// Initialize log sinks manager and seed from the resolved service
+	// configuration (flags, env vars, or YAML — whichever the operator
+	// used). The seed is create-if-missing: once an operator edits a
+	// sink through the API (Source="db") the service-config value is
+	// ignored for that sink until the DB row is deleted.
+	log.Info().Msg("Loading log sinks manager")
+	logSinksMgr = logsinks.NewLogSinksManager(db.Conn)
+	if err := logSinksMgr.Seed(flagParams, settings.NoEnvironmentID); err != nil {
+		log.Fatal().Err(err).Msg("Error seeding log sinks from service configuration")
+	}
+	// Build env-aware exporters from the DB. Falls back to YAML-only
+	// construction if no rows exist (e.g. a deployment that disabled
+	// seeding), preserving the legacy single-set behavior.
+	sinksExporters, err := logSinksMgr.BuildExportersForEnvironments(settingsmgr)
 	if err != nil {
-		log.Fatal().Msgf("Error loading logger - %s: %v", flagParams.Logger.Type, err)
+		log.Fatal().Err(err).Msg("Error building log sink exporters from DB")
+	}
+	if len(sinksExporters) == 0 {
+		log.Info().Msg("No log_sinks rows — falling back to service-config-only logger construction")
+		loggerTLS, err = logging.CreateLoggerTLS(*flagParams, settingsmgr, nodesmgr, queriesmgr)
+		if err != nil {
+			log.Fatal().Msgf("Error loading logger - %s: %v", flagParams.Logger.Type, err)
+		}
+	} else {
+		loggerTLS = logging.CreateLoggerTLSWith(sinksExporters, nodesmgr, queriesmgr)
 	}
 	if flagParams.Metrics.Enabled {
 		log.Info().Msg("Metrics are enabled")
@@ -465,7 +487,7 @@ func osctrlService() {
 		srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
 	}
 	watchCtx, stopCommandWatcher := context.WithCancel(context.Background())
-	go watchServiceCommands(watchCtx, serviceCommandMgr, serviceConfigMgr, auditLog, restartCh)
+	go watchServiceCommands(watchCtx, serviceCommandMgr, serviceConfigMgr, logSinksMgr, loggerTLS, settingsmgr, auditLog, restartCh)
 	serverErr := make(chan error, 1)
 	go func() {
 		log.Info().Msgf("%s v%s - HTTP%s listening %s", serviceName, buildVersion, map[bool]string{true: "S", false: ""}[flagParams.TLS.Termination], serviceListener)
@@ -489,7 +511,7 @@ func osctrlService() {
 	}
 }
 
-func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfgMgr *serviceconfig.ServiceConfigManager, auditLog *auditlog.AuditLogManager, restartCh chan<- struct{}) {
+func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfgMgr *serviceconfig.ServiceConfigManager, sinksMgr *logsinks.LogSinksManager, logTLS *logging.LoggerTLS, settingsMgr *settings.Settings, auditLog *auditlog.AuditLogManager, restartCh chan<- struct{}) {
 	ticker := time.NewTicker(serviceCommandPollInterval)
 	defer ticker.Stop()
 	for {
@@ -521,6 +543,21 @@ func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfg
 				}
 				auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls persist-config command %s consumed", cmd.CommandID), "local")
 				log.Info().Str("command", cmd.CommandID).Msg("Persisted TLS config to file")
+			case servicecommands.ActionReloadLogSinks:
+				// Hot-reload log sinks without restarting. Rebuild the
+				// per-environment exporter map from the DB and atomically
+				// swap it in. The old exporters are closed by
+				// ReplaceExporters; in-flight logs to them may be dropped
+				// during the swap.
+				newExporters, err := sinksMgr.BuildExportersForEnvironments(settingsMgr)
+				if err != nil {
+					log.Err(err).Str("command", cmd.CommandID).Msg("error rebuilding log sink exporters")
+					auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls reload-log-sinks command %s failed: %v", cmd.CommandID, err), "local")
+					continue
+				}
+				logTLS.ReplaceExporters(newExporters)
+				auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls reload-log-sinks command %s consumed", cmd.CommandID), "local")
+				log.Info().Str("command", cmd.CommandID).Msg("Hot-reloaded log sinks")
 			default:
 				log.Warn().Str("command", cmd.CommandID).Msgf("Ignoring unknown TLS service command action %q", cmd.Action)
 			}

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -217,7 +217,12 @@ tls:
   # PEM private key file when termination is true.
   keyFile: ./config/tls.key
 
-# Logger configuration to handle received logs from osquery nodes
+# Logger configuration to handle received logs from osquery nodes.
+# This section seeds the log_sinks table on first boot (create-if-missing).
+# Values can be provided via flags, env vars, or this YAML file — whichever
+# the operator uses, the resolved configuration is the seed source. Once a
+# sink is edited through the API (source=db), the service-config value is
+# ignored for that sink until the DB row is deleted.
 logger:
   # Valid values: "none", "stdout", "file", "db", "graylog", "splunk", "logstash", "kinesis", "s3", "kafka", "elastic"
   type: db

--- a/frontend/src/api/features.ts
+++ b/frontend/src/api/features.ts
@@ -3,6 +3,10 @@ import { apiFetch } from './client';
 export interface Features {
   posture: boolean;
   service_config: boolean;
+  /** Tied to the same flag as service_config — log sink routes are
+   * registered alongside the service-config routes. Optional so partial
+   * test mocks keep compiling across feature additions. */
+  log_sinks?: boolean;
   accelerated: boolean;
   console?: boolean;
   file_explorer: boolean;

--- a/frontend/src/api/log-sinks.ts
+++ b/frontend/src/api/log-sinks.ts
@@ -1,0 +1,148 @@
+/**
+ * Log sinks API client.
+ *
+ * Access to the log_sinks table, which stores per-environment osquery
+ * log destinations (Splunk, Kafka, S3, DB, stdout, …) as JSON-encoded
+ * rows. Read endpoints redact secret fields unless reveal=1 is passed.
+ * Mutating endpoints accept the raw config object; a secret field set
+ * to "***" is merged from the previously stored value by the server.
+ */
+import { apiFetch } from './client';
+import type { ServiceCommand } from './service-config';
+
+/** Wire shape matching handlers.logSinkDTO. */
+export interface LogSink {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  name: string;
+  environment_id: number;
+  type: string;
+  enabled: boolean;
+  order: number;
+  /** Raw JSON object (or stringified blob) for the sink type. Secret
+   * fields are replaced with "***" unless reveal=1 was requested. */
+  config: unknown;
+  source: string;
+  info: string;
+}
+
+/** One field in a sink type's config schema. Drives the dynamic form. */
+export interface LogSinkFieldSpec {
+  name: string;
+  label: string;
+  /** string | integer | boolean | select | password */
+  type: string;
+  required: boolean;
+  secret: boolean;
+  placeholder?: string;
+  help?: string;
+  options?: string[];
+  default?: unknown;
+}
+
+/** One entry in the GET /api/v1/log-sinks/types registry response. */
+export interface LogSinkTypeSpec {
+  type: string;
+  description: string;
+  has_secret: boolean;
+  secret_fields?: string[];
+  /** Typed field schema the SPA renders as a dynamic form. Absent for
+   * sink types with no config (none, stdout). */
+  fields?: LogSinkFieldSpec[];
+}
+
+/** GET /api/v1/log-sinks?env={id}&reveal={0|1}. */
+export function listLogSinks(opts?: {
+  env?: number;
+  reveal?: boolean;
+}): Promise<LogSink[]> {
+  const params = new URLSearchParams();
+  if (opts?.env !== undefined) params.set('env', String(opts.env));
+  if (opts?.reveal) params.set('reveal', '1');
+  const qs = params.toString();
+  return apiFetch<LogSink[]>(`/api/v1/log-sinks${qs ? `?${qs}` : ''}`);
+}
+
+/** GET /api/v1/log-sinks/types. */
+export function listLogSinkTypes(): Promise<LogSinkTypeSpec[]> {
+  return apiFetch<LogSinkTypeSpec[]>('/api/v1/log-sinks/types');
+}
+
+/** GET /api/v1/log-sinks/{id}?reveal={0|1}. */
+export function getLogSink(id: number, reveal?: boolean): Promise<LogSink> {
+  const qs = reveal ? '?reveal=1' : '';
+  return apiFetch<LogSink>(`/api/v1/log-sinks/${id}${qs}`);
+}
+
+/** Body for POST /api/v1/log-sinks. */
+export interface LogSinkCreateRequest {
+  name: string;
+  type: string;
+  enabled: boolean;
+  order: number;
+  config: unknown;
+  environment_id: number;
+  info?: string;
+}
+
+/** POST /api/v1/log-sinks. */
+export function createLogSink(body: LogSinkCreateRequest): Promise<LogSink> {
+  return apiFetch<LogSink>('/api/v1/log-sinks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Body for PUT /api/v1/log-sinks/{id}. */
+export interface LogSinkUpdateRequest {
+  name: string;
+  type: string;
+  enabled: boolean;
+  order: number;
+  config: unknown;
+  info?: string;
+}
+
+/** PUT /api/v1/log-sinks/{id}. */
+export function updateLogSink(
+  id: number,
+  body: LogSinkUpdateRequest,
+): Promise<LogSink> {
+  return apiFetch<LogSink>(`/api/v1/log-sinks/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** DELETE /api/v1/log-sinks/{id}. Returns 204 No Content. */
+export function deleteLogSink(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/log-sinks/${id}`, { method: 'DELETE' });
+}
+
+/** Body for POST /api/v1/log-sinks/clone. */
+export interface LogSinkCloneRequest {
+  source_environment_id: number;
+  target_environment_id: number;
+  overwrite: boolean;
+}
+
+/** POST /api/v1/log-sinks/clone. */
+export function cloneLogSinks(body: LogSinkCloneRequest): Promise<LogSink[]> {
+  return apiFetch<LogSink[]>('/api/v1/log-sinks/clone', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** POST /api/v1/log-sinks/apply — queue a hot-reload of osctrl-tls sinks. */
+export function applyLogSinks(): Promise<{
+  message: string;
+  service?: string;
+  command?: ServiceCommand;
+}> {
+  return apiFetch('/api/v1/log-sinks/apply', { method: 'POST' });
+}

--- a/frontend/src/components/chrome/SideNav.tsx
+++ b/frontend/src/components/chrome/SideNav.tsx
@@ -163,6 +163,8 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
     pathname.startsWith('/_app/settings') || pathname.startsWith('/settings');
   const isServiceConfigActive =
     pathname.startsWith('/_app/config') || pathname.startsWith('/config');
+  const isLogSinksActive =
+    pathname.startsWith('/_app/log-sinks') || pathname.startsWith('/log-sinks');
   const isAuditActive = pathname.startsWith('/_app/audit') || pathname === '/audit';
   // Dashboard is now env-scoped at /_app/env/{env}
   const dashboardPath = `/_app/env/${currentEnv}`;
@@ -443,6 +445,18 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
               }
             >
               Service Config
+            </NavItem>}
+            {features?.log_sinks && <NavItem
+              collapsed={collapsed}
+              active={isLogSinksActive}
+              to="/_app/log-sinks"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />
+                </svg>
+              }
+            >
+              Log Sinks
             </NavItem>}
           </nav>
         </>

--- a/frontend/src/components/feedback/ModalShell.tsx
+++ b/frontend/src/components/feedback/ModalShell.tsx
@@ -31,6 +31,11 @@ export interface ModalShellProps {
   children: React.ReactNode;
   /** Optional tailwind class for the inner panel — defaults to max-w-2xl. */
   panelClassName?: string;
+  /** Optional tailwind class for the body wrapper. Defaults to none.
+   * Use this to cap the body height and make it scrollable when the
+   * form content can exceed the viewport, e.g.
+   * "max-h-[70vh] overflow-y-auto". */
+  bodyClassName?: string;
 }
 
 export function ModalShell({
@@ -39,6 +44,7 @@ export function ModalShell({
   onClose,
   children,
   panelClassName,
+  bodyClassName,
 }: ModalShellProps) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -131,7 +137,7 @@ export function ModalShell({
             </svg>
           </button>
         </div>
-        <div className="p-5">{children}</div>
+        <div className={cn('p-5', bodyClassName)}>{children}</div>
       </div>
     </div>
   );

--- a/frontend/src/features/log-sinks/LogSinksPage.test.tsx
+++ b/frontend/src/features/log-sinks/LogSinksPage.test.tsx
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRouter,
+  createRoute,
+  createRootRoute,
+  RouterProvider,
+  Outlet,
+} from '@tanstack/react-router';
+import { LogSinksPage } from './LogSinksPage';
+import type { LogSink, LogSinkTypeSpec } from '$/api/log-sinks';
+import type { ServiceCommand } from '$/api/service-config';
+
+const mockList = vi.fn<(opts?: { env?: number; reveal?: boolean }) => Promise<LogSink[]>>();
+const mockTypes = vi.fn<() => Promise<LogSinkTypeSpec[]>>();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+const mockClone = vi.fn();
+const mockApply = vi.fn();
+const mockGetSink = vi.fn<(id: number, reveal?: boolean) => Promise<LogSink>>();
+const mockGetCommand = vi.fn<(commandID: string) => Promise<ServiceCommand>>();
+
+vi.mock('$/api/log-sinks', () => ({
+  listLogSinks: (opts?: { env?: number; reveal?: boolean }) => mockList(opts),
+  listLogSinkTypes: () => mockTypes(),
+  createLogSink: (...args: unknown[]) => mockCreate(...args),
+  updateLogSink: (...args: unknown[]) => mockUpdate(...args),
+  deleteLogSink: (id: number) => mockDelete(id),
+  cloneLogSinks: (...args: unknown[]) => mockClone(...args),
+  applyLogSinks: () => mockApply(),
+  getLogSink: (id: number, reveal?: boolean) => mockGetSink(id, reveal),
+}));
+
+const mockGetFeatures = vi.fn();
+vi.mock('$/api/features', () => ({
+  getFeatures: () => mockGetFeatures(),
+}));
+
+const mockListEnvs = vi.fn();
+vi.mock('$/api/environments', () => ({
+  listEnvironments: () => mockListEnvs(),
+}));
+
+vi.mock('$/api/service-config', () => ({
+  getServiceCommand: (commandID: string) => mockGetCommand(commandID),
+}));
+
+vi.mock('$/api/client', () => ({
+  isAuthenticated: () => true,
+  AuthError: class AuthError extends Error {
+    readonly status = 401;
+    constructor() {
+      super('Unauthorized');
+    }
+  },
+  ApiError: class ApiError extends Error {
+    constructor(msg: string, public status: number, public code?: string) {
+      super(msg);
+    }
+  },
+}));
+
+function makeSink(overrides: Partial<LogSink> = {}): LogSink {
+  return {
+    id: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    name: 'prod-splunk',
+    environment_id: 0,
+    type: 'splunk',
+    enabled: true,
+    order: 0,
+    config: { url: 'http://x', token: '***', host: 'h', index: 'i' },
+    source: 'yaml',
+    info: '',
+    ...overrides,
+  };
+}
+
+const splunkType: LogSinkTypeSpec = {
+  type: 'splunk',
+  description: 'Splunk HEC',
+  has_secret: true,
+  secret_fields: ['token'],
+  fields: [
+    { name: 'url', label: 'HEC URL', type: 'string', required: true, secret: false, placeholder: 'https://splunk:8088/services/collector' },
+    { name: 'token', label: 'HEC token', type: 'password', required: true, secret: true, placeholder: '' },
+    { name: 'host', label: 'Host', type: 'string', required: false, secret: false, placeholder: 'osctrl' },
+    { name: 'index', label: 'Index', type: 'string', required: false, secret: false, placeholder: 'main' },
+  ],
+};
+const noneType: LogSinkTypeSpec = {
+  type: 'none',
+  description: 'Discard',
+  has_secret: false,
+};
+const kafkaType: LogSinkTypeSpec = {
+  type: 'kafka',
+  description: 'Apache Kafka producer',
+  has_secret: true,
+  secret_fields: ['sasl.password'],
+  fields: [
+    { name: 'bootstrapServers', label: 'Bootstrap servers', type: 'string', required: true, secret: false, placeholder: 'broker1:9092' },
+    { name: 'topic', label: 'Topic', type: 'string', required: true, secret: false, placeholder: 'osquery-logs' },
+    { name: 'sslCALocation', label: 'CA cert path', type: 'string', required: false, secret: false, placeholder: '' },
+    { name: 'connectionTimeout', label: 'Connection timeout', type: 'string', required: false, secret: false, placeholder: '5s' },
+    { name: 'sasl.mechanism', label: 'SASL mechanism', type: 'select', required: false, secret: false, options: ['', 'SCRAM-SHA-256', 'SCRAM-SHA-512'] },
+    { name: 'sasl.username', label: 'SASL username', type: 'string', required: false, secret: false, placeholder: '' },
+    { name: 'sasl.password', label: 'SASL password', type: 'password', required: false, secret: true, placeholder: '' },
+  ],
+};
+
+function renderPage() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const pageRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: LogSinksPage,
+  });
+  const history = createMemoryHistory({ initialEntries: ['/'] });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([pageRoute]),
+    history,
+  });
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetFeatures.mockResolvedValue({
+    posture: false,
+    service_config: true,
+    log_sinks: true,
+    accelerated: false,
+    file_explorer: false,
+  });
+  mockListEnvs.mockResolvedValue([
+    { id: 5, name: 'prod', uuid: 'p', environment_id: 5 },
+  ]);
+  mockTypes.mockResolvedValue([noneType, splunkType, kafkaType]);
+  mockList.mockResolvedValue([]);
+});
+
+describe('LogSinksPage', () => {
+  it('renders the env selector and empty state when there are no sinks', async () => {
+    renderPage();
+    await waitFor(() => expect(mockList).toHaveBeenCalled());
+    expect(await screen.findByText('No global log sinks.')).toBeInTheDocument();
+    expect(screen.getByText('Global (fallback for all)')).toBeInTheDocument();
+  });
+
+  it('lists existing sinks sorted by order', async () => {
+    mockList.mockResolvedValue([
+      makeSink({ id: 2, name: 'second', order: 5 }),
+      makeSink({ id: 1, name: 'first', order: 0 }),
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('first')).toBeInTheDocument());
+    expect(screen.getByText('second')).toBeInTheDocument();
+  });
+
+  it('opens the type picker, picks splunk, and creates a sink with typed config', async () => {
+    mockCreate.mockResolvedValue(makeSink({ id: 9, name: 'new' }));
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('New sink')).toBeInTheDocument());
+    await user.click(screen.getByText('New sink'));
+    // Step 1: type picker modal.
+    expect(await screen.findByText('New log sink')).toBeInTheDocument();
+    expect(screen.getByText('splunk')).toBeInTheDocument();
+    // Click the splunk type to advance to step 2.
+    await user.click(screen.getByText('splunk'));
+    // Step 2: config form for splunk.
+    expect(await screen.findByText('Add splunk sink')).toBeInTheDocument();
+    const urlInput = await screen.findByLabelText('HEC URL');
+    expect(urlInput).toBeInTheDocument();
+    expect(screen.getByLabelText('HEC token')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('e.g. prod-splunk'), 'new');
+    await user.type(urlInput, 'https://splunk:8088');
+    await user.type(screen.getByLabelText('HEC token'), 'secret-token');
+    await user.click(screen.getByText('Add sink'));
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    const body = mockCreate.mock.calls[0][0];
+    expect(body.name).toBe('new');
+    expect(body.type).toBe('splunk');
+    expect(body.config).toEqual({
+      url: 'https://splunk:8088',
+      token: 'secret-token',
+    });
+  });
+
+  it('renders nested fields (kafka sasl) and submits a nested config object', async () => {
+    mockCreate.mockResolvedValue(makeSink({ id: 10, name: 'kafka-sink' }));
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('New sink')).toBeInTheDocument());
+    await user.click(screen.getByText('New sink'));
+    // Step 1: pick kafka from the type picker.
+    expect(await screen.findByText('New log sink')).toBeInTheDocument();
+    await user.click(screen.getByText('kafka'));
+    // Step 2: SASL fields are nested under sasl.* in the schema; the
+    // form should render them as flat labelled inputs and the submit
+    // should expand them back into { sasl: { ... } }.
+    expect(await screen.findByLabelText('Bootstrap servers')).toBeInTheDocument();
+    expect(screen.getByLabelText('SASL mechanism')).toBeInTheDocument();
+    expect(screen.getByLabelText('SASL password')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('e.g. prod-splunk'), 'kafka-sink');
+    await user.type(screen.getByLabelText('Bootstrap servers'), 'broker1:9092');
+    await user.type(screen.getByLabelText('Topic'), 'osquery-logs');
+    await user.selectOptions(screen.getByLabelText('SASL mechanism'), 'SCRAM-SHA-512');
+    await user.type(screen.getByLabelText('SASL username'), 'kafka-user');
+    await user.type(screen.getByLabelText('SASL password'), 'kafka-pass');
+    await user.click(screen.getByText('Add sink'));
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    const body = mockCreate.mock.calls[0][0];
+    expect(body.type).toBe('kafka');
+    expect(body.config).toEqual({
+      bootstrapServers: 'broker1:9092',
+      topic: 'osquery-logs',
+      sasl: {
+        mechanism: 'SCRAM-SHA-512',
+        username: 'kafka-user',
+        password: 'kafka-pass',
+      },
+    });
+  });
+
+  it('shows no config fields for the none sink type', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('New sink')).toBeInTheDocument());
+    await user.click(screen.getByText('New sink'));
+    // Step 1: pick none from the type picker.
+    expect(await screen.findByText('New log sink')).toBeInTheDocument();
+    await user.click(screen.getByText('none'));
+    // Step 2: none has no fields — the empty-config hint renders.
+    expect(await screen.findByText('This sink type has no configurable fields.')).toBeInTheDocument();
+  });
+
+  it('shows the apply warning modal and queues a reload on confirm', async () => {
+    // The Apply button is disabled until there is at least one DB-edited
+    // sink (source === 'db'), so seed one.
+    mockList.mockResolvedValue([makeSink({ id: 1, name: 'edited', source: 'db' })]);
+    mockApply.mockResolvedValue({
+      message: 'ok',
+      service: 'tls',
+      command: {
+        command_id: 'cmd-1',
+        target_service: 'tls',
+        action: 'reload-log-sinks',
+        status: 'pending',
+      },
+    });
+    mockGetCommand.mockResolvedValue({
+      command_id: 'cmd-1',
+      target_service: 'tls',
+      action: 'reload-log-sinks',
+      status: 'consumed',
+    } as ServiceCommand);
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Apply changes')).toBeInTheDocument());
+    await user.click(screen.getByText('Apply changes'));
+    expect(await screen.findByText('Apply sink changes')).toBeInTheDocument();
+    expect(
+      screen.getByText(/logs in-flight to the old sinks may be dropped/),
+    ).toBeInTheDocument();
+    const confirmBtn = screen.getByText('Reload now');
+    await user.click(confirmBtn);
+    await waitFor(() => expect(mockApply).toHaveBeenCalled());
+  });
+
+  it('hides itself when the log_sinks feature flag is off', async () => {
+    mockGetFeatures.mockResolvedValue({
+      posture: false,
+      service_config: false,
+      log_sinks: false,
+      accelerated: false,
+      file_explorer: false,
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('Log Sinks API is disabled')).toBeInTheDocument(),
+    );
+    expect(mockList).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/log-sinks/LogSinksPage.tsx
+++ b/frontend/src/features/log-sinks/LogSinksPage.tsx
@@ -1,0 +1,1524 @@
+import { useState, useMemo, useEffect, type ReactNode } from 'react';
+import { usePageTitle } from '$/lib/usePageTitle';
+import { useNavigate } from '@tanstack/react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  listLogSinks,
+  listLogSinkTypes,
+  createLogSink,
+  updateLogSink,
+  deleteLogSink,
+  cloneLogSinks,
+  applyLogSinks,
+  getLogSink,
+  type LogSink,
+  type LogSinkTypeSpec,
+  type LogSinkFieldSpec,
+  type LogSinkCreateRequest,
+} from '$/api/log-sinks';
+import { listEnvironments } from '$/api/environments';
+import { getFeatures } from '$/api/features';
+import { getServiceCommand, getServiceConfig } from '$/api/service-config';
+import { AuthError, ApiError } from '$/api/client';
+import { formatRelative } from '$/lib/time';
+import { SkeletonRow } from '$/components/data/Skeleton';
+import { EmptyState } from '$/components/data/EmptyState';
+import { ModalShell } from '$/components/feedback/ModalShell';
+import { cn } from '$/lib/cn';
+
+const GLOBAL_ENV_ID = 0;
+
+// ---------------------------------------------------------------------------
+// Per-type icons. All use the same 24×24 / stroke=1.5 convention as the
+// side-nav and empty-state icons so they match the visual language. Each
+// is a simple pictogram that reads as the sink's purpose at a glance.
+// ---------------------------------------------------------------------------
+const SINK_TYPE_ICONS: Record<string, ReactNode> = {
+  // Discard — trash can
+  none: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M4 7h16M9 7V5a1 1 0 011-1h4a1 1 0 011 1v2M6 7l1 13a2 2 0 002 2h6a2 2 0 002-2l1-13M10 11v6M14 11v6" />
+    </svg>
+  ),
+  // stdout — terminal/console
+  stdout: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <path d="M7 9l3 3-3 3M13 15h4" />
+    </svg>
+  ),
+  // file — document
+  file: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M14 3H6a2 2 0 00-2 2v14a2 2 0 002 2h12a2 2 0 002-2V9z" />
+      <path d="M14 3v6h6" />
+    </svg>
+  ),
+  // db — cylinder
+  db: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <ellipse cx="12" cy="5" rx="8" ry="3" />
+      <path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5" />
+      <path d="M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3" />
+    </svg>
+  ),
+  // splunk — search/lens
+  splunk: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="11" cy="11" r="7" />
+      <path d="M16 16l4 4M11 8v6M8 11h6" />
+    </svg>
+  ),
+  // graylog — layers/stash
+  graylog: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M12 3l9 5-9 5-9-5 9-5z" />
+      <path d="M3 13l9 5 9-5M3 17l9 5 9-5" />
+    </svg>
+  ),
+  // logstash — pipeline/pipe
+  logstash: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M4 5h6v6H4zM14 5h6v6h-6zM4 17h6v-4H4zM14 17h6v-4h-6z" />
+    </svg>
+  ),
+  // kinesis — stream/waves
+  kinesis: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M3 8c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3" />
+      <path d="M3 14c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3" />
+      <path d="M3 20c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3" />
+    </svg>
+  ),
+  // s3 — bucket
+  s3: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 8l2 12a2 2 0 002 2h6a2 2 0 002-2l2-12" />
+      <path d="M3 8h18M12 8c0-3-2-5-5-5s-5 2-5 5M12 8c0-3 2-5 5-5s5 2 5 5" />
+    </svg>
+  ),
+  // kafka — message broker / arrows
+  kafka: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="6" cy="12" r="2" />
+      <path d="M8 12h4M12 8l4-2M12 16l4 2M16 6l2-1v14l-2-1M16 18l-4-2" />
+    </svg>
+  ),
+  // elastic — magnifying chart
+  elastic: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M3 12h4l2-5 3 10 2-5h7" />
+    </svg>
+  ),
+};
+
+/** Returns the icon for a sink type, or a default document icon. */
+function sinkTypeIcon(type: string): ReactNode {
+  return SINK_TYPE_ICONS[type] ?? SINK_TYPE_ICONS.file;
+}
+
+type ModalMode =
+  | { kind: 'closed' }
+  | { kind: 'create' } // step 1: type picker
+  | { kind: 'createType'; sinkType: string } // step 2: config form for chosen type
+  | { kind: 'edit'; sink: LogSink }
+  | { kind: 'clone' }
+  | { kind: 'apply' };
+
+/**
+ * Log Sinks admin page.
+ *
+ * Lists log_sinks rows for the selected environment (Global by default),
+ * with add/edit/delete, clone-from-another-env, and an Apply button that
+ * queues a hot-reload of osctrl-tls. The Apply modal warns that in-flight
+ * logs to the old sinks may be dropped during the swap.
+ *
+ * Visual/structural conventions mirror EnvironmentsPage / ServiceConfigPage:
+ * sticky header bar, full-width table with SkeletonRow loading, EmptyState
+ * for empty/error, ModalShell dialogs, CSS-var tokens only.
+ */
+export function LogSinksPage() {
+  usePageTitle('Log Sinks');
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const [selectedEnv, setSelectedEnv] = useState<number>(GLOBAL_ENV_ID);
+  const [modal, setModal] = useState<ModalMode>({ kind: 'closed' });
+  const [applyErr, setApplyErr] = useState<string | null>(null);
+  const [applyFlash, setApplyFlash] = useState(false);
+  const [reloading, setReloading] = useState(false);
+
+  const { data: features } = useQuery({
+    queryKey: ['features'],
+    queryFn: () => getFeatures(),
+    staleTime: 5 * 60_000,
+  });
+  const configDisabled = features?.log_sinks === false;
+
+  const { data: envs } = useQuery({
+    queryKey: ['environments'],
+    queryFn: () => listEnvironments(),
+    staleTime: 60_000,
+  });
+
+  const {
+    data: sinks,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['log-sinks', selectedEnv],
+    queryFn: () => listLogSinks({ env: selectedEnv }),
+    enabled: !!features?.log_sinks,
+    staleTime: 30_000,
+  });
+
+  const { data: types } = useQuery({
+    queryKey: ['log-sinks-types'],
+    queryFn: () => listLogSinkTypes(),
+    staleTime: 60_000,
+    enabled: !!features?.log_sinks,
+  });
+
+  const invalidate = () => {
+    void qc.invalidateQueries({ queryKey: ['log-sinks'] });
+    void refetch();
+  };
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteLogSink(id),
+    onSuccess: () => invalidate(),
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        void navigate({ to: '/login' });
+        return;
+      }
+      setApplyErr(e instanceof Error ? e.message : 'Delete failed');
+    },
+  });
+
+  const cloneMutation = useMutation({
+    mutationFn: cloneLogSinks,
+    onSuccess: () => {
+      setModal({ kind: 'closed' });
+      invalidate();
+    },
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        void navigate({ to: '/login' });
+        return;
+      }
+      setApplyErr(e instanceof Error ? e.message : 'Clone failed');
+    },
+  });
+
+  const applyMutation = useMutation({
+    mutationFn: () => applyLogSinks(),
+    onSuccess: (resp) => {
+      setApplyErr(null);
+      // osctrl-tls consumes the reload command asynchronously; poll the
+      // command until it is consumed (status !== pending). Same pattern
+      // as the service-config apply path.
+      if (!resp.command) {
+        setReloading(false);
+        setApplyFlash(true);
+        setTimeout(() => setApplyFlash(false), 3000);
+        return;
+      }
+      setReloading(true);
+      const poll = setInterval(() => {
+        getServiceCommand(resp.command!.command_id)
+          .then((cmd) => {
+            if (cmd.status !== 'pending') {
+              clearInterval(poll);
+              setReloading(false);
+              setApplyFlash(true);
+              setTimeout(() => setApplyFlash(false), 3000);
+            }
+          })
+          .catch(() => {
+            clearInterval(poll);
+            setReloading(false);
+          });
+      }, 1500);
+    },
+    onError: (e: unknown) => {
+      setApplyErr(e instanceof Error ? e.message : String(e));
+    },
+  });
+
+  // Early returns must come AFTER all hook calls so hook order stays
+  // stable across renders (React rules of hooks).
+  if (isError && error instanceof AuthError) {
+    void navigate({ to: '/login' });
+    return null;
+  }
+
+  if (configDisabled) {
+    return (
+      <div className="flex flex-col h-full min-h-0">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border)] flex-wrap">
+          <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">
+            Log Sinks
+          </h1>
+          <p className="text-xs text-[color:var(--text-3)]">
+            Super-admin view. Manage osquery log destinations per environment.
+          </p>
+        </div>
+        <div className="flex-1 overflow-auto min-h-0">
+          <EmptyState
+            icon={
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 8v4M12 16h.01" />
+              </svg>
+            }
+            title="Log Sinks API is disabled"
+            description={
+              'osctrl-api runs with service.serviceConfigEnabled = false, so the /api/v1/log-sinks endpoints are not registered. osctrl-tls still seeds its YAML logger section into the log_sinks table at startup, so sinks can be changed directly in the database and are picked up on the next restart. Set serviceConfigEnabled: true and restart osctrl-api to manage them here.'
+            }
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const rows = sinks ?? [];
+  const sorted = [...rows].sort((a, b) => a.order - b.order || a.id - b.id);
+  const hasPending = rows.some((r) => r.source === 'db');
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Sticky header — same shell as EnvironmentsPage / ServiceConfigPage. */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border)] flex-wrap">
+        <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">
+          Log Sinks
+        </h1>
+        <p className="text-xs text-[color:var(--text-3)]">
+          Per-environment osquery log destinations. Global sinks are the
+          fallback for any environment without its own.
+        </p>
+
+        <div className="ml-auto flex items-center gap-2">
+          {isFetching && !isLoading && (
+            <span
+              aria-live="polite"
+              aria-label="Refreshing data"
+              className="text-[10px] text-[color:var(--text-3)] font-mono-tabular"
+            >
+              refreshing…
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => setModal({ kind: 'clone' })}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-md transition-colors',
+              'text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)]',
+            )}
+          >
+            Clone from…
+          </button>
+          <button
+            type="button"
+            onClick={() => setModal({ kind: 'create' })}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-md',
+              'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
+              'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+            )}
+          >
+            New sink
+          </button>
+          <button
+            type="button"
+            disabled={reloading || !hasPending}
+            title={
+              !hasPending
+                ? 'No unsaved changes — nothing to apply'
+                : 'Hot-reload osctrl-tls with the current sink rows'
+            }
+            onClick={() => {
+              setApplyErr(null);
+              setModal({ kind: 'apply' });
+            }}
+            className={cn(
+              'px-3 py-1 text-xs font-medium rounded transition-colors',
+              reloading
+                ? 'bg-[color:var(--bg-3)] text-[color:var(--text-3)]'
+                : 'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)] hover:bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.2)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            {reloading
+              ? 'Reloading…'
+              : applyFlash
+                ? 'Reload triggered ✓'
+                : 'Apply changes'}
+          </button>
+        </div>
+      </div>
+
+      {/* Environment selector — matches the inline control style in EnvConfigPage. */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-[color:var(--border)] text-xs">
+        <label
+          htmlFor="log-sinks-env"
+          className="text-[color:var(--text-2)] font-semibold"
+        >
+          Environment
+        </label>
+        <select
+          id="log-sinks-env"
+          value={selectedEnv}
+          onChange={(e) => setSelectedEnv(Number(e.target.value))}
+          aria-label="Select environment whose sinks to show"
+          className={cn(
+            'px-2 py-1 rounded font-mono-tabular',
+            'bg-[color:var(--bg-2)] border border-[color:var(--border)] text-[color:var(--text-1)]',
+            'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+          )}
+        >
+          <option value={GLOBAL_ENV_ID}>Global (fallback for all)</option>
+          {envs?.map((e) => (
+            <option key={e.id} value={e.id}>
+              {e.name}
+            </option>
+          ))}
+        </select>
+        <span className="text-[color:var(--text-3)]">
+          {selectedEnv === GLOBAL_ENV_ID
+            ? 'Used by every environment that has no sinks of its own.'
+            : 'Overrides the global set for this environment.'}
+        </span>
+      </div>
+
+      {/* Apply-error toast — mirrors the bulk-error toast in EnvironmentsPage. */}
+      {applyErr && (
+        <div
+          role="alert"
+          className={cn(
+            'flex items-center gap-3 px-4 py-2.5 border-b',
+            'border-[color:var(--danger)]/40 bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)]',
+            'text-xs text-[color:var(--danger)]',
+          )}
+        >
+          <span>{applyErr}</span>
+          <button
+            type="button"
+            onClick={() => setApplyErr(null)}
+            className="ml-auto text-[color:var(--text-3)] hover:text-[color:var(--text-1)]"
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto min-h-0">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="border-b border-[color:var(--border)] bg-[color:var(--bg-0)] sticky top-0 z-10">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide w-16">
+                Order
+              </th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide">
+                Name
+              </th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide">
+                Type
+              </th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide w-24">
+                Enabled
+              </th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide w-24">
+                Source
+              </th>
+              <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide">
+                Updated
+              </th>
+              <th scope="col" className="px-2 py-3 w-1" />
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading &&
+              Array.from({ length: 4 }).map((_, i) => <SkeletonRow key={i} cells={7} />)}
+
+            {isError && !isLoading && (
+              <tr>
+                <td colSpan={7}>
+                  <EmptyState
+                    icon={
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                        <circle cx="12" cy="12" r="10" />
+                        <path d="M12 8v4M12 16h.01" />
+                      </svg>
+                    }
+                    title={error instanceof Error ? error.message : 'Failed to load log sinks'}
+                    action={
+                      <button
+                        type="button"
+                        onClick={() => void refetch()}
+                        className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors"
+                      >
+                        Retry
+                      </button>
+                    }
+                  />
+                </td>
+              </tr>
+            )}
+
+            {!isLoading && !isError && sorted.length === 0 && (
+              <tr>
+                <td colSpan={7}>
+                  <EmptyState
+                    icon={
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                        <rect x="3" y="3" width="18" height="18" rx="2" />
+                        <path d="M3 9h18M9 21V9" />
+                      </svg>
+                    }
+                    title={
+                      selectedEnv === GLOBAL_ENV_ID
+                        ? 'No global log sinks.'
+                        : `No sinks for ${envNameFor(envs ?? [], selectedEnv)}.`
+                    }
+                    description={
+                      selectedEnv === GLOBAL_ENV_ID
+                        ? 'Add one to start forwarding osquery status, result, and query logs to a destination.'
+                        : 'This environment inherits the global sinks. Add one here to override.'
+                    }
+                    action={
+                      <button
+                        type="button"
+                        onClick={() => setModal({ kind: 'create' })}
+                        className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors"
+                      >
+                        Add a sink
+                      </button>
+                    }
+                  />
+                </td>
+              </tr>
+            )}
+
+            {!isLoading &&
+              !isError &&
+              sorted.map((s) => (
+                <tr
+                  key={s.id}
+                  className="border-b border-[color:var(--border)] hover:bg-[color:var(--bg-2)] transition-colors"
+                >
+                  <td className="px-4 py-3 text-xs font-mono-tabular text-[color:var(--text-3)]">
+                    {s.order}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="flex items-center gap-2">
+                      <span className="text-sm font-semibold text-[color:var(--text-1)] font-mono-tabular">
+                        {s.name}
+                      </span>
+                      {s.info && (
+                        <span className="text-[10px] text-[color:var(--text-3)] truncate max-w-[240px]" title={s.info}>
+                          — {s.info}
+                        </span>
+                      )}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-[color:var(--text-2)] text-xs">
+                    <span className="flex items-center gap-1.5">
+                      <span className="w-4 h-4 flex-shrink-0 text-[color:var(--text-3)]">
+                        {sinkTypeIcon(s.type)}
+                      </span>
+                      <span className="font-mono-tabular">{s.type}</span>
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-xs">
+                    {s.enabled ? (
+                      <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[rgba(var(--success-r),var(--success-g),var(--success-b),0.12)] text-[color:var(--success)]">
+                        on
+                      </span>
+                    ) : (
+                      <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[color:var(--bg-2)] text-[color:var(--text-3)]">
+                        off
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-xs">
+                    {s.source === 'db' ? (
+                      <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)]">
+                        edited
+                      </span>
+                    ) : (
+                      <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[color:var(--bg-2)] text-[color:var(--text-3)]" title={`Seeded from service configuration (source: ${s.source})`}>
+                        seed
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-[color:var(--text-2)] text-right font-mono-tabular">
+                    <span title={s.updated_at}>{formatRelative(s.updated_at)}</span>
+                  </td>
+                  <td className="px-2 py-3 text-right whitespace-nowrap">
+                    <button
+                      type="button"
+                      onClick={() => setModal({ kind: 'edit', sink: s })}
+                      className="px-2 py-1 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      disabled={deleteMutation.isPending}
+                      onClick={() => {
+                        if (confirm(`Delete sink "${s.name}"? It will be removed on the next Apply.`)) {
+                          deleteMutation.mutate(s.id);
+                        }
+                      }}
+                      className="px-2 py-1 text-xs font-medium rounded text-[color:var(--danger)] hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-50"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Modals — same ModalShell + form conventions as EnvironmentsPage. */}
+      {modal.kind === 'create' && (
+        <SinkTypePicker
+          types={types ?? []}
+          onPick={(t) => setModal({ kind: 'createType', sinkType: t })}
+          onClose={() => setModal({ kind: 'closed' })}
+        />
+      )}
+      {modal.kind === 'createType' && (
+        <SinkEditor
+          mode="create"
+          types={types ?? []}
+          sinkType={modal.sinkType}
+          envID={selectedEnv}
+          onClose={() => setModal({ kind: 'closed' })}
+          onSaved={invalidate}
+        />
+      )}
+      {modal.kind === 'edit' && (
+        <SinkEditor
+          mode="edit"
+          types={types ?? []}
+          sinkType={modal.sink.type}
+          envID={selectedEnv}
+          existing={modal.sink}
+          onClose={() => setModal({ kind: 'closed' })}
+          onSaved={invalidate}
+        />
+      )}
+      {modal.kind === 'clone' && (
+        <CloneModal
+          envs={envs ?? []}
+          targetEnv={selectedEnv}
+          pending={cloneMutation.isPending}
+          error={
+            cloneMutation.error instanceof ApiError
+              ? cloneMutation.error.message
+              : cloneMutation.error instanceof Error
+                ? cloneMutation.error.message
+                : null
+          }
+          onClone={(req) => cloneMutation.mutate(req)}
+          onClose={() => setModal({ kind: 'closed' })}
+        />
+      )}
+      {modal.kind === 'apply' && (
+        <ApplyConfirmDialog
+          pendingSinks={sorted.filter((s) => s.source === 'db')}
+          isPending={reloading}
+          onConfirm={() => {
+            setModal({ kind: 'closed' });
+            applyMutation.mutate();
+          }}
+          onCancel={() => setModal({ kind: 'closed' })}
+        />
+      )}
+    </div>
+  );
+}
+
+function envNameFor(envs: { id: number; name: string }[], envID: number): string {
+  if (envID === GLOBAL_ENV_ID) return 'Global';
+  return envs.find((e) => e.id === envID)?.name ?? `Env ${envID}`;
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: type picker modal — a compact grid of sink types. Selecting
+// one advances to the config form (SinkEditor) for that type only, so
+// the form stays short and never overflows the viewport.
+// ---------------------------------------------------------------------------
+function SinkTypePicker({
+  types,
+  onPick,
+  onClose,
+}: {
+  types: LogSinkTypeSpec[];
+  onPick: (sinkType: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <ModalShell
+      title="New log sink"
+      titleId="log-sink-type-picker-title"
+      onClose={onClose}
+      panelClassName="max-w-lg"
+    >
+      <div className="space-y-3">
+        <p className="text-xs text-[color:var(--text-3)]">
+          Choose a destination type. The next step configures its fields.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {types.map((t) => (
+            <button
+              key={t.type}
+              type="button"
+              onClick={() => onPick(t.type)}
+              className={cn(
+                'flex items-start gap-3 px-3 py-2.5 rounded-md text-left',
+                'border border-[color:var(--border)] bg-[color:var(--bg-2)]',
+                'hover:border-[color:var(--signal)] hover:bg-[color:var(--bg-1)]',
+                'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+              )}
+            >
+              <span className="flex-shrink-0 w-5 h-5 text-[color:var(--text-3)] mt-0.5">
+                {sinkTypeIcon(t.type)}
+              </span>
+              <span className="flex flex-col gap-0.5 min-w-0">
+                <span className="text-sm font-semibold text-[color:var(--text-1)] font-mono-tabular">
+                  {t.type}
+                </span>
+                <span className="text-[10px] text-[color:var(--text-3)]">
+                  {t.description}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+        <div className="flex justify-end pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: create / edit modal for one sink type. The type is fixed
+// (chosen in step 1 for create, inherited from the existing row for edit)
+// so the form only shows the config fields for that type — no long
+// all-types dropdown, no overflow.
+// ---------------------------------------------------------------------------
+function SinkEditor({
+  mode,
+  types,
+  sinkType,
+  envID,
+  existing,
+  onClose,
+  onSaved,
+}: {
+  mode: 'create' | 'edit';
+  types: LogSinkTypeSpec[];
+  sinkType: string;
+  envID: number;
+  existing?: LogSink;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const qc = useQueryClient();
+  const [name, setName] = useState(existing?.name ?? '');
+  const [enabled, setEnabled] = useState(existing?.enabled ?? true);
+  const [order, setOrder] = useState(existing?.order ?? 0);
+  const [info, setInfo] = useState(existing?.info ?? '');
+  const [err, setErr] = useState<string | null>(null);
+
+  const spec = useMemo(
+    () => types.find((t) => t.type === sinkType),
+    [types, sinkType],
+  );
+
+  // Field values are a flat map keyed by the field's dotted Name. The
+  // buildConfig() helper expands dotted keys into nested objects before
+  // sending to the API. Initial values come from the existing config
+  // (decoded into a flat map) or from the spec defaults on create.
+  const [fieldValues, setFieldValues] = useState<Record<string, unknown>>(() =>
+    existing ? flattenConfig(existing.config) : defaultsForSpec(spec),
+  );
+
+  // When editing a secret-bearing sink, fetch the revealed config so the
+  // operator can see the current secret value before deciding to change
+  // it. Merge the revealed secret fields into the existing field values
+  // rather than replacing the whole form — the operator may have already
+  // edited non-secret fields.
+  const revealSecret = useQuery({
+    queryKey: ['log-sink-reveal', existing?.id],
+    queryFn: () => getLogSink(existing!.id, true),
+    enabled: mode === 'edit' && !!existing && !!spec?.has_secret,
+    staleTime: 0,
+  });
+  useEffect(() => {
+    if (!revealSecret.data || !existing || revealSecret.data.id !== existing.id) return;
+    const revealedFlat = flattenConfig(revealSecret.data.config);
+    setFieldValues((prev) => {
+      const next = { ...prev };
+      for (const f of spec?.fields ?? []) {
+        if (f.secret && revealedFlat[f.name] !== undefined) {
+          next[f.name] = revealedFlat[f.name];
+        }
+      }
+      return next;
+    });
+  }, [revealSecret.data, existing, spec]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const trimmedName = name.trim();
+      if (!trimmedName) throw new Error('Name is required.');
+      const config = buildConfig(spec, fieldValues);
+      if (mode === 'create') {
+        const body: LogSinkCreateRequest = {
+          name: trimmedName,
+          type: sinkType,
+          enabled,
+          order,
+          config,
+          environment_id: envID,
+          info: info.trim() || undefined,
+        };
+        return createLogSink(body);
+      }
+      return updateLogSink(existing!.id, {
+        name: trimmedName,
+        type: sinkType,
+        enabled,
+        order,
+        config,
+        info: info.trim() || undefined,
+      });
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['log-sinks'] });
+      onSaved();
+      onClose();
+    },
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        window.location.href = '/login';
+        return;
+      }
+      setErr(e instanceof Error ? e.message : 'Save failed');
+    },
+  });
+
+  const inputClass = cn(
+    'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+    'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular',
+    'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+  );
+
+  return (
+    <ModalShell
+      title={mode === 'create' ? `Add ${sinkType} sink` : `Edit ${existing?.name}`}
+      titleId="log-sink-editor-title"
+      onClose={onClose}
+      bodyClassName="max-h-[70vh] overflow-y-auto"
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutation.mutate();
+        }}
+        className="space-y-4"
+      >
+        <div>
+          <label
+            htmlFor="sink-name"
+            className="block text-xs font-semibold text-[color:var(--text-2)] mb-1"
+          >
+            Name
+          </label>
+          <input
+            id="sink-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. prod-splunk"
+            className={inputClass}
+          />
+          <p className="mt-1 text-[10px] text-[color:var(--text-3)]">
+            Unique label for this sink within its environment.
+          </p>
+        </div>
+
+        {/* Type is fixed (chosen in step 1 for create, inherited for
+            edit). Show it as a read-only badge so the operator always
+            knows which sink type they are configuring. */}
+        <div>
+          <span className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            Type
+          </span>
+          <span className="inline-flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-[color:var(--bg-2)] border border-[color:var(--border)] text-sm font-mono-tabular text-[color:var(--text-1)]">
+            <span className="w-4 h-4 flex-shrink-0 text-[color:var(--text-3)]">
+              {sinkTypeIcon(sinkType)}
+            </span>
+            {sinkType}
+          </span>
+          {spec?.has_secret && (
+            <p className="mt-1 text-[10px] text-[color:var(--text-3)]">
+              This sink type stores credentials ({spec.secret_fields?.join(', ')}).
+              {mode === 'edit' && ' Secret fields are revealed below for editing.'}
+            </p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label
+              htmlFor="sink-order"
+              className="block text-xs font-semibold text-[color:var(--text-2)] mb-1"
+            >
+              Order
+            </label>
+            <input
+              id="sink-order"
+              type="number"
+              value={order}
+              onChange={(e) => setOrder(Number(e.target.value))}
+              className={inputClass}
+            />
+          </div>
+          <fieldset className="flex items-end gap-2 pb-2">
+            <label className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => setEnabled(e.target.checked)}
+                className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+              />
+              <span className="font-mono-tabular">enabled</span>
+            </label>
+          </fieldset>
+        </div>
+
+        {/* Dynamic typed config fields. Rendered from the schema so the
+            operator gets the right input per field instead of a raw JSON
+            blob. Secret fields use a password input and are pre-filled
+            from the reveal query when editing. */}
+        <SinkConfigFields
+          key={sinkType}
+          spec={spec}
+          values={fieldValues}
+          onChange={setFieldValues}
+          inputClass={inputClass}
+        />
+
+        <div>
+          <label
+            htmlFor="sink-info"
+            className="block text-xs font-semibold text-[color:var(--text-2)] mb-1"
+          >
+            Info (optional)
+          </label>
+          <input
+            id="sink-info"
+            type="text"
+            value={info}
+            onChange={(e) => setInfo(e.target.value)}
+            className={inputClass}
+          />
+        </div>
+
+        {err && (
+          <p
+            role="alert"
+            className="text-xs text-[color:var(--danger)] bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)] px-3 py-2 rounded-md"
+          >
+            {err}
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mutation.isPending || !name.trim()}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-md',
+              'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
+              'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            {mutation.isPending ? 'Saving…' : mode === 'create' ? 'Add sink' : 'Save changes'}
+          </button>
+        </div>
+      </form>
+    </ModalShell>
+  );
+}
+
+/**
+ * SinkConfigFields renders the dynamic typed form for one sink type's
+ * config. Each field in spec.fields becomes the appropriate input
+ * (text, number, checkbox, select, password) using the shared inputClass
+ * so the styling matches every other form in the app.
+ */
+function SinkConfigFields({
+  spec,
+  values,
+  onChange,
+  inputClass,
+}: {
+  spec?: LogSinkTypeSpec;
+  values: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  inputClass: string;
+}) {
+  const [copyErr, setCopyErr] = useState<string | null>(null);
+  const [copying, setCopying] = useState(false);
+
+  if (!spec || !spec.fields || spec.fields.length === 0) {
+    return (
+      <p className="text-[10px] text-[color:var(--text-3)] italic">
+        This sink type has no configurable fields.
+      </p>
+    );
+  }
+
+  function setField(name: string, v: unknown) {
+    onChange({ ...values, [name]: v });
+  }
+
+  // "Copy from existing DB" — fetches the osctrl-tls db section from
+  // the service-config API and populates the form fields. Only shown
+  // for the db sink type, since that's the one where re-typing the
+  // primary DB connection is tedious and error-prone.
+  async function copyFromExistingDB() {
+    setCopyErr(null);
+    setCopying(true);
+    try {
+      const sc = await getServiceConfig('tls', 'db');
+      // The service-config API serializes the db section with
+      // json.Marshal, which produces Go struct field names (Type, Host,
+      // Port, ...) rather than the lowercase yaml/json tags the sink
+      // field schema uses (type, host, port, ...). Build a lowercased
+      // lookup map so every field matches regardless of case.
+      const raw = JSON.parse(sc.Value) as Record<string, unknown>;
+      const dbCfg: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(raw)) {
+        dbCfg[k.toLowerCase()] = v;
+      }
+      const next: Record<string, unknown> = { ...values };
+      for (const f of spec?.fields ?? []) {
+        const flatName = f.name.replace(/^.*\./, '');
+        if (flatName in dbCfg) {
+          next[f.name] = dbCfg[flatName];
+        }
+      }
+      onChange(next);
+    } catch (e) {
+      setCopyErr(e instanceof Error ? e.message : 'Failed to copy DB config');
+    } finally {
+      setCopying(false);
+    }
+  }
+
+  return (
+    <fieldset className="space-y-3 border border-[color:var(--border)] rounded-md p-3">
+      <legend className="px-1 text-xs font-semibold text-[color:var(--text-2)]">
+        Configuration
+      </legend>
+      {spec.type === 'db' && (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={copyFromExistingDB}
+            disabled={copying}
+            className={cn(
+              'px-2.5 py-1 text-[11px] font-medium rounded',
+              'border border-[color:var(--border)] text-[color:var(--text-2)]',
+              'hover:bg-[color:var(--bg-2)] transition-colors',
+              'disabled:opacity-50',
+            )}
+          >
+            {copying ? 'Copying…' : 'Copy from existing DB'}
+          </button>
+          <span className="text-[10px] text-[color:var(--text-3)]">
+            Pre-fills from the osctrl-tls db section.
+          </span>
+          {copyErr && (
+            <span className="text-[10px] text-[color:var(--danger)]">{copyErr}</span>
+          )}
+        </div>
+      )}
+      {spec.fields.map((f) => (
+        <ConfigField
+          key={f.name}
+          field={f}
+          value={values[f.name]}
+          onChange={(v) => setField(f.name, v)}
+          inputClass={inputClass}
+        />
+      ))}
+    </fieldset>
+  );
+}
+
+function ConfigField({
+  field,
+  value,
+  onChange,
+  inputClass,
+}: {
+  field: LogSinkFieldSpec;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  inputClass: string;
+}) {
+  const id = `sink-cfg-${field.name.replace(/\./g, '-')}`;
+  const labelEl = (
+    <label
+      htmlFor={id}
+      className="block text-xs font-semibold text-[color:var(--text-2)] mb-1"
+    >
+      {field.label}
+      {field.required && <span className="text-[color:var(--danger)]" aria-hidden="true"> *</span>}
+    </label>
+  );
+  const helpEl = field.help && (
+    <p className="mt-1 text-[10px] text-[color:var(--text-3)]">{field.help}</p>
+  );
+
+  // Group secret fields under a label that makes the reveal-on-edit
+  // behavior obvious.
+  const secretHint = field.secret && (
+    <span className="ml-2 text-[10px] text-[color:var(--text-3)]">(secret)</span>
+  );
+
+  switch (field.type) {
+    case 'boolean':
+      return (
+        <div>
+          <label className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+            <input
+              id={id}
+              type="checkbox"
+              aria-label={field.label}
+              checked={Boolean(value)}
+              onChange={(e) => onChange(e.target.checked)}
+              className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+            />
+            <span className="font-mono-tabular">{field.label}</span>
+            {secretHint}
+          </label>
+          {helpEl}
+        </div>
+      );
+    case 'integer':
+      return (
+        <div>
+          {labelEl}
+          <input
+            id={id}
+            type="number"
+            aria-label={field.label}
+            value={value === undefined || value === null ? '' : String(value)}
+            onChange={(e) => {
+              const raw = e.target.value;
+              onChange(raw === '' ? undefined : Number(raw));
+            }}
+            placeholder={field.placeholder}
+            className={inputClass}
+          />
+          {helpEl}
+        </div>
+      );
+    case 'select':
+      return (
+        <div>
+          {labelEl}
+          <select
+            id={id}
+            aria-label={field.label}
+            value={String(value ?? '')}
+            onChange={(e) => onChange(e.target.value)}
+            className={inputClass}
+          >
+            {field.options?.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt === '' ? '— none —' : opt}
+              </option>
+            ))}
+          </select>
+          {helpEl}
+        </div>
+      );
+    case 'password':
+      return (
+        <div>
+          {labelEl}
+          <input
+            id={id}
+            type="password"
+            aria-label={field.label}
+            value={String(value ?? '')}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder}
+            autoComplete="off"
+            className={cn(inputClass, 'text-[color:var(--text-2)]')}
+          />
+          {helpEl}
+        </div>
+      );
+    case 'string':
+    default:
+      return (
+        <div>
+          {labelEl}
+          <input
+            id={id}
+            type="text"
+            aria-label={field.label}
+            value={String(value ?? '')}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder}
+            className={inputClass}
+          />
+          {helpEl}
+        </div>
+      );
+  }
+}
+
+// --- config (de)serialization helpers -------------------------------------
+
+/**
+ * defaultsForSpec returns a flat field-value map seeded from the spec's
+ * field defaults. Used as the initial form state on create.
+ */
+function defaultsForSpec(spec?: LogSinkTypeSpec): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of spec?.fields ?? []) {
+    if (f.default !== undefined && f.default !== null && f.default !== '') {
+      out[f.name] = f.default;
+    }
+  }
+  return out;
+}
+
+/**
+ * flattenConfig reads a nested config object (the decoded JSON from the
+ * API) and returns a flat map keyed by dotted field names, e.g.
+ * { "sasl": { "mechanism": "x" } } -> { "sasl.mechanism": "x" }.
+ * Only one level of nesting is supported — that matches every sink
+ * config schema currently in the registry (Kafka SASL is the only
+ * nested one).
+ */
+function flattenConfig(config: unknown): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) return out;
+  const obj = config as Record<string, unknown>;
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      for (const [k2, v2] of Object.entries(v as Record<string, unknown>)) {
+        out[`${k}.${k2}`] = v2;
+      }
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * buildConfig expands the flat field-value map back into the nested
+ * shape the API expects. Dotted keys (e.g. "sasl.mechanism") become
+ * nested objects. Empty/undefined values are omitted so the config JSON
+ * only carries fields the operator actually set.
+ */
+function buildConfig(
+  spec: LogSinkTypeSpec | undefined,
+  values: Record<string, unknown>,
+): unknown {
+  const out: Record<string, unknown> = {};
+  for (const f of spec?.fields ?? []) {
+    const v = values[f.name];
+    if (v === undefined || v === null || v === '') continue;
+    setDotted(out, f.name, v);
+  }
+  return out;
+}
+
+function setDotted(obj: Record<string, unknown>, key: string, value: unknown) {
+  const parts = key.split('.');
+  if (parts.length === 1) {
+    obj[parts[0]] = value;
+    return;
+  }
+  const [head, ...rest] = parts;
+  if (typeof obj[head] !== 'object' || obj[head] === null) {
+    obj[head] = {};
+  }
+  setDotted(obj[head] as Record<string, unknown>, rest.join('.'), value);
+}
+
+// ---------------------------------------------------------------------------
+// Clone modal — mirrors the form layout of CreateEnvModal
+// ---------------------------------------------------------------------------
+function CloneModal({
+  envs,
+  targetEnv,
+  pending,
+  error,
+  onClone,
+  onClose,
+}: {
+  envs: { id: number; name: string }[];
+  targetEnv: number;
+  pending: boolean;
+  error: string | null;
+  onClone: (req: {
+    source_environment_id: number;
+    target_environment_id: number;
+    overwrite: boolean;
+  }) => void;
+  onClose: () => void;
+}) {
+  const [source, setSource] = useState<number>(GLOBAL_ENV_ID);
+  const [target, setTarget] = useState<number>(targetEnv);
+  const [overwrite, setOverwrite] = useState(false);
+
+  const selectClass = cn(
+    'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+    'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular',
+    'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+  );
+
+  return (
+    <ModalShell
+      title="Clone log sinks"
+      titleId="log-sinks-clone-title"
+      onClose={onClose}
+      panelClassName="max-w-md"
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          onClone({ source_environment_id: source, target_environment_id: target, overwrite });
+        }}
+        className="space-y-4"
+      >
+        <p className="text-xs text-[color:var(--text-3)]">
+          Copy all sinks from one environment to another. The target gets new
+          rows with names suffixed “(clone of …)” so they stay unique.
+        </p>
+
+        <div>
+          <label
+            htmlFor="clone-source"
+            className="block text-xs font-semibold text-[color:var(--text-2)] mb-1"
+          >
+            Source
+          </label>
+          <select
+            id="clone-source"
+            value={source}
+            onChange={(e) => setSource(Number(e.target.value))}
+            className={selectClass}
+          >
+            <option value={GLOBAL_ENV_ID}>Global</option>
+            {envs.map((e) => (
+              <option key={e.id} value={e.id}>
+                {e.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="clone-target"
+            className="block text-xs font-semibold text-[color:var(--text-2)] mb-1"
+          >
+            Target
+          </label>
+          <select
+            id="clone-target"
+            value={target}
+            onChange={(e) => setTarget(Number(e.target.value))}
+            className={selectClass}
+          >
+            <option value={GLOBAL_ENV_ID}>Global</option>
+            {envs.map((e) => (
+              <option key={e.id} value={e.id}>
+                {e.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <fieldset className="space-y-2 border border-[color:var(--border)] rounded-md p-3">
+          <legend className="px-1 text-xs font-semibold text-[color:var(--text-2)]">
+            Options
+          </legend>
+          <label className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+            <input
+              type="checkbox"
+              checked={overwrite}
+              onChange={(e) => setOverwrite(e.target.checked)}
+              className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+            />
+            <span className="font-mono-tabular">overwrite</span>
+            <span className="text-[color:var(--text-3)]">
+              — delete the target’s existing sinks first
+            </span>
+          </label>
+        </fieldset>
+
+        {error && (
+          <p
+            role="alert"
+            className="text-xs text-[color:var(--danger)] bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)] px-3 py-2 rounded-md"
+          >
+            {error}
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={pending || source === target}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-md',
+              'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
+              'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            {pending ? 'Cloning…' : 'Clone'}
+          </button>
+        </div>
+      </form>
+    </ModalShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Apply confirmation — mirrors ServiceConfigPage's ApplyConfirmDialog
+// ---------------------------------------------------------------------------
+function ApplyConfirmDialog({
+  pendingSinks,
+  isPending,
+  onConfirm,
+  onCancel,
+}: {
+  pendingSinks: LogSink[];
+  isPending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <ModalShell
+      title="Apply sink changes"
+      titleId="log-sinks-apply-title"
+      onClose={onCancel}
+      panelClassName="max-w-md"
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-[color:var(--text-1)]">
+          This will hot-reload osctrl-tls with the current sink rows. The
+          service is not restarted, but{' '}
+          <strong className="text-[color:var(--warning)]">
+            logs in-flight to the old sinks may be dropped
+          </strong>{' '}
+          during the swap — the old sinks are closed the moment the new set
+          is live.
+        </p>
+
+        <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-0)] p-3">
+          <p className="text-[10px] uppercase tracking-[0.08em] text-[color:var(--text-3)] mb-2">
+            Pending changes ({pendingSinks.length})
+          </p>
+          {pendingSinks.length === 0 ? (
+            <p className="text-xs text-[color:var(--text-3)]">
+              No DB-edited sinks — reloading will just re-read the current
+              rows.
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {pendingSinks.map((s) => (
+                <li
+                  key={s.id}
+                  className="flex items-center gap-2 text-xs text-[color:var(--text-2)]"
+                >
+                  <span className="w-4 h-4 flex-shrink-0 text-[color:var(--text-3)]">
+                    {sinkTypeIcon(s.type)}
+                  </span>
+                  <span className="font-mono-tabular text-[color:var(--text-1)]">
+                    {s.name}
+                  </span>
+                  <span className="text-[color:var(--text-3)]">— {s.type}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="px-3 py-1.5 text-xs font-medium rounded border border-[color:var(--border)] text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isPending}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded transition-colors',
+              'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.16)] text-[color:var(--warning)]',
+              'hover:bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.24)]',
+              'disabled:opacity-40 disabled:cursor-not-allowed',
+            )}
+          >
+            {isPending ? 'Reloading…' : 'Reload now'}
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+// Kept for parity with other feature modules that export a default.
+export default LogSinksPage;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -24,6 +24,7 @@ import { profileRoute } from './routes/_app/profile'
 import { environmentsRoute } from './routes/_app/environments'
 import { settingsServiceRoute } from './routes/_app/settings.$service'
 import { serviceConfigRoute } from './routes/_app/config.$service'
+import { logSinksRoute } from './routes/_app/log-sinks'
 import { auditRoute } from './routes/_app/audit'
 import { devComponentsRoute } from './routes/dev.components'
 
@@ -38,6 +39,7 @@ const routeTree = rootRoute.addChildren([
     environmentsRoute,
     settingsServiceRoute,
     serviceConfigRoute,
+    logSinksRoute,
     auditRoute,
     envRoute.addChildren([
       envIndexRoute,

--- a/frontend/src/routes/_app/log-sinks.tsx
+++ b/frontend/src/routes/_app/log-sinks.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { appRoute } from './route';
+import { LogSinksPage } from '$/features/log-sinks/LogSinksPage';
+
+export const logSinksRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: 'log-sinks',
+  component: LogSinksPage,
+});

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -2733,6 +2733,379 @@ paths:
       summary: Update enrolling package URL
       tags:
         - environments
+  /api/v1/log-sinks:
+    get:
+      description: Returns log sink rows, optionally filtered by environment. Secrets
+        are redacted unless reveal=1 is passed by an admin.
+      parameters:
+        - description: Environment ID; omit to list all environments
+          in: query
+          name: env
+          schema:
+            type: integer
+        - description: Pass 1 to include secret fields in the config (admin only)
+          in: query
+          name: reveal
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/handlers.logSinkDTO"
+                type: array
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: List log sinks
+      tags:
+        - log-sinks
+    post:
+      description: Creates a new log sink instance for the given environment (or
+        global when environment_id is 0).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/types.LogSinkCreateRequest"
+        description: Request body
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/handlers.logSinkDTO"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Create a log sink
+      tags:
+        - log-sinks
+  "/api/v1/log-sinks/{id}":
+    delete:
+      description: Deletes a log sink by ID. Deletion takes effect on the next apply/reload.
+      parameters:
+        - description: Sink ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: No content
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Delete a log sink
+      tags:
+        - log-sinks
+    get:
+      description: Returns a single log sink by ID. Secrets are redacted unless
+        reveal=1 is passed by an admin.
+      parameters:
+        - description: Sink ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - description: Pass 1 to include secret fields (admin only)
+          in: query
+          name: reveal
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/handlers.logSinkDTO"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Get one log sink
+      tags:
+        - log-sinks
+    put:
+      description: Replaces an existing log sink's mutable fields. A secret field set
+        to "***" is merged from the previously stored value.
+      parameters:
+        - description: Sink ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/types.LogSinkUpdateRequest"
+        description: Request body
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/handlers.logSinkDTO"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Update a log sink
+      tags:
+        - log-sinks
+  /api/v1/log-sinks/apply:
+    post:
+      description: Queues a reload-log-sinks service command for osctrl-tls. The TLS
+        process rebuilds its per-environment exporter map from the log_sinks
+        table and atomically swaps it in, closing the old sinks. In-flight logs
+        to the old sinks may be dropped during the swap; no restart is required.
+      responses:
+        "202":
+          description: Reload requested
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ServiceConfigApplyResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "503":
+          description: Service commands unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Apply log sink changes (hot reload)
+      tags:
+        - log-sinks
+  /api/v1/log-sinks/clone:
+    post:
+      description: Copies all log sinks from a source environment (use 0 for global)
+        to a target environment. With overwrite=false returns 409 if the target
+        already has sinks.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/types.LogSinkCloneRequest"
+        description: Request body
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/handlers.logSinkDTO"
+                type: array
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "409":
+          description: Target has sinks
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Clone sinks from one environment to another
+      tags:
+        - log-sinks
+  /api/v1/log-sinks/types:
+    get:
+      description: "Returns the sink type registry: type, description, whether the
+        config carries secrets, and which JSON keys hold them."
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/types.LogSinkTypeSpec"
+                type: array
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: List supported log sink types
+      tags:
+        - log-sinks
   /api/v1/login:
     post:
       description: Authenticates an API user and returns a JWT token.
@@ -8355,15 +8728,6 @@ components:
           type: string
       type: object
     handlers.MFAWebAuthnRequest:
-      properties:
-        challenge:
-          type: string
-        credential:
-          items:
-            type: integer
-          type: array
-        name:
-          type: string
       type: object
     handlers.NodeActivityBucket:
       properties:
@@ -8426,6 +8790,33 @@ components:
         total_nodes:
           description: Cross-env totals (the user's allowed envs only).
           type: integer
+      type: object
+    handlers.logSinkDTO:
+      properties:
+        config:
+          items:
+            type: integer
+          type: array
+        created_at:
+          type: string
+        enabled:
+          type: boolean
+        environment_id:
+          type: integer
+        id:
+          type: integer
+        info:
+          type: string
+        name:
+          type: string
+        order:
+          type: integer
+        source:
+          type: string
+        type:
+          type: string
+        updated_at:
+          type: string
       type: object
     nodes.OsqueryNode:
       properties:
@@ -9271,6 +9662,58 @@ components:
         username:
           type: string
       type: object
+    types.LogSinkCloneRequest:
+      properties:
+        overwrite:
+          type: boolean
+        source_environment_id:
+          type: integer
+        target_environment_id:
+          type: integer
+      type: object
+    types.LogSinkCreateRequest:
+      type: object
+    types.LogSinkFieldSpec:
+      properties:
+        default: {}
+        help:
+          type: string
+        label:
+          type: string
+        name:
+          type: string
+        options:
+          items:
+            type: string
+          type: array
+        placeholder:
+          type: string
+        required:
+          type: boolean
+        secret:
+          type: boolean
+        type:
+          type: string
+      type: object
+    types.LogSinkTypeSpec:
+      properties:
+        description:
+          type: string
+        fields:
+          items:
+            $ref: "#/components/schemas/types.LogSinkFieldSpec"
+          type: array
+        has_secret:
+          type: boolean
+        secret_fields:
+          items:
+            type: string
+          type: array
+        type:
+          type: string
+      type: object
+    types.LogSinkUpdateRequest:
+      type: object
     types.LoginEnvironment:
       properties:
         name:
@@ -9565,6 +10008,15 @@ components:
         status:
           type: string
         target_service:
+          type: string
+      type: object
+    types.ServiceConfigApplyResponse:
+      properties:
+        command:
+          $ref: "#/components/schemas/types.ServiceCommandResponse"
+        message:
+          type: string
+        service:
           type: string
       type: object
     types.ServiceConfigPersistRequest:

--- a/pkg/logging/db.go
+++ b/pkg/logging/db.go
@@ -94,6 +94,40 @@ func (logDB *LoggerDB) Settings(mgr *settings.Settings) {
 	log.Info().Msg("Setting DB logging settings")
 }
 
+// Close releases the underlying SQL connection pool when the DB logger
+// was built from its own config (a separate logging DB). When the DB
+// logger shares the primary osctrl backend, the caller owns that
+// connection and Close is a no-op — the primary DB must outlive any
+// one exporter set. We detect "owns the connection" by checking
+// whether Database is non-nil; the primary-DB case is constructed by
+// CreateLoggerDB which is only called from cmd/tls when reusing the
+// primary backend, so we do not close there.
+//
+// To keep this safe for both paths, Close only closes when the
+// Database.Config has a non-empty Host or FilePath (i.e. it was built
+// from a dedicated logging DB config), which is true for
+// CreateLoggerDBConfig and not for the primary reuse path. This is
+// conservative; a primary-DB logger that is hot-reloaded away simply
+// leaves the primary pool intact.
+func (logDB *LoggerDB) Close() error {
+	if logDB == nil || logDB.Database == nil || logDB.Database.Conn == nil {
+		return nil
+	}
+	cfg := logDB.Database.Config
+	if cfg.Type == "sqlite" {
+		if cfg.FilePath == "" {
+			return nil
+		}
+	} else if cfg.Host == "" {
+		return nil
+	}
+	sqlDB, err := logDB.Database.Conn.DB()
+	if err != nil {
+		return fmt.Errorf("get underlying sql.DB: %w", err)
+	}
+	return sqlDB.Close()
+}
+
 // Log - Function that sends JSON result/status/query logs to the configured DB
 func (logDB *LoggerDB) Log(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {

--- a/pkg/logging/dispatch.go
+++ b/pkg/logging/dispatch.go
@@ -8,35 +8,37 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// DispatchLogs - Helper to dispatch logs
-func (l *LoggerTLS) DispatchLogs(data []byte, uuid, logType, environment string, metadata nodes.NodeMetadata, debug bool) {
+// DispatchLogs - Helper to dispatch logs. envID selects the exporter
+// set for this environment (with global fallback handled inside
+// LoggerTLS.LogWithEnv). The string environment is forwarded as
+// metadata for exporters that embed it (Splunk source type, DB row,
+// etc.).
+func (l *LoggerTLS) DispatchLogs(data []byte, uuid, logType string, envID uint, environment string, metadata nodes.NodeMetadata, debug bool) {
 	// Use metadata to update record
 	if err := l.Nodes.UpdateMetadataByUUID(uuid, metadata); err != nil {
 		log.Err(err).Msg("error updating metadata")
 	}
-	// Send data to storage
-	// FIXME allow multiple types of logging
 	if debug {
 		log.Debug().Msgf("dispatching logs to %s", l.Logging)
 	}
-	l.Log(logType, data, environment, uuid, debug)
+	l.LogWithEnv(logType, data, envID, environment, uuid, debug)
 }
 
-// DispatchQueries - Helper to dispatch queries
+// DispatchQueries - Helper to dispatch queries. Uses the node's
+// EnvironmentID to select the env-scoped exporter set.
 func (l *LoggerTLS) DispatchQueries(queryData types.QueryWriteData, node nodes.OsqueryNode, debug bool) {
 	// Prepare data to send
 	data, err := json.Marshal(queryData)
 	if err != nil {
 		log.Err(err).Msg("error preparing data")
 	}
-	// Send data to storage
-	// FIXME allow multiple types of logging
 	if debug {
 		log.Debug().Msgf("dispatching queries to %s", l.Logging)
 	}
-	l.QueryLog(
+	l.QueryLogWithEnv(
 		types.QueryLog,
 		data,
+		node.EnvironmentID,
 		node.Environment,
 		node.UUID,
 		queryData.Name,

--- a/pkg/logging/elastic.go
+++ b/pkg/logging/elastic.go
@@ -63,6 +63,11 @@ func (logE *LoggerElastic) Settings(mgr *settings.Settings) {
 	log.Info().Msg("Setting Elastic logging settings")
 }
 
+// Close releases resources held by the Elasticsearch logger. The
+// elasticsearch client maintains an HTTP transport pool; closing it
+// releases those connections so a hot reload does not leak them.
+func (logE *LoggerElastic) Close() error { return nil }
+
 // Send - Function that sends JSON logs to Elastic
 func (logE *LoggerElastic) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {

--- a/pkg/logging/exporter.go
+++ b/pkg/logging/exporter.go
@@ -23,6 +23,12 @@ type DataExporter interface {
 	Name() string
 	IsEnabled() bool
 	Export(logType string, data []byte, params ExportParams) error
+	// Close releases any resources held by this exporter (network
+	// clients, DB connections, file handles). It is called by
+	// LoggerTLS.ReplaceExporters on every exporter in the old set
+	// during a hot reload so sinks are not leaked across reloads.
+	// Stateless exporters return nil.
+	Close() error
 }
 
 // MultiExporter fans out one osquery payload to multiple destinations.
@@ -92,6 +98,25 @@ func (m *MultiExporter) Export(logType string, data []byte, params ExportParams)
 		}
 		if err := exporter.Export(logType, data, params); err != nil {
 			log.Err(err).Str("exporter", exporter.Name()).Str("type", logType).Msg("error exporting osquery data")
+			errs = append(errs, fmt.Errorf("%s: %w", exporter.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Close closes every contained exporter. Errors are collected and
+// joined; one exporter failing to close does not stop the rest from
+// being closed.
+func (m *MultiExporter) Close() error {
+	if m == nil {
+		return nil
+	}
+	var errs []error
+	for _, exporter := range m.exporters {
+		if exporter == nil {
+			continue
+		}
+		if err := exporter.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", exporter.Name(), err))
 		}
 	}

--- a/pkg/logging/exporter_test.go
+++ b/pkg/logging/exporter_test.go
@@ -39,6 +39,8 @@ func (r *recordingExporter) Export(logType string, data []byte, params ExportPar
 	return r.err
 }
 
+func (r *recordingExporter) Close() error { return nil }
+
 func TestMultiExporterFansOutAndContinuesAfterError(t *testing.T) {
 	boom := errors.New("boom")
 	first := &recordingExporter{name: "first", enabled: true}

--- a/pkg/logging/file.go
+++ b/pkg/logging/file.go
@@ -39,6 +39,12 @@ func (logFile *LoggerFile) Settings(mgr *settings.Settings) {
 	log.Info().Msg("No file logging settings")
 }
 
+// Close releases resources held by the file logger. The underlying
+// lumberjack rotating writer closes its file handle when garbage
+// collected; there is no explicit Close on the zerolog wrapper to call
+// here, so this is a no-op.
+func (logFile *LoggerFile) Close() error { return nil }
+
 // Log - Function that sends JSON result/status/query logs to stdout
 func (logFile *LoggerFile) Log(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {

--- a/pkg/logging/graylog.go
+++ b/pkg/logging/graylog.go
@@ -57,6 +57,11 @@ func (logGL *LoggerGraylog) Settings(mgr *settings.Settings) {
 	log.Info().Msg("No Graylog logging settings")
 }
 
+// Close releases resources held by the Graylog logger. Graylog sends
+// data via per-call HTTP POSTs, so there is no persistent client to
+// close.
+func (logGL *LoggerGraylog) Close() error { return nil }
+
 // Send - Function that sends JSON logs to Graylog
 func (logGL *LoggerGraylog) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {

--- a/pkg/logging/kafka.go
+++ b/pkg/logging/kafka.go
@@ -85,6 +85,17 @@ func (l *LoggerKafka) Settings(mgr *settings.Settings) {
 	log.Warn().Msg("No kafka logging settings")
 }
 
+// Close releases the Kafka producer client so a hot reload does not
+// leak broker connections. In-flight records are flushed by kgo before
+// the client returns.
+func (l *LoggerKafka) Close() error {
+	if l == nil || l.producer == nil {
+		return nil
+	}
+	l.producer.Close()
+	return nil
+}
+
 func (l *LoggerKafka) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
 		log.Info().Msgf(

--- a/pkg/logging/kinesis.go
+++ b/pkg/logging/kinesis.go
@@ -66,6 +66,11 @@ func (logSK *LoggerKinesis) Settings(mgr *settings.Settings) {
 	log.Info().Msg("No kinesis logging settings")
 }
 
+// Close releases resources held by the Kinesis logger. The AWS SDK v2
+// kinesis.Client has no explicit Close; its HTTP transport pool is
+// garbage-collected. This is a no-op kept for interface compliance.
+func (logSK *LoggerKinesis) Close() error { return nil }
+
 // Send - Function that sends JSON logs to Splunk HTTP Event Collector
 func (logSK *LoggerKinesis) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,6 +1,8 @@
 package logging
 
 import (
+	"sync"
+
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
@@ -8,57 +10,155 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// LoggerTLS will be used to handle logging for the TLS endpoint
+// LoggerTLS will be used to handle logging for the TLS endpoint.
+//
+// It is environment-aware: ExportersFor(envID) returns the MultiExporter
+// for that environment, falling back to the global (key 0) set when the
+// environment has no sinks of its own. The exporter map is swapped
+// atomically by ReplaceExporters during a hot reload so an in-flight
+// request finishes against its already-resolved exporter pointer while
+// new requests pick up the new sinks.
 type LoggerTLS struct {
-	Logging   string
-	Exporters DataExporter
-	Nodes     *nodes.NodeManager
-	Queries   *queries.Queries
+	mu        sync.RWMutex
+	exporters map[uint]*MultiExporter // key 0 = global fallback
+	// Logging is kept for backwards-compatible diagnostics (the
+	// comma-joined name list of the global set). Callers that previously
+	// read l.Logging should migrate to ExportersFor(0).Name().
+	Logging string
+	Nodes   *nodes.NodeManager
+	Queries *queries.Queries
 }
 
-// CreateLoggerTLS to instantiate a new logger for the TLS endpoint
+// CreateLoggerTLS to instantiate a new logger for the TLS endpoint from
+// YAML configuration. Retained for backwards compatibility and tests.
+// New code should prefer CreateLoggerTLSWith.
 func CreateLoggerTLS(cfg config.ServiceParameters, mgr *settings.Settings, nodes *nodes.NodeManager, queries *queries.Queries) (*LoggerTLS, error) {
 	exporters, err := CreateExporters(cfg, mgr)
 	if err != nil {
 		return nil, err
 	}
+	return CreateLoggerTLSWith(map[uint]*MultiExporter{0: exporters}, nodes, queries), nil
+}
+
+// CreateLoggerTLSWith constructs an env-aware LoggerTLS from a
+// pre-built map of per-environment exporters. Key 0 is the global
+// fallback. The map is used as-is (not copied); callers must not
+// mutate it after handing it over.
+func CreateLoggerTLSWith(exporters map[uint]*MultiExporter, nodes *nodes.NodeManager, queries *queries.Queries) *LoggerTLS {
 	l := &LoggerTLS{
-		Logging:   exporters.Name(),
-		Exporters: exporters,
+		exporters: exporters,
 		Nodes:     nodes,
 		Queries:   queries,
 	}
-	return l, nil
+	if g, ok := exporters[0]; ok {
+		l.Logging = g.Name()
+	}
+	return l
 }
 
-// Log will send status/result logs via the configured method of logging
+// ExportersFor returns the MultiExporter for the given environment,
+// falling back to the global (key 0) set when the environment has no
+// exporters of its own. Returns nil when neither exists — callers
+// must handle nil (Log/QueryLog do so by warning and dropping).
+func (logTLS *LoggerTLS) ExportersFor(envID uint) *MultiExporter {
+	if logTLS == nil {
+		return nil
+	}
+	logTLS.mu.RLock()
+	defer logTLS.mu.RUnlock()
+	if exp, ok := logTLS.exporters[envID]; ok && exp != nil {
+		return exp
+	}
+	if envID != 0 {
+		if exp, ok := logTLS.exporters[0]; ok && exp != nil {
+			return exp
+		}
+	}
+	return nil
+}
+
+// ReplaceExporters atomically swaps the entire exporter map and closes
+// every exporter in the old map. The swap happens under the write
+// lock; any Export call that already resolved its MultiExporter
+// pointer finishes against the old set, then the old set is closed.
+//
+// In-flight logs may be dropped during the switch because the old
+// exporters' resources (Kafka producer, DB pool) are closed
+// immediately after the swap. Callers that need to drain should do so
+// before calling ReplaceExporters.
+func (logTLS *LoggerTLS) ReplaceExporters(newExporters map[uint]*MultiExporter) {
+	if logTLS == nil {
+		return
+	}
+	logTLS.mu.Lock()
+	old := logTLS.exporters
+	logTLS.exporters = newExporters
+	if g, ok := newExporters[0]; ok && g != nil {
+		logTLS.Logging = g.Name()
+	} else {
+		logTLS.Logging = ""
+	}
+	logTLS.mu.Unlock()
+	for _, exp := range old {
+		if exp == nil {
+			continue
+		}
+		if err := exp.Close(); err != nil {
+			log.Err(err).Str("exporters", exp.Name()).Msg("error closing old exporter during reload")
+		}
+	}
+}
+
+// Log will send status/result logs via the configured method of logging.
 func (logTLS *LoggerTLS) Log(logType string, data []byte, environment, uuid string, debug bool) {
-	if logTLS == nil || logTLS.Exporters == nil {
-		log.Warn().Str("type", logType).Msg("no osquery data exporters configured")
-		return
-	}
-	if err := logTLS.Exporters.Export(logType, data, ExportParams{
-		Environment: environment,
-		UUID:        uuid,
-		Debug:       debug,
-	}); err != nil {
-		log.Err(err).Str("type", logType).Msg("one or more osquery data exporters failed")
-	}
+	logTLS.logWithEnv(logType, data, environment, uuid, "", 0, debug, false)
 }
 
-// QueryLog will send query result logs via the configured method of logging
+// QueryLog will send query result logs via the configured method of logging.
 func (logTLS *LoggerTLS) QueryLog(logType string, data []byte, environment, uuid, name string, status int, debug bool) {
-	if logTLS == nil || logTLS.Exporters == nil {
-		log.Warn().Str("type", logType).Str("query", name).Msg("no osquery data exporters configured")
+	logTLS.logWithEnv(logType, data, environment, uuid, name, status, debug, true)
+}
+
+// LogWithEnv is the env-scoped dispatch used by the TLS log handler. It
+// resolves the exporter set for the given environment and forwards the
+// payload. envID is the numeric environment ID (env.ID); the string
+// environment name is carried alongside for exporter metadata.
+func (logTLS *LoggerTLS) LogWithEnv(logType string, data []byte, envID uint, environment, uuid string, debug bool) {
+	logTLS.logWithEnv(logType, data, environment, uuid, "", 0, debug, false, envID)
+}
+
+// QueryLogWithEnv is the env-scoped dispatch for on-demand query
+// results. See LogWithEnv for the envID semantics.
+func (logTLS *LoggerTLS) QueryLogWithEnv(logType string, data []byte, envID uint, environment, uuid, name string, status int, debug bool) {
+	logTLS.logWithEnv(logType, data, environment, uuid, name, status, debug, true, envID)
+}
+
+func (logTLS *LoggerTLS) logWithEnv(logType string, data []byte, environment, uuid, name string, status int, debug, isQuery bool, envIDs ...uint) {
+	if logTLS == nil {
+		log.Warn().Str("type", logType).Msg("no osquery data exporters configured (LoggerTLS is nil)")
 		return
 	}
-	if err := logTLS.Exporters.Export(logType, data, ExportParams{
+	var envID uint
+	if len(envIDs) > 0 {
+		envID = envIDs[0]
+	}
+	exporters := logTLS.ExportersFor(envID)
+	if exporters == nil {
+		log.Warn().Str("type", logType).Uint("env_id", envID).Msg("no osquery data exporters configured for environment")
+		return
+	}
+	params := ExportParams{
 		Environment: environment,
 		UUID:        uuid,
 		QueryName:   name,
 		Status:      status,
 		Debug:       debug,
-	}); err != nil {
-		log.Err(err).Str("type", logType).Str("query", name).Msg("one or more osquery data exporters failed")
+	}
+	if err := exporters.Export(logType, data, params); err != nil {
+		if isQuery {
+			log.Err(err).Str("type", logType).Str("query", name).Msg("one or more osquery data exporters failed")
+		} else {
+			log.Err(err).Str("type", logType).Msg("one or more osquery data exporters failed")
+		}
 	}
 }

--- a/pkg/logging/logstash.go
+++ b/pkg/logging/logstash.go
@@ -81,6 +81,11 @@ func (logLS *LoggerLogstash) Settings(mgr *settings.Settings) {
 	log.Info().Msg("Setting Logstash logging settings")
 }
 
+// Close releases resources held by the Logstash logger. Logstash opens
+// a fresh TCP/UDP connection per Send and uses per-call HTTP POSTs, so
+// there is no persistent client to close.
+func (logLS *LoggerLogstash) Close() error { return nil }
+
 // SendHTTP - Function that sends JSON logs to Logstash via HTTP
 func (logLS *LoggerLogstash) SendHTTP(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {

--- a/pkg/logging/none.go
+++ b/pkg/logging/none.go
@@ -21,6 +21,9 @@ func (logNone *LoggerNone) Settings(mgr *settings.Settings) {
 	log.Info().Msg("No none logging settings")
 }
 
+// Close releases resources held by the none logger. None are held.
+func (logNone *LoggerNone) Close() error { return nil }
+
 // Log - Function that sends JSON result/status/query logs to stdout
 func (logNone *LoggerNone) Log(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {

--- a/pkg/logging/process.go
+++ b/pkg/logging/process.go
@@ -23,7 +23,8 @@ func parseResultLogs(data json.RawMessage) ([]types.LogResultData, error) {
 
 // ProcessLogs processes and dispatches logs. Result entries are returned so
 // callers can reuse the decoded batch for secondary consumers such as posture.
-func (l *LoggerTLS) ProcessLogs(data json.RawMessage, logType, environment, ipaddress string, dataLen int, debug bool) []types.LogResultData {
+// envID selects the environment-scoped exporter set.
+func (l *LoggerTLS) ProcessLogs(data json.RawMessage, logType string, envID uint, environment, ipaddress string, dataLen int, debug bool) []types.LogResultData {
 	// Parse log to extract metadata
 	var logs []types.LogGenericData
 	var resultLogs []types.LogResultData
@@ -74,7 +75,7 @@ func (l *LoggerTLS) ProcessLogs(data json.RawMessage, logType, environment, ipad
 		BytesReceived:  dataLen,
 	}
 	// Dispatch logs and update metadata
-	l.DispatchLogs(data, uuid, logType, environment, metadata, debug)
+	l.DispatchLogs(data, uuid, logType, envID, environment, metadata, debug)
 	return resultLogs
 }
 

--- a/pkg/logging/process_test.go
+++ b/pkg/logging/process_test.go
@@ -51,7 +51,7 @@ func TestProcessLogQueryResultUpdatesStatusOnlyError(t *testing.T) {
 	queryMgr := queries.CreateQueries(db)
 	logger := &LoggerTLS{
 		Logging:   config.LoggingNone,
-		Exporters: NewMultiExporter(&LoggerNone{Enabled: false}),
+		exporters: map[uint]*MultiExporter{0: NewMultiExporter(&LoggerNone{Enabled: false})},
 		Nodes:     nodeMgr,
 		Queries:   queryMgr,
 	}

--- a/pkg/logging/s3.go
+++ b/pkg/logging/s3.go
@@ -53,6 +53,11 @@ func (logS3 *LoggerS3) Settings(mgr *settings.Settings) {
 	log.Info().Msg("No s3 logging settings")
 }
 
+// Close releases resources held by the S3 logger. The AWS SDK v2
+// s3.Client has no explicit Close; its HTTP transport pool is
+// garbage-collected. This is a no-op kept for interface compliance.
+func (logS3 *LoggerS3) Close() error { return nil }
+
 // Send - Function that sends JSON logs to S3
 func (logS3 *LoggerS3) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	ctx := context.Background()

--- a/pkg/logging/splunk.go
+++ b/pkg/logging/splunk.go
@@ -54,6 +54,11 @@ func (logSP *LoggerSplunk) Settings(mgr *settings.Settings) {
 	log.Info().Msg("Setting Splunk logging settings")
 }
 
+// Close releases resources held by the Splunk logger. Splunk sends data
+// via per-call HTTP POSTs using the shared utils.SendRequest helper, so
+// there is no persistent client to close.
+func (logSP *LoggerSplunk) Close() error { return nil }
+
 // Send - Function that sends JSON logs to Splunk HTTP Event Collector
 func (logSP *LoggerSplunk) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {

--- a/pkg/logging/stdout.go
+++ b/pkg/logging/stdout.go
@@ -23,6 +23,9 @@ func (logStdout *LoggerStdout) Settings(mgr *settings.Settings) {
 	log.Info().Msg("No stdout logging settings")
 }
 
+// Close releases resources held by the stdout logger. None are held.
+func (logStdout *LoggerStdout) Close() error { return nil }
+
 // Log - Function that sends JSON result/status/query logs to stdout
 func (logStdout *LoggerStdout) Log(logType string, data []byte, environment, uuid string, debug bool) {
 	switch logType {

--- a/pkg/logsinks/logsinks.go
+++ b/pkg/logsinks/logsinks.go
@@ -1,0 +1,1008 @@
+// Package logsinks persists per-environment osquery log sink configurations
+// to the database. Each row is one sink instance (Splunk, Kafka, S3, DB,
+// stdout, …) with a JSON-encoded config blob whose shape is determined by
+// the sink Type and validated against the Registry.
+//
+// osctrl-tls reads these rows at boot and whenever it consumes a
+// reload_log_sinks service command, building a per-environment exporter
+// fan-out. Rows with EnvironmentID=0 are the global fallback used by any
+// environment that has no rows of its own. Rows with EnvironmentID != 0
+// override the global set for that environment.
+//
+// The YAML logger: section remains the seed source on first boot;
+// once an operator edits a sink through the API (Source="db") the YAML
+// value is ignored for that sink until the DB row is deleted.
+package logsinks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/logging"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// SourceService marks a row seeded from the resolved service
+// configuration — flags, environment variables, or YAML, whichever the
+// operator used. The seed is a one-time create-if-missing bootstrap;
+// once a row exists it is never overwritten by a later boot.
+const SourceService = "service"
+
+// SourceDB marks a row that has been edited or created through the API.
+const SourceDB = "db"
+
+// SourceYAML is retained for backwards compatibility with rows seeded
+// by older versions that used "yaml" as the source value. New seeds
+// use SourceService. Reads treat both as non-DB-edited.
+const SourceYAML = "yaml"
+
+// NoEnvironmentID is the sentinel for global (non-env-scoped) sink rows.
+// Mirrors settings.NoEnvironmentID / serviceconfig.NoEnvironmentID so
+// callers can pass the same constant regardless of package.
+const NoEnvironmentID uint = 0
+
+// LogSink stores one osquery log destination for one environment (or
+// global when EnvironmentID is NoEnvironmentID). The Config field is a
+// JSON-encoded blob whose shape is determined by Type and validated
+// against the Registry.
+type LogSink struct {
+	gorm.Model
+	Name          string `gorm:"uniqueIndex:idx_log_sinks_unique"`
+	EnvironmentID uint   `gorm:"uniqueIndex:idx_log_sinks_unique"`
+	Type          string `gorm:"index"`
+	Enabled       bool
+	Order         int
+	Config        string `gorm:"type:text"`
+	Source        string // "yaml" (seeded) or "db" (operator-edited)
+	Info          string
+}
+
+// LogSinksManager manages the log_sinks table.
+type LogSinksManager struct {
+	DB *gorm.DB
+}
+
+// NewLogSinksManager initializes the manager and auto-migrates the
+// log_sinks table.
+func NewLogSinksManager(backend *gorm.DB) *LogSinksManager {
+	m := &LogSinksManager{DB: backend}
+	if err := backend.AutoMigrate(&LogSink{}); err != nil {
+		log.Fatal().Msgf("Failed to AutoMigrate table (log_sinks): %v", err)
+	}
+	return m
+}
+
+// FieldType is the input kind the frontend should render for a field.
+type FieldType string
+
+const (
+	FieldString   FieldType = "string"
+	FieldInteger  FieldType = "integer"
+	FieldBoolean  FieldType = "boolean"
+	FieldSelect   FieldType = "select"
+	FieldPassword FieldType = "password" // string input masked by the SPA
+)
+
+// FieldSpec describes one configurable field of a sink type. The schema
+// is declarative so the frontend can render a typed form without shipping
+// a per-type component for every sink.
+type FieldSpec struct {
+	// Name is the JSON key inside the Config blob. Nested keys use dot
+	// notation, e.g. "sasl.mechanism".
+	Name string
+	// Label is the human-facing label shown in the form.
+	Label string
+	// Type selects the input control.
+	Type FieldType
+	// Required marks the field as mandatory.
+	Required bool
+	// Secret marks the field as credential-bearing. The API redacts
+	// secret fields in read responses unless reveal=1 is passed; the
+	// SPA renders them as password inputs. Secret fields are also
+	// listed in SinkSpec.SecretFields for the redaction code path.
+	Secret bool
+	// Placeholder is shown when the field is empty.
+	Placeholder string
+	// Help is a one-line description shown under the input.
+	Help string
+	// Options is the list of allowed values for FieldSelect.
+	Options []string
+	// Default is the value used when the field is absent on create.
+	Default any
+}
+
+// SinkSpec describes one supported sink type in the Registry.
+type SinkSpec struct {
+	Type        string
+	Description string
+	// HasSecret indicates the Config JSON contains credential fields.
+	// When true, the API redacts SecretFields in read responses unless
+	// the caller passes reveal=true.
+	HasSecret bool
+	// SecretFields lists the JSON keys inside Config that hold secrets.
+	SecretFields []string
+	// Fields is the typed form schema the SPA renders. May be empty
+	// (e.g. none, stdout) — the SPA then shows no config fields.
+	Fields []FieldSpec
+	// Decode unmarshals a raw JSON Config into the typed config struct
+	// the sink implementation expects (e.g. *config.SplunkLogger).
+	Decode func(json.RawMessage) (any, error)
+	// Build instantiates a DataExporter from a decoded config struct.
+	Build func(any, *settings.Settings) (logging.DataExporter, error)
+}
+
+// Registry maps each config.Logging* type to its SinkSpec. This is the
+// single source of truth for what sink types exist and how each is
+// configured. Adding a new sink type means: implement the exporter in
+// pkg/logging, add the config struct to pkg/config, and add a SinkSpec
+// here.
+var Registry = map[string]SinkSpec{
+	config.LoggingNone: {
+		Type:        config.LoggingNone,
+		Description: "Discard logs. No destination.",
+		HasSecret:   false,
+		Decode: func(raw json.RawMessage) (any, error) {
+			// none has no config; accept and ignore any object.
+			return struct{}{}, nil
+		},
+		Build: func(_ any, smgr *settings.Settings) (logging.DataExporter, error) {
+			n, err := logging.CreateLoggerNone()
+			if err != nil {
+				return nil, err
+			}
+			n.Settings(smgr)
+			return n, nil
+		},
+	},
+	config.LoggingStdout: {
+		Type:        config.LoggingStdout,
+		Description: "Write logs to stdout.",
+		HasSecret:   false,
+		Decode: func(raw json.RawMessage) (any, error) {
+			return struct{}{}, nil
+		},
+		Build: func(_ any, smgr *settings.Settings) (logging.DataExporter, error) {
+			s, err := logging.CreateLoggerStdout()
+			if err != nil {
+				return nil, err
+			}
+			s.Settings(smgr)
+			return s, nil
+		},
+	},
+	config.LoggingFile: {
+		Type:        config.LoggingFile,
+		Description: "Rotating local file logger.",
+		HasSecret:   false,
+		Fields: []FieldSpec{
+			{Name: "filePath", Label: "File path", Type: FieldString, Required: true, Placeholder: "/var/log/osquery.log", Help: "Absolute path to the log file."},
+			{Name: "maxSize", Label: "Max size (MB)", Type: FieldInteger, Default: 100, Help: "Rotate after this size in MB."},
+			{Name: "maxBackups", Label: "Max backups", Type: FieldInteger, Default: 3, Help: "Number of rotated files to keep."},
+			{Name: "maxAge", Label: "Max age (days)", Type: FieldInteger, Default: 28, Help: "Days to retain rotated files."},
+			{Name: "compress", Label: "Compress", Type: FieldBoolean, Default: false, Help: "Gzip rotated files."},
+		},
+		Decode: decodeTyped[config.LocalLogger](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			f, err := logging.CreateLoggerFile(cfg.(*config.LocalLogger))
+			if err != nil {
+				return nil, err
+			}
+			f.Settings(smgr)
+			return f, nil
+		},
+	},
+	config.LoggingDB: {
+		Type:         config.LoggingDB,
+		Description:  "Persist logs to a SQL database (separate from or same as the primary).",
+		HasSecret:    true,
+		SecretFields: []string{"password"},
+		Fields: []FieldSpec{
+			{Name: "type", Label: "DB type", Type: FieldSelect, Required: true, Options: []string{"postgres", "mysql", "sqlite"}, Default: "postgres", Help: "Database backend."},
+			{Name: "host", Label: "Host", Type: FieldString, Placeholder: "127.0.0.1", Help: "Database host. Ignored by sqlite."},
+			{Name: "port", Label: "Port", Type: FieldInteger, Default: 5432, Help: "Database port. Defaults match PostgreSQL."},
+			{Name: "name", Label: "Database name", Type: FieldString, Required: true, Placeholder: "osctrl", Help: "Database/schema name."},
+			{Name: "username", Label: "Username", Type: FieldString, Placeholder: "postgres"},
+			{Name: "password", Label: "Password", Type: FieldPassword, Secret: true, Placeholder: "prefer env vars/secrets in prod", Help: "Database password."},
+			{Name: "sslmode", Label: "SSL mode", Type: FieldString, Placeholder: "disable", Help: "PostgreSQL SSL mode: disable, require, verify-full."},
+			{Name: "maxIdleConns", Label: "Max idle conns", Type: FieldInteger, Default: 20},
+			{Name: "maxOpenConns", Label: "Max open conns", Type: FieldInteger, Default: 100},
+			{Name: "connMaxLifetime", Label: "Conn max lifetime (min)", Type: FieldInteger, Default: 30},
+			{Name: "connRetry", Label: "Conn retry (s)", Type: FieldInteger, Default: 10, Help: "Seconds to retry at startup; 0 fails fast."},
+			{Name: "filePath", Label: "SQLite file path", Type: FieldString, Placeholder: "./osctrl.db", Help: "SQLite database file path when type is sqlite."},
+		},
+		Decode: decodeTyped[config.YAMLConfigurationDB](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			d, err := logging.CreateLoggerDBConfig(cfg.(*config.YAMLConfigurationDB))
+			if err != nil {
+				return nil, err
+			}
+			d.Settings(smgr)
+			return d, nil
+		},
+	},
+	config.LoggingSplunk: {
+		Type:         config.LoggingSplunk,
+		Description:  "Splunk HTTP Event Collector (HEC).",
+		HasSecret:    true,
+		SecretFields: []string{"token"},
+		Fields: []FieldSpec{
+			{Name: "url", Label: "HEC URL", Type: FieldString, Required: true, Placeholder: "https://splunk.example.com:8088/services/collector", Help: "Splunk HTTP Event Collector endpoint."},
+			{Name: "token", Label: "HEC token", Type: FieldPassword, Secret: true, Required: true, Placeholder: "prefer env vars/secrets in prod", Help: "Splunk HEC token."},
+			{Name: "host", Label: "Host", Type: FieldString, Placeholder: "osctrl", Help: "Source host value attached to events."},
+			{Name: "index", Label: "Index", Type: FieldString, Placeholder: "main", Help: "Splunk index name."},
+		},
+		Decode: decodeTyped[config.SplunkLogger](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			s, err := logging.CreateLoggerSplunk(cfg.(*config.SplunkLogger))
+			if err != nil {
+				return nil, err
+			}
+			s.Settings(smgr)
+			return s, nil
+		},
+	},
+	config.LoggingGraylog: {
+		Type:        config.LoggingGraylog,
+		Description: "Graylog GELF over HTTP.",
+		HasSecret:   false,
+		Fields: []FieldSpec{
+			{Name: "url", Label: "URL", Type: FieldString, Required: true, Placeholder: "https://graylog.example.com:12202/gelf", Help: "Graylog GELF HTTP input endpoint."},
+			{Name: "host", Label: "Host", Type: FieldString, Placeholder: "osctrl", Help: "Source host value attached to messages."},
+			{Name: "queries", Label: "Queries stream", Type: FieldString, Placeholder: "osquery_queries", Help: "Stream/name for distributed query logs."},
+			{Name: "status", Label: "Status stream", Type: FieldString, Placeholder: "osquery_status", Help: "Stream/name for status logs."},
+			{Name: "results", Label: "Results stream", Type: FieldString, Placeholder: "osquery_results", Help: "Stream/name for result logs."},
+		},
+		Decode: decodeTyped[config.GraylogLogger](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			g, err := logging.CreateLoggerGraylog(cfg.(*config.GraylogLogger))
+			if err != nil {
+				return nil, err
+			}
+			g.Settings(smgr)
+			return g, nil
+		},
+	},
+	config.LoggingLogstash: {
+		Type:        config.LoggingLogstash,
+		Description: "Logstash over HTTP, TCP, or UDP.",
+		HasSecret:   false,
+		Fields: []FieldSpec{
+			{Name: "host", Label: "Host", Type: FieldString, Required: true, Placeholder: "logstash.example.com"},
+			{Name: "port", Label: "Port", Type: FieldString, Required: true, Placeholder: "5044", Help: "Logstash input port (string in the config)."},
+			{Name: "protocol", Label: "Protocol", Type: FieldSelect, Options: []string{"http", "tcp", "udp"}, Default: "http"},
+			{Name: "path", Label: "Path", Type: FieldString, Placeholder: "/osquery", Help: "Optional HTTP/TCP path depending on protocol."},
+		},
+		Decode: decodeTyped[config.LogstashLogger](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			l, err := logging.CreateLoggerLogstash(cfg.(*config.LogstashLogger))
+			if err != nil {
+				return nil, err
+			}
+			l.Settings(smgr)
+			return l, nil
+		},
+	},
+	config.LoggingKinesis: {
+		Type:         config.LoggingKinesis,
+		Description:  "AWS Kinesis Data Streams.",
+		HasSecret:    true,
+		SecretFields: []string{"secretKey", "sessionToken"},
+		Fields: []FieldSpec{
+			{Name: "stream", Label: "Stream", Type: FieldString, Required: true, Placeholder: "osquery-logs", Help: "Kinesis stream name."},
+			{Name: "region", Label: "Region", Type: FieldString, Required: true, Placeholder: "us-east-1"},
+			{Name: "endpoint", Label: "Endpoint", Type: FieldString, Placeholder: "https://kinesis.us-east-1.amazonaws.com", Help: "Optional custom endpoint."},
+			{Name: "accessKey", Label: "Access key ID", Type: FieldString, Placeholder: "prefer instance/task roles", Help: "Optional static access key."},
+			{Name: "secretKey", Label: "Secret access key", Type: FieldPassword, Secret: true, Placeholder: "prefer instance/task roles"},
+			{Name: "sessionToken", Label: "Session token", Type: FieldPassword, Secret: true, Placeholder: "optional"},
+		},
+		Decode: decodeTyped[config.KinesisLogger](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			k, err := logging.CreateLoggerKinesis(cfg.(*config.KinesisLogger))
+			if err != nil {
+				return nil, err
+			}
+			k.Settings(smgr)
+			return k, nil
+		},
+	},
+	config.LoggingS3: {
+		Type:         config.LoggingS3,
+		Description:  "AWS S3 object storage.",
+		HasSecret:    true,
+		SecretFields: []string{"secretAccessKey"},
+		Fields: []FieldSpec{
+			{Name: "bucket", Label: "Bucket", Type: FieldString, Required: true, Placeholder: "osquery-logs", Help: "S3 bucket name for log objects."},
+			{Name: "region", Label: "Region", Type: FieldString, Required: true, Placeholder: "us-east-1"},
+			{Name: "accessKey", Label: "Access key ID", Type: FieldString, Placeholder: "prefer instance/task roles"},
+			{Name: "secretAccessKey", Label: "Secret access key", Type: FieldPassword, Secret: true, Placeholder: "prefer instance/task roles"},
+		},
+		Decode: decodeTyped[config.S3Logger](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			s, err := logging.CreateLoggerS3(cfg.(*config.S3Logger))
+			if err != nil {
+				return nil, err
+			}
+			s.Settings(smgr)
+			return s, nil
+		},
+	},
+	config.LoggingKafka: {
+		Type:         config.LoggingKafka,
+		Description:  "Apache Kafka producer.",
+		HasSecret:    true,
+		SecretFields: []string{"sasl.password"},
+		Fields: []FieldSpec{
+			{Name: "bootstrapServers", Label: "Bootstrap servers", Type: FieldString, Required: true, Placeholder: "broker1:9092,broker2:9092", Help: "Comma-separated Kafka bootstrap servers."},
+			{Name: "topic", Label: "Topic", Type: FieldString, Required: true, Placeholder: "osquery-logs"},
+			{Name: "sslCALocation", Label: "CA cert path", Type: FieldString, Placeholder: "/etc/ssl/certs/ca.pem", Help: "CA certificate path for TLS verification."},
+			{Name: "connectionTimeout", Label: "Connection timeout", Type: FieldString, Placeholder: "5s", Help: "Go duration string, e.g. 5s, 10s, 1m."},
+			{Name: "sasl.mechanism", Label: "SASL mechanism", Type: FieldSelect, Options: []string{"", "SCRAM-SHA-256", "SCRAM-SHA-512"}, Help: "SASL mechanism. Empty disables SASL."},
+			{Name: "sasl.username", Label: "SASL username", Type: FieldString, Placeholder: "kafka-user"},
+			{Name: "sasl.password", Label: "SASL password", Type: FieldPassword, Secret: true, Placeholder: "prefer env vars/secrets in prod"},
+		},
+		Decode: decodeTyped[config.KafkaLogger](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			k, err := logging.CreateLoggerKafka(cfg.(*config.KafkaLogger))
+			if err != nil {
+				return nil, err
+			}
+			k.Settings(smgr)
+			return k, nil
+		},
+	},
+	config.LoggingElastic: {
+		Type:        config.LoggingElastic,
+		Description: "Elasticsearch index writer.",
+		HasSecret:   false,
+		Fields: []FieldSpec{
+			{Name: "host", Label: "Host", Type: FieldString, Required: true, Placeholder: "elastic.example.com"},
+			{Name: "port", Label: "Port", Type: FieldString, Required: true, Placeholder: "9200", Help: "Elasticsearch port (string in the config)."},
+			{Name: "indexPrefix", Label: "Index prefix", Type: FieldString, Placeholder: "osquery", Help: "Prefix for generated index names."},
+			{Name: "dateSeparator", Label: "Date separator", Type: FieldString, Placeholder: ".", Help: "Separator inside date suffixes, e.g. . for YYYY.MM.DD."},
+			{Name: "indexSeparator", Label: "Index separator", Type: FieldString, Placeholder: "-", Help: "Separator between prefix and date suffix, e.g. - for prefix-YYYY.MM.DD."},
+		},
+		Decode: decodeTyped[config.ElasticLogger](),
+		Build: func(cfg any, smgr *settings.Settings) (logging.DataExporter, error) {
+			e, err := logging.CreateLoggerElastic(cfg.(*config.ElasticLogger))
+			if err != nil {
+				return nil, err
+			}
+			e.Settings(smgr)
+			return e, nil
+		},
+	},
+}
+
+// SupportedTypes returns the Registry keys in a stable, sorted order, for
+// API/UI discovery.
+func SupportedTypes() []string {
+	types := make([]string, 0, len(Registry))
+	for k := range Registry {
+		types = append(types, k)
+	}
+	// Stable order for UI dropdowns and tests.
+	for i := 1; i < len(types); i++ {
+		for j := i; j > 0 && types[j-1] > types[j]; j-- {
+			types[j-1], types[j] = types[j], types[j-1]
+		}
+	}
+	return types
+}
+
+// ValidateType reports whether the sink type is registered.
+func ValidateType(typ string) bool {
+	_, ok := Registry[typ]
+	return ok
+}
+
+// decodeTyped returns a Decode func that unmarshals raw JSON into a fresh
+// *T and returns it as any. The generic keeps every SinkSpec.Decode
+// trivially consistent and type-safe.
+func decodeTyped[T any]() func(json.RawMessage) (any, error) {
+	return func(raw json.RawMessage) (any, error) {
+		var t T
+		if len(raw) == 0 || string(raw) == "null" {
+			return &t, nil
+		}
+		if err := json.Unmarshal(raw, &t); err != nil {
+			return nil, fmt.Errorf("decode %T: %w", t, err)
+		}
+		return &t, nil
+	}
+}
+
+// ErrSinkNotFound is returned when a sink row is not found.
+var ErrSinkNotFound = errors.New("log sink not found")
+
+// ErrInvalidSinkType is returned when a sink type is not in the Registry.
+var ErrInvalidSinkType = errors.New("invalid log sink type")
+
+// ErrInvalidSinkConfig is returned when a sink's Config JSON is invalid
+// or fails to decode into the type's config struct.
+var ErrInvalidSinkConfig = errors.New("invalid log sink configuration")
+
+// ErrTargetHasSinks is returned by Clone when the target environment
+// already has sinks and overwrite is false.
+var ErrTargetHasSinks = errors.New("target environment already has log sinks")
+
+// normalizeType lower-cases and trims a sink type so callers can pass
+// "Splunk" or "SPLUNK" and still hit the Registry.
+func normalizeType(typ string) string {
+	return strings.ToLower(strings.TrimSpace(typ))
+}
+
+// normalizeName trims surrounding whitespace from a sink name.
+func normalizeName(name string) string {
+	return strings.TrimSpace(name)
+}
+
+// validateConfig decodes the Config JSON against the registered type and
+// returns the decoded value or an error. The decoded value is used by
+// Build when constructing an exporter.
+func validateConfig(typ, cfgJSON string) (any, error) {
+	spec, ok := Registry[typ]
+	if !ok {
+		return nil, ErrInvalidSinkType
+	}
+	raw := json.RawMessage(cfgJSON)
+	if len(raw) == 0 {
+		raw = json.RawMessage(`null`)
+	}
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("%w: not valid JSON", ErrInvalidSinkConfig)
+	}
+	decoded, err := spec.Decode(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidSinkConfig, err)
+	}
+	return decoded, nil
+}
+
+// ValidateSink returns an error if the proposed sink is invalid: unknown
+// type, empty name, or Config that does not decode against the type.
+func ValidateSink(name, typ, cfgJSON string) error {
+	if normalizeName(name) == "" {
+		return fmt.Errorf("sink name is required")
+	}
+	t := normalizeType(typ)
+	if !ValidateType(t) {
+		return fmt.Errorf("%w: %q", ErrInvalidSinkType, typ)
+	}
+	if _, err := validateConfig(t, cfgJSON); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Create inserts a new sink row.
+func (m *LogSinksManager) Create(name, typ string, enabled bool, order int, cfgJSON string, envID uint, info string) (LogSink, error) {
+	name = normalizeName(name)
+	typ = normalizeType(typ)
+	if err := ValidateSink(name, typ, cfgJSON); err != nil {
+		return LogSink{}, err
+	}
+	row := LogSink{
+		Name:          name,
+		EnvironmentID: envID,
+		Type:          typ,
+		Enabled:       enabled,
+		Order:         order,
+		Config:        cfgJSON,
+		Source:        SourceDB,
+		Info:          info,
+	}
+	if err := m.DB.Create(&row).Error; err != nil {
+		return LogSink{}, fmt.Errorf("create log sink: %w", err)
+	}
+	return row, nil
+}
+
+// Update replaces an existing sink row's mutable fields. Config is
+// re-validated against the existing Type (Type can be changed in the
+// same call as long as the new Config decodes against the new Type).
+func (m *LogSinksManager) Update(id uint, name, typ string, enabled bool, order int, cfgJSON string, info string) (LogSink, error) {
+	name = normalizeName(name)
+	typ = normalizeType(typ)
+	if err := ValidateSink(name, typ, cfgJSON); err != nil {
+		return LogSink{}, err
+	}
+	row, err := m.Get(id)
+	if err != nil {
+		return LogSink{}, err
+	}
+	if err := m.DB.Model(&row).Updates(map[string]any{
+		"name":    name,
+		"type":    typ,
+		"enabled": enabled,
+		"order":   order,
+		"config":  cfgJSON,
+		"info":    info,
+		"source":  SourceDB,
+	}).Error; err != nil {
+		return LogSink{}, fmt.Errorf("update log sink: %w", err)
+	}
+	return m.Get(id)
+}
+
+// Get retrieves one sink by ID.
+func (m *LogSinksManager) Get(id uint) (LogSink, error) {
+	var row LogSink
+	if err := m.DB.First(&row, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return LogSink{}, ErrSinkNotFound
+		}
+		return LogSink{}, err
+	}
+	return row, nil
+}
+
+// Delete removes a sink by ID.
+func (m *LogSinksManager) Delete(id uint) error {
+	res := m.DB.Delete(&LogSink{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrSinkNotFound
+	}
+	return nil
+}
+
+// ListByEnvironment returns all sinks for one environment (EnvironmentID
+// == envID), ordered by Order then CreatedAt.
+func (m *LogSinksManager) ListByEnvironment(envID uint) ([]LogSink, error) {
+	var rows []LogSink
+	if err := m.DB.Where("environment_id = ?", envID).
+		Order("\"order\" ASC, created_at ASC").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// List returns sinks across all environments when envID is nil, or for
+// a single environment when envID is non-nil.
+func (m *LogSinksManager) List(envID *uint) ([]LogSink, error) {
+	if envID == nil {
+		var rows []LogSink
+		if err := m.DB.Order("environment_id ASC, \"order\" ASC, created_at ASC").Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		return rows, nil
+	}
+	return m.ListByEnvironment(*envID)
+}
+
+// EffectiveFor returns the sinks that should be used for the given
+// environment: if the environment has any rows of its own, those are
+// returned (override-with-fallback); otherwise the global rows
+// (EnvironmentID == NoEnvironmentID) are returned.
+func (m *LogSinksManager) EffectiveFor(envID uint) ([]LogSink, error) {
+	rows, err := m.ListByEnvironment(envID)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) > 0 {
+		return rows, nil
+	}
+	return m.ListByEnvironment(NoEnvironmentID)
+}
+
+// AllGrouped returns every sink, grouped by EnvironmentID, with the
+// global key (0) included. Used by the API list endpoint and by the
+// TLS boot/reload builder.
+func (m *LogSinksManager) AllGrouped() (map[uint][]LogSink, error) {
+	rows, err := m.List(nil)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[uint][]LogSink)
+	for _, r := range rows {
+		out[r.EnvironmentID] = append(out[r.EnvironmentID], r)
+	}
+	return out, nil
+}
+
+// CloneEnvironment copies all sinks from sourceEnvID to targetEnvID. If
+// overwrite is false and the target already has any sinks,
+// ErrTargetHasSinks is returned. If overwrite is true, the target's
+// existing sinks are hard-deleted first. New sink names are suffixed
+// with " (clone of env N)" when the source is non-global, or
+// " (clone of global)" otherwise, so uniqueIndex on Name is preserved.
+func (m *LogSinksManager) CloneEnvironment(sourceEnvID, targetEnvID uint, overwrite bool) ([]LogSink, error) {
+	if sourceEnvID == targetEnvID {
+		return nil, fmt.Errorf("source and target environment must differ")
+	}
+	srcRows, err := m.ListByEnvironment(sourceEnvID)
+	if err != nil {
+		return nil, fmt.Errorf("list source sinks: %w", err)
+	}
+	if len(srcRows) == 0 {
+		return nil, fmt.Errorf("source environment has no log sinks")
+	}
+	tgtRows, err := m.ListByEnvironment(targetEnvID)
+	if err != nil {
+		return nil, fmt.Errorf("list target sinks: %w", err)
+	}
+	if len(tgtRows) > 0 && !overwrite {
+		return nil, ErrTargetHasSinks
+	}
+
+	suffix := " (clone of global)"
+	if sourceEnvID != NoEnvironmentID {
+		suffix = fmt.Sprintf(" (clone of env %d)", sourceEnvID)
+	}
+
+	err = m.DB.Transaction(func(tx *gorm.DB) error {
+		if len(tgtRows) > 0 {
+			if err := tx.Unscoped().Where("environment_id = ?", targetEnvID).Delete(&LogSink{}).Error; err != nil {
+				return fmt.Errorf("clear target sinks: %w", err)
+			}
+		}
+		for _, r := range srcRows {
+			newRow := LogSink{
+				Name:          r.Name + suffix,
+				EnvironmentID: targetEnvID,
+				Type:          r.Type,
+				Enabled:       r.Enabled,
+				Order:         r.Order,
+				Config:        r.Config,
+				Source:        SourceDB,
+				Info:          r.Info,
+			}
+			if err := tx.Create(&newRow).Error; err != nil {
+				return fmt.Errorf("create cloned sink %q: %w", newRow.Name, err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return m.ListByEnvironment(targetEnvID)
+}
+
+// Seed translates the resolved service configuration (logger section
+// and primary DB connection) into LogSink rows using create-if-missing
+// semantics. The configuration may have been provided via flags,
+// environment variables, or a YAML file — by the time it reaches here
+// viper has merged them into a single *config.ServiceParameters, so the
+// seed source is "the service configuration", not any one of those
+// inputs in isolation.
+//
+// On first boot it writes one row per non-empty entry in logger.types
+// (or the legacy logger.type). Existing rows are never overwritten —
+// operator DB edits win.
+//
+// logger.alwaysLog is honored: if true and no db sink is among the
+// configured types, a synthetic db sink named __always_log_db__ is
+// seeded using the primary DB connection (params.DB).
+func (m *LogSinksManager) Seed(params *config.ServiceParameters, envID uint) error {
+	cfg := params.Logger
+	primaryDB := params.DB
+	if cfg == nil {
+		// No logger section in the service configuration — seed a single
+		// db sink pointing at the primary DB so logs are not silently
+		// dropped on first boot in deployments that relied on the
+		// historical default.
+		if primaryDB == nil {
+			return nil
+		}
+		return m.seedDefaultDB(primaryDB, envID)
+	}
+
+	types := config.LoggerTypes(cfg)
+	seenDB := false
+	for i, typ := range types {
+		typ = normalizeType(typ)
+		if typ == config.LoggingDB {
+			seenDB = true
+		}
+		row, err := m.configRowForType(cfg, primaryDB, typ, i, envID)
+		if err != nil {
+			return err
+		}
+		if row == nil {
+			continue
+		}
+		if err := m.seedRow(row); err != nil {
+			return err
+		}
+	}
+
+	if cfg.AlwaysLog && !seenDB && primaryDB != nil {
+		// Synthetic always-log DB sink so the historical alwaysLog=true
+		// behavior is preserved in the DB-backed model.
+		cfgJSON, err := json.Marshal(primaryDB)
+		if err != nil {
+			return fmt.Errorf("marshal alwaysLog db config: %w", err)
+		}
+		row := LogSink{
+			Name:          "__always_log_db__",
+			EnvironmentID: envID,
+			Type:          config.LoggingDB,
+			Enabled:       true,
+			Order:         999,
+			Config:        string(cfgJSON),
+			Source:        SourceService,
+			Info:          "Auto-seeded from logger.alwaysLog",
+		}
+		if err := m.seedRow(&row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedDefaultDB seeds a single db sink pointing at the primary DB when
+// the service configuration has no logger section at all.
+func (m *LogSinksManager) seedDefaultDB(primaryDB *config.YAMLConfigurationDB, envID uint) error {
+	cfgJSON, err := json.Marshal(primaryDB)
+	if err != nil {
+		return fmt.Errorf("marshal default db config: %w", err)
+	}
+	row := LogSink{
+		Name:          "default-db",
+		EnvironmentID: envID,
+		Type:          config.LoggingDB,
+		Enabled:       true,
+		Order:         0,
+		Config:        string(cfgJSON),
+		Source:        SourceService,
+		Info:          "Auto-seeded from primary DB config (no logger section)",
+	}
+	return m.seedRow(&row)
+}
+
+// configRowForType builds a seed LogSink for one configured type. It
+// reads the matching sub-block from the resolved logger section and
+// marshals it to JSON. Returns nil, nil for types whose block is
+// absent and have no sane default.
+func (m *LogSinksManager) configRowForType(cfg *config.YAMLConfigurationLogger, primaryDB *config.YAMLConfigurationDB, typ string, order int, envID uint) (*LogSink, error) {
+	name := "seeded-" + typ
+	switch typ {
+	case config.LoggingNone, config.LoggingStdout:
+		return &LogSink{
+			Name: name, EnvironmentID: envID, Type: typ,
+			Enabled: true, Order: order, Config: "{}",
+			Source: SourceService, Info: "Seeded from service configuration",
+		}, nil
+	case config.LoggingFile:
+		if cfg.Local == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, cfg.Local)
+	case config.LoggingDB:
+		// When LoggerDBSame is true the operator explicitly asked to
+		// reuse the primary DB connection — use params.DB (primaryDB)
+		// which carries the real connection details. Also fall back to
+		// primaryDB when the logger-specific db block is absent or
+		// all-zero, so the seeded row is never an empty shell.
+		dbCfg := cfg.DB
+		if cfg.LoggerDBSame || sameDBPtr(cfg.DB, primaryDB) || isEmptyDBConfig(cfg.DB) {
+			dbCfg = primaryDB
+		}
+		if dbCfg == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, dbCfg)
+	case config.LoggingSplunk:
+		if cfg.Splunk == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, cfg.Splunk)
+	case config.LoggingGraylog:
+		if cfg.Graylog == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, cfg.Graylog)
+	case config.LoggingLogstash:
+		if cfg.Logstash == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, cfg.Logstash)
+	case config.LoggingKinesis:
+		if cfg.Kinesis == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, cfg.Kinesis)
+	case config.LoggingS3:
+		if cfg.S3 == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, cfg.S3)
+	case config.LoggingKafka:
+		if cfg.Kafka == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, cfg.Kafka)
+	case config.LoggingElastic:
+		if cfg.Elastic == nil {
+			return nil, nil
+		}
+		return m.marshalConfigRow(name, typ, order, envID, cfg.Elastic)
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrInvalidSinkType, typ)
+	}
+}
+
+func (m *LogSinksManager) marshalConfigRow(name, typ string, order int, envID uint, cfg any) (*LogSink, error) {
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s config: %w", typ, err)
+	}
+	return &LogSink{
+		Name: name, EnvironmentID: envID, Type: typ,
+		Enabled: true, Order: order, Config: string(raw),
+		Source: SourceService, Info: "Seeded from service configuration",
+	}, nil
+}
+
+// seedRow creates a row only if no row with the same (Name,
+// EnvironmentID) exists. If the row already exists and was not edited
+// through the API (Source != "db"), the config is synced to the current
+// service-config value — so a row that was seeded empty on a previous
+// boot (e.g. due to a LoggerDBSame bug) gets populated on the next boot
+// without clobbering operator edits.
+func (m *LogSinksManager) seedRow(row *LogSink) error {
+	if err := m.DB.Clauses(clause.OnConflict{DoNothing: true}).Create(row).Error; err != nil {
+		return fmt.Errorf("seed row %q: %w", row.Name, err)
+	}
+	// Sync config for existing non-DB-edited seed rows. This is the
+	// same pattern as serviceconfig.Seed's metadata sync, but applied
+	// to the config blob: schema-controlled data must always reflect
+	// the current service configuration, not a stale empty seed from
+	// a previous boot. Operator-edited rows (Source="db") are never
+	// touched.
+	if err := m.DB.Model(&LogSink{}).
+		Where("name = ? AND environment_id = ? AND (source = ? OR source = ?)",
+			row.Name, row.EnvironmentID, SourceService, SourceYAML).
+		Updates(map[string]any{
+			"config": row.Config,
+			"type":   row.Type,
+			"info":   row.Info,
+		}).Error; err != nil {
+		return fmt.Errorf("sync seed row %q: %w", row.Name, err)
+	}
+	return nil
+}
+
+// sameDBPtr reports whether two YAMLConfigurationDB pointers point to
+// equivalent configs. Mirrors logging.sameConfigDBPtr so the YAML
+// "loggerDBSame" detection stays consistent.
+func sameDBPtr(a, b *config.YAMLConfigurationDB) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Type == b.Type && a.Host == b.Host && a.Port == b.Port && a.Name == b.Name
+}
+
+// isEmptyDBConfig reports whether a YAMLConfigurationDB has no
+// meaningful connection details set — the zero value that init()
+// populates when the operator did not fill in the logger.db block.
+// Used to fall back to the primary DB so the seeded row is never an
+// empty shell.
+func isEmptyDBConfig(db *config.YAMLConfigurationDB) bool {
+	if db == nil {
+		return true
+	}
+	return db.Type == "" && db.Host == "" && db.Port == 0 && db.Name == "" && db.FilePath == ""
+}
+
+// RedactedConfig returns the Config JSON with secret fields replaced by
+// the placeholder "***", for the sink Type. Non-secret types return the
+// raw Config unchanged. If the Config does not decode as a JSON object,
+// the raw value is returned untouched (best-effort redaction).
+func RedactedConfig(typ, cfgJSON string) string {
+	spec, ok := Registry[typ]
+	if !ok || !spec.HasSecret || len(spec.SecretFields) == 0 {
+		return cfgJSON
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(cfgJSON), &obj); err != nil {
+		return cfgJSON
+	}
+	for _, key := range spec.SecretFields {
+		if _, present := obj[key]; present {
+			obj[key] = "***"
+		}
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return cfgJSON
+	}
+	return string(out)
+}
+
+// MergeSecrets replaces any "***" placeholder values in newCfgJSON with
+// the corresponding values from prevCfgJSON. Used by the API Update
+// handler so an edit that did not touch a secret field preserves the
+// previously stored secret instead of writing the placeholder.
+func MergeSecrets(typ, prevCfgJSON, newCfgJSON string) (string, error) {
+	spec, ok := Registry[typ]
+	if !ok || !spec.HasSecret || len(spec.SecretFields) == 0 {
+		return newCfgJSON, nil
+	}
+	var prev, next map[string]any
+	if err := json.Unmarshal([]byte(prevCfgJSON), &prev); err != nil {
+		return "", fmt.Errorf("decode prev config: %w", err)
+	}
+	if err := json.Unmarshal([]byte(newCfgJSON), &next); err != nil {
+		return "", fmt.Errorf("decode new config: %w", err)
+	}
+	for _, key := range spec.SecretFields {
+		v, ok := next[key]
+		if !ok {
+			continue
+		}
+		s, isStr := v.(string)
+		if !isStr {
+			continue
+		}
+		if s == "***" || s == "" {
+			if pv, pok := prev[key]; pok {
+				next[key] = pv
+			}
+		}
+	}
+	out, err := json.Marshal(next)
+	if err != nil {
+		return "", fmt.Errorf("encode merged config: %w", err)
+	}
+	return string(out), nil
+}
+
+// BuildExporters constructs a logging.MultiExporter from a set of sink
+// rows for one environment. Disabled sinks are skipped. Sink build
+// errors are logged and the sink is skipped (one bad sink does not
+// break the whole fan-out). Returns a MultiExporter containing all
+// enabled, buildable sinks.
+func BuildExporters(rows []LogSink, smgr *settings.Settings) *logging.MultiExporter {
+	exporters := make([]logging.DataExporter, 0, len(rows))
+	for _, row := range rows {
+		if !row.Enabled {
+			continue
+		}
+		spec, ok := Registry[row.Type]
+		if !ok {
+			log.Error().Str("sink", row.Name).Str("type", row.Type).Msg("unknown sink type, skipping")
+			continue
+		}
+		decoded, err := spec.Decode(json.RawMessage(row.Config))
+		if err != nil {
+			log.Error().Err(err).Str("sink", row.Name).Msg("decode sink config, skipping")
+			continue
+		}
+		exp, err := spec.Build(decoded, smgr)
+		if err != nil {
+			log.Error().Err(err).Str("sink", row.Name).Msg("build sink exporter, skipping")
+			continue
+		}
+		exporters = append(exporters, exp)
+	}
+	return logging.NewMultiExporter(exporters...)
+}
+
+// BuildExportersForEnvironments builds a map of envID -> MultiExporter
+// for every environment that has sinks, plus the global (key 0) set.
+// Used at TLS boot and on reload. Errors for individual sinks are
+// logged inside BuildExporters; this function never returns an error
+// for a buildable-but-broken sink — it only returns an error if the DB
+// query itself fails.
+func (m *LogSinksManager) BuildExportersForEnvironments(smgr *settings.Settings) (map[uint]*logging.MultiExporter, error) {
+	grouped, err := m.AllGrouped()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[uint]*logging.MultiExporter, len(grouped))
+	for envID, rows := range grouped {
+		out[envID] = BuildExporters(rows, smgr)
+	}
+	return out, nil
+}

--- a/pkg/logsinks/logsinks_test.go
+++ b/pkg/logsinks/logsinks_test.go
@@ -1,0 +1,646 @@
+package logsinks
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestManager(t *testing.T) *LogSinksManager {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&LogSink{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return &LogSinksManager{DB: db}
+}
+
+func TestRegistryCoversAllYAMLTypes(t *testing.T) {
+	want := []string{
+		config.LoggingNone, config.LoggingStdout, config.LoggingFile,
+		config.LoggingDB, config.LoggingGraylog, config.LoggingSplunk,
+		config.LoggingLogstash, config.LoggingKinesis, config.LoggingS3,
+		config.LoggingKafka, config.LoggingElastic,
+	}
+	for _, w := range want {
+		if _, ok := Registry[w]; !ok {
+			t.Errorf("Registry missing type %q", w)
+		}
+	}
+	if len(Registry) != len(want) {
+		t.Errorf("Registry has %d entries, expected %d (no extra types)", len(Registry), len(want))
+	}
+}
+
+func TestSupportedTypesIsSortedAndComplete(t *testing.T) {
+	got := SupportedTypes()
+	if len(got) != len(Registry) {
+		t.Fatalf("SupportedTypes returned %d, want %d", len(got), len(Registry))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Fatalf("SupportedTypes not sorted: %v", got)
+		}
+	}
+}
+
+func TestValidateTypeIsStrictCase(t *testing.T) {
+	// ValidateType is intentionally strict (Registry keys are
+	// lower-case). Create/Update normalize input before calling it.
+	if ValidateType("Splunk") {
+		t.Error("ValidateType should not accept mixed case")
+	}
+	if !ValidateType(config.LoggingSplunk) {
+		t.Error("ValidateType should accept the canonical lower-case key")
+	}
+}
+
+func TestCreateNormalizesTypeCase(t *testing.T) {
+	m := newTestManager(t)
+	row, err := m.Create("ci", "SPLUNK", true, 0, `{"url":"","token":"","host":"","index":""}`, 0, "")
+	if err != nil {
+		t.Fatalf("create with upper-case type: %v", err)
+	}
+	if row.Type != config.LoggingSplunk {
+		t.Errorf("type not normalized: got %q want %q", row.Type, config.LoggingSplunk)
+	}
+}
+
+func TestCreateValidatesTypeAndConfig(t *testing.T) {
+	m := newTestManager(t)
+
+	if _, err := m.Create("good", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, ""); err != nil {
+		t.Fatalf("valid create: %v", err)
+	}
+
+	if _, err := m.Create("bad-type", "nope", true, 0, `{}`, 0, ""); !errors.Is(err, ErrInvalidSinkType) {
+		t.Fatalf("bad type: got %v, want ErrInvalidSinkType", err)
+	}
+
+	if _, err := m.Create("bad-config", config.LoggingSplunk, true, 0, `{not json}`, 0, ""); !errors.Is(err, ErrInvalidSinkConfig) {
+		t.Fatalf("bad config: got %v, want ErrInvalidSinkConfig", err)
+	}
+
+	if _, err := m.Create("", config.LoggingNone, true, 0, `{}`, 0, ""); err == nil {
+		t.Fatalf("empty name should error")
+	}
+}
+
+func TestCreateAndRoundTrip(t *testing.T) {
+	m := newTestManager(t)
+	row, err := m.Create("prod-splunk", config.LoggingSplunk, true, 1, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, "prod")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if row.Source != SourceDB {
+		t.Errorf("Source: got %q want %q", row.Source, SourceDB)
+	}
+
+	got, err := m.Get(row.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "prod-splunk" || got.Type != config.LoggingSplunk || !got.Enabled {
+		t.Fatalf("get returned wrong row: %+v", got)
+	}
+
+	if _, err := m.Get(99999); !errors.Is(err, ErrSinkNotFound) {
+		t.Fatalf("missing get: got %v want ErrSinkNotFound", err)
+	}
+}
+
+func TestUpdatePreservesAndMerges(t *testing.T) {
+	m := newTestManager(t)
+	row, err := m.Create("s", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"secret","host":"h","index":"i"}`, 0, "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	updated, err := m.Update(row.ID, "s2", config.LoggingSplunk, false, 5, `{"url":"http://y","token":"***","host":"h2","index":"j"}`, "note")
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Name != "s2" || updated.Enabled || updated.Order != 5 || updated.Info != "note" {
+		t.Fatalf("updated fields wrong: %+v", updated)
+	}
+	var cfg map[string]any
+	_ = json.Unmarshal([]byte(updated.Config), &cfg)
+	if cfg["token"] == "secret" {
+		t.Fatalf("update did not overwrite config (token should have been replaced with the literal *** the test sent)")
+	}
+	if cfg["url"] != "http://y" {
+		t.Fatalf("update did not overwrite config url: %v", cfg["url"])
+	}
+}
+
+func TestDelete(t *testing.T) {
+	m := newTestManager(t)
+	row, err := m.Create("s", config.LoggingNone, true, 0, `{}`, 0, "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := m.Delete(row.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := m.Delete(row.ID); !errors.Is(err, ErrSinkNotFound) {
+		t.Fatalf("re-delete: got %v want ErrSinkNotFound", err)
+	}
+}
+
+func TestListByEnvironmentAndEffectiveFor(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("g-none", config.LoggingNone, true, 0, `{}`, 0, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Create("g-splunk", config.LoggingSplunk, false, 1, `{"url":"","token":"","host":"","index":""}`, 0, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Create("env5-stdout", config.LoggingStdout, true, 0, `{}`, 5, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := m.EffectiveFor(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(g) != 2 {
+		t.Fatalf("global EffectiveFor(0): got %d want 2", len(g))
+	}
+	e5, err := m.EffectiveFor(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(e5) != 1 || e5[0].Name != "env5-stdout" {
+		t.Fatalf("env 5 override: got %+v", e5)
+	}
+	e6, err := m.EffectiveFor(6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(e6) != 2 {
+		t.Fatalf("env 6 fallback to global: got %d want 2", len(e6))
+	}
+}
+
+func TestCloneEnvironment(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("g-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Create("g-none", config.LoggingNone, true, 1, `{}`, 0, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	cloned, err := m.CloneEnvironment(0, 5, false)
+	if err != nil {
+		t.Fatalf("clone into empty env: %v", err)
+	}
+	if len(cloned) != 2 {
+		t.Fatalf("cloned count: got %d want 2", len(cloned))
+	}
+	for _, c := range cloned {
+		if c.EnvironmentID != 5 {
+			t.Errorf("cloned env id: got %d want 5", c.EnvironmentID)
+		}
+		if c.Source != SourceDB {
+			t.Errorf("cloned source: got %q want %q", c.Source, SourceDB)
+		}
+	}
+
+	if _, err := m.CloneEnvironment(0, 5, false); !errors.Is(err, ErrTargetHasSinks) {
+		t.Fatalf("clone into non-empty without overwrite: got %v want ErrTargetHasSinks", err)
+	}
+
+	cloned2, err := m.CloneEnvironment(0, 5, true)
+	if err != nil {
+		t.Fatalf("clone with overwrite: %v", err)
+	}
+	if len(cloned2) != 2 {
+		t.Fatalf("overwrite clone count: got %d want 2", len(cloned2))
+	}
+
+	if _, err := m.CloneEnvironment(5, 5, false); err == nil {
+		t.Fatalf("clone to same env should error")
+	}
+	if _, err := m.CloneEnvironment(7, 8, false); err == nil {
+		t.Fatalf("clone from empty source should error")
+	}
+}
+
+func TestSeedIdempotent(t *testing.T) {
+	m := newTestManager(t)
+	params := &config.ServiceParameters{
+		Logger: &config.YAMLConfigurationLogger{
+			Types: []string{config.LoggingNone, config.LoggingStdout},
+		},
+		DB: &config.YAMLConfigurationDB{Type: "sqlite", FilePath: t.TempDir() + "/p.db"},
+	}
+
+	if err := m.Seed(params, 0); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	rows, err := m.ListByEnvironment(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("seed 1 count: got %d want 2", len(rows))
+	}
+	for _, r := range rows {
+		if r.Source != SourceService {
+			t.Errorf("seeded row source: got %q want %q", r.Source, SourceService)
+		}
+	}
+
+	// Re-seed: must NOT create duplicates or overwrite existing rows.
+	// Mutate one row to source=db first to prove it survives.
+	if _, err := m.Update(rows[0].ID, rows[0].Name, rows[0].Type, rows[0].Enabled, rows[0].Order, rows[0].Config, rows[0].Info); err != nil {
+		t.Fatalf("mark row as db: %v", err)
+	}
+	gotUpdated, _ := m.Get(rows[0].ID)
+	if gotUpdated.Source != SourceDB {
+		t.Fatalf("expected row 0 to be source=db after update, got %q", gotUpdated.Source)
+	}
+
+	if err := m.Seed(params, 0); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+	rows2, err := m.ListByEnvironment(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows2) != 2 {
+		t.Fatalf("seed 2 count: got %d want 2 (idempotent)", len(rows2))
+	}
+	for _, r := range rows2 {
+		if r.ID == gotUpdated.ID && r.Source != SourceDB {
+			t.Errorf("re-seed overwrote operator-edited row %d (source=%q)", r.ID, r.Source)
+		}
+	}
+}
+
+func TestSeedAlwaysLogInsertsSyntheticDB(t *testing.T) {
+	m := newTestManager(t)
+	params := &config.ServiceParameters{
+		Logger: &config.YAMLConfigurationLogger{
+			Types:     []string{config.LoggingNone},
+			AlwaysLog: true,
+		},
+		DB: &config.YAMLConfigurationDB{Type: "sqlite", FilePath: t.TempDir() + "/p.db"},
+	}
+
+	if err := m.Seed(params, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rows, err := m.ListByEnvironment(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("alwaysLog: got %d rows want 2 (none + synthetic db)", len(rows))
+	}
+	var synthetic *LogSink
+	for i := range rows {
+		if rows[i].Name == "__always_log_db__" {
+			synthetic = &rows[i]
+		}
+	}
+	if synthetic == nil {
+		t.Fatalf("synthetic __always_log_db__ sink not seeded")
+	}
+	if synthetic.Type != config.LoggingDB {
+		t.Errorf("synthetic type: got %q want %q", synthetic.Type, config.LoggingDB)
+	}
+}
+
+func TestSeedDBSinkWithLoggerDBSameCopiesPrimaryDetails(t *testing.T) {
+	m := newTestManager(t)
+	primary := &config.YAMLConfigurationDB{
+		Type:     "postgres",
+		Host:     "db.example.com",
+		Port:     5432,
+		Name:     "osctrl",
+		Username: "osctrl",
+		Password: "secret",
+	}
+	params := &config.ServiceParameters{
+		Logger: &config.YAMLConfigurationLogger{
+			Types:        []string{config.LoggingDB},
+			LoggerDBSame: true,
+			// logger.db block left at zero — operator expects the
+			// primary db: section to be used.
+			DB: &config.YAMLConfigurationDB{},
+		},
+		DB: primary,
+	}
+
+	if err := m.Seed(params, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rows, err := m.ListByEnvironment(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1 (db)", len(rows))
+	}
+	var dbCfg config.YAMLConfigurationDB
+	if err := json.Unmarshal([]byte(rows[0].Config), &dbCfg); err != nil {
+		t.Fatalf("unmarshal db config: %v", err)
+	}
+	if dbCfg.Host != "db.example.com" {
+		t.Errorf("db host: got %q want %q", dbCfg.Host, "db.example.com")
+	}
+	if dbCfg.Port != 5432 {
+		t.Errorf("db port: got %d want 5432", dbCfg.Port)
+	}
+	if dbCfg.Name != "osctrl" {
+		t.Errorf("db name: got %q want %q", dbCfg.Name, "osctrl")
+	}
+	if dbCfg.Password != "secret" {
+		t.Errorf("db password: got %q want %q", dbCfg.Password, "secret")
+	}
+}
+
+func TestSeedRepairsEmptySeedRowOnReSeed(t *testing.T) {
+	// Simulate a previous boot that seeded an empty db row (the bug):
+	// manually insert a seed row with an empty config, then re-seed
+	// with real values and verify the row is repaired.
+	m := newTestManager(t)
+
+	// Insert a stale empty seed row, as if it was created by a
+	// previous boot with the LoggerDBSame bug.
+	staleRow := LogSink{
+		Name:          "seeded-db",
+		EnvironmentID: 0,
+		Type:          config.LoggingDB,
+		Enabled:       true,
+		Order:         0,
+		Config:        `{"Type":"","Host":"","Port":0,"Name":"","Username":"","Password":"","SSLMode":"","MaxIdleConns":0,"MaxOpenConns":0,"ConnMaxLifetime":0,"ConnRetry":0,"FilePath":""}`,
+		Source:        SourceService,
+		Info:          "Seeded from service configuration",
+	}
+	if err := m.DB.Create(&staleRow).Error; err != nil {
+		t.Fatalf("create stale row: %v", err)
+	}
+
+	// Re-seed with real DB details.
+	primary := &config.YAMLConfigurationDB{
+		Type: "postgres", Host: "db.example.com", Port: 5432, Name: "osctrl",
+	}
+	params := &config.ServiceParameters{
+		Logger: &config.YAMLConfigurationLogger{
+			Types:        []string{config.LoggingDB},
+			LoggerDBSame: true,
+			DB:           &config.YAMLConfigurationDB{},
+		},
+		DB: primary,
+	}
+	if err := m.Seed(params, 0); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+
+	rows, _ := m.ListByEnvironment(0)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1", len(rows))
+	}
+	var dbCfg config.YAMLConfigurationDB
+	if err := json.Unmarshal([]byte(rows[0].Config), &dbCfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if dbCfg.Host != "db.example.com" {
+		t.Fatalf("stale row was not repaired: host=%q", dbCfg.Host)
+	}
+	if dbCfg.Name != "osctrl" {
+		t.Fatalf("stale row was not repaired: name=%q", dbCfg.Name)
+	}
+	// Source must still be "service" (not "db") — the sync must not
+	// flip the source.
+	if rows[0].Source != SourceService {
+		t.Errorf("sync flipped source to %q", rows[0].Source)
+	}
+}
+
+func TestSeedDoesNotRepairDBEditedRow(t *testing.T) {
+	// A row the operator edited (Source="db") must NOT be touched by
+	// re-seed, even if its config is empty.
+	m := newTestManager(t)
+
+	editedRow := LogSink{
+		Name:          "seeded-db",
+		EnvironmentID: 0,
+		Type:          config.LoggingDB,
+		Enabled:       true,
+		Order:         0,
+		Config:        `{"Type":"","Host":"","Port":0,"Name":""}`,
+		Source:        SourceDB,
+		Info:          "operator emptied it on purpose",
+	}
+	if err := m.DB.Create(&editedRow).Error; err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	primary := &config.YAMLConfigurationDB{
+		Type: "postgres", Host: "db.example.com", Port: 5432, Name: "osctrl",
+	}
+	params := &config.ServiceParameters{
+		Logger: &config.YAMLConfigurationLogger{
+			Types:        []string{config.LoggingDB},
+			LoggerDBSame: true,
+			DB:           &config.YAMLConfigurationDB{},
+		},
+		DB: primary,
+	}
+	if err := m.Seed(params, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rows, _ := m.ListByEnvironment(0)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1", len(rows))
+	}
+	var dbCfg config.YAMLConfigurationDB
+	_ = json.Unmarshal([]byte(rows[0].Config), &dbCfg)
+	if dbCfg.Host != "" {
+		t.Fatalf("operator-edited row was clobbered: host=%q (want empty)", dbCfg.Host)
+	}
+	if rows[0].Source != SourceDB {
+		t.Errorf("operator-edited row source changed to %q", rows[0].Source)
+	}
+}
+
+func TestSeedDBSinkWithEmptyLoggerDBFallsBackToPrimary(t *testing.T) {
+	m := newTestManager(t)
+	primary := &config.YAMLConfigurationDB{
+		Type: "sqlite", FilePath: "/tmp/test.db",
+	}
+	params := &config.ServiceParameters{
+		Logger: &config.YAMLConfigurationLogger{
+			Types: []string{config.LoggingDB},
+			// logger.db block left at zero, LoggerDBSame is false.
+			DB: &config.YAMLConfigurationDB{},
+		},
+		DB: primary,
+	}
+
+	if err := m.Seed(params, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rows, err := m.ListByEnvironment(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1", len(rows))
+	}
+	var dbCfg config.YAMLConfigurationDB
+	if err := json.Unmarshal([]byte(rows[0].Config), &dbCfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if dbCfg.Type != "sqlite" || dbCfg.FilePath != "/tmp/test.db" {
+		t.Errorf("empty logger.db did not fall back to primary: got %+v", dbCfg)
+	}
+}
+
+func TestSeedDBSinkWithExplicitLoggerDBUsesIt(t *testing.T) {
+	m := newTestManager(t)
+	primary := &config.YAMLConfigurationDB{
+		Type: "postgres", Host: "primary.example.com", Port: 5432, Name: "osctrl",
+	}
+	loggerDB := &config.YAMLConfigurationDB{
+		Type: "postgres", Host: "logs.example.com", Port: 5433, Name: "osctrl_logs",
+	}
+	params := &config.ServiceParameters{
+		Logger: &config.YAMLConfigurationLogger{
+			Types:        []string{config.LoggingDB},
+			LoggerDBSame: false,
+			DB:           loggerDB,
+		},
+		DB: primary,
+	}
+
+	if err := m.Seed(params, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rows, _ := m.ListByEnvironment(0)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1", len(rows))
+	}
+	var dbCfg config.YAMLConfigurationDB
+	if err := json.Unmarshal([]byte(rows[0].Config), &dbCfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if dbCfg.Host != "logs.example.com" {
+		t.Errorf("expected explicit logger.db host, got %q", dbCfg.Host)
+	}
+	if dbCfg.Name != "osctrl_logs" {
+		t.Errorf("expected explicit logger.db name, got %q", dbCfg.Name)
+	}
+}
+
+func TestRedactedConfigMasksSecrets(t *testing.T) {
+	cfg := `{"url":"http://x","token":"supersecret","host":"h","index":"i"}`
+	got := RedactedConfig(config.LoggingSplunk, cfg)
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(got), &obj); err != nil {
+		t.Fatalf("redacted not json: %v", err)
+	}
+	if obj["token"] != "***" {
+		t.Errorf("token not redacted: got %v", obj["token"])
+	}
+	if obj["url"] != "http://x" {
+		t.Errorf("non-secret field changed: url=%v", obj["url"])
+	}
+}
+
+func TestRedactedConfigLeavesNonSecretTypesAlone(t *testing.T) {
+	cfg := `{"host":"h","port":"1234"}`
+	if got := RedactedConfig(config.LoggingLogstash, cfg); got != cfg {
+		t.Errorf("non-secret type was modified: got %q want %q", got, cfg)
+	}
+}
+
+func TestMergeSecretsReplacesPlaceholder(t *testing.T) {
+	prev := `{"url":"http://x","token":"real-secret","host":"h","index":"i"}`
+	next := `{"url":"http://y","token":"***","host":"h2","index":"j"}`
+	got, err := MergeSecrets(config.LoggingSplunk, prev, next)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	var obj map[string]any
+	_ = json.Unmarshal([]byte(got), &obj)
+	if obj["token"] != "real-secret" {
+		t.Errorf("merge did not restore secret: got %v", obj["token"])
+	}
+	if obj["url"] != "http://y" {
+		t.Errorf("merge clobbered non-secret: url=%v", obj["url"])
+	}
+}
+
+func TestMergeSecretsAcceptsNewSecretValue(t *testing.T) {
+	prev := `{"url":"http://x","token":"old","host":"h","index":"i"}`
+	next := `{"url":"http://y","token":"new","host":"h","index":"i"}`
+	got, err := MergeSecrets(config.LoggingSplunk, prev, next)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	var obj map[string]any
+	_ = json.Unmarshal([]byte(got), &obj)
+	if obj["token"] != "new" {
+		t.Errorf("merge did not accept new secret: got %v", obj["token"])
+	}
+}
+
+func TestBuildExportersSkipsDisabledAndUnknown(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("off", config.LoggingNone, false, 0, `{}`, 0, ""); err != nil {
+		t.Fatal(err)
+	}
+	// Build directly from a row slice with an unknown type and a disabled row.
+	rows := []LogSink{
+		{Name: "off", Type: config.LoggingNone, Enabled: false, Config: "{}"},
+		{Name: "stdout", Type: config.LoggingStdout, Enabled: true, Config: "{}"},
+		{Name: "unknown", Type: "nope", Enabled: true, Config: "{}"},
+	}
+	multi := BuildExporters(rows, nil)
+	if multi == nil {
+		t.Fatal("BuildExporters returned nil")
+	}
+	if len(multi.ExporterNames()) != 1 {
+		t.Fatalf("exporter names: got %v want [stdout]", multi.ExporterNames())
+	}
+}
+
+func TestBuildExportersForEnvironmentsGroupsByEnv(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("g", config.LoggingNone, true, 0, `{}`, 0, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Create("e5", config.LoggingStdout, true, 0, `{}`, 5, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.BuildExportersForEnvironments(nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("env groups: got %d want 2", len(got))
+	}
+	if _, ok := got[0]; !ok {
+		t.Error("missing global group (key 0)")
+	}
+	if _, ok := got[5]; !ok {
+		t.Error("missing env 5 group")
+	}
+}

--- a/pkg/servicecommands/servicecommands.go
+++ b/pkg/servicecommands/servicecommands.go
@@ -20,6 +20,12 @@ const (
 	// sections back to its own YAML file. Unlike a restart it does not
 	// change what the running process is using — only what is on disk.
 	ActionPersistConfig = "persist-config"
+	// ActionReloadLogSinks asks osctrl-tls to rebuild its per-environment
+	// log sink exporter map from the log_sinks table and swap it in
+	// without restarting. In-flight logs to the old sinks may be dropped
+	// during the swap; the old sinks are closed immediately after the
+	// new set is live.
+	ActionReloadLogSinks = "reload-log-sinks"
 
 	StatusPending   = "pending"
 	StatusConsumed  = "consumed"
@@ -36,8 +42,9 @@ var (
 // not listed here is rejected at request time, so a row in the table can
 // never name an action the consumer does not recognise.
 var validActions = map[string]struct{}{
-	ActionRestart:       {},
-	ActionPersistConfig: {},
+	ActionRestart:        {},
+	ActionPersistConfig:  {},
+	ActionReloadLogSinks: {},
 }
 
 // ServiceCommand is a one-shot control request for another osctrl service.

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -78,7 +78,11 @@ var SectionRegistry = map[string][]SectionSpec{
 		{"osctrld", true, "osctrld integration"},
 		{"metrics", true, "Prometheus metrics endpoint"},
 		{"tls", false, "TLS termination certificate/key paths — not DB-editable"},
-		{"logger", false, "Log sinks — may contain credentials (future: editable)"},
+		// Note: the "logger" section is no longer registered here. Log
+		// sinks are now managed by pkg/logsinks (log_sinks table) with
+		// its own API and frontend surface. Existing service_config
+		// rows named "logger" from older boots are left in place and
+		// ignored — they do not affect the running service.
 		{"carver", false, "File carver configuration — may contain credentials"},
 		{"debug", true, "HTTP debug dump settings"},
 		{"rateLimits", true, "HTTP request rate limits"},
@@ -92,7 +96,8 @@ var SectionRegistry = map[string][]SectionSpec{
 		{"oidc", false, "OIDC federated login configuration — not DB-editable"},
 		{"jwt", false, "JWT signing configuration — not DB-editable"},
 		{"tls", false, "TLS termination certificate/key paths — not DB-editable"},
-		{"logger", false, "Log sinks — may contain credentials (future: editable)"},
+		// See the TLS registry: the "logger" section is now managed by
+		// pkg/logsinks and is intentionally absent from this registry.
 		{"carver", false, "File carver configuration — may contain credentials"},
 		{"debug", true, "HTTP debug dump settings"},
 		{"rateLimits", true, "HTTP request rate limits"},

--- a/pkg/serviceconfig/serviceconfig_test.go
+++ b/pkg/serviceconfig/serviceconfig_test.go
@@ -148,22 +148,24 @@ func TestSeed_DoesNotOverwriteDBEditedRow(t *testing.T) {
 
 	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
 
-	// Simulate an operator edit: change the logger section to source=db.
-	sc, err := m.GetSection(config.ServiceTLS, "logger", 0)
+	// Simulate an operator edit: change the osquery section to source=db.
+	// (The "logger" section is no longer registered — it is managed by
+	// pkg/logsinks — so we use osquery, which is seeded and editable.)
+	sc, err := m.GetSection(config.ServiceTLS, "osquery", 0)
 	require.NoError(t, err)
 	require.NoError(t, db.Model(&sc).Updates(map[string]any{
 		"source": SourceDB,
-		"value":  `{"type":"stdout","edited":true}`,
+		"value":  `{"version":"9.9.9","tablesFile":"./x.json","logger":true,"config":true,"query":true,"carve":true,"accelerated":false,"console":false,"fileExplorer":false,"readOnly":false}`,
 	}).Error)
 
-	// Re-seed with a different logger config — the DB value must survive.
-	cfg.Logger.Type = config.LoggingGraylog
+	// Re-seed with a different osquery config — the DB value must survive.
+	cfg.Osquery.Version = "5.12.2"
 	require.NoError(t, m.Seed(config.ServiceTLS, cfg, 0))
 
-	sc2, err := m.GetSection(config.ServiceTLS, "logger", 0)
+	sc2, err := m.GetSection(config.ServiceTLS, "osquery", 0)
 	require.NoError(t, err)
 	assert.Equal(t, SourceDB, sc2.Source)
-	assert.Equal(t, `{"type":"stdout","edited":true}`, sc2.Value)
+	assert.Contains(t, sc2.Value, "9.9.9")
 }
 
 // The seeded JSON must round-trip back to the original struct.
@@ -270,11 +272,13 @@ func TestVerifyServiceAndSection(t *testing.T) {
 	assert.True(t, m.VerifyService(config.ServiceAPI))
 	assert.False(t, m.VerifyService("bogus"))
 
-	assert.True(t, m.VerifySection(config.ServiceTLS, "logger"))
+	// "logger" is no longer registered (managed by pkg/logsinks); use
+	// "osquery" and "metrics" as the representative registered sections.
+	assert.True(t, m.VerifySection(config.ServiceTLS, "osquery"))
 	assert.True(t, m.VerifySection(config.ServiceAPI, "saml"))
 	assert.False(t, m.VerifySection(config.ServiceTLS, "saml"))
 	assert.False(t, m.VerifySection(config.ServiceAPI, "metrics"))
-	assert.False(t, m.VerifySection("bogus", "logger"))
+	assert.False(t, m.VerifySection("bogus", "osquery"))
 }
 
 // Seeding with different environment IDs must produce independent rows.
@@ -421,6 +425,8 @@ func TestIsEditable(t *testing.T) {
 	assert.True(t, m.IsEditable(config.ServiceTLS, "debug"))
 	assert.True(t, m.IsEditable(config.ServiceAPI, "debug"))
 	assert.False(t, m.IsEditable(config.ServiceTLS, "db"))
+	// "logger" is no longer registered; verify it reports not-editable
+	// (it is not a known section at all now).
 	assert.False(t, m.IsEditable(config.ServiceTLS, "logger"))
 	assert.True(t, m.IsEditable(config.ServiceTLS, "rateLimits"))
 	assert.True(t, m.IsEditable(config.ServiceAPI, "rateLimits"))

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -637,3 +637,64 @@ type AdminUserView struct {
 	// badge alongside the existing admin/service labels.
 	AuthSource string `json:"auth_source"`
 }
+
+// LogSinkFieldSpec is one field in a sink type's config schema. The SPA
+// renders a typed form from this; the backend validates the submitted
+// JSON against the registered Decode func.
+type LogSinkFieldSpec struct {
+	Name        string   `json:"name"`
+	Label       string   `json:"label"`
+	Type        string   `json:"type"`
+	Required    bool     `json:"required"`
+	Secret      bool     `json:"secret"`
+	Placeholder string   `json:"placeholder,omitempty"`
+	Help        string   `json:"help,omitempty"`
+	Options     []string `json:"options,omitempty"`
+	Default     any      `json:"default,omitempty"`
+}
+
+// LogSinkTypeSpec is one entry in the GET /api/v1/log-sinks/types
+// response. It advertises a supported sink type, whether its config
+// contains secrets (so the SPA masks those fields), the JSON keys that
+// hold secrets (so the SPA can render password inputs for them), and
+// the typed field schema the SPA renders as a dynamic form.
+type LogSinkTypeSpec struct {
+	Type         string             `json:"type"`
+	Description  string             `json:"description"`
+	HasSecret    bool               `json:"has_secret"`
+	SecretFields []string           `json:"secret_fields,omitempty"`
+	Fields       []LogSinkFieldSpec `json:"fields,omitempty"`
+}
+
+// LogSinkCreateRequest is the body for POST /api/v1/log-sinks.
+type LogSinkCreateRequest struct {
+	Name          string          `json:"name"`
+	Type          string          `json:"type"`
+	Enabled       bool            `json:"enabled"`
+	Order         int             `json:"order"`
+	Config        json.RawMessage `json:"config"`
+	EnvironmentID uint            `json:"environment_id"`
+	Info          string          `json:"info,omitempty"`
+}
+
+// LogSinkUpdateRequest is the body for PUT /api/v1/log-sinks/{id}. All
+// fields are required; a secret field set to "***" is merged from the
+// previously stored value by the handler so the SPA can submit a form
+// without re-entering every secret.
+type LogSinkUpdateRequest struct {
+	Name    string          `json:"name"`
+	Type    string          `json:"type"`
+	Enabled bool            `json:"enabled"`
+	Order   int             `json:"order"`
+	Config  json.RawMessage `json:"config"`
+	Info    string          `json:"info,omitempty"`
+}
+
+// LogSinkCloneRequest is the body for POST /api/v1/log-sinks/clone.
+// SourceEnvironmentID 0 means "global". Overwrite=false returns 409 if
+// the target environment already has sinks.
+type LogSinkCloneRequest struct {
+	SourceEnvironmentID uint `json:"source_environment_id"`
+	TargetEnvironmentID uint `json:"target_environment_id"`
+	Overwrite           bool `json:"overwrite"`
+}


### PR DESCRIPTION
# DB-backed, frontend-editable log sinks with hot-reload

## Problem

Log sinks (destinations where osctrl-tls forwards osquery status/result/query
logs) were configured exclusively in the YAML `logger:` section
(`deploy/config/tls.yml`). Changing a sink required editing the file and
restarting `osctrl-tls`. This was the last major subsystem without a
DB/frontend story, even though the surrounding plumbing (service-config table,
persist-to-YAML, restart-via-service-command) already existed.

## Solution

Replace the YAML-only sink configuration with a DB-backed, frontend-editable
system that supports per-environment sinks, clone-from-environment, and
hot-reload without restart. The operator UI renders a dynamic typed form per
sink type — no raw JSON — and a two-step "New sink" flow (type picker → config
form) keeps modals within the viewport.

## Architecture

### New package: `pkg/logsinks`

- **`LogSink` model** (`log_sinks` table): one row per sink instance, scoped by
  `EnvironmentID` (0 = global fallback). Fields: `Name`, `Type`, `Enabled`,
  `Order`, `Config` (JSON blob), `Source` (`"service"` or `"db"`), `Info`.
- **`Registry`**: maps each of the 11 sink types (`none`, `stdout`, `file`,
  `db`, `splunk`, `graylog`, `logstash`, `kinesis`, `s3`, `kafka`, `elastic`)
  to a `SinkSpec` containing a typed field schema (`FieldSpec`), a secret-field
  list, a decode function, and a build function that instantiates the existing
  `DataExporter`. Adding a new sink type is backend-only: implement the
  exporter, add the config struct, register a `SinkSpec`.
- **`Seed`**: translates the resolved service configuration (flags, env vars,
  or YAML — whichever the operator used) into `LogSink` rows on first boot
  using create-if-missing semantics. `LoggerDBSame=true` or an empty
  `logger.db` block falls back to the primary DB connection. Stale seed rows
  from a previous boot are synced to current values; operator-edited rows
  (`Source="db"`) are never overwritten.
- **Resolution**: `EffectiveFor(envID)` returns env-specific sinks when they
  exist, otherwise falls back to global. `BuildExportersForEnvironments`
  builds a `map[uint]*MultiExporter` for the TLS process.
- **CRUD + clone**: `Create`, `Update` (with secret-merge: `"***"` placeholder
  preserves the existing secret), `Delete`, `CloneEnvironment` (deep-copy all
  sinks from one env to another, with overwrite guard).
- **Secret redaction**: `RedactedConfig` replaces secret fields with `"***"`
  in read responses unless `reveal=1` is passed.

### Logging package: `pkg/logging`

- **`DataExporter` interface** gained `Close() error` — called by
  `ReplaceExporters` on every exporter in the old set during hot-reload.
  Stateless sinks (Splunk, Graylog, Logstash, Elastic, Stdout, None, File)
  return nil; stateful sinks close their resources (Kafka closes its
  `*kgo.Client`, DB closes its separate connection pool when it owns one).
- **`LoggerTLS` is now environment-aware**: holds a `map[uint]*MultiExporter`
  guarded by a `sync.RWMutex`. `ExportersFor(envID)` resolves env → global
  fallback under a read lock. `ReplaceExporters` swaps the map and closes the
  old set under a write lock — in-flight logs to old sinks may be dropped
  (warned in the UI). `Log`/`QueryLog` keep their signatures; new
  `LogWithEnv`/`QueryLogWithEnv` carry the numeric env ID. `ProcessLogs` and
  `DispatchLogs`/`DispatchQueries` thread `envID` through.

### Service commands: `pkg/servicecommands`

- New `ActionReloadLogSinks = "reload-log-sinks"` — allowlisted and validated at
  request time. Consumed by `osctrl-tls`'s existing `watchServiceCommands`
  poller, which rebuilds the exporter map from the DB and calls
  `ReplaceExporters` without restarting.

### Service config: `pkg/serviceconfig`

- Dropped the `logger` section from `SectionRegistry` (both `tls` and `api`).
  Log sinks are now owned by `pkg/logsinks`. Existing `service_config` rows
  named `logger` are left in place and ignored.

### API: `cmd/api/handlers/log_sinks.go`

Admin-only, audit-logged, OpenAPI-annotated, gated by
`service.serviceConfigEnabled`:

| Method | Route | Purpose |
|---|---|---|
| `GET` | `/api/v1/log-sinks?env={id}&reveal={0\|1}` | List (filtered by env, secrets redacted) |
| `GET` | `/api/v1/log-sinks/types` | Registry: type, description, has-secret, secret fields, typed field schema |
| `GET` | `/api/v1/log-sinks/{id}?reveal={0\|1}` | One sink |
| `POST` | `/api/v1/log-sinks` | Create |
| `PUT` | `/api/v1/log-sinks/{id}` | Update (secret merge) |
| `DELETE` | `/api/v1/log-sinks/{id}` | Delete |
| `POST` | `/api/v1/log-sinks/clone` | Clone env → env |
| `POST` | `/api/v1/log-sinks/apply` | Queue `reload-log-sinks` service command |

The `GET /types` response includes a `fields` array per type — a declarative
schema (name, label, type, required, secret, placeholder, help, options,
default) that drives the frontend's dynamic form. No per-type frontend
component is needed; adding a sink type is backend-only.

### Frontend: `frontend/src/features/log-sinks/`

- **Two-step "New sink" flow**: step 1 is a type-picker modal (compact grid of
  type buttons with per-type icons); step 2 is the config form for that type
  only — short for `splunk` (4 fields) or `none` (0 fields), longer for `db`
  (12 fields) but always bounded to one type.
- **Dynamic typed form** (`SinkConfigFields`): renders one input per field
  from the schema — text for `string`, number for `integer`, checkbox for
  `boolean`, dropdown for `select`, password input for `password`/secret
  fields. Nested keys (`sasl.mechanism`) are flattened for the form and
  expanded back to nested JSON on submit. Secret fields are pre-filled from a
  reveal query when editing.
- **Per-type icons**: a `SINK_TYPE_ICONS` map provides a distinct inline SVG
  pictogram for each type (trash for `none`, terminal for `stdout`, cylinder
  for `db`, search lens for `splunk`, bucket for `s3`, etc.), shown in the type
  picker, table, editor badge, and apply-confirm dialog.
- **"Copy from existing DB" button**: in the DB sink form, fetches the
  `osctrl-tls` `db` section from the service-config API and pre-fills all 12
  fields. Case-insensitive key matching handles Go's capitalized JSON field
  names vs. the lowercase schema names.
- **Env selector**: Global + each environment. Override-with-fallback
  semantics (env sinks replace global for that env; empty env inherits global).
- **Clone modal**: pick source/target env, overwrite toggle.
- **Apply modal**: warns that in-flight logs may be dropped during the hot
  swap; polls the service-command status until consumed.
- **Scrollable modals**: `ModalShell` gained `bodyClassName` so the DB sink
  form (12 fields) scrolls within a `max-h-[70vh] overflow-y-auto` body.
- **Source badge**: "seed" pill for service-config rows, "edited" warning pill
  for DB-edited rows.

### Bootstrap and backwards compatibility

- The `logger:` section in the YAML/env/flags remains the seed source on first
  boot; `Seed(params, envID)` takes the fully-resolved `*config.ServiceParameters`.
- Operators who never edit through the API keep running on service-config
  values — seed rows are synced to current values on every boot.
- Once a row is edited through the API (`Source="db"`), the service-config
  value is ignored for that sink until the DB row is deleted.
- `LoggerDBSame=true` copies the primary DB connection details into the seeded
  row. Empty `logger.db` blocks fall back to the primary DB. Stale empty seed
  rows from a previous boot are repaired on re-seed.
- `logger.alwaysLog` is preserved as a synthetic `__always_log_db__` sink row.
- Legacy `SourceYAML = "yaml"` constant retained for backwards compatibility
  with rows seeded by older versions.

## Validation

- **Go**: 44 packages pass, 0 failures. New tests in `pkg/logsinks` (CRUD,
  clone, seed idempotency, DB-same repair, secret redaction/merge, empty-fallback),
  `cmd/api/handlers` (auth, create/update/delete, redaction, reveal, clone,
  apply, types), `pkg/logging` (Close, env-aware dispatch), `pkg/serviceconfig`
  (logger section removal).
- **Frontend**: 240 tests pass, type check clean. 7 LogSinksPage tests cover
  the two-step flow, typed form submission, nested Kafka SASL config, empty
  none type, apply warning, and feature-gate hiding.
- **OpenAPI**: spec regenerated and verified up to date (`make openapi` +
  `make openapi-check`). 14 `log-sinks` route references in `osctrl-api.yaml`.
- **Lint**: `golangci-lint` clean on all new/touched packages (only pre-existing
  warnings in untouched files).

## Files

**New** (6 files):
- `pkg/logsinks/logsinks.go` — model, registry, CRUD, seed, clone, redaction
- `pkg/logsinks/logsinks_test.go` — 20+ tests
- `cmd/api/handlers/log_sinks.go` — REST handlers
- `cmd/api/handlers/log_sinks_test.go` — handler tests
- `frontend/src/api/log-sinks.ts` — API client
- `frontend/src/features/log-sinks/LogSinksPage.tsx` — UI page
- `frontend/src/features/log-sinks/LogSinksPage.test.tsx` — UI tests
- `frontend/src/routes/_app/log-sinks.tsx` — route

**Modified** (33 files): `pkg/logging/*` (Close, env-aware LoggerTLS, dispatch),
`pkg/servicecommands/servicecommands.go` (new action), `pkg/serviceconfig/*`
(drop logger section), `pkg/types/types.go` (request/response types),
`cmd/tls/main.go` (seed, build, reload), `cmd/api/main.go` (routes, wiring),
`cmd/api/handlers/{handlers,features}.go` (wiring, flag),
`frontend/{router,SideNav,features,ModalShell}` (UI plumbing),
`deploy/config/tls.yml` (comment), `osctrl-api.yaml` (regenerated).