### PR TITLE
Revert log sinks to service configuration

### DIFF
--- a/cmd/api/handlers/log_sinks.go
+++ b/cmd/api/handlers/log_sinks.go
@@ -374,6 +374,61 @@ func (h *HandlersApi) LogSinksDeleteHandler(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// LogSinksRevertHandler — POST /api/v1/log-sinks/{id}/revert
+//
+// Flips a sink row's Source from "db" back to "service" so the next
+// hot-reload re-syncs the config from the current service configuration
+// (flags, env vars, or YAML). The operator clicks "Revert", then
+// "Apply" to trigger the reload — the re-seed overwrites the config
+// with the service-config values before the exporters are rebuilt.
+//
+// @Summary Revert sink to service config
+// @Description Flips a sink's source back to "service" so the next reload re-syncs the config from the service configuration. No config change happens here — the sync runs in osctrl-tls during the reload.
+// @Tags log-sinks
+// @Produce json
+// @Param id path int true "Sink ID"
+// @Success 200 {object} logSinkDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
+// @Security ApiKeyAuth
+// @Router /api/v1/log-sinks/{id}/revert [post]
+func (h *HandlersApi) LogSinksRevertHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireLogSinksAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.LogSinks == nil {
+		apiErrorResponse(w, "log sinks not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	id, err := parseLogSinkID(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid sink id", http.StatusBadRequest, err)
+		return
+	}
+	if err := h.LogSinks.RevertToService(id); err != nil {
+		if errors.Is(err, logsinks.ErrSinkNotFound) {
+			apiErrorResponse(w, "log sink not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error reverting log sink", http.StatusInternalServerError, err)
+		return
+	}
+	row, err := h.LogSinks.Get(id)
+	if err != nil {
+		apiErrorResponse(w, "error getting reverted log sink", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("reverted log sink %q to service config", row.Name), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toLogSinkDTO(row, false))
+}
+
 // LogSinksCloneHandler — POST /api/v1/log-sinks/clone
 //
 // @Summary Clone sinks from one environment to another

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1055,6 +1055,9 @@ func osctrlAPIService() {
 			"DELETE "+_apiPath(apiLogSinksPath)+"/{id}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksDeleteHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		muxAPI.Handle(
+			"POST "+_apiPath(apiLogSinksPath)+"/{id}/revert",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksRevertHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
 			"POST "+_apiPath(apiLogSinksPath)+"/clone",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksCloneHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		muxAPI.Handle(

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -552,11 +552,18 @@ func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfg
 				auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls persist-config command %s consumed", cmd.CommandID), "local")
 				log.Info().Str("command", cmd.CommandID).Msg("Persisted TLS config to file")
 			case servicecommands.ActionReloadLogSinks:
-				// Hot-reload log sinks without restarting. Rebuild the
-				// per-environment exporter map from the DB and atomically
-				// swap it in. The old exporters are closed by
-				// ReplaceExporters; in-flight logs to them may be dropped
-				// during the swap.
+				// Hot-reload log sinks without restarting. Re-seed from the
+				// service configuration first so reverted rows (Source flipped
+				// back to "service" by the API) get their config synced from
+				// the current flags/env/YAML, then rebuild the per-environment
+				// exporter map and atomically swap it in. The old exporters
+				// are closed by ReplaceExporters; in-flight logs to them may
+				// be dropped during the swap.
+				if err := sinksMgr.Seed(flagParams, settings.NoEnvironmentID); err != nil {
+					log.Err(err).Str("command", cmd.CommandID).Msg("error re-seeding log sinks during reload")
+					auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls reload-log-sinks command %s failed: %v", cmd.CommandID, err), "local")
+					continue
+				}
 				newExporters, err := sinksMgr.BuildExportersForEnvironments(settingsMgr)
 				if err != nil {
 					log.Err(err).Str("command", cmd.CommandID).Msg("error rebuilding log sink exporters")

--- a/frontend/src/api/log-sinks.ts
+++ b/frontend/src/api/log-sinks.ts
@@ -122,6 +122,11 @@ export function deleteLogSink(id: number): Promise<void> {
   return apiFetch<void>(`/api/v1/log-sinks/${id}`, { method: 'DELETE' });
 }
 
+/** POST /api/v1/log-sinks/{id}/revert — flip source back to "service" so the next reload re-syncs from the service config. */
+export function revertLogSink(id: number): Promise<LogSink> {
+  return apiFetch<LogSink>(`/api/v1/log-sinks/${id}/revert`, { method: 'POST' });
+}
+
 /** Body for POST /api/v1/log-sinks/clone. */
 export interface LogSinkCloneRequest {
   source_environment_id: number;

--- a/frontend/src/features/log-sinks/LogSinksPage.test.tsx
+++ b/frontend/src/features/log-sinks/LogSinksPage.test.tsx
@@ -19,6 +19,7 @@ const mockTypes = vi.fn<() => Promise<LogSinkTypeSpec[]>>();
 const mockCreate = vi.fn();
 const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
+const mockRevert = vi.fn<(id: number) => Promise<LogSink>>();
 const mockClone = vi.fn();
 const mockApply = vi.fn();
 const mockGetSink = vi.fn<(id: number, reveal?: boolean) => Promise<LogSink>>();
@@ -30,6 +31,7 @@ vi.mock('$/api/log-sinks', () => ({
   createLogSink: (...args: unknown[]) => mockCreate(...args),
   updateLogSink: (...args: unknown[]) => mockUpdate(...args),
   deleteLogSink: (id: number) => mockDelete(id),
+  revertLogSink: (id: number) => mockRevert(id),
   cloneLogSinks: (...args: unknown[]) => mockClone(...args),
   applyLogSinks: () => mockApply(),
   getLogSink: (id: number, reveal?: boolean) => mockGetSink(id, reveal),
@@ -170,6 +172,27 @@ describe('LogSinksPage', () => {
     renderPage();
     await waitFor(() => expect(screen.getByText('first')).toBeInTheDocument());
     expect(screen.getByText('second')).toBeInTheDocument();
+  });
+
+  it('shows a Revert button for edited sinks and calls revertLogSink', async () => {
+    mockRevert.mockResolvedValue(makeSink({ id: 1, name: 'edited', source: 'service' }));
+    mockList.mockResolvedValue([makeSink({ id: 1, name: 'edited', source: 'db' })]);
+    const user = userEvent.setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderPage();
+    await screen.findByText('Revert');
+    const revertBtn = screen.getByText('Revert');
+    expect(revertBtn).toBeInTheDocument();
+    await user.click(revertBtn);
+    await waitFor(() => expect(mockRevert).toHaveBeenCalledWith(1));
+    vi.mocked(window.confirm).mockRestore();
+  });
+
+  it('does not show a Revert button for seed sinks', async () => {
+    mockList.mockResolvedValue([makeSink({ id: 1, name: 'seeded', source: 'service' })]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('seeded')).toBeInTheDocument());
+    expect(screen.queryByText('Revert')).not.toBeInTheDocument();
   });
 
   it('opens the type picker, picks splunk, and creates a sink with typed config', async () => {

--- a/frontend/src/features/log-sinks/LogSinksPage.tsx
+++ b/frontend/src/features/log-sinks/LogSinksPage.tsx
@@ -8,6 +8,7 @@ import {
   createLogSink,
   updateLogSink,
   deleteLogSink,
+  revertLogSink,
   cloneLogSinks,
   applyLogSinks,
   getLogSink,
@@ -196,6 +197,18 @@ export function LogSinksPage() {
         return;
       }
       setApplyErr(e instanceof Error ? e.message : 'Delete failed');
+    },
+  });
+
+  const revertMutation = useMutation({
+    mutationFn: (id: number) => revertLogSink(id),
+    onSuccess: () => invalidate(),
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        void navigate({ to: '/login' });
+        return;
+      }
+      setApplyErr(e instanceof Error ? e.message : 'Revert failed');
     },
   });
 
@@ -573,6 +586,21 @@ export function LogSinksPage() {
                     >
                       Edit
                     </button>
+                    {s.source === 'db' && (
+                      <button
+                        type="button"
+                        disabled={revertMutation.isPending}
+                        onClick={() => {
+                          if (confirm(`Revert "${s.name}" to service config? The config will be re-synced from the YAML/flags on the next Apply.`)) {
+                            revertMutation.mutate(s.id);
+                          }
+                        }}
+                        title="Reset this sink back to the service configuration values. Takes effect on the next Apply."
+                        className="px-2 py-1 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-50"
+                      >
+                        Revert
+                      </button>
+                    )}
                     <button
                       type="button"
                       disabled={deleteMutation.isPending}

--- a/pkg/logsinks/logsinks.go
+++ b/pkg/logsinks/logsinks.go
@@ -561,6 +561,32 @@ func (m *LogSinksManager) Delete(id uint) error {
 	return nil
 }
 
+// RevertToService flips a sink row's Source from "db" back to "service",
+// so the next Seed (at TLS boot or during hot-reload) re-syncs the config
+// from the current service configuration (flags, env vars, or YAML). The
+// config itself is NOT changed here — the sync happens in the TLS
+// process during the reload, which has access to the resolved service
+// parameters. The operator clicks "Revert", then "Apply" to trigger the
+// reload; the re-seed overwrites the config with the service-config
+// values before the exporters are rebuilt.
+//
+// If the row's Source is already "service" (or the legacy "yaml"), this
+// is a no-op. Rows that do not exist return ErrSinkNotFound.
+func (m *LogSinksManager) RevertToService(id uint) error {
+	row, err := m.Get(id)
+	if err != nil {
+		return err
+	}
+	if row.Source != SourceDB {
+		return nil
+	}
+	if err := m.DB.Model(&row).Update("source", SourceService).Error; err != nil {
+		return fmt.Errorf("revert log sink %d: %w", id, err)
+	}
+	log.Debug().Uint("sink_id", id).Str("name", row.Name).Msg("Reverted sink to service config")
+	return nil
+}
+
 // ListByEnvironment returns all sinks for one environment (EnvironmentID
 // == envID), ordered by Order then CreatedAt.
 func (m *LogSinksManager) ListByEnvironment(envID uint) ([]LogSink, error) {

--- a/pkg/logsinks/logsinks_test.go
+++ b/pkg/logsinks/logsinks_test.go
@@ -159,6 +159,37 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestRevertToService(t *testing.T) {
+	m := newTestManager(t)
+	// Create a sink (Source defaults to "db").
+	row, err := m.Create("s", config.LoggingNone, true, 0, `{}`, 0, "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if row.Source != SourceDB {
+		t.Fatalf("new sink source: got %q want %q", row.Source, SourceDB)
+	}
+
+	// Revert flips Source back to "service".
+	if err := m.RevertToService(row.ID); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	got, _ := m.Get(row.ID)
+	if got.Source != SourceService {
+		t.Fatalf("after revert: source=%q want %q", got.Source, SourceService)
+	}
+
+	// Reverting again is a no-op.
+	if err := m.RevertToService(row.ID); err != nil {
+		t.Fatalf("revert again: %v", err)
+	}
+
+	// Reverting a non-existent row returns ErrSinkNotFound.
+	if err := m.RevertToService(99999); !errors.Is(err, ErrSinkNotFound) {
+		t.Fatalf("revert missing: got %v want ErrSinkNotFound", err)
+	}
+}
+
 func TestListByEnvironmentAndEffectiveFor(t *testing.T) {
 	m := newTestManager(t)
 	if _, err := m.Create("g-none", config.LoggingNone, true, 0, `{}`, 0, ""); err != nil {


### PR DESCRIPTION
# Revert log sinks to service configuration

## Problem

Once a log sink was edited through the admin UI (`source = "db"`), there
was no way to roll it back to the values defined in the YAML/env/flags
service configuration without manually editing the database or the YAML
file and restarting. Operators who wanted to discard their UI edits and
return to the seeded config had no self-service path.

## Solution

Add a "Revert" button on each edited sink row that flips `source` back
to `"service"`, then re-syncs the config from the current service
configuration during the next hot-reload — no restart, no YAML editing,
no backend access needed.

## How it works

1. **Operator clicks "Revert"** on a sink row with `source = "db"`.
   A confirm dialog explains the config will be re-synced from the
   YAML/flags on the next Apply.

2. **API**: `POST /api/v1/log-sinks/{id}/revert` calls
   `LogSinksManager.RevertToService(id)` which sets `source = "service"`
   on the row. The config blob is not changed here — only the source
   flag. The sync happens in the TLS process which has access to the
   resolved service parameters.

3. **Operator clicks "Apply changes"** — queues a `reload-log-sinks`
   service command to `osctrl-tls`.

4. **TLS hot-reload**: the `ActionReloadLogSinks` handler now calls
   `Seed(flagParams, ...)` before `BuildExportersForEnvironments`. Since
   the reverted row now has `source = "service"`, `seedRow`'s sync step
   overwrites the config with the current service-config values
   (flags, env vars, or YAML). The exporters are then rebuilt from the
   freshly synced rows and atomically swapped in.

5. **Seed sinks** (`source = "service"`) do not show the Revert button
   — there is nothing to revert. The existing `seedRow` sync keeps
   them up to date on every boot and reload.

## Changes

### Backend

**`pkg/logsinks/logsinks.go`**:
- New `RevertToService(id uint) error` method: flips `source` from
  `"db"` to `"service"`. No-op if already `"service"` or legacy
  `"yaml"`. Returns `ErrSinkNotFound` for missing rows.

**`cmd/tls/main.go`** — `ActionReloadLogSinks` handler:
- Added `sinksMgr.Seed(flagParams, ...)` call before
  `BuildExportersForEnvironments` so reverted rows get their config
  re-synced from the current service configuration during the reload.
  Previously the reload only read existing DB rows without re-seeding.

**`cmd/api/handlers/log_sinks.go`**:
- New `LogSinksRevertHandler` — `POST /api/v1/log-sinks/{id}/revert`.
  Admin-only, audit-logged. Returns the updated row (secrets redacted).

**`cmd/api/main.go`**:
- Registered the revert route alongside the other log-sinks CRUD
  routes, gated by `serviceConfigEnabled`.

### Frontend

**`frontend/src/api/log-sinks.ts`**:
- New `revertLogSink(id)` function.

**`frontend/src/features/log-sinks/LogSinksPage.tsx`**:
- `revertMutation` (useMutation) calling `revertLogSink`.
- "Revert" button in the table row action cell, shown only when
  `source === 'db'`. Styled as a muted secondary action
  (`text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)]`) to
  distinguish it from Edit (primary) and Delete (danger).
- Confirm dialog: "Revert '{name}' to service config? The config will
  be re-synced from the YAML/flags on the next Apply."
- Tooltip: "Reset this sink back to the service configuration values.
  Takes effect on the next Apply."

### Tests

**`pkg/logsinks/logsinks_test.go`** — `TestRevertToService`:
- Creates a sink (source defaults to "db"), reverts it, verifies
  source is now "service". Verifies revert is idempotent (no-op on
  already-service rows). Verifies missing row returns
  `ErrSinkNotFound`.

**`frontend/src/features/log-sinks/LogSinksPage.test.tsx`** — two new tests:
- "shows a Revert button for edited sinks and calls revertLogSink" —
  seeds a `source: 'db'` row, finds the Revert button, clicks it
  (with `confirm` mocked), verifies `revertLogSink` was called with
  the right ID.
- "does not show a Revert button for seed sinks" — seeds a
  `source: 'service'` row, verifies no Revert button is rendered.

## Validation

- **Go**: 44 packages pass, 0 failures.
- **Frontend**: 242 tests pass (2 new), type check clean.
- All existing log-sinks tests continue to pass unchanged.

## Files

**Modified** (6 files):
- `pkg/logsinks/logsinks.go` — `RevertToService` method
- `pkg/logsinks/logsinks_test.go` — revert test
- `cmd/tls/main.go` — re-seed during reload
- `cmd/api/handlers/log_sinks.go` — revert handler
- `cmd/api/main.go` — route registration
- `frontend/src/api/log-sinks.ts` — `revertLogSink` function
- `frontend/src/features/log-sinks/LogSinksPage.tsx` — revert button
- `frontend/src/features/log-sinks/LogSinksPage.test.tsx` — 2 tests