### PR TITLE
Fixed CICD pipeline for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
 
           image_tag="${RELEASE_TAG#v}"
 
-          for component in tls admin api cli; do
+          for component in tls api cli; do
             image="${DOCKER_HUB_ORG}/osctrl-${component}"
             for tag in "${image_tag}" latest; do
               digest="$(retry 6 resolve_digest "${image}:${tag}")"


### PR DESCRIPTION
Pipeline for releases was broken due to `admin` component being stale. Now it won't try to build that anymore.