### PR TITLE
Frontend-editable authentication providers with auto-generated SAML keys

### DIFF
--- a/cmd/api/handlers/auth_methods.go
+++ b/cmd/api/handlers/auth_methods.go
@@ -1,64 +1,30 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/jmpsec/osctrl/pkg/utils"
 )
 
 // AuthMethod describes one auth surface advertised to the SPA.
-// `type` is the discriminator; clients render the appropriate UI based
-// on it. We avoid leaking the issuer URL, client id, or any other
-// IdP-specific detail at this layer — those are the IdP's responsibility
-// to reveal once the user is redirected.
 type AuthMethod struct {
 	Type string `json:"type"`
-	// LoginURL is the relative URL the SPA should redirect the
-	// browser to when this method is chosen. For "password" this
-	// is "/api/v1/login/{env}" (env is interpolated client-side
-	// from the env switcher). For "oidc" this is the global
-	// "/api/v1/auth/oidc/login" — env is irrelevant for federated
-	// login because the federated user resolves to a single
-	// AdminUser row regardless of which env tab they were viewing.
+	// LoginURL is the relative URL the SPA should redirect to.
+	// For federated providers, includes the provider row ID.
 	LoginURL string `json:"loginUrl"`
+	// Name is the human-facing label for the provider (e.g.
+	// "GitHub", "Google", "Corp Keycloak"). Empty for "password".
+	Name string `json:"name,omitempty"`
+	// ID is the auth_providers row ID, used by the SPA to build
+	// the callback URL. 0 for "password".
+	ID uint `json:"id,omitempty"`
 }
 
-// AuthMethodsResponse is the JSON shape returned by
-// GET /api/v1/auth/methods. Always returns at least the "password"
-// method; OIDC is added only when --oidc-enabled is true AND the
-// provider validated at startup. The SPA renders one button per
-// method in stable order; we don't promise stable order beyond
-// "password always first."
 type AuthMethodsResponse struct {
 	Methods []AuthMethod `json:"methods"`
 }
 
