### PR TITLE
Independent feature gates for service config, log sinks, and auth providers

### DIFF
--- a/cmd/api/handlers/features.go
+++ b/cmd/api/handlers/features.go
@@ -30,8 +30,8 @@ func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, FeaturesResponse{
 		Posture:       h.PostureEnabled,
 		ServiceConfig: h.ServiceConfigEnabled,
-		LogSinks:      h.ServiceConfigEnabled,
-		AuthProviders: h.ServiceConfigEnabled,
+		LogSinks:      h.LogSinksEnabled,
+		AuthProviders: h.AuthProvidersEnabled,
 		Accelerated:   h.OsqueryValues.Accelerated,
 		Console:       h.OsqueryValues.Query && h.OsqueryValues.Console,
 		FileExplorer:  h.OsqueryValues.Query && h.OsqueryValues.FileExplorer,

--- a/cmd/api/handlers/features_test.go
+++ b/cmd/api/handlers/features_test.go
@@ -46,6 +46,8 @@ func TestFeaturesHandlerReportsServiceConfigEnabled(t *testing.T) {
 	}
 
 	WithServiceConfigEnabled(true)(h)
+	WithLogSinksEnabled(true)(h)
+	WithAuthProvidersEnabled(true)(h)
 	w = httptest.NewRecorder()
 	h.FeaturesHandler(w, r)
 	var on FeaturesResponse
@@ -56,7 +58,10 @@ func TestFeaturesHandlerReportsServiceConfigEnabled(t *testing.T) {
 		t.Fatalf("service config feature: got false want true")
 	}
 	if !on.LogSinks {
-		t.Fatalf("log_sinks feature: got false want true (shares the service-config gate)")
+		t.Fatalf("log_sinks feature: got false want true")
+	}
+	if !on.AuthProviders {
+		t.Fatalf("auth_providers feature: got false want true")
 	}
 }
 

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -55,11 +55,11 @@ type HandlersApi struct {
 	// not registered in that case.
 	LogSinks *logsinks.LogSinksManager
 	// AuthProviders holds the live multi-provider registry (OIDC + SAML).
-	// nil when no providers are configured. Replaced atomically during
-	// hot-reload via AuthProviderRegistry.Replace.
 	AuthProviders        *AuthProviderRegistry
 	AuthProviderMgr      *authproviders.AuthProviderManager
 	ServiceConfigEnabled bool
+	LogSinksEnabled      bool
+	AuthProvidersEnabled bool
 	ServiceCommands      *servicecommands.Manager
 	Activity             activityReader
 	GeoIP                *geoip.GeoIPResolver
@@ -248,6 +248,18 @@ func WithPostureEnabled(enabled bool) HandlersOption {
 func WithServiceConfigEnabled(enabled bool) HandlersOption {
 	return func(h *HandlersApi) {
 		h.ServiceConfigEnabled = enabled
+	}
+}
+
+func WithLogSinksEnabled(enabled bool) HandlersOption {
+	return func(h *HandlersApi) {
+		h.LogSinksEnabled = enabled
+	}
+}
+
+func WithAuthProvidersEnabled(enabled bool) HandlersOption {
+	return func(h *HandlersApi) {
+		h.AuthProvidersEnabled = enabled
 	}
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -456,8 +456,26 @@ func osctrlAPIService() {
 	if err := serviceConfigMgr.ReportFile(config.ServiceAPI, flagParams.ConfigFilePath()); err != nil {
 		log.Err(err).Msg("Error reporting service config file status")
 	}
+	// Resolve the per-feature enabled flags. They default to true
+	// when nil (backwards compat: service-config-enabled controls
+	// the master gate, and each sub-feature can be independently
+	// disabled by setting its flag to false).
+	logSinksEnabled := true
+	if flagParams.Service.LogSinksEnabled != nil {
+		logSinksEnabled = *flagParams.Service.LogSinksEnabled
+	}
+	authProvidersEnabled := true
+	if flagParams.Service.AuthProvidersEnabled != nil {
+		authProvidersEnabled = *flagParams.Service.AuthProvidersEnabled
+	}
 	if !flagParams.Service.ServiceConfigEnabled {
 		log.Info().Msg("Service config API is disabled (enable with --service-config-enabled) — sections are still seeded and resolved, change the service_config rows or the YAML file directly")
+	}
+	if !logSinksEnabled {
+		log.Info().Msg("Log sinks API is disabled (enable with --log-sinks-enabled) — rows can still be changed directly in the database")
+	}
+	if !authProvidersEnabled {
+		log.Info().Msg("Auth providers API is disabled (enable with --auth-providers-enabled) — rows can still be changed directly in the database")
 	}
 	if flagParams.RateLimits == nil {
 		flagParams.RateLimits = config.DefaultRateLimitsPtr()
@@ -544,6 +562,8 @@ func osctrlAPIService() {
 		handlers.WithLogSinks(logSinksMgr),
 		handlers.WithAuthProviders(authProviderRegistry, authProvidersMgr),
 		handlers.WithServiceConfigEnabled(flagParams.Service.ServiceConfigEnabled),
+		handlers.WithLogSinksEnabled(logSinksEnabled),
+		handlers.WithAuthProvidersEnabled(authProvidersEnabled),
 		handlers.WithServiceCommands(serviceCommandMgr),
 		handlers.WithConfigPersist(persistConfig),
 		handlers.WithActivityReader(activity.NewRedisStore(redis.Client, activity.DefaultPrefix, activity.DefaultRetentionDays, 8*24*time.Hour)),
@@ -1005,8 +1025,16 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"PATCH "+_apiPath(apiSettingsPath)+"/{service}/{name}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.SettingPatchHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
-	// API: service config. The whole surface is opt-in: with
-	// --service-config-enabled off, none of these routes exist. Seeding
+	// Rate-limit the restart/apply endpoints to 3 per 10 minutes per IP
+	// by default — strict enough to prevent brute-forcing restarts,
+	// generous enough for an operator to retry after a failed restart.
+	// Rejections are audit-logged so SoC tooling sees attempted abuse.
+	restartLimiter := ratelimit.NewFromConfig(flagParams.RateLimits.ServiceConfigApply)
+	restartRateLimit := restartLimiter.HTTPMiddleware(ratelimit.KeyByIP, func(r *http.Request, key string) {
+		handlersApi.AuditLog.SettingsAction("", fmt.Sprintf("service-config apply rate limit exceeded from %s", key), utils.GetIP(r))
+	})
+
+	// API: service config. Opt-in via --service-config-enabled. Seeding
 	// YAML into the service_config rows and resolving them at startup
 	// happen either way, so the rows stay the values the services run on
 	// and can be changed directly in the database.
@@ -1020,39 +1048,28 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"GET "+_apiPath(apiServiceConfigPath)+"/{service}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigServiceHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
-		// Literal-prefixed like /commands/{command_id}: "{service}/status" would
-		// conflict with it — neither pattern is more specific than the other, and
-		// ServeMux panics at registration.
 		muxAPI.Handle(
 			"GET "+_apiPath(apiServiceConfigPath)+"/status/{service}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigStatusHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		muxAPI.Handle(
 			"GET "+_apiPath(apiServiceConfigPath)+"/{service}/{section}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigSectionHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
-		// Rate-limit the restart endpoint to 3 per 10 minutes per IP by default
-		// — strict enough to prevent brute-forcing restarts, generous enough
-		// for an operator to retry after a failed restart. Rejections are
-		// audit-logged so SoC tooling sees attempted abuse.
-		restartLimiter := ratelimit.NewFromConfig(flagParams.RateLimits.ServiceConfigApply)
-		restartRateLimit := restartLimiter.HTTPMiddleware(ratelimit.KeyByIP, func(r *http.Request, key string) {
-			handlersApi.AuditLog.SettingsAction("", fmt.Sprintf("service-config apply rate limit exceeded from %s", key), utils.GetIP(r))
-		})
 		muxAPI.Handle(
 			"PUT "+_apiPath(apiServiceConfigPath)+"/{service}/{section}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigUpdateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		muxAPI.Handle(
 			"POST "+_apiPath(apiServiceConfigPath)+"/apply",
 			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
-		// Persist writes a file rather than restarting anything, but it is the
-		// same class of privileged, disk-touching operation — same limiter.
 		muxAPI.Handle(
 			"POST "+_apiPath(apiServiceConfigPath)+"/persist",
 			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.ServiceConfigPersistHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
+	}
 
-		// API: log sinks. Shares the service-config feature gate. The
-		// apply endpoint reuses the same restart limiter since a log
-		// sink reload is the same class of privileged, runtime-affecting
-		// operation as a service-config apply.
+	// API: log sinks. Independently gated by --log-sinks-enabled. Does
+	// NOT require --service-config-enabled. The apply endpoint reuses
+	// the same restart limiter since a log sink reload is the same class
+	// of privileged operation.
+	if logSinksEnabled {
 		muxAPI.Handle(
 			"GET "+_apiPath(apiLogSinksPath),
 			handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksListHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
@@ -1080,8 +1097,12 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"POST "+_apiPath(apiLogSinksPath)+"/apply",
 			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
+	}
 
-		// API: auth providers. Shares the service-config feature gate.
+	// API: auth providers. Independently gated by
+	// --auth-providers-enabled. Does NOT require
+	// --service-config-enabled.
+	if authProvidersEnabled {
 		muxAPI.Handle(
 			"GET "+_apiPath(apiAuthProvidersPath),
 			handlerAuthCheck(http.HandlerFunc(handlersApi.AuthProvidersListHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -284,6 +284,26 @@ func initServiceFlags(params *ServiceParameters) []cli.Flag {
 			Destination: &params.Service.ServiceConfigEnabled,
 		},
 		&cli.BoolFlag{
+			Name:    "log-sinks-enabled",
+			Value:   true,
+			Usage:   "Serve the log-sinks API and show the matching section in the SPA. Independent of --service-config-enabled. Set false to hide the log-sinks management UI.",
+			Sources: cli.EnvVars("LOG_SINKS_ENABLED"),
+			Action: func(ctx context.Context, cmd *cli.Command, b bool) error {
+				params.Service.LogSinksEnabled = &b
+				return nil
+			},
+		},
+		&cli.BoolFlag{
+			Name:    "auth-providers-enabled",
+			Value:   true,
+			Usage:   "Serve the auth-providers API and show the matching section in the SPA. Independent of --service-config-enabled. Set false to hide the auth-providers management UI.",
+			Sources: cli.EnvVars("AUTH_PROVIDERS_ENABLED"),
+			Action: func(ctx context.Context, cmd *cli.Command, b bool) error {
+				params.Service.AuthProvidersEnabled = &b
+				return nil
+			},
+		},
+		&cli.BoolFlag{
 			Name:        "mfa-required",
 			Value:       false,
 			Usage:       "Require a second authentication factor (TOTP, passkey or security key) for password logins. Users without one enroll at their next login. Service accounts and federated logins are unaffected.",

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -134,6 +134,16 @@ type YAMLConfigurationService struct {
 	// in the YAML file, and are picked up on the next restart. Consumed by
 	// osctrl-api; osctrl-tls ignores it.
 	ServiceConfigEnabled bool `yaml:"serviceConfigEnabled"`
+	// LogSinksEnabled controls whether the log-sinks API and SPA section
+	// exist. When false, the /api/v1/log-sinks routes are not registered
+	// and the SPA hides the section. Independent of ServiceConfigEnabled.
+	// Defaults to true (nil).
+	LogSinksEnabled *bool `yaml:"logSinksEnabled"`
+	// AuthProvidersEnabled controls whether the auth-providers API and
+	// SPA section exist. When false, the /api/v1/auth-providers routes
+	// are not registered and the SPA hides the section. Independent of
+	// ServiceConfigEnabled. Defaults to true (nil).
+	AuthProvidersEnabled *bool `yaml:"authProvidersEnabled"`
 	// MFARequired makes a second authentication factor mandatory for
 	// password logins. Users who have none are sent through enrollment at
 	// their next login instead of being locked out. Service accounts are


### PR DESCRIPTION
# Independent feature gates for service config, log sinks, and auth providers

## Problem

Log sinks and auth providers route registration was nested inside the
`if serviceConfigEnabled` block, making `--service-config-enabled` a
master gate. An operator who wanted log sinks or auth providers
accessible without exposing the service-config management UI had no
way to do it — enabling service config was a prerequisite for the other
two.

## Solution

Decouple all three features into fully independent gates. Each has its
own flag, env var, handler field, and route registration block. No
feature requires another to be enabled.

## Changes

### Config (`pkg/config/types.go`, `pkg/config/flags.go`)

Two new `*bool` fields on `YAMLConfigurationService`:

| Field | Flag | Env var | Default (nil → true) |
|---|---|---|---|
| `LogSinksEnabled` | `--log-sinks-enabled` | `LOG_SINKS_ENABLED` | `true` |
| `AuthProvidersEnabled` | `--auth-providers-enabled` | `AUTH_PROVIDERS_ENABLED` | `true` |

`ServiceConfigEnabled` remains a plain `bool` (default `false`,
unchanged). The new fields are `*bool` so nil means "default to true"
— existing deployments that only set `SERVICE_CONFIG_ENABLED=true` get
all three enabled without any config changes.

Flag help text updated to say "Independent of --service-config-enabled"
instead of "Only takes effect when --service-config-enabled is also true".

### Handlers (`cmd/api/handlers/handlers.go`, `features.go`)

- `HandlersApi` gained `LogSinksEnabled bool` and
  `AuthProvidersEnabled bool` fields.
- New `WithLogSinksEnabled(bool)` and `WithAuthProvidersEnabled(bool)`
  options.
- `FeaturesResponse` now reports each flag independently:
  `LogSinks: h.LogSinksEnabled`, `AuthProviders: h.AuthProvidersEnabled`
  — no `&& h.ServiceConfigEnabled` condition.

### Route registration (`cmd/api/main.go`)

- The `restartLimiter` / `restartRateLimit` definition moved out of the
  service-config `if` block to the top level, so all three apply
  endpoints can share it regardless of which features are enabled.
- Three independent `if` blocks:
  - `if flagParams.Service.ServiceConfigEnabled { ... }` — service-config routes only.
  - `if logSinksEnabled { ... }` — log-sinks routes only.
  - `if authProvidersEnabled { ... }` — auth-providers routes only.
- Log messages updated: each disabled feature logs independently
  without conditioning on `ServiceConfigEnabled`.

### Defaults and backwards compatibility

| Scenario | Before | After |
|---|---|---|
| `SERVICE_CONFIG_ENABLED=true` (no other flags) | All three enabled | All three enabled (new flags default to true) |
| `SERVICE_CONFIG_ENABLED=false` (no other flags) | All three disabled | Log sinks + auth providers enabled (new defaults), service config disabled |
| `--service-config-enabled=false --log-sinks-enabled=false` | N/A | Log sinks disabled, auth providers enabled, service config disabled |
| `--service-config-enabled=false --auth-providers-enabled=false` | N/A | Auth providers disabled, log sinks enabled, service config disabled |

The key change: an operator can now run with
`--service-config-enabled=false` and still manage log sinks and auth
providers from the UI — the service-config section is simply hidden.

## Validation

- **Go**: 45 packages pass, 0 failures.
- **Frontend**: 242 tests pass, type check clean.

## Files

**Modified** (5 files):
- `pkg/config/types.go` — `LogSinksEnabled *bool`, `AuthProvidersEnabled *bool` fields
- `pkg/config/flags.go` — `--log-sinks-enabled`, `--auth-providers-enabled` flags
- `cmd/api/handlers/handlers.go` — `LogSinksEnabled`, `AuthProvidersEnabled` fields + options
- `cmd/api/handlers/features.go` — independent feature reporting
- `cmd/api/handlers/features_test.go` — updated test to set all three flags
- `cmd/api/main.go` — independent `if` blocks, moved `restartLimiter` to top level