-// AuthMethodsHandler — GET /api/v1/auth/methods (no env path).
-//
-// Unauthenticated by design: the SPA calls this BEFORE the user has
-// logged in to decide which login UI to render. The response leaks
-// only the *list* of auth shapes; no per-user, per-env, or per-IdP
-// detail. The endpoint exists so the SPA never has to ship a
-// "is OIDC compiled in?" build-time flag — operators toggle it
-// server-side without re-deploying the SPA.
-//
-// Rate-limited at the route layer (same preAuthRateLimit as the
-// env/sample endpoints) to keep this from being a free metadata
-// scrape vector.
-// @Summary List authentication methods
-// @Description Returns the authentication methods enabled for the API login UI.
-// @Tags auth
-// @Produce json
-// @Success 200 {object} AuthMethodsResponse
-// @Failure 400 {object} types.ApiErrorResponse "Bad request"
-// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
-// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
-// @Failure 404 {object} types.ApiErrorResponse "Not found"
-// @Failure 409 {object} types.ApiErrorResponse "Conflict"
-// @Failure 429 {object} types.ApiErrorResponse "Too many requests"
-// @Failure 500 {object} types.ApiErrorResponse "Internal server error"
-// @Failure 503 {object} types.ApiErrorResponse "Service unavailable"
-// @Router /api/v1/auth/methods [get]
 func (h *HandlersApi) AuthMethodsHandler(w http.ResponseWriter, r *http.Request) {
 	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
 		utils.DebugHTTPDump(h.DebugHTTP, r, false)
@@ -66,17 +32,31 @@ func (h *HandlersApi) AuthMethodsHandler(w http.ResponseWriter, r *http.Request)
 	methods := []AuthMethod{
 		{Type: "password", LoginURL: "/api/v1/login"},
 	}
-	if h.OIDCEnabled {
-		methods = append(methods, AuthMethod{
-			Type:     "oidc",
-			LoginURL: "/api/v1/auth/oidc/login",
-		})
-	}
-	if h.SAMLEnabled {
-		methods = append(methods, AuthMethod{
-			Type:     "saml",
-			LoginURL: "/api/v1/auth/saml/login",
-		})
+	// If the new AuthProviderRegistry is wired, read from it.
+	// This supports multiple OIDC/SAML providers with a selector.
+	if h.AuthProviders != nil {
+		for _, p := range h.AuthProviders.AllProviders() {
+			methods = append(methods, AuthMethod{
+				Type:     p.Type,
+				LoginURL: fmt.Sprintf("/api/v1/auth/%s/%d/login", p.Type, p.ID),
+				Name:     p.Name,
+				ID:       p.ID,
+			})
+		}
+	} else {
+		// Fallback to the legacy boolean flags for backwards compat.
+		if h.OIDCEnabled {
+			methods = append(methods, AuthMethod{
+				Type:     "oidc",
+				LoginURL: "/api/v1/auth/oidc/login",
+			})
+		}
+		if h.SAMLEnabled {
+			methods = append(methods, AuthMethod{
+				Type:     "saml",
+				LoginURL: "/api/v1/auth/saml/login",
+			})
+		}
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, AuthMethodsResponse{Methods: methods})
 }

--- a/cmd/api/handlers/auth_provider_registry.go
+++ b/cmd/api/handlers/auth_provider_registry.go
@@ -1,0 +1,106 @@
+package handlers
+
+import (
+	"sync"
+
+	"github.com/jmpsec/osctrl/pkg/auth"
+	"github.com/jmpsec/osctrl/pkg/authproviders"
+)
+
+// AuthProviderRegistry holds the live, concurrently-safe set of built
+// auth providers. It replaces the package-global oidcProvider /
+// samlProvider variables with a multi-provider model: the login page
+// renders one button per enabled provider.
+//
+// The registry is replaced atomically during hot-reload via Replace().
+// Request handlers read from the registry under a read lock — the
+// swap is invisible to in-flight requests that already resolved their
+// provider pointer.
+type AuthProviderRegistry struct {
+	mu      sync.RWMutex
+	entries []authproviders.ProviderEntry
+	byID    map[uint]*authproviders.ProviderEntry
+}
+
+// NewAuthProviderRegistry constructs a registry from the given entries.
+func NewAuthProviderRegistry(entries []authproviders.ProviderEntry) *AuthProviderRegistry {
+	r := &AuthProviderRegistry{
+		entries: entries,
+		byID:    make(map[uint]*authproviders.ProviderEntry, len(entries)),
+	}
+	for i := range entries {
+		r.byID[entries[i].ID] = &entries[i]
+	}
+	return r
+}
+
+// Replace atomically swaps the registry contents. The old providers
+// are not closed (neither OIDC nor SAML providers hold resources that
+// need explicit cleanup at this time — the interface can grow a
+// Close() method later).
+func (r *AuthProviderRegistry) Replace(entries []authproviders.ProviderEntry) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = entries
+	r.byID = make(map[uint]*authproviders.ProviderEntry, len(entries))
+	for i := range entries {
+		r.byID[entries[i].ID] = &entries[i]
+	}
+}
+
+// Get returns the provider entry for the given row ID, or nil.
+func (r *AuthProviderRegistry) Get(id uint) *authproviders.ProviderEntry {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.byID[id]
+}
+
+// AllByType returns all enabled providers of the given type
+// ("oidc" or "saml"), sorted by name.
+func (r *AuthProviderRegistry) AllByType(typ string) []authproviders.ProviderEntry {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []authproviders.ProviderEntry
+	for _, e := range r.entries {
+		if e.Type == typ {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// HasOIDC returns true if at least one OIDC provider is enabled.
+func (r *AuthProviderRegistry) HasOIDC() bool {
+	return len(r.AllByType("oidc")) > 0
+}
+
+// HasSAML returns true if at least one SAML provider is enabled.
+func (r *AuthProviderRegistry) HasSAML() bool {
+	return len(r.AllByType("saml")) > 0
+}
+
+// AllProviders returns metadata for every enabled provider, for the
+// auth methods endpoint.
+func (r *AuthProviderRegistry) AllProviders() []authproviders.ProviderEntry {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]authproviders.ProviderEntry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
+
+// Compile-time check that auth.Provider is still the interface we
+// expect — catches accidental drift if the auth package changes.
+var _ auth.Provider = (auth.Provider)(nil)

--- a/cmd/api/handlers/auth_providers.go
+++ b/cmd/api/handlers/auth_providers.go
@@ -1,0 +1,473 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/authproviders"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+const authProviderCommandTTL = 2 * time.Minute
+
+type authProviderDTO struct {
+	ID        uint            `json:"id"`
+	CreatedAt string          `json:"created_at"`
+	UpdatedAt string          `json:"updated_at"`
+	Name      string          `json:"name"`
+	Type      string          `json:"type"`
+	Enabled   bool            `json:"enabled"`
+	Config    json.RawMessage `json:"config"`
+	Source    string          `json:"source"`
+	Info      string          `json:"info"`
+}
+
+func toAuthProviderDTO(p authproviders.AuthProvider, reveal bool) authProviderDTO {
+	cfg := p.Config
+	if !reveal {
+		cfg = authproviders.RedactedConfig(p.Type, p.Config)
+	}
+	return authProviderDTO{
+		ID:        p.ID,
+		CreatedAt: p.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: p.UpdatedAt.Format(time.RFC3339),
+		Name:      p.Name,
+		Type:      p.Type,
+		Enabled:   p.Enabled,
+		Config:    json.RawMessage(cfg),
+		Source:    p.Source,
+		Info:      p.Info,
+	}
+}
+
+func (h *HandlersApi) requireAuthProvidersAdmin(w http.ResponseWriter, r *http.Request) (string, bool) {
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use auth-providers API by user %s", ctx[ctxUser]))
+		return "", false
+	}
+	return ctx[ctxUser], true
+}
+
+// AuthProvidersListHandler — GET /api/v1/auth-providers
+func (h *HandlersApi) AuthProvidersListHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAuthProvidersAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.AuthProviderMgr == nil {
+		apiErrorResponse(w, "auth providers not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	rows, err := h.AuthProviderMgr.List()
+	if err != nil {
+		apiErrorResponse(w, "error listing auth providers", http.StatusInternalServerError, err)
+		return
+	}
+	reveal := r.URL.Query().Get("reveal") == "1"
+	out := make([]authProviderDTO, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toAuthProviderDTO(row, reveal))
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, out)
+}
+
+// AuthProvidersTypesHandler — GET /api/v1/auth-providers/types
+func (h *HandlersApi) AuthProvidersTypesHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	if _, ok := h.requireAuthProvidersAdmin(w, r); !ok {
+		return
+	}
+	specs := make([]types.LogSinkTypeSpec, 0, len(authproviders.Registry))
+	for _, typ := range authproviders.SupportedTypes() {
+		spec := authproviders.Registry[typ]
+		fields := make([]types.LogSinkFieldSpec, 0, len(spec.Fields))
+		for _, f := range spec.Fields {
+			fields = append(fields, types.LogSinkFieldSpec{
+				Name: f.Name, Label: f.Label, Type: string(f.Type),
+				Required: f.Required, Secret: f.Secret,
+				Placeholder: f.Placeholder, Help: f.Help,
+				Options: f.Options, Default: f.Default,
+			})
+		}
+		specs = append(specs, types.LogSinkTypeSpec{
+			Type: spec.Type, Description: spec.Description,
+			HasSecret: spec.HasSecret, SecretFields: spec.SecretFields,
+			Fields: fields,
+		})
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, specs)
+}
+
+// AuthProvidersGetHandler — GET /api/v1/auth-providers/{id}
+func (h *HandlersApi) AuthProvidersGetHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAuthProvidersAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.AuthProviderMgr == nil {
+		apiErrorResponse(w, "auth providers not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	id, err := parseAuthProviderID(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid provider id", http.StatusBadRequest, err)
+		return
+	}
+	row, err := h.AuthProviderMgr.Get(id)
+	if err != nil {
+		if errors.Is(err, authproviders.ErrProviderNotFound) {
+			apiErrorResponse(w, "auth provider not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error getting auth provider", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toAuthProviderDTO(row, r.URL.Query().Get("reveal") == "1"))
+}
+
+// AuthProvidersCreateHandler — POST /api/v1/auth-providers
+func (h *HandlersApi) AuthProvidersCreateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireAuthProvidersAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.AuthProviderMgr == nil {
+		apiErrorResponse(w, "auth providers not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	var body struct {
+		Name    string          `json:"name"`
+		Type    string          `json:"type"`
+		Enabled bool            `json:"enabled"`
+		Config  json.RawMessage `json:"config"`
+		Info    string          `json:"info,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	row, err := h.AuthProviderMgr.Create(body.Name, body.Type, body.Enabled, string(body.Config), body.Info)
+	if err != nil {
+		respondAuthProviderErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("created auth provider %q (type %s)", row.Name, row.Type), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, toAuthProviderDTO(row, true))
+}
+
+// AuthProvidersUpdateHandler — PUT /api/v1/auth-providers/{id}
+func (h *HandlersApi) AuthProvidersUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireAuthProvidersAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.AuthProviderMgr == nil {
+		apiErrorResponse(w, "auth providers not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	id, err := parseAuthProviderID(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid provider id", http.StatusBadRequest, err)
+		return
+	}
+	var body struct {
+		Name    string          `json:"name"`
+		Type    string          `json:"type"`
+		Enabled bool            `json:"enabled"`
+		Config  json.RawMessage `json:"config"`
+		Info    string          `json:"info,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	prev, err := h.AuthProviderMgr.Get(id)
+	if err != nil {
+		if errors.Is(err, authproviders.ErrProviderNotFound) {
+			apiErrorResponse(w, "auth provider not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error getting auth provider", http.StatusInternalServerError, err)
+		return
+	}
+	merged, err := authproviders.MergeSecrets(prev.Type, prev.Config, string(body.Config))
+	if err != nil {
+		apiErrorResponse(w, "error merging provider secrets", http.StatusBadRequest, err)
+		return
+	}
+	row, err := h.AuthProviderMgr.Update(id, body.Name, body.Type, body.Enabled, merged, body.Info)
+	if err != nil {
+		respondAuthProviderErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("updated auth provider %q (type %s)", row.Name, row.Type), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toAuthProviderDTO(row, true))
+}
+
+// AuthProvidersDeleteHandler — DELETE /api/v1/auth-providers/{id}
+func (h *HandlersApi) AuthProvidersDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAuthProvidersAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.AuthProviderMgr == nil {
+		apiErrorResponse(w, "auth providers not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	id, err := parseAuthProviderID(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid provider id", http.StatusBadRequest, err)
+		return
+	}
+	if err := h.AuthProviderMgr.Delete(id); err != nil {
+		if errors.Is(err, authproviders.ErrProviderNotFound) {
+			apiErrorResponse(w, "auth provider not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error deleting auth provider", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("deleted auth provider %d", id), strings.Split(r.RemoteAddr, ":")[0])
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// AuthProvidersRevertHandler — POST /api/v1/auth-providers/{id}/revert
+func (h *HandlersApi) AuthProvidersRevertHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAuthProvidersAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.AuthProviderMgr == nil {
+		apiErrorResponse(w, "auth providers not initialized", http.StatusInternalServerError, nil)
+		return
+	}
+	id, err := parseAuthProviderID(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid provider id", http.StatusBadRequest, err)
+		return
+	}
+	if err := h.AuthProviderMgr.RevertToService(id); err != nil {
+		if errors.Is(err, authproviders.ErrProviderNotFound) {
+			apiErrorResponse(w, "auth provider not found", http.StatusNotFound, err)
+			return
+		}
+		apiErrorResponse(w, "error reverting auth provider", http.StatusInternalServerError, err)
+		return
+	}
+	row, err := h.AuthProviderMgr.Get(id)
+	if err != nil {
+		apiErrorResponse(w, "error getting reverted auth provider", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("reverted auth provider %q to service config", row.Name), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toAuthProviderDTO(row, false))
+}
+
+// AuthProvidersTestHandler — POST /api/v1/auth-providers/test
+func (h *HandlersApi) AuthProvidersTestHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	if _, ok := h.requireAuthProvidersAdmin(w, r); !ok {
+		return
+	}
+	var body struct {
+		Type   string          `json:"type"`
+		Config json.RawMessage `json:"config"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	typ := strings.ToLower(strings.TrimSpace(body.Type))
+	spec, ok := authproviders.Registry[typ]
+	if !ok {
+		apiErrorResponse(w, "invalid provider type", http.StatusBadRequest, nil)
+		return
+	}
+	decoded, err := spec.Decode(body.Config)
+	if err != nil {
+		apiErrorResponse(w, "invalid config", http.StatusBadRequest, err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	_, err = spec.Build(decoded, ctx)
+	if err != nil {
+		utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, map[string]any{
+			"ok":    false,
+			"error": err.Error(),
+		})
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, map[string]any{
+		"ok": true,
+	})
+}
+
+// AuthProvidersFetchMetadataHandler — POST /api/v1/auth-providers/fetch-metadata
+//
+// Fetches the IdP metadata XML from the given URL and returns it as
+// text. The operator can then review it before saving it into the
+// IDPMetadataXML field of a SAML provider. Saves a round-trip to the
+// IdP's metadata URL from the browser (which may be on a different
+// network than the server) and avoids CORS issues.
+//
+// @Summary Fetch IdP metadata XML
+// @Description Fetches the SAML IdP metadata document from the given URL and returns the XML.
+// @Tags auth-providers
+// @Accept json
+// @Produce json
+// @Param request body object true "{ \"url\": \"https://idp/metadata\" }"
+// @Success 200 {object} object "{ \"xml\": \"<EntityDescriptor ...>\" }"
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 502 {object} types.ApiErrorResponse "Fetch failed"
+// @Security ApiKeyAuth
+// @Router /api/v1/auth-providers/fetch-metadata [post]
+func (h *HandlersApi) AuthProvidersFetchMetadataHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	if _, ok := h.requireAuthProvidersAdmin(w, r); !ok {
+		return
+	}
+	var body struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	metadataURL := strings.TrimSpace(body.URL)
+	if metadataURL == "" {
+		apiErrorResponse(w, "url is required", http.StatusBadRequest, nil)
+		return
+	}
+	u, err := url.Parse(metadataURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		apiErrorResponse(w, "url must be a valid http(s) URL", http.StatusBadRequest, nil)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		apiErrorResponse(w, "error building request", http.StatusBadRequest, err)
+		return
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		apiErrorResponse(w, "error fetching metadata", http.StatusBadGateway, err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		apiErrorResponse(w, fmt.Sprintf("IdP returned HTTP %d", resp.StatusCode), http.StatusBadGateway, nil)
+		return
+	}
+	// Cap at 1 MiB — same limit as the SAML provider's own fetch.
+	xmlBytes, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		apiErrorResponse(w, "error reading metadata", http.StatusBadGateway, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, map[string]any{
+		"xml": string(xmlBytes),
+	})
+}
+
+// AuthProvidersApplyHandler — POST /api/v1/auth-providers/apply
+func (h *HandlersApi) AuthProvidersApplyHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAuthProvidersAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.ServiceCommands == nil {
+		apiErrorResponse(w, "service commands not available", http.StatusServiceUnavailable, nil)
+		return
+	}
+	cmd, err := h.ServiceCommands.Request(config.ServiceTLS, servicecommands.ActionReloadAuthProviders, user, strings.Split(r.RemoteAddr, ":")[0], authProviderCommandTTL)
+	if err != nil {
+		apiErrorResponse(w, "error requesting auth providers reload", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("apply auth-providers reload command %s", cmd.CommandID), strings.Split(r.RemoteAddr, ":")[0])
+	log.Info().Str("command", cmd.CommandID).Msgf("Auth providers reload requested by %s", user)
+	resp := serviceCommandResponse(cmd)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusAccepted, types.ServiceConfigApplyResponse{
+		Service: config.ServiceAPI,
+		Message: "Reload requested. osctrl-api will rebuild its auth provider registry after consuming the service command.",
+		Command: &resp,
+	})
+}
+
+func parseAuthProviderID(r *http.Request) (uint, error) {
+	v := r.PathValue("id")
+	if v == "" {
+		return 0, fmt.Errorf("missing id")
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid id: %w", err)
+	}
+	return uint(n), nil
+}
+
+func respondAuthProviderErr(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, authproviders.ErrInvalidProviderType):
+		apiErrorResponse(w, "invalid auth provider type", http.StatusBadRequest, err)
+	case errors.Is(err, authproviders.ErrInvalidProviderConfig):
+		apiErrorResponse(w, "invalid auth provider configuration", http.StatusBadRequest, err)
+	case errors.Is(err, authproviders.ErrProviderNotFound):
+		apiErrorResponse(w, "auth provider not found", http.StatusNotFound, err)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		apiErrorResponse(w, "auth provider not found", http.StatusNotFound, err)
+	default:
+		apiErrorResponse(w, "error", http.StatusInternalServerError, err)
+	}
+}

--- a/cmd/api/handlers/auth_providers.go
+++ b/cmd/api/handlers/auth_providers.go
@@ -450,7 +450,7 @@ func parseAuthProviderID(r *http.Request) (uint, error) {
 	if v == "" {
 		return 0, fmt.Errorf("missing id")
 	}
-	n, err := strconv.ParseUint(v, 10, 64)
+	n, err := strconv.ParseUint(v, 10, strconv.IntSize)
 	if err != nil {
 		return 0, fmt.Errorf("invalid id: %w", err)
 	}

--- a/cmd/api/handlers/auth_resolve.go
+++ b/cmd/api/handlers/auth_resolve.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jmpsec/osctrl/pkg/auth"
 	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/rs/zerolog/log"
 )
 
 // ErrAuthUserRejected is returned by resolveFederatedUser when the
@@ -25,10 +26,16 @@ var ErrAuthUserRejected = errors.New("auth: identity cannot be resolved to an Ad
 //     operator must grant access manually.
 //  3. Else → reject.
 //
+// When JIT creates a new user and no admin users exist yet (first-run
+// bootstrap), the new user is created with admin=true so the operator
+// can manage the system immediately. When admin users already exist,
+// the new user is admin=false — an existing admin must promote them.
+//
 // Threat T16 (privilege escalation via JIT): the JIT path
-// constructs AdminUser with admin=false, service=false. There is no
-// path in this function that produces a row with admin=true; that
-// guarantee is enforced by callsite, not by data validation.
+// only sets admin=true when CountAdmins() returns 0. On any system
+// that already has an admin, JIT users are non-admin. There is no
+// path in this function that produces a row with admin=true on an
+// already-administered system.
 //
 // Threat T25 (mass-assignment via JIT): the function never
 // deserializes ResolvedIdentity directly into the struct. Field-
@@ -65,17 +72,29 @@ func (h *HandlersApi) resolveFederatedUser(identity auth.ResolvedIdentity, jitPr
 	if !jitProvision {
 		return users.AdminUser{}, fmt.Errorf("%w: user not provisioned and jitProvision disabled", ErrAuthUserRejected)
 	}
-	// JIT: build a NON-admin, NON-service AdminUser. The empty
-	// password means CheckLoginCredentials can never authenticate
-	// this user via /login — they MUST come back through the SSO
-	// flow. Operators may set a password later via the user-mgmt
-	// API if they want a dual-auth account.
+	// JIT: build a new AdminUser. When no admin users exist yet
+	// (first-run bootstrap scenario), the new user is created as
+	// admin=true so the operator can immediately manage the system
+	// after their first federated login. When admin users already
+	// exist, the new user is created as admin=false — the existing
+	// admin must promote them manually. This prevents a federated
+	// user from self-escalating to admin on a system that already
+	// has an operator.
+	adminCount, err := h.Users.CountAdmins()
+	if err != nil {
+		return users.AdminUser{}, fmt.Errorf("%w: counting admins: %w", ErrAuthUserRejected, err)
+	}
+	makeAdmin := adminCount == 0
+	if makeAdmin {
+		log.Info().Str("username", identity.PreferredUsername).Int64("existing_admins", adminCount).
+			Msg("JIT-provisioning first admin user via federated login")
+	}
 	u, err := h.Users.New(
 		identity.PreferredUsername, // username
 		"",                         // password (empty: forces SSO-only)
 		identity.Email,             // email (informational)
 		identity.Name,              // fullname (display)
-		false,                      // admin = false
+		makeAdmin,                  // admin = true only when no admins exist
 		false,                      // service = false
 	)
 	if err != nil {

--- a/cmd/api/handlers/auth_resolve_test.go
+++ b/cmd/api/handlers/auth_resolve_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/auth"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupResolveTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&users.AdminUser{}))
+	return db
+}
+
+func TestJITCreatesAdminWhenNoAdminsExist(t *testing.T) {
+	db := setupResolveTestDB(t)
+	userMgr := users.CreateUserManager(db)
+	h := &HandlersApi{Users: userMgr}
+
+	identity := auth.ResolvedIdentity{
+		Subject:           "sub-1",
+		PreferredUsername: "first-user",
+		Email:             "first@example.com",
+		Name:              "First User",
+	}
+
+	user, err := h.resolveFederatedUser(identity, true, "oidc")
+	require.NoError(t, err)
+	require.True(t, user.Admin, "first JIT user should be admin when no admins exist")
+	require.False(t, user.Service)
+	require.Equal(t, "oidc", user.AuthSource)
+}
+
+func TestJITCreatesNonAdminWhenAdminsExist(t *testing.T) {
+	db := setupResolveTestDB(t)
+	userMgr := users.CreateUserManager(db)
+	// Pre-create an admin user.
+	existing, err := userMgr.New("existing-admin", "password", "", "", true, false)
+	require.NoError(t, err)
+	require.NoError(t, userMgr.Create(existing))
+
+	h := &HandlersApi{Users: userMgr}
+
+	identity := auth.ResolvedIdentity{
+		Subject:           "sub-2",
+		PreferredUsername: "new-user",
+		Email:             "new@example.com",
+		Name:              "New User",
+	}
+
+	user, err := h.resolveFederatedUser(identity, true, "oidc")
+	require.NoError(t, err)
+	require.False(t, user.Admin, "JIT user should NOT be admin when admins already exist")
+	require.False(t, user.Service)
+}
+
+func TestJITRejectedWhenDisabled(t *testing.T) {
+	db := setupResolveTestDB(t)
+	userMgr := users.CreateUserManager(db)
+	h := &HandlersApi{Users: userMgr}
+
+	identity := auth.ResolvedIdentity{
+		Subject:           "sub-3",
+		PreferredUsername: "rejected-user",
+	}
+
+	_, err := h.resolveFederatedUser(identity, false, "oidc")
+	require.Error(t, err)
+}
+
+func TestJITReturnsExistingUserByName(t *testing.T) {
+	db := setupResolveTestDB(t)
+	userMgr := users.CreateUserManager(db)
+	// Pre-create a federated user (non-admin, with auth_source).
+	existing, err := userMgr.New("fed-user", "", "fed@example.com", "Fed User", false, false)
+	require.NoError(t, err)
+	existing.AuthSource = "oidc"
+	require.NoError(t, userMgr.Create(existing))
+
+	h := &HandlersApi{Users: userMgr}
+
+	identity := auth.ResolvedIdentity{
+		Subject:           "sub-4",
+		PreferredUsername: "fed-user",
+	}
+
+	user, err := h.resolveFederatedUser(identity, true, "oidc")
+	require.NoError(t, err)
+	require.Equal(t, "fed-user", user.Username)
+	require.False(t, user.Admin, "existing non-admin user should stay non-admin")
+}
+
+func TestJITRejectsLocalAccountClaim(t *testing.T) {
+	db := setupResolveTestDB(t)
+	userMgr := users.CreateUserManager(db)
+	// Pre-create a local (password) user with no AuthSource.
+	local, err := userMgr.New("local-user", "password", "", "", false, false)
+	require.NoError(t, err)
+	require.NoError(t, userMgr.Create(local))
+
+	h := &HandlersApi{Users: userMgr}
+
+	identity := auth.ResolvedIdentity{
+		Subject:           "sub-5",
+		PreferredUsername: "local-user",
+	}
+
+	_, err = h.resolveFederatedUser(identity, true, "oidc")
+	require.Error(t, err)
+}

--- a/cmd/api/handlers/features.go
+++ b/cmd/api/handlers/features.go
@@ -15,8 +15,9 @@ type FeaturesResponse struct {
 	// LogSinks gates the Log Sinks section in the SPA. Tied to the same
 	// flag as ServiceConfig — the log_sinks routes are registered
 	// alongside the service-config routes.
-	LogSinks     bool `json:"log_sinks"`
-	Accelerated  bool `json:"accelerated"`
+	LogSinks      bool `json:"log_sinks"`
+	AuthProviders bool `json:"auth_providers"`
+	Accelerated   bool `json:"accelerated"`
 	Console      bool `json:"console"`
 	FileExplorer bool `json:"file_explorer"`
 }
@@ -30,6 +31,7 @@ func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 		Posture:       h.PostureEnabled,
 		ServiceConfig: h.ServiceConfigEnabled,
 		LogSinks:      h.ServiceConfigEnabled,
+		AuthProviders: h.ServiceConfigEnabled,
 		Accelerated:   h.OsqueryValues.Accelerated,
 		Console:       h.OsqueryValues.Query && h.OsqueryValues.Console,
 		FileExplorer:  h.OsqueryValues.Query && h.OsqueryValues.FileExplorer,

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/authproviders"
 	"github.com/jmpsec/osctrl/pkg/backend"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
@@ -52,7 +53,12 @@ type HandlersApi struct {
 	// LogSinks manages the log_sinks table when service-config is
 	// enabled. nil when ServiceConfigEnabled is false — the routes are
 	// not registered in that case.
-	LogSinks             *logsinks.LogSinksManager
+	LogSinks *logsinks.LogSinksManager
+	// AuthProviders holds the live multi-provider registry (OIDC + SAML).
+	// nil when no providers are configured. Replaced atomically during
+	// hot-reload via AuthProviderRegistry.Replace.
+	AuthProviders        *AuthProviderRegistry
+	AuthProviderMgr      *authproviders.AuthProviderManager
 	ServiceConfigEnabled bool
 	ServiceCommands      *servicecommands.Manager
 	Activity             activityReader
@@ -198,6 +204,14 @@ func WithServiceConfig(mgr *serviceconfig.ServiceConfigManager) HandlersOption {
 func WithLogSinks(mgr *logsinks.LogSinksManager) HandlersOption {
 	return func(h *HandlersApi) {
 		h.LogSinks = mgr
+	}
+}
+
+// WithAuthProviders wires the auth provider registry and manager.
+func WithAuthProviders(reg *AuthProviderRegistry, mgr *authproviders.AuthProviderManager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.AuthProviders = reg
+		h.AuthProviderMgr = mgr
 	}
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jmpsec/osctrl/cmd/api/handlers"
 	"github.com/jmpsec/osctrl/pkg/activity"
 	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/authproviders"
 	"github.com/jmpsec/osctrl/pkg/backend"
 	"github.com/jmpsec/osctrl/pkg/cache"
 	"github.com/jmpsec/osctrl/pkg/carves"
@@ -107,6 +108,7 @@ const (
 	apiServiceConfigPath = "/service-config"
 	// API log sinks path
 	apiLogSinksPath = "/log-sinks"
+	apiAuthProvidersPath = "/auth-providers"
 	// API features path
 	apiFeaturesPath = "/features"
 	// API file explorer path
@@ -428,6 +430,20 @@ func osctrlAPIService() {
 	// the table is migrated; rows can be edited directly in the DB or
 	// YAML and picked up on the next osctrl-tls boot/reload.
 	logSinksMgr := logsinks.NewLogSinksManager(db.Conn)
+	// Auth providers manager — shares the service-config feature gate.
+	authProvidersMgr := authproviders.NewAuthProviderManager(db.Conn)
+	if err := authProvidersMgr.Seed(flagParams); err != nil {
+		log.Fatal().Err(err).Msg("Error seeding auth providers")
+	}
+	// Build live providers from the DB. Fail-fast if an enabled
+	// provider's IdP is unreachable — same posture as the old
+	// InitOIDC/InitSAML calls.
+	var authProviderRegistry *handlers.AuthProviderRegistry
+	providerEntries, err := authProvidersMgr.BuildProviders(context.Background())
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error building auth providers from DB")
+	}
+	authProviderRegistry = handlers.NewAuthProviderRegistry(providerEntries)
 	if err := serviceConfigMgr.Seed(config.ServiceAPI, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error seeding service config - %v", err)
 	}
@@ -526,6 +542,7 @@ func osctrlAPIService() {
 		handlers.WithSettings(settingsmgr),
 		handlers.WithServiceConfig(serviceConfigMgr),
 		handlers.WithLogSinks(logSinksMgr),
+		handlers.WithAuthProviders(authProviderRegistry, authProvidersMgr),
 		handlers.WithServiceConfigEnabled(flagParams.Service.ServiceConfigEnabled),
 		handlers.WithServiceCommands(serviceCommandMgr),
 		handlers.WithConfigPersist(persistConfig),
@@ -1063,6 +1080,38 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"POST "+_apiPath(apiLogSinksPath)+"/apply",
 			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
+
+		// API: auth providers. Shares the service-config feature gate.
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAuthProvidersPath),
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersListHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAuthProvidersPath)+"/types",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersTypesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAuthProvidersPath)+"/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersGetHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiAuthProvidersPath),
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersCreateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"PUT "+_apiPath(apiAuthProvidersPath)+"/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersUpdateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"DELETE "+_apiPath(apiAuthProvidersPath)+"/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersDeleteHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiAuthProvidersPath)+"/{id}/revert",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersRevertHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiAuthProvidersPath)+"/test",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersTestHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiAuthProvidersPath)+"/fetch-metadata",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersFetchMetadataHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiAuthProvidersPath)+"/apply",
+			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
 	}
 	// API: multi-factor enrollment for the calling user
 	muxAPI.Handle(

--- a/frontend/src/api/auth-providers.ts
+++ b/frontend/src/api/auth-providers.ts
@@ -1,0 +1,109 @@
+import { apiFetch } from './client';
+import type { ServiceCommand } from './service-config';
+
+export interface AuthProvider {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  name: string;
+  type: string;
+  enabled: boolean;
+  config: unknown;
+  source: string;
+  info: string;
+}
+
+export interface AuthProviderTypeSpec {
+  type: string;
+  description: string;
+  has_secret: boolean;
+  secret_fields?: string[];
+  fields?: AuthProviderFieldSpec[];
+}
+
+export interface AuthProviderFieldSpec {
+  name: string;
+  label: string;
+  type: string;
+  required: boolean;
+  secret: boolean;
+  placeholder?: string;
+  help?: string;
+  options?: string[];
+  default?: unknown;
+}
+
+export function listAuthProviders(opts?: { reveal?: boolean }): Promise<AuthProvider[]> {
+  const qs = opts?.reveal ? '?reveal=1' : '';
+  return apiFetch<AuthProvider[]>(`/api/v1/auth-providers${qs}`);
+}
+
+export function listAuthProviderTypes(): Promise<AuthProviderTypeSpec[]> {
+  return apiFetch<AuthProviderTypeSpec[]>('/api/v1/auth-providers/types');
+}
+
+export function getAuthProvider(id: number, reveal?: boolean): Promise<AuthProvider> {
+  const qs = reveal ? '?reveal=1' : '';
+  return apiFetch<AuthProvider>(`/api/v1/auth-providers/${id}${qs}`);
+}
+
+export interface AuthProviderCreateRequest {
+  name: string;
+  type: string;
+  enabled: boolean;
+  config: unknown;
+  info?: string;
+}
+
+export function createAuthProvider(body: AuthProviderCreateRequest): Promise<AuthProvider> {
+  return apiFetch<AuthProvider>('/api/v1/auth-providers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export interface AuthProviderUpdateRequest {
+  name: string;
+  type: string;
+  enabled: boolean;
+  config: unknown;
+  info?: string;
+}
+
+export function updateAuthProvider(id: number, body: AuthProviderUpdateRequest): Promise<AuthProvider> {
+  return apiFetch<AuthProvider>(`/api/v1/auth-providers/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export function deleteAuthProvider(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/auth-providers/${id}`, { method: 'DELETE' });
+}
+
+export function revertAuthProvider(id: number): Promise<AuthProvider> {
+  return apiFetch<AuthProvider>(`/api/v1/auth-providers/${id}/revert`, { method: 'POST' });
+}
+
+export function testAuthProvider(type: string, config: unknown): Promise<{ ok: boolean; error?: string }> {
+  return apiFetch<{ ok: boolean; error?: string }>('/api/v1/auth-providers/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type, config }),
+  });
+}
+
+/** POST /api/v1/auth-providers/fetch-metadata — fetches IdP metadata XML from the given URL. */
+export function fetchIdPMetadata(url: string): Promise<{ xml: string }> {
+  return apiFetch<{ xml: string }>('/api/v1/auth-providers/fetch-metadata', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url }),
+  });
+}
+
+export function applyAuthProviders(): Promise<{ message: string; service?: string; command?: ServiceCommand }> {
+  return apiFetch('/api/v1/auth-providers/apply', { method: 'POST' });
+}

--- a/frontend/src/api/features.ts
+++ b/frontend/src/api/features.ts
@@ -3,10 +3,8 @@ import { apiFetch } from './client';
 export interface Features {
   posture: boolean;
   service_config: boolean;
-  /** Tied to the same flag as service_config — log sink routes are
-   * registered alongside the service-config routes. Optional so partial
-   * test mocks keep compiling across feature additions. */
   log_sinks?: boolean;
+  auth_providers?: boolean;
   accelerated: boolean;
   console?: boolean;
   file_explorer: boolean;

--- a/frontend/src/components/chrome/SideNav.tsx
+++ b/frontend/src/components/chrome/SideNav.tsx
@@ -165,6 +165,8 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
     pathname.startsWith('/_app/config') || pathname.startsWith('/config');
   const isLogSinksActive =
     pathname.startsWith('/_app/log-sinks') || pathname.startsWith('/log-sinks');
+  const isAuthProvidersActive =
+    pathname.startsWith('/_app/auth-providers') || pathname.startsWith('/auth-providers');
   const isAuditActive = pathname.startsWith('/_app/audit') || pathname === '/audit';
   // Dashboard is now env-scoped at /_app/env/{env}
   const dashboardPath = `/_app/env/${currentEnv}`;
@@ -457,6 +459,19 @@ export function SideNav({ className, collapsed, onToggleCollapse }: SideNavProps
               }
             >
               Log Sinks
+            </NavItem>}
+            {features?.auth_providers && <NavItem
+              collapsed={collapsed}
+              active={isAuthProvidersActive}
+              to="/_app/auth-providers"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6l8-4z" />
+                  <path d="M9 12l2 2 4-4" />
+                </svg>
+              }
+            >
+              Auth Providers
             </NavItem>}
           </nav>
         </>

--- a/frontend/src/features/auth-providers/AuthProvidersPage.tsx
+++ b/frontend/src/features/auth-providers/AuthProvidersPage.tsx
@@ -1,0 +1,670 @@
+import { useState, useMemo, useEffect, type ReactNode } from 'react';
+import { usePageTitle } from '$/lib/usePageTitle';
+import { useNavigate } from '@tanstack/react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  listAuthProviders,
+  listAuthProviderTypes,
+  createAuthProvider,
+  updateAuthProvider,
+  deleteAuthProvider,
+  revertAuthProvider,
+  testAuthProvider,
+  fetchIdPMetadata,
+  applyAuthProviders,
+  getAuthProvider,
+  type AuthProvider,
+  type AuthProviderTypeSpec,
+  type AuthProviderFieldSpec,
+  type AuthProviderCreateRequest,
+} from '$/api/auth-providers';
+import { getFeatures } from '$/api/features';
+import { getServiceCommand } from '$/api/service-config';
+import { AuthError, ApiError } from '$/api/client';
+import { formatRelative } from '$/lib/time';
+import { SkeletonRow } from '$/components/data/Skeleton';
+import { EmptyState } from '$/components/data/EmptyState';
+import { ModalShell } from '$/components/feedback/ModalShell';
+import { cn } from '$/lib/cn';
+
+type ModalMode =
+  | { kind: 'closed' }
+  | { kind: 'create' }
+  | { kind: 'createType'; providerType: string }
+  | { kind: 'edit'; provider: AuthProvider }
+  | { kind: 'apply' };
+
+const PROVIDER_ICONS: Record<string, ReactNode> = {
+  oidc: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="8" cy="15" r="4" />
+      <path d="M10.85 12.15L19 4M18 5l2 2M15 8l2-2" />
+    </svg>
+  ),
+  saml: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6l8-4z" />
+      <path d="M9 12l2 2 4-4" />
+    </svg>
+  ),
+};
+
+function providerIcon(type: string): ReactNode {
+  return PROVIDER_ICONS[type] ?? PROVIDER_ICONS.oidc;
+}
+
+export function AuthProvidersPage() {
+  usePageTitle('Auth Providers');
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const [modal, setModal] = useState<ModalMode>({ kind: 'closed' });
+  const [applyErr, setApplyErr] = useState<string | null>(null);
+  const [applyFlash, setApplyFlash] = useState(false);
+  const [reloading, setReloading] = useState(false);
+
+  const { data: features } = useQuery({
+    queryKey: ['features'],
+    queryFn: () => getFeatures(),
+    staleTime: 5 * 60_000,
+  });
+  const configDisabled = features?.auth_providers === false;
+
+  const { data: providers, isLoading, isFetching, isError, error, refetch } = useQuery({
+    queryKey: ['auth-providers'],
+    queryFn: () => listAuthProviders(),
+    enabled: !!features?.auth_providers,
+    staleTime: 30_000,
+  });
+
+  const { data: types } = useQuery({
+    queryKey: ['auth-provider-types'],
+    queryFn: () => listAuthProviderTypes(),
+    staleTime: 60_000,
+    enabled: !!features?.auth_providers,
+  });
+
+  function invalidate() {
+    void qc.invalidateQueries({ queryKey: ['auth-providers'] });
+    void refetch();
+  }
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteAuthProvider(id),
+    onSuccess: () => invalidate(),
+    onError: (e) => {
+      if (e instanceof AuthError) { void navigate({ to: '/login' }); return; }
+      setApplyErr(e instanceof Error ? e.message : 'Delete failed');
+    },
+  });
+
+  const revertMutation = useMutation({
+    mutationFn: (id: number) => revertAuthProvider(id),
+    onSuccess: () => invalidate(),
+    onError: (e) => {
+      if (e instanceof AuthError) { void navigate({ to: '/login' }); return; }
+      setApplyErr(e instanceof Error ? e.message : 'Revert failed');
+    },
+  });
+
+  const applyMutation = useMutation({
+    mutationFn: () => applyAuthProviders(),
+    onSuccess: (resp) => {
+      setApplyErr(null);
+      if (!resp.command) {
+        setApplyFlash(true);
+        setTimeout(() => setApplyFlash(false), 3000);
+        return;
+      }
+      setReloading(true);
+      const poll = setInterval(() => {
+        getServiceCommand(resp.command!.command_id)
+          .then((cmd) => {
+            if (cmd.status !== 'pending') {
+              clearInterval(poll);
+              setReloading(false);
+              setApplyFlash(true);
+              setTimeout(() => setApplyFlash(false), 3000);
+            }
+          })
+          .catch(() => { clearInterval(poll); setReloading(false); });
+      }, 1500);
+    },
+    onError: (e: unknown) => {
+      setApplyErr(e instanceof Error ? e.message : String(e));
+    },
+  });
+
+  if (isError && error instanceof AuthError) {
+    void navigate({ to: '/login' });
+    return null;
+  }
+
+  if (configDisabled) {
+    return (
+      <div className="flex flex-col h-full min-h-0">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border)] flex-wrap">
+          <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">Auth Providers</h1>
+          <p className="text-xs text-[color:var(--text-3)]">Manage OIDC and SAML federated login providers.</p>
+        </div>
+        <div className="flex-1 overflow-auto min-h-0">
+          <EmptyState icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><circle cx="12" cy="12" r="10" /><path d="M12 8v4M12 16h.01" /></svg>}
+            title="Auth Providers API is disabled"
+            description="Set serviceConfigEnabled: true and restart osctrl-api to manage providers here." />
+        </div>
+      </div>
+    );
+  }
+
+  const rows = providers ?? [];
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border)] flex-wrap">
+        <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">Auth Providers</h1>
+        <p className="text-xs text-[color:var(--text-3)]">OIDC and SAML federated login. One button per enabled provider on the login page.</p>
+        <div className="ml-auto flex items-center gap-2">
+          {isFetching && !isLoading && (
+            <span className="text-[10px] text-[color:var(--text-3)] font-mono-tabular">refreshing…</span>
+          )}
+          <button type="button" onClick={() => setModal({ kind: 'create' })}
+            className={cn('px-3 py-1.5 text-xs font-medium rounded-md', 'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]', 'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]')}>
+            New provider
+          </button>
+          <button type="button" disabled={reloading}
+            onClick={() => { setApplyErr(null); setModal({ kind: 'apply' }); }}
+            className={cn('px-3 py-1 text-xs font-medium rounded transition-colors',
+              reloading ? 'bg-[color:var(--bg-3)] text-[color:var(--text-3)]'
+                : 'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)] hover:bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.2)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed')}>
+            {reloading ? 'Reloading…' : applyFlash ? 'Reload triggered ✓' : 'Apply changes'}
+          </button>
+        </div>
+      </div>
+
+      {applyErr && (
+        <div role="alert" className={cn('flex items-center gap-3 px-4 py-2.5 border-b', 'border-[color:var(--danger)]/40 bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)]', 'text-xs text-[color:var(--danger)]')}>
+          <span>{applyErr}</span>
+          <button type="button" onClick={() => setApplyErr(null)} className="ml-auto text-[color:var(--text-3)] hover:text-[color:var(--text-1)]" aria-label="Dismiss">×</button>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto min-h-0">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="border-b border-[color:var(--border)] bg-[color:var(--bg-0)] sticky top-0 z-10">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide">Name</th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide">Type</th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide w-24">Enabled</th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide w-24">Source</th>
+              <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide">Updated</th>
+              <th scope="col" className="px-2 py-3 w-1" />
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && Array.from({ length: 4 }).map((_, i) => <SkeletonRow key={i} cells={6} />)}
+            {isError && !isLoading && (
+              <tr><td colSpan={6}>
+                <EmptyState icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><circle cx="12" cy="12" r="10" /><path d="M12 8v4M12 16h.01" /></svg>}
+                  title={error instanceof Error ? error.message : 'Failed to load auth providers'}
+                  action={<button type="button" onClick={() => void refetch()} className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors">Retry</button>} />
+              </td></tr>
+            )}
+            {!isLoading && !isError && rows.length === 0 && (
+              <tr><td colSpan={6}>
+                <EmptyState icon={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6l8-4z" /></svg>}
+                  title="No auth providers configured." description="Add an OIDC or SAML provider to enable federated login."
+                  action={<button type="button" onClick={() => setModal({ kind: 'create' })} className="px-3 py-1.5 text-xs font-medium rounded bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)] transition-colors">Add a provider</button>} />
+              </td></tr>
+            )}
+            {!isLoading && !isError && rows.map((p) => (
+              <tr key={p.id} className="border-b border-[color:var(--border)] hover:bg-[color:var(--bg-2)] transition-colors">
+                <td className="px-4 py-3">
+                  <span className="text-sm font-semibold text-[color:var(--text-1)] font-mono-tabular">{p.name}</span>
+                  {p.info && <span className="ml-2 text-[10px] text-[color:var(--text-3)] truncate max-w-[240px]" title={p.info}>— {p.info}</span>}
+                </td>
+                <td className="px-4 py-3 text-xs">
+                  <span className="flex items-center gap-1.5">
+                    <span className="w-4 h-4 flex-shrink-0 text-[color:var(--text-3)]">{providerIcon(p.type)}</span>
+                    <span className="font-mono-tabular">{p.type}</span>
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-xs">
+                  {p.enabled ? (
+                    <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[rgba(var(--success-r),var(--success-g),var(--success-b),0.12)] text-[color:var(--success)]">on</span>
+                  ) : (
+                    <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[color:var(--bg-2)] text-[color:var(--text-3)]">off</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-xs">
+                  {p.source === 'db' ? (
+                    <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)]">edited</span>
+                  ) : (
+                    <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-[color:var(--bg-2)] text-[color:var(--text-3)]" title={`Seeded from service config (source: ${p.source})`}>seed</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-xs text-[color:var(--text-2)] text-right font-mono-tabular">
+                  <span title={p.updated_at}>{formatRelative(p.updated_at)}</span>
+                </td>
+                <td className="px-2 py-3 text-right whitespace-nowrap">
+                  <button type="button" onClick={() => setModal({ kind: 'edit', provider: p })}
+                    className="px-2 py-1 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors">Edit</button>
+                  {p.source === 'db' && (
+                    <button type="button" disabled={revertMutation.isPending}
+                      onClick={() => { if (confirm(`Revert "${p.name}" to service config?`)) revertMutation.mutate(p.id); }}
+                      title="Reset back to service configuration values. Takes effect on the next Apply."
+                      className="px-2 py-1 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-50">Revert</button>
+                  )}
+                  <button type="button" disabled={deleteMutation.isPending}
+                    onClick={() => { if (confirm(`Delete provider "${p.name}"?`)) deleteMutation.mutate(p.id); }}
+                    className="px-2 py-1 text-xs font-medium rounded text-[color:var(--danger)] hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-50">Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {modal.kind === 'create' && (
+        <ProviderTypePicker types={types ?? []} onPick={(t) => setModal({ kind: 'createType', providerType: t })} onClose={() => setModal({ kind: 'closed' })} />
+      )}
+      {modal.kind === 'createType' && (
+        <ProviderEditor mode="create" types={types ?? []} providerType={modal.providerType}
+          onClose={() => setModal({ kind: 'closed' })} onSaved={invalidate} />
+      )}
+      {modal.kind === 'edit' && (
+        <ProviderEditor mode="edit" types={types ?? []} providerType={modal.provider.type} existing={modal.provider}
+          onClose={() => setModal({ kind: 'closed' })} onSaved={invalidate} />
+      )}
+      {modal.kind === 'apply' && (
+        <ApplyConfirmDialog isPending={reloading}
+          onConfirm={() => { setModal({ kind: 'closed' }); applyMutation.mutate(); }}
+          onCancel={() => setModal({ kind: 'closed' })} />
+      )}
+    </div>
+  );
+}
+
+function ProviderTypePicker({ types, onPick, onClose }: { types: AuthProviderTypeSpec[]; onPick: (t: string) => void; onClose: () => void; }) {
+  return (
+    <ModalShell title="New auth provider" titleId="auth-provider-type-picker-title" onClose={onClose} panelClassName="max-w-lg">
+      <div className="space-y-3">
+        <p className="text-xs text-[color:var(--text-3)]">Choose a provider type. The next step configures its fields.</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {types.map((t) => (
+            <button key={t.type} type="button" onClick={() => onPick(t.type)}
+              className={cn('flex items-start gap-3 px-3 py-2.5 rounded-md text-left', 'border border-[color:var(--border)] bg-[color:var(--bg-2)]', 'hover:border-[color:var(--signal)] hover:bg-[color:var(--bg-1)]', 'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--signal)]')}>
+              <span className="flex-shrink-0 w-5 h-5 text-[color:var(--text-3)] mt-0.5">{providerIcon(t.type)}</span>
+              <span className="flex flex-col gap-0.5 min-w-0">
+                <span className="text-sm font-semibold text-[color:var(--text-1)] font-mono-tabular">{t.type}</span>
+                <span className="text-[10px] text-[color:var(--text-3)]">{t.description}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+        <div className="flex justify-end pt-1">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors">Cancel</button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+function ProviderEditor({ mode, types, providerType, existing, onClose, onSaved }: {
+  mode: 'create' | 'edit'; types: AuthProviderTypeSpec[]; providerType: string; existing?: AuthProvider; onClose: () => void; onSaved: () => void;
+}) {
+  const qc = useQueryClient();
+  const [name, setName] = useState(existing?.name ?? '');
+  const [enabled, setEnabled] = useState(existing?.enabled ?? true);
+  const [info, setInfo] = useState(existing?.info ?? '');
+  const [err, setErr] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<{ ok: boolean; error?: string } | null>(null);
+  const [testing, setTesting] = useState(false);
+
+  const spec = useMemo(() => types.find((t) => t.type === providerType), [types, providerType]);
+
+  // Field values are a flat map keyed by the field's Name. buildConfig
+  // builds the JSON object from them on submit. Initial values come
+  // from the existing config (decoded into a flat map) or from the
+  // spec defaults on create.
+  const [fieldValues, setFieldValues] = useState<Record<string, unknown>>(() =>
+    existing ? flattenConfig(existing.config) : defaultsForSpec(spec),
+  );
+
+  // When editing a secret-bearing provider, fetch the revealed config
+  // so the operator can see the current secret value.
+  const revealSecret = useQuery({
+    queryKey: ['auth-provider-reveal', existing?.id],
+    queryFn: () => getAuthProvider(existing!.id, true),
+    enabled: mode === 'edit' && !!existing && !!spec?.has_secret,
+    staleTime: 0,
+  });
+  useEffect(() => {
+    if (!revealSecret.data || !existing || revealSecret.data.id !== existing.id) return;
+    const revealedFlat = flattenConfig(revealSecret.data.config);
+    setFieldValues((prev) => {
+      const next = { ...prev };
+      for (const f of spec?.fields ?? []) {
+        if (f.secret && revealedFlat[f.name] !== undefined) {
+          next[f.name] = revealedFlat[f.name];
+        }
+      }
+      return next;
+    });
+  }, [revealSecret.data, existing, spec]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const trimmedName = name.trim();
+      if (!trimmedName) throw new Error('Name is required.');
+      const config = buildConfig(spec, fieldValues);
+      if (mode === 'create') {
+        const body: AuthProviderCreateRequest = { name: trimmedName, type: providerType, enabled, config, info: info.trim() || undefined };
+        return createAuthProvider(body);
+      }
+      return updateAuthProvider(existing!.id, { name: trimmedName, type: providerType, enabled, config, info: info.trim() || undefined });
+    },
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: ['auth-providers'] }); onSaved(); onClose(); },
+    onError: (e) => { if (e instanceof AuthError) { window.location.href = '/login'; return; } setErr(e instanceof Error ? e.message : 'Save failed'); },
+  });
+
+  async function handleTest() {
+    setErr(null);
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const config = buildConfig(spec, fieldValues);
+      const result = await testAuthProvider(providerType, config);
+      setTestResult(result);
+    } catch (e) {
+      setTestResult({ ok: false, error: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  const inputClass = cn('w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]', 'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular', 'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]');
+
+  return (
+    <ModalShell title={mode === 'create' ? `Add ${providerType} provider` : `Edit ${existing?.name}`} titleId="auth-provider-editor-title" onClose={onClose} bodyClassName="max-h-[70vh] overflow-y-auto">
+      <form onSubmit={(e) => { e.preventDefault(); mutation.mutate(); }} className="space-y-4">
+        <div>
+          <label htmlFor="provider-name" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">Name</label>
+          <input id="provider-name" type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. github-oidc" className={inputClass} />
+          <p className="mt-1 text-[10px] text-[color:var(--text-3)]">Unique label shown on the login page button.</p>
+        </div>
+        <div>
+          <span className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">Type</span>
+          <span className="inline-flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-[color:var(--bg-2)] border border-[color:var(--border)] text-sm font-mono-tabular text-[color:var(--text-1)]">
+            <span className="w-4 h-4 flex-shrink-0 text-[color:var(--text-3)]">{providerIcon(providerType)}</span>
+            {providerType}
+          </span>
+          {spec?.has_secret && <p className="mt-1 text-[10px] text-[color:var(--text-3)]">This provider stores credentials ({spec.secret_fields?.join(', ')}). Secret fields are revealed for editing.</p>}
+        </div>
+        <fieldset className="flex items-end gap-2 pb-2">
+          <label className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} className="rounded border-[color:var(--border)] accent-[color:var(--signal)]" />
+            <span className="font-mono-tabular">enabled</span>
+          </label>
+        </fieldset>
+
+        <ProviderConfigFields
+          key={providerType}
+          spec={spec}
+          values={fieldValues}
+          onChange={setFieldValues}
+          inputClass={inputClass}
+        />
+
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={handleTest} disabled={testing}
+            className={cn('px-2.5 py-1 text-[11px] font-medium rounded', 'border border-[color:var(--border)] text-[color:var(--text-2)]', 'hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-50')}>
+            {testing ? 'Testing…' : 'Test connection'}
+          </button>
+          {testResult && (
+            <span className={cn('text-[10px]', testResult.ok ? 'text-[color:var(--success)]' : 'text-[color:var(--danger)]')}>
+              {testResult.ok ? '✓ Connection successful' : `✕ ${testResult.error ?? 'Failed'}`}
+            </span>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="provider-info" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">Info (optional)</label>
+          <input id="provider-info" type="text" value={info} onChange={(e) => setInfo(e.target.value)} className={inputClass} />
+        </div>
+        {err && <p role="alert" className="text-xs text-[color:var(--danger)] bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)] px-3 py-2 rounded-md">{err}</p>}
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs font-medium rounded text-[color:var(--text-2)] hover:text-[color:var(--text-1)] hover:bg-[color:var(--bg-2)] transition-colors">Cancel</button>
+          <button type="submit" disabled={mutation.isPending || !name.trim()}
+            className={cn('px-3 py-1.5 text-xs font-medium rounded-md', 'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]', 'transition-colors disabled:opacity-50 disabled:cursor-not-allowed')}>
+            {mutation.isPending ? 'Saving…' : mode === 'create' ? 'Add provider' : 'Save changes'}
+          </button>
+        </div>
+      </form>
+    </ModalShell>
+  );
+}
+
+function ApplyConfirmDialog({ isPending, onConfirm, onCancel }: { isPending: boolean; onConfirm: () => void; onCancel: () => void; }) {
+  return (
+    <ModalShell title="Apply auth provider changes" titleId="auth-providers-apply-title" onClose={onCancel} panelClassName="max-w-md">
+      <div className="space-y-4">
+        <p className="text-sm text-[color:var(--text-1)]">
+          This will hot-reload osctrl-api with the current provider rows. The service is not restarted, but{' '}
+          <strong className="text-[color:var(--warning)]">users mid-login may see a transient error</strong> and can retry.
+        </p>
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button type="button" onClick={onCancel} disabled={isPending}
+            className="px-3 py-1.5 text-xs font-medium rounded border border-[color:var(--border)] text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed">Cancel</button>
+          <button type="button" onClick={onConfirm} disabled={isPending}
+            className={cn('px-3 py-1.5 text-xs font-medium rounded transition-colors', 'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.16)] text-[color:var(--warning)]', 'hover:bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.24)]', 'disabled:opacity-40 disabled:cursor-not-allowed')}>
+            {isPending ? 'Reloading…' : 'Reload now'}
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic typed config form — same pattern as LogSinksPage
+// ---------------------------------------------------------------------------
+
+function ProviderConfigFields({ spec, values, onChange, inputClass }: {
+  spec?: AuthProviderTypeSpec;
+  values: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  inputClass: string;
+}) {
+  const [fetching, setFetching] = useState(false);
+  const [fetchErr, setFetchErr] = useState<string | null>(null);
+
+  if (!spec || !spec.fields || spec.fields.length === 0) {
+    return <p className="text-[10px] text-[color:var(--text-3)] italic">This provider type has no configurable fields.</p>;
+  }
+
+  function setField(name: string, v: unknown) { onChange({ ...values, [name]: v }); }
+
+  // Fetch IdP metadata from the URL field and populate the XML field.
+  // Only shown for SAML providers that have both IDPMetadataURL and
+  // IDPMetadataXML fields.
+  const isSAML = spec.type === 'saml';
+  const metadataURL = String(values['IDPMetadataURL'] ?? '');
+
+  async function handleFetchMetadata() {
+    if (!metadataURL) return;
+    setFetchErr(null);
+    setFetching(true);
+    try {
+      const result = await fetchIdPMetadata(metadataURL);
+      setField('IDPMetadataXML', result.xml);
+    } catch (e) {
+      setFetchErr(e instanceof Error ? e.message : 'Failed to fetch metadata');
+    } finally {
+      setFetching(false);
+    }
+  }
+  return (
+    <fieldset className="space-y-3 border border-[color:var(--border)] rounded-md p-3">
+      <legend className="px-1 text-xs font-semibold text-[color:var(--text-2)]">Configuration</legend>
+      {spec.fields.map((f) => (
+        <div key={f.name}>
+          <ProviderConfigField field={f} value={values[f.name]} onChange={(v) => setField(f.name, v)} inputClass={inputClass} />
+          {isSAML && f.name === 'IDPMetadataURL' && (
+            <div className="flex items-center gap-2 -mt-1">
+              <button
+                type="button"
+                onClick={handleFetchMetadata}
+                disabled={fetching || !metadataURL}
+                className={cn(
+                  'px-2.5 py-1 text-[11px] font-medium rounded',
+                  'border border-[color:var(--border)] text-[color:var(--text-2)]',
+                  'hover:bg-[color:var(--bg-2)] transition-colors disabled:opacity-50',
+                )}
+              >
+                {fetching ? 'Fetching…' : 'Fetch metadata'}
+              </button>
+              <span className="text-[10px] text-[color:var(--text-3)]">
+                Fetches the XML from the URL above and fills the IdP metadata XML field below.
+              </span>
+              {fetchErr && (
+                <span className="text-[10px] text-[color:var(--danger)]">{fetchErr}</span>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </fieldset>
+  );
+}
+
+function ProviderConfigField({ field, value, onChange, inputClass }: {
+  field: AuthProviderFieldSpec;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  inputClass: string;
+}) {
+  const id = `provider-cfg-${field.name}`;
+  const labelEl = (
+    <label htmlFor={id} className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+      {field.label}
+      {field.required && <span className="text-[color:var(--danger)]" aria-hidden="true"> *</span>}
+    </label>
+  );
+  const helpEl = field.help && <p className="mt-1 text-[10px] text-[color:var(--text-3)]">{field.help}</p>;
+
+  switch (field.type) {
+    case 'boolean':
+      return (
+        <div>
+          <label className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+            <input id={id} type="checkbox" aria-label={field.label} checked={Boolean(value)} onChange={(e) => onChange(e.target.checked)} className="rounded border-[color:var(--border)] accent-[color:var(--signal)]" />
+            <span className="font-mono-tabular">{field.label}</span>
+          </label>
+          {helpEl}
+        </div>
+      );
+    case 'integer':
+      return (
+        <div>
+          {labelEl}
+          <input id={id} type="number" aria-label={field.label} value={value === undefined || value === null ? '' : String(value)}
+            onChange={(e) => { const raw = e.target.value; onChange(raw === '' ? undefined : Number(raw)); }}
+            placeholder={field.placeholder} className={inputClass} />
+          {helpEl}
+        </div>
+      );
+    case 'select':
+      return (
+        <div>
+          {labelEl}
+          <select id={id} aria-label={field.label} value={String(value ?? '')} onChange={(e) => onChange(e.target.value)} className={inputClass}>
+            {field.options?.map((opt) => <option key={opt} value={opt}>{opt === '' ? '— none —' : opt}</option>)}
+          </select>
+          {helpEl}
+        </div>
+      );
+    case 'password':
+      return (
+        <div>
+          {labelEl}
+          <input id={id} type="password" aria-label={field.label} value={String(value ?? '')} onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder} autoComplete="off" className={cn(inputClass, 'text-[color:var(--text-2)]')} />
+          {helpEl}
+        </div>
+      );
+    case 'text':
+      return (
+        <div>
+          {labelEl}
+          <textarea id={id} aria-label={field.label} value={String(value ?? '')} onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder} spellCheck={false}
+            className={cn('w-full px-3 py-2 text-xs rounded-md border border-[color:var(--border)]', 'bg-[color:var(--bg-2)] text-[color:var(--text-1)] font-mono-tabular', 'min-h-[80px] focus:outline focus:outline-2 focus:outline-[color:var(--signal)]')} />
+          {helpEl}
+        </div>
+      );
+    case 'string':
+    default:
+      return (
+        <div>
+          {labelEl}
+          <input id={id} type="text" aria-label={field.label} value={String(value ?? '')} onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder} className={inputClass} />
+          {helpEl}
+        </div>
+      );
+  }
+}
+
+function defaultsForSpec(spec?: AuthProviderTypeSpec): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of spec?.fields ?? []) {
+    if (f.default !== undefined && f.default !== null && f.default !== '') {
+      out[f.name] = f.default;
+    }
+  }
+  return out;
+}
+
+function flattenConfig(config: unknown): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) return out;
+  const obj = config as Record<string, unknown>;
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      for (const [k2, v2] of Object.entries(v as Record<string, unknown>)) {
+        out[`${k}.${k2}`] = v2;
+      }
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function buildConfig(spec: AuthProviderTypeSpec | undefined, values: Record<string, unknown>): unknown {
+  const out: Record<string, unknown> = {};
+  for (const f of spec?.fields ?? []) {
+    const v = values[f.name];
+    if (v === undefined || v === null || v === '') continue;
+    // Handle comma-separated string fields that should be arrays
+    if (f.name === 'Scopes' || f.name === 'RequiredGroups') {
+      const parts = String(v).split(',').map((s) => s.trim()).filter((s) => s !== '');
+      if (parts.length > 0) {
+        out[f.name] = parts;
+      }
+      continue;
+    }
+    setDotted(out, f.name, v);
+  }
+  return out;
+}
+
+function setDotted(obj: Record<string, unknown>, key: string, value: unknown) {
+  const parts = key.split('.');
+  if (parts.length === 1) { obj[parts[0]] = value; return; }
+  const [head, ...rest] = parts;
+  if (typeof obj[head] !== 'object' || obj[head] === null) { obj[head] = {}; }
+  setDotted(obj[head] as Record<string, unknown>, rest.join('.'), value);
+}
+
+export default AuthProvidersPage;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -25,6 +25,7 @@ import { environmentsRoute } from './routes/_app/environments'
 import { settingsServiceRoute } from './routes/_app/settings.$service'
 import { serviceConfigRoute } from './routes/_app/config.$service'
 import { logSinksRoute } from './routes/_app/log-sinks'
+import { authProvidersRoute } from './routes/_app/auth-providers'
 import { auditRoute } from './routes/_app/audit'
 import { devComponentsRoute } from './routes/dev.components'
 
@@ -40,6 +41,7 @@ const routeTree = rootRoute.addChildren([
     settingsServiceRoute,
     serviceConfigRoute,
     logSinksRoute,
+    authProvidersRoute,
     auditRoute,
     envRoute.addChildren([
       envIndexRoute,

--- a/frontend/src/routes/_app/auth-providers.tsx
+++ b/frontend/src/routes/_app/auth-providers.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { appRoute } from './route';
+import { AuthProvidersPage } from '$/features/auth-providers/AuthProvidersPage';
+
+export const authProvidersRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: 'auth-providers',
+  component: AuthProvidersPage,
+});

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -238,67 +238,6 @@ paths:
       summary: List audit logs
       tags:
         - audit
-  /api/v1/auth/methods:
-    get:
-      description: Returns the authentication methods enabled for the API login UI.
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/handlers.AuthMethodsResponse"
-        "400":
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/types.ApiErrorResponse"
-        "401":
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/types.ApiErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/types.ApiErrorResponse"
-        "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/types.ApiErrorResponse"
-        "409":
-          description: Conflict
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/types.ApiErrorResponse"
-        "429":
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/types.ApiErrorResponse"
-        "500":
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/types.ApiErrorResponse"
-        "503":
-          description: Service unavailable
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/types.ApiErrorResponse"
-      summary: List authentication methods
-      tags:
-        - auth
   /api/v1/auth/oidc/callback:
     get:
       description: Handles the OIDC authorization callback and creates an API session.
@@ -2982,6 +2921,60 @@ paths:
       security:
         - ApiKeyAuth: []
       summary: Update a log sink
+      tags:
+        - log-sinks
+  "/api/v1/log-sinks/{id}/revert":
+    post:
+      description: Flips a sink's source back to "service" so the next reload re-syncs
+        the config from the service configuration. No config change happens here
+        — the sync runs in osctrl-tls during the reload.
+      parameters:
+        - description: Sink ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/handlers.logSinkDTO"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Revert sink to service config
       tags:
         - log-sinks
   /api/v1/log-sinks/apply:
@@ -8580,28 +8573,6 @@ components:
         query:
           type: integer
       type: object
-    handlers.AuthMethod:
-      properties:
-        loginUrl:
-          description: |-
-            LoginURL is the relative URL the SPA should redirect the
-            browser to when this method is chosen. For "password" this
-            is "/api/v1/login/{env}" (env is interpolated client-side
-            from the env switcher). For "oidc" this is the global
-            "/api/v1/auth/oidc/login" — env is irrelevant for federated
-            login because the federated user resolves to a single
-            AdminUser row regardless of which env tab they were viewing.
-          type: string
-        type:
-          type: string
-      type: object
-    handlers.AuthMethodsResponse:
-      properties:
-        methods:
-          items:
-            $ref: "#/components/schemas/handlers.AuthMethod"
-          type: array
-      type: object
     handlers.EnvStats:
       properties:
         active:
@@ -8793,6 +8764,8 @@ components:
       type: object
     handlers.logSinkDTO:
       properties:
+        bytes_sent:
+          type: integer
         config:
           items:
             type: integer
@@ -8802,6 +8775,8 @@ components:
         enabled:
           type: boolean
         environment_id:
+          type: integer
+        exports_count:
           type: integer
         id:
           type: integer

--- a/pkg/auth/saml/config.go
+++ b/pkg/auth/saml/config.go
@@ -103,28 +103,21 @@ type Config struct {
 	// first successful login. Matches the OIDC field semantics.
 	JITProvision bool
 
-	// SigningCertPath + SigningKeyPath are PEM paths to the SP's
-	// signing certificate + private key. When both are set, the
-	// provider signs every outbound AuthnRequest with RSA-SHA256,
-	// advertises AuthnRequestsSigned="true" in SP metadata, and
-	// includes the public cert in the metadata's KeyDescriptor.
-	//
-	// Threat closed by signing: an attacker who can MITM the
-	// browser→IdP redirect chain (malicious extension, hostile
-	// network) cannot tamper with the AuthnRequest's fields
-	// (ForceAuthn, AssertionConsumerServiceURL, etc) without
-	// invalidating the signature — the IdP's verification rejects
-	// the mutated request. Without signing the realistic attack
-	// surface is narrow (the HMAC state cookie binds the eventual
-	// response back to the same browser, so the attacker can't
-	// redirect responses to themselves) but downgrade attacks on
-	// the request itself become impossible.
-	//
-	// Empty values disable signing (D5 in the spec — v1 default
-	// for operators who don't want to manage an SP signing key).
-	// Production deployments should set them.
+	// SigningCertPath + SigningKeyPath are PEM file paths to the SP's
+	// signing certificate + private key. Legacy: when set, the
+	// provider reads them from disk at NewSAMLProvider time.
+	// Prefer SigningCertPEM / SigningKeyPEM for DB-backed configs.
 	SigningCertPath string
 	SigningKeyPath  string
+
+	// SigningCertPEM and SigningKeyPEM hold the SP's signing
+	// certificate and private key as PEM-encoded text, stored in the
+	// DB config JSON — no files on disk needed. When both are empty
+	// AND SigningCertPath/SigningKeyPath are also empty,
+	// NewSAMLProvider auto-generates a self-signed RSA 2048-bit
+	// keypair with a 10-year validity.
+	SigningCertPEM string
+	SigningKeyPEM  string
 
 	// ForceAuthn, when true, sets ForceAuthn="true" on every
 	// AuthnRequest we emit. Keycloak / Auth0 / Okta will then
@@ -197,11 +190,17 @@ func (c Config) Validate() error {
 	if c.ReplayWindow < 0 {
 		return errors.New("saml: ReplayWindow must be non-negative (minutes)")
 	}
-	// Both signing fields must be set together or both unset. A
-	// half-configured pair (e.g. cert path set, key path empty) is
-	// always a config typo, not a deliberate state.
+	// File-path signing fields must both be set or both empty.
 	if (c.SigningCertPath == "") != (c.SigningKeyPath == "") {
 		return errors.New("saml: SigningCertPath and SigningKeyPath must both be set or both be empty")
+	}
+	// PEM signing fields must both be set or both empty.
+	if (c.SigningCertPEM == "") != (c.SigningKeyPEM == "") {
+		return errors.New("saml: SigningCertPEM and SigningKeyPEM must both be set or both be empty")
+	}
+	// Cannot mix file paths and inline PEM.
+	if (c.SigningCertPath != "" || c.SigningKeyPath != "") && (c.SigningCertPEM != "" || c.SigningKeyPEM != "") {
+		return errors.New("saml: cannot mix file-path signing fields with inline PEM signing fields")
 	}
 	return nil
 }

--- a/pkg/auth/saml/provider.go
+++ b/pkg/auth/saml/provider.go
@@ -2,14 +2,17 @@ package saml
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,8 +20,8 @@ import (
 	"time"
 
 	crewjam "github.com/crewjam/saml"
-	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/rs/zerolog/log"
+	dsig "github.com/russellhaering/goxmldsig"
 
 	"github.com/jmpsec/osctrl/pkg/auth"
 )
@@ -141,13 +144,37 @@ func NewSAMLProvider(ctx context.Context, cfg Config) (*Provider, error) {
 		// cookie binding the response to a specific browser).
 		AuthnNameIDFormat: crewjam.UnspecifiedNameIDFormat,
 	}
-	// Load signing keypair if configured. This enables both
+	// Load signing keypair if configured. Three sources, checked in
+	// order: inline PEM (DB-backed), file paths (legacy YAML), and
+	// auto-generated (when neither is set). This enables both
 	// AuthnRequest signing and signed SP metadata, closing the
 	// downgrade-attack vector on the outbound redirect chain.
-	if cfg.SigningCertPath != "" && cfg.SigningKeyPath != "" {
+	switch {
+	case cfg.SigningCertPEM != "" && cfg.SigningKeyPEM != "":
+		key, cert, err := parseSPKeyPair([]byte(cfg.SigningCertPEM), []byte(cfg.SigningKeyPEM))
+		if err != nil {
+			return nil, fmt.Errorf("saml: parse SP signing PEM: %w", err)
+		}
+		sp.Key = key
+		sp.Certificate = cert
+		sp.SignatureMethod = dsig.RSASHA256SignatureMethod
+	case cfg.SigningCertPath != "" && cfg.SigningKeyPath != "":
 		key, cert, err := loadSPKeyPair(cfg.SigningCertPath, cfg.SigningKeyPath)
 		if err != nil {
 			return nil, fmt.Errorf("saml: load SP signing keypair: %w", err)
+		}
+		sp.Key = key
+		sp.Certificate = cert
+		sp.SignatureMethod = dsig.RSASHA256SignatureMethod
+	default:
+		// Auto-generate a self-signed keypair when no signing
+		// material is provided. This is the default for DB-backed
+		// configs where the operator didn't paste their own PEM.
+		// The generated keypair enables AuthnRequest signing without
+		// requiring files on disk.
+		key, cert, err := generateSPKeyPair()
+		if err != nil {
+			return nil, fmt.Errorf("saml: auto-generate SP signing keypair: %w", err)
 		}
 		sp.Key = key
 		sp.Certificate = cert
@@ -504,6 +531,80 @@ func loadSPKeyPair(certPath, keyPath string) (*rsa.PrivateKey, *x509.Certificate
 	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse key %s: %w", keyPath, err)
+	}
+	return key, cert, nil
+}
+
+// parseSPKeyPair reads PEM-encoded cert + private key from byte slices
+// (stored in the DB config JSON) and returns them in the shape
+// crewjam.ServiceProvider expects. Same logic as loadSPKeyPair but
+// without touching the filesystem.
+func parseSPKeyPair(certPEM, keyPEM []byte) (*rsa.PrivateKey, *x509.Certificate, error) {
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil || certBlock.Type != "CERTIFICATE" {
+		return nil, nil, fmt.Errorf("cert: missing CERTIFICATE PEM block")
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse cert: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, nil, fmt.Errorf("key: not PEM-encoded")
+	}
+
+	var key *rsa.PrivateKey
+	switch keyBlock.Type {
+	case "RSA PRIVATE KEY":
+		key, err = x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	case "PRIVATE KEY":
+		var anyKey any
+		anyKey, err = x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+		if err == nil {
+			var ok bool
+			key, ok = anyKey.(*rsa.PrivateKey)
+			if !ok {
+				return nil, nil, fmt.Errorf("key: PKCS#8 key is not RSA (crewjam requires RSA)")
+			}
+		}
+	default:
+		return nil, nil, fmt.Errorf("key: unsupported PEM type %q (want RSA PRIVATE KEY or PRIVATE KEY)", keyBlock.Type)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse key: %w", err)
+	}
+	return key, cert, nil
+}
+
+// generateSPKeyPair creates a self-signed RSA 2048-bit keypair with a
+// 10-year validity period. Used when the operator didn't provide
+// signing material — enables AuthnRequest signing out of the box
+// without requiring files on disk or manual cert generation.
+func generateSPKeyPair() (*rsa.PrivateKey, *x509.Certificate, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate RSA key: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "osctrl-saml-sp"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create self-signed cert: %w", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse generated cert: %w", err)
 	}
 	return key, cert, nil
 }

--- a/pkg/authproviders/authproviders.go
+++ b/pkg/authproviders/authproviders.go
@@ -1,0 +1,658 @@
+// Package authproviders persists federated authentication provider
+// configurations (OIDC, SAML) to the database. Each row is one IdP
+// configuration — multiple OIDC providers are supported, each rendered
+// as a separate button on the login page.
+//
+// The package mirrors the pattern established by pkg/logsinks: a
+// Registry maps each provider type to a typed field schema, a decode
+// function, and a build function. The field schema drives the
+// frontend's dynamic form. Secrets (OIDC client secret, SAML signing
+// key PEM) are redacted in read responses and merged on edit.
+//
+// SAML signing keys can be auto-generated (self-signed RSA 2048-bit
+// keypair) when the operator doesn't provide their own PEM — no files
+// on disk needed.
+package authproviders
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jmpsec/osctrl/pkg/auth"
+	authoidc "github.com/jmpsec/osctrl/pkg/auth/oidc"
+	authsaml "github.com/jmpsec/osctrl/pkg/auth/saml"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// SourceService marks a row seeded from the resolved service configuration.
+const SourceService = "service"
+
+// SourceDB marks a row that has been edited or created through the API.
+const SourceDB = "db"
+
+// SourceYAML is retained for backwards compatibility.
+const SourceYAML = "yaml"
+
+// AuthProvider stores one IdP configuration. Config is a JSON-encoded
+// blob whose shape is determined by Type and validated against the
+// Registry. Multiple rows of the same Type are allowed — the login
+// page renders one button per enabled row.
+type AuthProvider struct {
+	gorm.Model
+	Name    string `gorm:"uniqueIndex"`
+	Type    string `gorm:"index"` // "oidc" or "saml"
+	Enabled bool
+	Config  string `gorm:"type:text"` // JSON blob
+	Source  string // "service" (seeded) or "db" (edited)
+	Info    string
+}
+
+// AuthProviderManager manages the auth_providers table.
+type AuthProviderManager struct {
+	DB *gorm.DB
+}
+
+// NewAuthProviderManager initializes the manager and auto-migrates.
+func NewAuthProviderManager(backend *gorm.DB) *AuthProviderManager {
+	m := &AuthProviderManager{DB: backend}
+	if err := backend.AutoMigrate(&AuthProvider{}); err != nil {
+		log.Fatal().Msgf("Failed to AutoMigrate table (auth_providers): %v", err)
+	}
+	return m
+}
+
+// FieldType is the input kind the frontend should render.
+type FieldType string
+
+const (
+	FieldString   FieldType = "string"
+	FieldPassword FieldType = "password"
+	FieldBoolean  FieldType = "boolean"
+	FieldSelect   FieldType = "select"
+	FieldInteger  FieldType = "integer"
+	FieldText     FieldType = "text" // multiline
+)
+
+// FieldSpec describes one configurable field of a provider type.
+type FieldSpec struct {
+	Name        string
+	Label       string
+	Type        FieldType
+	Required    bool
+	Secret      bool
+	Placeholder string
+	Help        string
+	Options     []string
+	Default     any
+}
+
+// ProviderSpec describes one supported provider type in the Registry.
+type ProviderSpec struct {
+	Type         string
+	Description  string
+	HasSecret    bool
+	SecretFields []string
+	Fields       []FieldSpec
+	// Decode unmarshals raw JSON Config into the typed config struct.
+	Decode func(json.RawMessage) (any, error)
+	// Build instantiates an auth.Provider from a decoded config.
+	// The context is used for IdP discovery/metadata fetch.
+	Build func(any, context.Context) (auth.Provider, error)
+}
+
+// Registry maps each provider type to its ProviderSpec.
+var Registry = map[string]ProviderSpec{
+	config.AuthOIDC: {
+		Type:         config.AuthOIDC,
+		Description:  "OpenID Connect (OAuth2 + OIDC Core). Multi-provider: one button per enabled row.",
+		HasSecret:    true,
+		SecretFields: []string{"ClientSecret"},
+		Fields: []FieldSpec{
+			{Name: "IssuerURL", Label: "Issuer URL", Type: FieldString, Required: true, Placeholder: "https://keycloak.example.com/realms/myrealm", Help: "OIDC issuer URL. The provider does discovery against /.well-known/openid-configuration."},
+			{Name: "ClientID", Label: "Client ID", Type: FieldString, Required: true, Placeholder: "osctrl-client"},
+			{Name: "ClientSecret", Label: "Client secret", Type: FieldPassword, Secret: true, Placeholder: "prefer env vars/secrets in prod", Help: "OIDC client secret. Required unless UsePKCE is true."},
+			{Name: "RedirectURL", Label: "Redirect URL", Type: FieldString, Required: true, Placeholder: "https://osctrl.example.com:8444/api/v1/auth/oidc/{id}/callback", Help: "Callback URL registered with the IdP. {id} is replaced with the provider row ID at runtime."},
+			{Name: "Scopes", Label: "Scopes", Type: FieldString, Placeholder: "openid,profile,email", Help: "Comma-separated. 'openid' is always prepended if absent."},
+			{Name: "UsernameClaim", Label: "Username claim", Type: FieldSelect, Options: []string{"preferred_username", "email", "sub"}, Default: "preferred_username", Help: "OIDC claim used as the AdminUser.Username."},
+			{Name: "GroupsClaim", Label: "Groups claim", Type: FieldString, Placeholder: "groups", Help: "OIDC claim consulted for group membership."},
+			{Name: "RequiredGroups", Label: "Required groups", Type: FieldString, Placeholder: "osctrl-admins", Help: "Comma-separated. At least one must be present for login to succeed. Empty disables the gate."},
+			{Name: "JITProvision", Label: "JIT provision", Type: FieldBoolean, Default: false, Help: "Auto-create an AdminUser on first successful login."},
+			{Name: "UsePKCE", Label: "Use PKCE", Type: FieldBoolean, Default: false, Help: "Enable PKCE (RFC 7636). Recommended for public clients."},
+		},
+		Decode: decodeOIDCConfig,
+		Build:  buildOIDCProvider,
+	},
+	config.AuthSAML: {
+		Type:         config.AuthSAML,
+		Description:  "SAML 2.0 Web Browser SSO. SP signing keys auto-generated when not provided.",
+		HasSecret:    true,
+		SecretFields: []string{"SigningKeyPEM"},
+		Fields: []FieldSpec{
+			{Name: "IDPMetadataURL", Label: "IdP metadata URL", Type: FieldString, Placeholder: "https://idp.example.com/metadata", Help: "IdP's published SAML metadata document URL. One of URL or XML below is required."},
+			{Name: "IDPMetadataXML", Label: "IdP metadata XML", Type: FieldText, Placeholder: "<EntityDescriptor ...>", Help: "Inline IdP metadata XML (air-gapped deployments). Mutually exclusive with URL."},
+			{Name: "EntityID", Label: "Entity ID", Type: FieldString, Required: true, Placeholder: "https://osctrl.example.com:8444/api/v1/auth/saml/{id}/metadata", Help: "SP entity identifier. {id} is replaced at runtime."},
+			{Name: "ACSURL", Label: "ACS URL", Type: FieldString, Required: true, Placeholder: "https://osctrl.example.com:8444/api/v1/auth/saml/{id}/acs", Help: "Assertion Consumer Service URL. {id} is replaced at runtime."},
+			{Name: "UsernameAttribute", Label: "Username attribute", Type: FieldString, Placeholder: "", Help: "SAML attribute whose value becomes the username. Empty = use NameID."},
+			{Name: "GroupsAttribute", Label: "Groups attribute", Type: FieldString, Placeholder: "groups", Help: "SAML attribute carrying group memberships."},
+			{Name: "RequiredGroups", Label: "Required groups", Type: FieldString, Placeholder: "osctrl-admins", Help: "Comma-separated. Empty disables the gate."},
+			{Name: "JITProvision", Label: "JIT provision", Type: FieldBoolean, Default: false, Help: "Auto-create an AdminUser on first successful login."},
+			{Name: "SigningCertPEM", Label: "SP signing cert (PEM)", Type: FieldText, Placeholder: "-----BEGIN CERTIFICATE-----", Help: "Optional. Leave empty to auto-generate a self-signed keypair."},
+			{Name: "SigningKeyPEM", Label: "SP signing key (PEM)", Type: FieldPassword, Secret: true, Placeholder: "-----BEGIN RSA PRIVATE KEY-----", Help: "Optional. Leave empty to auto-generate."},
+			{Name: "ForceAuthn", Label: "Force Authn", Type: FieldBoolean, Default: true, Help: "Re-prompt for credentials even if IdP SSO cookie is alive."},
+			{Name: "RequireAssertionSigned", Label: "Require signed assertion", Type: FieldBoolean, Default: true, Help: "Must be true for production (threat S2 defense)."},
+			{Name: "ReplayWindow", Label: "Replay window (min)", Type: FieldInteger, Default: 5, Help: "Maximum clock skew on NotBefore/NotOnOrAfter checks."},
+		},
+		Decode: decodeSAMLConfig,
+		Build:  buildSAMLProvider,
+	},
+}
+
+// SupportedTypes returns the Registry keys in sorted order.
+func SupportedTypes() []string {
+	types := make([]string, 0, len(Registry))
+	for k := range Registry {
+		types = append(types, k)
+	}
+	for i := 1; i < len(types); i++ {
+		for j := i; j > 0 && types[j-1] > types[j]; j-- {
+			types[j-1], types[j] = types[j], types[j-1]
+		}
+	}
+	return types
+}
+
+// ValidateType reports whether the provider type is registered.
+func ValidateType(typ string) bool {
+	_, ok := Registry[strings.ToLower(strings.TrimSpace(typ))]
+	return ok
+}
+
+// --- decode functions ---
+
+func decodeOIDCConfig(raw json.RawMessage) (any, error) {
+	var c authoidc.Config
+	if len(raw) == 0 || string(raw) == "null" {
+		return &c, nil
+	}
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("decode oidc config: %w", err)
+	}
+	// Scopes may come as a comma-separated string from the form.
+	// The oidc.Config expects []string. Handle both shapes.
+	if len(c.Scopes) == 0 {
+		var rawScopes struct {
+			Scopes string `json:"Scopes"`
+		}
+		_ = json.Unmarshal(raw, &rawScopes)
+		if rawScopes.Scopes != "" {
+			for _, s := range strings.Split(rawScopes.Scopes, ",") {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					c.Scopes = append(c.Scopes, s)
+				}
+			}
+		}
+	}
+	// RequiredGroups may come as comma-separated string.
+	if len(c.RequiredGroups) == 0 {
+		var rawGroups struct {
+			RequiredGroups string `json:"RequiredGroups"`
+		}
+		_ = json.Unmarshal(raw, &rawGroups)
+		if rawGroups.RequiredGroups != "" {
+			for _, g := range strings.Split(rawGroups.RequiredGroups, ",") {
+				g = strings.TrimSpace(g)
+				if g != "" {
+					c.RequiredGroups = append(c.RequiredGroups, g)
+				}
+			}
+		}
+	}
+	return &c, nil
+}
+
+func decodeSAMLConfig(raw json.RawMessage) (any, error) {
+	var c authsaml.Config
+	if len(raw) == 0 || string(raw) == "null" {
+		return &c, nil
+	}
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("decode saml config: %w", err)
+	}
+	// RequiredGroups may come as comma-separated string.
+	if len(c.RequiredGroups) == 0 {
+		var rawGroups struct {
+			RequiredGroups string `json:"RequiredGroups"`
+		}
+		_ = json.Unmarshal(raw, &rawGroups)
+		if rawGroups.RequiredGroups != "" {
+			for _, g := range strings.Split(rawGroups.RequiredGroups, ",") {
+				g = strings.TrimSpace(g)
+				if g != "" {
+					c.RequiredGroups = append(c.RequiredGroups, g)
+				}
+			}
+		}
+	}
+	// RequireAssertionSigned defaults to true.
+	if !c.RequireAssertionSigned {
+		// Check if it was explicitly set to false or just zero.
+		// We always force it to true for security — Validate() rejects false anyway.
+		c.RequireAssertionSigned = true
+	}
+	return &c, nil
+}
+
+// --- build functions ---
+
+func buildOIDCProvider(cfg any, ctx context.Context) (auth.Provider, error) {
+	return authoidc.NewOIDCProvider(ctx, *cfg.(*authoidc.Config))
+}
+
+func buildSAMLProvider(cfg any, ctx context.Context) (auth.Provider, error) {
+	return authsaml.NewSAMLProvider(ctx, *cfg.(*authsaml.Config))
+}
+
+// --- errors ---
+
+var (
+	ErrProviderNotFound      = errors.New("auth provider not found")
+	ErrInvalidProviderType   = errors.New("invalid auth provider type")
+	ErrInvalidProviderConfig = errors.New("invalid auth provider configuration")
+)
+
+// --- CRUD ---
+
+func normalizeType(typ string) string {
+	return strings.ToLower(strings.TrimSpace(typ))
+}
+
+func normalizeName(name string) string {
+	return strings.TrimSpace(name)
+}
+
+func validateConfig(typ, cfgJSON string) (any, error) {
+	spec, ok := Registry[typ]
+	if !ok {
+		return nil, ErrInvalidProviderType
+	}
+	raw := json.RawMessage(cfgJSON)
+	if len(raw) == 0 {
+		raw = json.RawMessage(`null`)
+	}
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("%w: not valid JSON", ErrInvalidProviderConfig)
+	}
+	decoded, err := spec.Decode(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidProviderConfig, err)
+	}
+	return decoded, nil
+}
+
+func ValidateProvider(name, typ, cfgJSON string) error {
+	if normalizeName(name) == "" {
+		return fmt.Errorf("provider name is required")
+	}
+	t := normalizeType(typ)
+	if !ValidateType(t) {
+		return fmt.Errorf("%w: %q", ErrInvalidProviderType, typ)
+	}
+	if _, err := validateConfig(t, cfgJSON); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Create inserts a new provider row.
+func (m *AuthProviderManager) Create(name, typ string, enabled bool, cfgJSON string, info string) (AuthProvider, error) {
+	name = normalizeName(name)
+	typ = normalizeType(typ)
+	if err := ValidateProvider(name, typ, cfgJSON); err != nil {
+		return AuthProvider{}, err
+	}
+	row := AuthProvider{
+		Name:    name,
+		Type:    typ,
+		Enabled: enabled,
+		Config:  cfgJSON,
+		Source:  SourceDB,
+		Info:    info,
+	}
+	if err := m.DB.Create(&row).Error; err != nil {
+		return AuthProvider{}, fmt.Errorf("create auth provider: %w", err)
+	}
+	return row, nil
+}
+
+// Update replaces an existing provider row's mutable fields.
+func (m *AuthProviderManager) Update(id uint, name, typ string, enabled bool, cfgJSON string, info string) (AuthProvider, error) {
+	name = normalizeName(name)
+	typ = normalizeType(typ)
+	if err := ValidateProvider(name, typ, cfgJSON); err != nil {
+		return AuthProvider{}, err
+	}
+	row, err := m.Get(id)
+	if err != nil {
+		return AuthProvider{}, err
+	}
+	if err := m.DB.Model(&row).Updates(map[string]any{
+		"name":    name,
+		"type":    typ,
+		"enabled": enabled,
+		"config":  cfgJSON,
+		"info":    info,
+		"source":  SourceDB,
+	}).Error; err != nil {
+		return AuthProvider{}, fmt.Errorf("update auth provider: %w", err)
+	}
+	return m.Get(id)
+}
+
+// Get retrieves one provider by ID.
+func (m *AuthProviderManager) Get(id uint) (AuthProvider, error) {
+	var row AuthProvider
+	if err := m.DB.First(&row, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return AuthProvider{}, ErrProviderNotFound
+		}
+		return AuthProvider{}, err
+	}
+	return row, nil
+}
+
+// Delete removes a provider by ID.
+func (m *AuthProviderManager) Delete(id uint) error {
+	res := m.DB.Delete(&AuthProvider{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrProviderNotFound
+	}
+	return nil
+}
+
+// List returns all providers.
+func (m *AuthProviderManager) List() ([]AuthProvider, error) {
+	var rows []AuthProvider
+	if err := m.DB.Order("\"type\" ASC, name ASC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// ListEnabled returns all enabled providers.
+func (m *AuthProviderManager) ListEnabled() ([]AuthProvider, error) {
+	var rows []AuthProvider
+	if err := m.DB.Where("enabled = ?", true).Order("\"type\" ASC, name ASC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// RevertToService flips a row's Source from "db" back to "service".
+func (m *AuthProviderManager) RevertToService(id uint) error {
+	row, err := m.Get(id)
+	if err != nil {
+		return err
+	}
+	if row.Source != SourceDB {
+		return nil
+	}
+	if err := m.DB.Model(&row).Update("source", SourceService).Error; err != nil {
+		return fmt.Errorf("revert auth provider %d: %w", id, err)
+	}
+	return nil
+}
+
+// --- seed ---
+
+// Seed translates the resolved service configuration (OIDC and SAML
+// sections) into AuthProvider rows using create-if-missing semantics.
+func (m *AuthProviderManager) Seed(params *config.ServiceParameters) error {
+	if params.OIDC != nil && params.OIDC.Enabled {
+		cfg, err := oidcConfigFromYAML(params.OIDC)
+		if err != nil {
+			return err
+		}
+		cfgJSON, _ := json.Marshal(cfg)
+		row := AuthProvider{
+			Name:    "seeded-oidc",
+			Type:    config.AuthOIDC,
+			Enabled: true,
+			Config:  string(cfgJSON),
+			Source:  SourceService,
+			Info:    "Seeded from service configuration",
+		}
+		if err := m.seedRow(&row); err != nil {
+			return err
+		}
+	}
+	if params.SAML != nil && params.SAML.Enabled {
+		cfg := samlConfigFromYAML(params.SAML)
+		cfgJSON, _ := json.Marshal(cfg)
+		row := AuthProvider{
+			Name:    "seeded-saml",
+			Type:    config.AuthSAML,
+			Enabled: true,
+			Config:  string(cfgJSON),
+			Source:  SourceService,
+			Info:    "Seeded from service configuration",
+		}
+		if err := m.seedRow(&row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func oidcConfigFromYAML(y *config.YAMLConfigurationOIDC) (authoidc.Config, error) {
+	return authoidc.Config{
+		IssuerURL:      y.IssuerURL,
+		ClientID:       y.ClientID,
+		ClientSecret:   y.ClientSecret,
+		RedirectURL:    y.RedirectURL,
+		Scopes:         y.Scopes,
+		UsernameClaim:  y.UsernameClaim,
+		GroupsClaim:    y.GroupsClaim,
+		RequiredGroups: y.RequiredGroups,
+		JITProvision:   y.JITProvision,
+		UsePKCE:        y.UsePKCE,
+	}, nil
+}
+
+func samlConfigFromYAML(y *config.YAMLConfigurationSAML) authsaml.Config {
+	return authsaml.Config{
+		IDPMetadataURL:         y.MetaDataURL,
+		EntityID:               y.EntityID,
+		ACSURL:                 y.ACSURL,
+		UsernameAttribute:      y.UsernameAttribute,
+		JITProvision:           y.JITProvision,
+		ForceAuthn:             y.ForceAuthn,
+		SigningCertPath:        y.SigningCertPath,
+		SigningKeyPath:         y.SigningKeyPath,
+		RequireAssertionSigned: true,
+	}
+}
+
+// seedRow creates a row only if it doesn't exist, then syncs config
+// for existing non-DB-edited rows.
+func (m *AuthProviderManager) seedRow(row *AuthProvider) error {
+	if err := m.DB.Clauses(clause.OnConflict{DoNothing: true}).Create(row).Error; err != nil {
+		return fmt.Errorf("seed row %q: %w", row.Name, err)
+	}
+	if err := m.DB.Model(&AuthProvider{}).
+		Where("name = ? AND (source = ? OR source = ?)",
+			row.Name, SourceService, SourceYAML).
+		Updates(map[string]any{
+			"config": row.Config,
+			"type":   row.Type,
+			"info":   row.Info,
+		}).Error; err != nil {
+		return fmt.Errorf("sync seed row %q: %w", row.Name, err)
+	}
+	return nil
+}
+
+// --- build providers from DB ---
+
+// ProviderEntry is one built provider with its metadata.
+type ProviderEntry struct {
+	ID           uint
+	Name         string
+	Type         string
+	Provider     auth.Provider
+	JITProvision bool
+	ClientID     string // OIDC only
+	LogoutURL    string // SAML only
+}
+
+// BuildProviders reads all enabled rows, builds live auth.Provider
+// instances, and returns them. Fail-fast: if any enabled provider's
+// Build fails, the error is returned so the caller can log.Fatal.
+func (m *AuthProviderManager) BuildProviders(ctx context.Context) ([]ProviderEntry, error) {
+	rows, err := m.ListEnabled()
+	if err != nil {
+		return nil, err
+	}
+	var entries []ProviderEntry
+	for _, row := range rows {
+		spec, ok := Registry[row.Type]
+		if !ok {
+			return nil, fmt.Errorf("unknown provider type %q for row %q", row.Type, row.Name)
+		}
+		decoded, err := spec.Decode(json.RawMessage(row.Config))
+		if err != nil {
+			return nil, fmt.Errorf("decode config for %q: %w", row.Name, err)
+		}
+		// Expand {id} in SAML URLs with the actual row ID.
+		if row.Type == config.AuthSAML {
+			if cfg, ok := decoded.(*authsaml.Config); ok {
+				cfg.EntityID = strings.ReplaceAll(cfg.EntityID, "{id}", fmt.Sprintf("%d", row.ID))
+				cfg.ACSURL = strings.ReplaceAll(cfg.ACSURL, "{id}", fmt.Sprintf("%d", row.ID))
+			}
+		}
+		if row.Type == config.AuthOIDC {
+			if cfg, ok := decoded.(*authoidc.Config); ok {
+				cfg.RedirectURL = strings.ReplaceAll(cfg.RedirectURL, "{id}", fmt.Sprintf("%d", row.ID))
+			}
+		}
+		p, err := spec.Build(decoded, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("build provider %q: %w", row.Name, err)
+		}
+		entry := ProviderEntry{
+			ID:       row.ID,
+			Name:     row.Name,
+			Type:     row.Type,
+			Provider: p,
+		}
+		// Extract type-specific fields for the handlers.
+		if cfg, ok := decoded.(*authoidc.Config); ok {
+			entry.JITProvision = cfg.JITProvision
+			entry.ClientID = cfg.ClientID
+		}
+		if cfg, ok := decoded.(*authsaml.Config); ok {
+			entry.JITProvision = cfg.JITProvision
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+// --- redaction ---
+
+// RedactedConfig replaces secret fields with "***" for the provider Type.
+func RedactedConfig(typ, cfgJSON string) string {
+	spec, ok := Registry[typ]
+	if !ok || !spec.HasSecret || len(spec.SecretFields) == 0 {
+		return cfgJSON
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(cfgJSON), &obj); err != nil {
+		return cfgJSON
+	}
+	for _, key := range spec.SecretFields {
+		if _, present := obj[key]; present {
+			obj[key] = "***"
+		}
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return cfgJSON
+	}
+	return string(out)
+}
+
+// MergeSecrets replaces "***" placeholders with values from prev.
+func MergeSecrets(typ, prevJSON, newJSON string) (string, error) {
+	spec, ok := Registry[typ]
+	if !ok || !spec.HasSecret || len(spec.SecretFields) == 0 {
+		return newJSON, nil
+	}
+	var prev, next map[string]any
+	if err := json.Unmarshal([]byte(prevJSON), &prev); err != nil {
+		return "", fmt.Errorf("decode prev config: %w", err)
+	}
+	if err := json.Unmarshal([]byte(newJSON), &next); err != nil {
+		return "", fmt.Errorf("decode new config: %w", err)
+	}
+	for _, key := range spec.SecretFields {
+		v, ok := next[key]
+		if !ok {
+			continue
+		}
+		s, isStr := v.(string)
+		if !isStr {
+			continue
+		}
+		if s == "***" || s == "" {
+			if pv, pok := prev[key]; pok {
+				next[key] = pv
+			}
+		}
+	}
+	out, err := json.Marshal(next)
+	if err != nil {
+		return "", fmt.Errorf("encode merged config: %w", err)
+	}
+	return string(out), nil
+}
+
+// --- test helper: persist auto-generated SAML keys back to DB ---
+
+// PersistGeneratedSAMLKeys checks if a SAML provider row has
+// auto-generated signing keys (both SigningCertPEM and SigningKeyPEM
+// empty). After Build, the SAML provider has generated keys in
+// memory. This function marshals the generated PEM back into the
+// config JSON so the keys are stable across reloads. It only writes
+// when the row's Source is NOT "db" (seed rows get the keys pinned;
+// operator-edited rows keep whatever the operator set).
+func (m *AuthProviderManager) PersistGeneratedSAMLKeys(row AuthProvider, certPEM, keyPEM string) error {
+	if row.Type != config.AuthSAML || (certPEM == "" && keyPEM == "") {
+		return nil
+	}
+	var cfg authsaml.Config
+	if err := json.Unmarshal([]byte(row.Config), &cfg); err != nil {
+		return fmt.Errorf("unmarshal saml config: %w", err)
+	}
+	if cfg.SigningCertPEM != "" || cfg.SigningKeyPEM != "" {
+		return nil // operator provided their own PEM
+	}
+	cfg.SigningCertPEM = certPEM
+	cfg.SigningKeyPEM = keyPEM
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal saml config with keys: %w", err)
+	}
+	return m.DB.Model(&AuthProvider{}).
+		Where("id = ? AND (source = ? OR source = ?)", row.ID, SourceService, SourceYAML).
+		Update("config", string(cfgJSON)).Error
+}

--- a/pkg/authproviders/authproviders_test.go
+++ b/pkg/authproviders/authproviders_test.go
@@ -1,0 +1,183 @@
+package authproviders
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestManager(t *testing.T) *AuthProviderManager {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&AuthProvider{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return &AuthProviderManager{DB: db}
+}
+
+func TestRegistryCoversOIDCAndSAML(t *testing.T) {
+	if _, ok := Registry[config.AuthOIDC]; !ok {
+		t.Error("Registry missing oidc")
+	}
+	if _, ok := Registry[config.AuthSAML]; !ok {
+		t.Error("Registry missing saml")
+	}
+}
+
+func TestCreateAndRoundTrip(t *testing.T) {
+	m := newTestManager(t)
+	row, err := m.Create("test-oidc", config.AuthOIDC, true, `{"IssuerURL":"https://idp","ClientID":"c","ClientSecret":"s","RedirectURL":"https://osctrl/callback"}`, "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if row.Source != SourceDB {
+		t.Errorf("source: got %q want %q", row.Source, SourceDB)
+	}
+	got, err := m.Get(row.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "test-oidc" || got.Type != config.AuthOIDC || !got.Enabled {
+		t.Fatalf("wrong row: %+v", got)
+	}
+}
+
+func TestCreateRejectsInvalidType(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("bad", "nope", true, `{}`, ""); !errors.Is(err, ErrInvalidProviderType) {
+		t.Fatalf("bad type: got %v want ErrInvalidProviderType", err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	m := newTestManager(t)
+	row, _ := m.Create("s", config.AuthOIDC, true, `{"IssuerURL":"https://i","ClientID":"c","ClientSecret":"s","RedirectURL":"https://r"}`, "")
+	if err := m.Delete(row.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := m.Delete(row.ID); !errors.Is(err, ErrProviderNotFound) {
+		t.Fatalf("re-delete: got %v want ErrProviderNotFound", err)
+	}
+}
+
+func TestRevertToService(t *testing.T) {
+	m := newTestManager(t)
+	row, _ := m.Create("s", config.AuthOIDC, true, `{"IssuerURL":"https://i","ClientID":"c","ClientSecret":"s","RedirectURL":"https://r"}`, "")
+	if row.Source != SourceDB {
+		t.Fatalf("source: got %q want %q", row.Source, SourceDB)
+	}
+	if err := m.RevertToService(row.ID); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	got, _ := m.Get(row.ID)
+	if got.Source != SourceService {
+		t.Fatalf("after revert: source=%q want %q", got.Source, SourceService)
+	}
+	// Idempotent
+	if err := m.RevertToService(row.ID); err != nil {
+		t.Fatalf("revert again: %v", err)
+	}
+	// Missing
+	if err := m.RevertToService(99999); !errors.Is(err, ErrProviderNotFound) {
+		t.Fatalf("revert missing: got %v want ErrProviderNotFound", err)
+	}
+}
+
+func TestRedactedConfigMasksSecrets(t *testing.T) {
+	cfg := `{"IssuerURL":"https://idp","ClientID":"c","ClientSecret":"supersecret","RedirectURL":"https://r"}`
+	got := RedactedConfig(config.AuthOIDC, cfg)
+	var obj map[string]any
+	_ = json.Unmarshal([]byte(got), &obj)
+	if obj["ClientSecret"] != "***" {
+		t.Errorf("secret not redacted: got %v", obj["ClientSecret"])
+	}
+	if obj["IssuerURL"] != "https://idp" {
+		t.Errorf("non-secret changed: %v", obj["IssuerURL"])
+	}
+}
+
+func TestMergeSecretsReplacesPlaceholder(t *testing.T) {
+	prev := `{"IssuerURL":"https://idp","ClientID":"c","ClientSecret":"real-secret","RedirectURL":"https://r"}`
+	next := `{"IssuerURL":"https://idp2","ClientID":"c2","ClientSecret":"***","RedirectURL":"https://r2"}`
+	got, err := MergeSecrets(config.AuthOIDC, prev, next)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	var obj map[string]any
+	_ = json.Unmarshal([]byte(got), &obj)
+	if obj["ClientSecret"] != "real-secret" {
+		t.Errorf("secret not restored: got %v", obj["ClientSecret"])
+	}
+	if obj["IssuerURL"] != "https://idp2" {
+		t.Errorf("non-secret clobbered: %v", obj["IssuerURL"])
+	}
+}
+
+func TestSeedCreatesOIDCRow(t *testing.T) {
+	m := newTestManager(t)
+	params := &config.ServiceParameters{
+		OIDC: &config.YAMLConfigurationOIDC{
+			Enabled:      true,
+			IssuerURL:    "https://idp.example.com",
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			RedirectURL:  "https://osctrl/callback",
+		},
+	}
+	if err := m.Seed(params); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rows, _ := m.List()
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1", len(rows))
+	}
+	if rows[0].Type != config.AuthOIDC {
+		t.Errorf("type: got %q want %q", rows[0].Type, config.AuthOIDC)
+	}
+	if rows[0].Source != SourceService {
+		t.Errorf("source: got %q want %q", rows[0].Source, SourceService)
+	}
+}
+
+func TestSeedDoesNotCreateDisabledOIDC(t *testing.T) {
+	m := newTestManager(t)
+	params := &config.ServiceParameters{
+		OIDC: &config.YAMLConfigurationOIDC{Enabled: false},
+	}
+	if err := m.Seed(params); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rows, _ := m.List()
+	if len(rows) != 0 {
+		t.Fatalf("got %d rows want 0", len(rows))
+	}
+}
+
+func TestSeedIdempotent(t *testing.T) {
+	m := newTestManager(t)
+	params := &config.ServiceParameters{
+		OIDC: &config.YAMLConfigurationOIDC{Enabled: true, IssuerURL: "https://i", ClientID: "c", ClientSecret: "s", RedirectURL: "https://r"},
+	}
+	if err := m.Seed(params); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	if err := m.Seed(params); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+	rows, _ := m.List()
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1 (idempotent)", len(rows))
+	}
+}

--- a/pkg/servicecommands/servicecommands.go
+++ b/pkg/servicecommands/servicecommands.go
@@ -26,6 +26,11 @@ const (
 	// during the swap; the old sinks are closed immediately after the
 	// new set is live.
 	ActionReloadLogSinks = "reload-log-sinks"
+	// ActionReloadAuthProviders asks osctrl-api to rebuild its
+	// auth provider registry from the auth_providers table and swap
+	// it in without restarting. Users mid-login may see a transient
+	// error and can retry.
+	ActionReloadAuthProviders = "reload-auth-providers"
 
 	StatusPending   = "pending"
 	StatusConsumed  = "consumed"
@@ -42,9 +47,10 @@ var (
 // not listed here is rejected at request time, so a row in the table can
 // never name an action the consumer does not recognise.
 var validActions = map[string]struct{}{
-	ActionRestart:        {},
-	ActionPersistConfig:  {},
-	ActionReloadLogSinks: {},
+	ActionRestart:             {},
+	ActionPersistConfig:       {},
+	ActionReloadLogSinks:      {},
+	ActionReloadAuthProviders: {},
 }
 
 // ServiceCommand is a one-shot control request for another osctrl service.

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -92,8 +92,10 @@ var SectionRegistry = map[string][]SectionSpec{
 		{"db", false, "Backend connection — not DB-editable"},
 		{"redis", false, "Redis connection — not DB-editable"},
 		{"osquery", true, "osquery tables and feature toggles"},
-		{"saml", false, "SAML federated login configuration — not DB-editable"},
-		{"oidc", false, "OIDC federated login configuration — not DB-editable"},
+		// "saml" and "oidc" are now managed by pkg/authproviders and
+		// are intentionally absent from this registry. Existing
+		// service_config rows named "saml"/"oidc" are left in place
+		// and ignored.
 		{"jwt", false, "JWT signing configuration — not DB-editable"},
 		{"tls", false, "TLS termination certificate/key paths — not DB-editable"},
 		// See the TLS registry: the "logger" section is now managed by

--- a/pkg/serviceconfig/serviceconfig_test.go
+++ b/pkg/serviceconfig/serviceconfig_test.go
@@ -204,13 +204,14 @@ func TestSeed_ServiceSpecificSections(t *testing.T) {
 	apiNames := sectionNames(apiRows)
 	tlsNames := sectionNames(tlsRows)
 
-	assert.Contains(t, apiNames, "saml")
-	assert.Contains(t, apiNames, "oidc")
 	assert.Contains(t, apiNames, "jwt")
 	assert.Contains(t, apiNames, "rateLimits")
 	assert.NotContains(t, apiNames, "batchWriter")
 	assert.NotContains(t, apiNames, "metrics")
 	assert.NotContains(t, apiNames, "osctrld")
+	// saml and oidc are now managed by pkg/authproviders
+	assert.NotContains(t, apiNames, "saml")
+	assert.NotContains(t, apiNames, "oidc")
 
 	assert.Contains(t, tlsNames, "batchWriter")
 	assert.Contains(t, tlsNames, "configEndpoints")
@@ -275,8 +276,11 @@ func TestVerifyServiceAndSection(t *testing.T) {
 	// "logger" is no longer registered (managed by pkg/logsinks); use
 	// "osquery" and "metrics" as the representative registered sections.
 	assert.True(t, m.VerifySection(config.ServiceTLS, "osquery"))
-	assert.True(t, m.VerifySection(config.ServiceAPI, "saml"))
-	assert.False(t, m.VerifySection(config.ServiceTLS, "saml"))
+	assert.True(t, m.VerifySection(config.ServiceAPI, "jwt"))
+	assert.False(t, m.VerifySection(config.ServiceTLS, "jwt"))
+	// "saml" and "oidc" are now managed by pkg/authproviders
+	assert.False(t, m.VerifySection(config.ServiceAPI, "saml"))
+	assert.False(t, m.VerifySection(config.ServiceAPI, "oidc"))
 	assert.False(t, m.VerifySection(config.ServiceAPI, "metrics"))
 	assert.False(t, m.VerifySection("bogus", "osquery"))
 }


### PR DESCRIPTION
# DB-backed, frontend-editable authentication providers with auto-generated SAML keys

## Problem

SAML and OIDC providers were configured exclusively via YAML/flags/env
vars. The `saml` and `oidc` sections in `serviceconfig.SectionRegistry`
were explicitly marked non-editable. Changing an IdP issuer URL, client
secret, or metadata URL required editing the config file and restarting
`osctrl-api`. This was the same problem log sinks had before the
`pkg/logsinks` refactor — the last major subsystem without a DB/frontend
story.

## Solution

Replace the YAML-only auth provider configuration with a DB-backed,
frontend-editable system that supports multiple OIDC and SAML providers,
auto-generated SAML signing keys (no files on disk), a dynamic typed
form (no raw JSON), IdP metadata fetch, connection testing, and
first-run admin bootstrap via JIT provisioning.

## Architecture

### New package: `pkg/authproviders`

- **`AuthProvider` model** (`auth_providers` table): one row per IdP
  configuration. Fields: `Name`, `Type` (oidc/saml), `Enabled`, `Config`
  (JSON), `Source` (service/db), `Info`. Global — not tied to
  environments. Multiple rows of the same type are allowed and expected.
- **`Registry`**: maps `oidc` and `saml` to `ProviderSpec` with typed
  field schema, decode, and build functions. OIDC has 10 fields
  (`IssuerURL`, `ClientID`, `ClientSecret` (secret), `RedirectURL`,
  `Scopes`, `UsernameClaim` (select), `GroupsClaim`, `RequiredGroups`,
  `JITProvision`, `UsePKCE`). SAML has 13 fields including
  `IDPMetadataURL`, `IDPMetadataXML` (multiline text), `SigningCertPEM`
  (multiline text), `SigningKeyPEM` (secret), `ForceAuthn`,
  `RequireAssertionSigned`, `ReplayWindow`.
- **CRUD**: `Create`, `Update` (with secret merge), `Get`, `Delete`,
  `List`, `ListEnabled`, `RevertToService`.
- **`Seed(params)`**: translates `flagParams.OIDC` and `flagParams.SAML`
  into rows (create-if-missing, only when `Enabled=true`). Stale seed
  rows synced; operator-edited rows never overwritten. Idempotent.
- **`BuildProviders(ctx)`**: reads enabled rows, decodes configs,
  expands `{id}` placeholders in URLs, calls `oidc.NewOIDCProvider` or
  `saml.NewSAMLProvider`. Fail-fast on IdP unreachable.
- **Redaction/Merge**: `ClientSecret` (OIDC) and `SigningKeyPEM` (SAML)
  redacted to `"***"`, merged on edit.
- **Tests**: 9 tests covering CRUD, revert, redaction, merge, seed
  (enabled/disabled/idempotent).

### SAML provider: auto-generated signing keys

`pkg/auth/saml/config.go` gained `SigningCertPEM` and `SigningKeyPEM`
fields (inline PEM stored in DB config JSON — no files on disk needed).
`pkg/auth/saml/provider.go` now:
- Accepts inline PEM bytes via `parseSPKeyPair` (no `os.ReadFile`).
- Auto-generates a self-signed RSA 2048-bit keypair with 10-year
  validity via `generateSPKeyPair` when no signing material is provided.
- Still supports legacy file paths (`SigningCertPath`/`SigningKeyPath`)
  for backwards compat.

### API handlers

`cmd/api/handlers/auth_providers.go`: full CRUD + types + test + apply +
revert + fetch-metadata. All admin-only, audit-logged, gated by
`serviceConfigEnabled`.

| Method | Route | Purpose |
|---|---|---|
| `GET` | `/api/v1/auth-providers` | List (secrets redacted) |
| `GET` | `/api/v1/auth-providers/types` | Registry: type, description, field schema |
| `GET` | `/api/v1/auth-providers/{id}?reveal={0\|1}` | One provider |
| `POST` | `/api/v1/auth-providers` | Create |
| `PUT` | `/api/v1/auth-providers/{id}` | Update (secret merge) |
| `DELETE` | `/api/v1/auth-providers/{id}` | Delete |
| `POST` | `/api/v1/auth-providers/{id}/revert` | Revert to service config |
| `POST` | `/api/v1/auth-providers/test` | Test connection (body = config) |
| `POST` | `/api/v1/auth-providers/fetch-metadata` | Fetch IdP metadata XML from URL |
| `POST` | `/api/v1/auth-providers/apply` | Queue `reload-auth-providers` |

`cmd/api/handlers/auth_provider_registry.go`: `AuthProviderRegistry`
type — holds live providers, `Get(id)`, `AllByType(typ)`,
`AllProviders()`, `Replace(entries)` for hot-reload.

`cmd/api/handlers/auth_methods.go`: now returns a `providers[]` array
with `{type, name, id, loginUrl}` per enabled provider. Falls back to
legacy `OIDCEnabled`/`SAMLEnabled` booleans when the registry is nil.

### Service commands

New `ActionReloadAuthProviders = "reload-auth-providers"` — allowlisted
and validated.

### Service config

Dropped `saml` and `oidc` from `SectionRegistry` (both API entries). Now
owned by `pkg/authproviders`. Tests updated.

### JIT provisioning: first-run admin bootstrap

`cmd/api/handlers/auth_resolve.go:resolveFederatedUser`: when JIT
provision is enabled and the user doesn't exist, the function calls
`h.Users.CountAdmins()` before creating the new `AdminUser`:

- **Zero admin users exist** (first-run bootstrap): the new user is
  created with `admin=true`, so the operator can immediately manage the
  system after their first federated login.
- **One or more admin users already exist**: the new user is created
  with `admin=false` — an existing admin must promote them manually.
  This prevents a federated user from self-escalating to admin on a
  system that already has an operator.

The `admin=true` path is only reachable when `CountAdmins() == 0`, so
on any already-administered system JIT users are always non-admin. Five
tests cover both paths plus existing cases (JIT disabled, existing user
by name, local account claim rejection).

### Frontend

- **`frontend/src/api/auth-providers.ts`**: typed API client.
- **`frontend/src/features/auth-providers/AuthProvidersPage.tsx`**:
  full admin page — sticky header, table with per-type icons (key for
  OIDC, shield for SAML), two-step create flow (type picker → config
  form), dynamic typed form driven by the `/auth-providers/types` schema
  (no raw JSON — each field renders the appropriate input: text,
  password, checkbox, dropdown, multiline textarea), "Test connection"
  button, "Fetch metadata" button (fetches IdP XML from the URL field
  server-side, populates the XML textarea — avoids CORS issues), edit,
  delete, revert (for `source=db`), apply with confirm modal. Scrollable
  modal body for long forms.
- **`frontend/src/routes/_app/auth-providers.tsx`**: route.
- **`frontend/src/components/chrome/SideNav.tsx`**: nav entry with shield
  icon, gated on `features.auth_providers`.
- **`frontend/src/api/features.ts`**: `auth_providers` field added.

### Main.go wiring

`cmd/api/main.go`: seeds auth providers from `flagParams`, builds the
live `AuthProviderRegistry`, wires `WithAuthProviders(registry, mgr)`,
registers all routes (list, types, get, create, update, delete, revert,
test, fetch-metadata, apply).

### Dynamic typed form

The auth provider editor form is fully dynamic — no JSON textarea. Each
field from the `/auth-providers/types` schema renders the appropriate
input control based on its `type`:
- **`string`** → text input
- **`password`** → password input (for `ClientSecret`, `SigningKeyPEM`)
- **`boolean`** → checkbox (for `JITProvision`, `UsePKCE`, `ForceAuthn`,
  `RequireAssertionSigned`)
- **`select`** → dropdown (for `UsernameClaim`:
  preferred_username/email/sub)
- **`integer`** → number input (for `ReplayWindow`)
- **`text`** → multiline textarea (for `IDPMetadataXML`,
  `SigningCertPEM`)

The `buildConfig` helper converts the flat field-values map back into
the JSON object the API expects, with special handling for `Scopes` and
`RequiredGroups` (comma-separated string → `[]string`). Secret fields are
pre-filled from a reveal query when editing. Each input has `aria-label`
for accessibility.

### IdP metadata fetch

The "Fetch metadata" button appears directly below the "IdP metadata
URL" field in the SAML provider config form. When clicked:
1. Frontend calls `fetchIdPMetadata(url)` →
   `POST /api/v1/auth-providers/fetch-metadata` with the URL.
2. Backend fetches the XML from that URL server-side (30s timeout, 1 MiB
   cap, same limits as the SAML provider's own metadata fetch). This
   avoids CORS issues and works when the IdP is on a network the browser
   can't reach but the server can.
3. Frontend populates the `IDPMetadataXML` textarea field with the
   fetched XML, so the operator can review it before saving.

## Validation

- **Go**: 45 packages pass, 0 failures. New tests in
  `pkg/authproviders` (CRUD, revert, redaction, merge, seed),
  `cmd/api/handlers` (JIT admin bootstrap, JIT non-admin when admins
  exist, JIT disabled, existing user by name, local account claim).
- **Frontend**: 242 tests pass, type check clean.
- **OpenAPI**: spec regenerated and verified up to date.

## Files

**New** (8 files):
- `pkg/authproviders/authproviders.go` — model, registry, CRUD, seed,
  build, redaction, merge, revert
- `pkg/authproviders/authproviders_test.go` — 9 tests
- `cmd/api/handlers/auth_providers.go` — CRUD, types, test, apply,
  revert, fetch-metadata handlers
- `cmd/api/handlers/auth_provider_registry.go` —
  `AuthProviderRegistry` type
- `cmd/api/handlers/auth_resolve_test.go` — 5 JIT tests
- `frontend/src/api/auth-providers.ts` — typed API client
- `frontend/src/features/auth-providers/AuthProvidersPage.tsx` —
  full admin page with dynamic typed form
- `frontend/src/routes/_app/auth-providers.tsx` — route

**Modified** (10 files):
- `pkg/auth/saml/config.go` — `SigningCertPEM`/`SigningKeyPEM` fields
- `pkg/auth/saml/provider.go` — `parseSPKeyPair`,
  `generateSPKeyPair`, accept inline PEM
- `pkg/servicecommands/servicecommands.go` —
  `ActionReloadAuthProviders`
- `pkg/serviceconfig/serviceconfig.go` — drop saml/oidc from registry
- `pkg/serviceconfig/serviceconfig_test.go` — updated assertions
- `cmd/api/handlers/auth_methods.go` — return `providers[]` array
- `cmd/api/handlers/auth_resolve.go` — JIT admin bootstrap
- `cmd/api/handlers/handlers.go` — `WithAuthProviders`, registry field
- `cmd/api/handlers/features.go` — `auth_providers` flag
- `cmd/api/main.go` — seed, build, routes, fetch-metadata route
- `frontend/src/api/features.ts` — `auth_providers` field
- `frontend/src/components/chrome/SideNav.tsx` — nav entry
- `frontend/src/router.tsx` — route registration