### PR TITLE
Posture checks stored in backend

### DIFF
--- a/cmd/api/handlers/nodes.go
+++ b/cmd/api/handlers/nodes.go
@@ -697,7 +697,16 @@ func (h *HandlersApi) PostureProfilesHandler(w http.ResponseWriter, r *http.Requ
 		apiErrorResponse(w, "missing auth context", http.StatusUnauthorized, nil)
 		return
 	}
-	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, posture.AllProfiles())
+	if h.Posture == nil {
+		apiErrorResponse(w, "posture not configured", http.StatusServiceUnavailable, nil)
+		return
+	}
+	profiles, err := h.Posture.AllProfiles()
+	if err != nil {
+		apiErrorResponse(w, "error getting posture profiles", http.StatusInternalServerError, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, profiles)
 }
 
 // PostureProfileHandler — GET /api/v1/posture/profiles/{id}
@@ -723,8 +732,12 @@ func (h *HandlersApi) PostureProfileHandler(w http.ResponseWriter, r *http.Reque
 		apiErrorResponse(w, "profile id required", http.StatusBadRequest, nil)
 		return
 	}
-	profile := posture.GetProfile(profileID)
-	if profile == nil {
+	if h.Posture == nil {
+		apiErrorResponse(w, "posture not configured", http.StatusServiceUnavailable, nil)
+		return
+	}
+	profile, err := h.Posture.GetProfile(profileID)
+	if err != nil {
 		apiErrorResponse(w, "profile not found", http.StatusNotFound, nil)
 		return
 	}
@@ -854,7 +867,10 @@ func (h *HandlersApi) NodePostureScoreHandler(w http.ResponseWriter, r *http.Req
 		apiErrorResponse(w, "error getting posture", http.StatusInternalServerError, err)
 		return
 	}
-	calculator := posture.NewScoreCalculator()
-	score := calculator.Score(records)
+	score, err := h.Posture.Score(records)
+	if err != nil {
+		apiErrorResponse(w, "error scoring posture", http.StatusInternalServerError, err)
+		return
+	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, score)
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -107,7 +107,7 @@ const (
 	// API service config path
 	apiServiceConfigPath = "/service-config"
 	// API log sinks path
-	apiLogSinksPath = "/log-sinks"
+	apiLogSinksPath      = "/log-sinks"
 	apiAuthProvidersPath = "/auth-providers"
 	// API features path
 	apiFeaturesPath = "/features"

--- a/cmd/cli/environment.go
+++ b/cmd/cli/environment.go
@@ -813,7 +813,11 @@ func postureProfileScheduleQueries(profileID, prefix string, intervalOverride in
 		if intervalOverride > 0 {
 			interval = intervalOverride
 		}
-		schedule[prefix+name] = environments.ScheduleQuery{
+		queryName := query.QueryName
+		if queryName == "" {
+			queryName = prefix + name
+		}
+		schedule[queryName] = environments.ScheduleQuery{
 			Query:    query.Query,
 			Interval: json.Number(strconv.Itoa(interval)),
 			Platform: query.Platform,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -587,6 +587,7 @@ export interface NodePosture {
 }
 
 export interface ProfileQuery {
+  query_name?: string;
   query: string;
   interval: number;
   platform?: string;

--- a/frontend/src/features/environments/EnvConfigPage.test.tsx
+++ b/frontend/src/features/environments/EnvConfigPage.test.tsx
@@ -264,6 +264,163 @@ describe('EnvConfigPage', () => {
     await user.click(await screen.findByRole('tab', { name: 'Schedule' }));
 
     expect(screen.queryByRole('button', { name: 'Add posture checks' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Posture' })).not.toBeInTheDocument();
     expect(mockGetPostureProfiles).not.toHaveBeenCalled();
+  });
+
+  it('adds a posture profile from the schedule picker into the posture tab', async () => {
+    const user = userEvent.setup();
+    mockGetFeatures.mockResolvedValue({ posture: true, service_config: false, accelerated: false, file_explorer: false });
+    mockGetPostureProfiles.mockResolvedValue([
+      {
+        id: 'linux-server',
+        name: 'Linux Servers',
+        description: 'Linux host posture checks',
+        platform: 'linux',
+        queries: {
+          users: {
+            query: 'SELECT username FROM users',
+            interval: 86400,
+            snapshot: true,
+          },
+        },
+      },
+    ]);
+
+    renderWithProviders();
+
+    await user.click(await screen.findByRole('tab', { name: 'Schedule' }));
+    await user.click(screen.getByRole('button', { name: 'Add posture checks' }));
+
+    expect(await screen.findByText('linux')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Add Linux Servers to schedule' }));
+    await user.click(screen.getByRole('tab', { name: 'Posture' }));
+
+    expect(screen.getByDisplayValue('osctrl:posture:users')).toBeInTheDocument();
+    expect(screen.getByLabelText('Profile')).toHaveValue('linux-server');
+  });
+
+  it('saves the selected posture profile for a new manual check', async () => {
+    const user = userEvent.setup();
+    mockGetFeatures.mockResolvedValue({ posture: true, service_config: false, accelerated: false, file_explorer: false });
+    mockGetPostureProfiles.mockResolvedValue([
+      {
+        id: 'linux-server',
+        name: 'Linux Servers',
+        description: 'Linux host posture checks',
+        platform: 'linux',
+        queries: {},
+      },
+    ]);
+    mockPatchConfig.mockImplementation(async (_env, body) => ({
+      options: '{}',
+      schedule: body.schedule,
+      packs: '{}',
+      decorators: '{}',
+      atc: '{}',
+      flags: '',
+    }));
+
+    renderWithProviders();
+
+    await user.click(await screen.findByRole('tab', { name: 'Posture' }));
+    await user.click(screen.getByRole('button', { name: 'Add check' }));
+    await user.selectOptions(screen.getByLabelText('Profile'), 'linux-server');
+    await user.click(screen.getByRole('button', { name: 'Save posture checks' }));
+
+    await waitFor(() => {
+      expect(mockPatchConfig).toHaveBeenCalledWith('dev', {
+        schedule: JSON.stringify({
+          'osctrl:posture:new_check': {
+            query: 'SELECT 1',
+            interval: 86400,
+            platform: 'linux',
+            snapshot: true,
+            profile_id: 'linux-server',
+          },
+        }, null, 2),
+      });
+    });
+  });
+
+  it('shows an environment-scoped posture tab when posture is enabled', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: true, service_config: false, accelerated: false, file_explorer: false });
+    mockGetConfig.mockResolvedValue({
+      options: '{}',
+      schedule: JSON.stringify({
+        'osctrl:posture:users': {
+          query: 'SELECT username FROM users',
+          interval: 86400,
+          snapshot: true,
+          profile_id: 'linux-server',
+        },
+      }),
+      packs: '{}',
+      decorators: '{}',
+      atc: '{}',
+      flags: '',
+    });
+
+    renderWithProviders();
+
+    expect(await screen.findByRole('tab', { name: 'Posture' })).toBeInTheDocument();
+  });
+
+  it('hides the posture tab when posture is disabled', async () => {
+    renderWithProviders();
+
+    await screen.findByRole('tab', { name: 'Settings' });
+
+    expect(screen.queryByRole('tab', { name: 'Posture' })).not.toBeInTheDocument();
+  });
+
+  it('edits posture checks through the environment schedule', async () => {
+    const user = userEvent.setup();
+    mockGetFeatures.mockResolvedValue({ posture: true, service_config: false, accelerated: false, file_explorer: false });
+    mockGetConfig.mockResolvedValue({
+      options: '{}',
+      schedule: JSON.stringify({
+        'osctrl:posture:users': {
+          query: 'SELECT username FROM users',
+          interval: 86400,
+          snapshot: true,
+          profile_id: 'linux-server',
+        },
+      }),
+      packs: '{}',
+      decorators: '{}',
+      atc: '{}',
+      flags: '',
+    });
+    mockPatchConfig.mockImplementation(async (_env, body) => ({
+      options: '{}',
+      schedule: body.schedule,
+      packs: '{}',
+      decorators: '{}',
+      atc: '{}',
+      flags: '',
+    }));
+
+    renderWithProviders();
+
+    await user.click(await screen.findByRole('tab', { name: 'Posture' }));
+    await user.clear(screen.getByLabelText('Query name'));
+    await user.type(screen.getByLabelText('Query name'), 'osctrl:posture:interactive_users');
+    await user.clear(screen.getByLabelText('Interval'));
+    await user.type(screen.getByLabelText('Interval'), '3600');
+    await user.click(screen.getByRole('button', { name: 'Save posture checks' }));
+
+    await waitFor(() => {
+      expect(mockPatchConfig).toHaveBeenCalledWith('dev', {
+        schedule: JSON.stringify({
+          'osctrl:posture:interactive_users': {
+            query: 'SELECT username FROM users',
+            interval: 3600,
+            snapshot: true,
+            profile_id: 'linux-server',
+          },
+        }, null, 2),
+      });
+    });
   });
 });

--- a/frontend/src/features/environments/EnvConfigPage.tsx
+++ b/frontend/src/features/environments/EnvConfigPage.tsx
@@ -24,6 +24,14 @@ import { DocsLink } from '$/components/atoms/DocsLink';
 import { AssembledConfigCard } from '$/features/enrollment/AssembledConfigCard';
 
 type SectionKey = 'options' | 'schedule' | 'packs' | 'decorators' | 'atc' | 'flags';
+type PostureScheduleEntry = {
+  profileID: string;
+  queryName: string;
+  query: string;
+  interval: number;
+  platform: string;
+  snapshot: boolean;
+};
 
 const POSTURE_INTERVALS = [
   { label: 'Daily', seconds: 86400, description: 'Once per day — sufficient for compliance' },
@@ -31,6 +39,7 @@ const POSTURE_INTERVALS = [
   { label: 'Every 6h', seconds: 21600, description: 'Four times per day — active monitoring' },
   { label: 'Every 1h', seconds: 3600, description: 'Hourly — high-frequency monitoring' },
 ];
+const POSTURE_QUERY_PREFIX = 'osctrl:posture:';
 
 // docs URLs point at the upstream osquery read-the-docs anchors so an
 // operator can jump from the section header straight to the canonical
@@ -121,6 +130,8 @@ export function EnvConfigPage() {
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const [showPosturePicker, setShowPosturePicker] = useState(false);
   const [postureAggressiveness, setPostureAggressiveness] = useState(1);
+  type TabKey = 'settings' | SectionKey | 'posture' | 'assembled';
+  const [activeTab, setActiveTab] = useState<TabKey>('settings');
   const featuresQuery = useQuery({
     queryKey: ['features'],
     queryFn: () => getFeatures(),
@@ -130,7 +141,7 @@ export function EnvConfigPage() {
   const postureProfilesQuery = useQuery({
     queryKey: ['posture-profiles'],
     queryFn: () => getPostureProfiles(),
-    enabled: showPosturePicker && postureEnabled,
+    enabled: (showPosturePicker || activeTab === 'posture') && postureEnabled,
     staleTime: 5 * 60_000,
     retry: 1,
   });
@@ -153,8 +164,6 @@ export function EnvConfigPage() {
   // config SECTION. The "settings" default keeps the slider-based forms
   // up-front so an operator who lands here to tune pull intervals doesn't
   // scroll past six 280px Monaco editors first.
-  type TabKey = 'settings' | SectionKey | 'assembled';
-  const [activeTab, setActiveTab] = useState<TabKey>('settings');
 
   useEffect(() => {
     if (cfgQuery.data && draft === null) {
@@ -341,6 +350,15 @@ export function EnvConfigPage() {
             onClick={() => setActiveTab(key)}
           />
         ))}
+        {postureEnabled && (
+          <TabButton
+            id="posture"
+            label="Posture"
+            active={activeTab === 'posture'}
+            dirty={dirty.has('schedule')}
+            onClick={() => setActiveTab('posture')}
+          />
+        )}
         <TabButton
           id="assembled"
           label="Full Configuration"
@@ -379,6 +397,15 @@ export function EnvConfigPage() {
 
         {activeTab === 'assembled' && (
           <AssembledConfigCard env={env} />
+        )}
+
+        {activeTab === 'posture' && postureEnabled && (
+          <PostureScheduleEditor
+            schedule={draft.schedule}
+            saving={saveOne.isPending}
+            onSave={(schedule) => saveOne.mutate({ key: 'schedule', value: schedule })}
+            profiles={postureProfiles ?? []}
+          />
         )}
 
         {SECTIONS.map(({ key, label, language, help, docsUrl }) => {
@@ -495,14 +522,13 @@ export function EnvConfigPage() {
       </div>
       {showPosturePicker && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setShowPosturePicker(false)}>
-          <div className="bg-[color:var(--bg-1)] rounded-xl border border-[color:var(--border)] max-w-2xl w-full mx-4 max-h-[80vh] overflow-auto" onClick={(e) => e.stopPropagation()}>
+          <div className="bg-[color:var(--bg-1)] rounded-md border border-[color:var(--border)] max-w-2xl w-full mx-4 max-h-[80vh] overflow-auto" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center justify-between px-5 py-3 border-b border-[color:var(--border)]">
               <h2 className="text-sm font-display font-semibold text-[color:var(--text-1)]">Posture check profiles</h2>
-              <button type="button" onClick={() => setShowPosturePicker(false)} className="text-[color:var(--text-3)] hover:text-[color:var(--text-1)]">✕</button>
+              <button type="button" onClick={() => setShowPosturePicker(false)} className="text-[color:var(--text-3)] hover:text-[color:var(--text-1)]">X</button>
             </div>
             <div className="p-4 space-y-4">
-              {/* Aggressiveness slider */}
-              <div className="rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-2)] p-3">
+              <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-2)] p-3">
                 <div className="flex items-center justify-between mb-2">
                   <span className="text-xs font-semibold text-[color:var(--text-2)]">Check frequency</span>
                   <span className="text-[10px] font-mono-tabular text-[color:var(--signal)]">
@@ -520,7 +546,8 @@ export function EnvConfigPage() {
                 />
                 <div className="flex justify-between mt-1">
                   {POSTURE_INTERVALS.map((p, i) => (
-                    <span
+                    <button
+                      type="button"
                       key={p.label}
                       className={cn(
                         'text-[9px] font-mono-tabular cursor-pointer select-none',
@@ -531,7 +558,7 @@ export function EnvConfigPage() {
                       onClick={() => setPostureAggressiveness(i + 1)}
                     >
                       {p.label}
-                    </span>
+                    </button>
                   ))}
                 </div>
                 <p className="mt-1.5 text-[10px] text-[color:var(--text-3)] leading-relaxed">
@@ -539,10 +566,9 @@ export function EnvConfigPage() {
                 </p>
               </div>
 
-              {/* Profile cards */}
               <div className="space-y-3">
                 {postureProfilesQuery.isLoading && (
-                  <p className="text-xs text-[color:var(--text-3)] text-center py-4">Loading posture profiles…</p>
+                  <p className="text-xs text-[color:var(--text-3)] text-center py-4">Loading posture profiles...</p>
                 )}
                 {postureProfilesQuery.isError && (
                   <div className="text-center py-4 space-y-2">
@@ -551,13 +577,13 @@ export function EnvConfigPage() {
                   </div>
                 )}
                 {(postureProfiles ?? []).map((profile: PostureProfile) => (
-                  <div key={profile.id} className="rounded-lg border border-[color:var(--border)] p-4">
+                  <div key={profile.id} className="rounded-md border border-[color:var(--border)] p-4">
                     <div className="flex items-center justify-between mb-2">
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-semibold text-[color:var(--text-1)]">{profile.name}</span>
                         <span className="text-[9px] font-mono-tabular uppercase tracking-wider px-1.5 py-0.5 rounded bg-[color:var(--bg-2)] text-[color:var(--text-3)] border border-[color:var(--border)]">{profile.platform}</span>
                       </div>
-                      <button type="button" onClick={() => applyPostureProfile(profile)} className="px-2 py-1 text-[11px] font-medium rounded text-[color:var(--signal)] hover:bg-[color:var(--signal)]/10 transition-colors">Add to schedule</button>
+                      <button type="button" onClick={() => applyPostureProfile(profile)} className="px-2 py-1 text-[11px] font-medium rounded text-[color:var(--signal)] hover:bg-[color:var(--signal)]/10 transition-colors" aria-label={`Add ${profile.name} to schedule`}>Add to schedule</button>
                     </div>
                     <p className="text-xs text-[color:var(--text-3)] mb-2">{profile.description}</p>
                     <div className="flex flex-wrap gap-1">
@@ -623,6 +649,286 @@ function TabButton({
       )}
     </button>
   );
+}
+
+function PostureScheduleEditor({
+  schedule,
+  saving,
+  onSave,
+  profiles,
+}: {
+  schedule: string;
+  saving: boolean;
+  onSave: (schedule: string) => void;
+  profiles: PostureProfile[];
+}) {
+  const parsed = useMemo(() => parsePostureSchedule(schedule, profiles), [schedule, profiles]);
+  const [rows, setRows] = useState<PostureScheduleEntry[]>(parsed.entries);
+  const [error, setError] = useState<string | null>(parsed.error);
+
+  useEffect(() => {
+    setRows(parsed.entries);
+    setError(parsed.error);
+  }, [parsed]);
+
+  function updateRow(index: number, patch: Partial<PostureScheduleEntry>) {
+    setRows((current) => current.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+  }
+
+  function updateProfile(index: number, profileID: string) {
+    const profile = profiles.find((p) => p.id === profileID);
+    setRows((current) => current.map((row, i) => (
+      i === index
+        ? { ...row, profileID, platform: profile?.platform || row.platform }
+        : row
+    )));
+  }
+
+  function saveRows() {
+    try {
+      onSave(buildScheduleWithPosture(schedule, rows));
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Invalid posture checks.');
+    }
+  }
+
+  return (
+    <section
+      className="border border-[color:var(--border)] rounded-md overflow-hidden bg-[color:var(--bg-1)]"
+      role="tabpanel"
+      aria-labelledby="tab-posture"
+    >
+      <header className="flex items-center gap-3 px-3 py-2 bg-[color:var(--bg-0)] border-b border-[color:var(--border)]">
+        <h2 className="font-display text-sm font-semibold text-[color:var(--text-1)]">Posture</h2>
+        <p className="text-[10px] text-[color:var(--text-3)] truncate flex-1">
+          Environment posture checks stored in this environment's schedule.
+        </p>
+        <button
+          type="button"
+          onClick={() =>
+            setRows((current) => [
+              ...current,
+              {
+                profileID: '',
+                queryName: POSTURE_QUERY_PREFIX + 'new_check',
+                query: 'SELECT 1',
+                interval: 86400,
+                platform: '',
+                snapshot: true,
+              },
+            ])
+          }
+          className="text-[10px] px-2 py-0.5 rounded text-[color:var(--signal)] hover:bg-[color:var(--signal)]/10"
+        >
+          Add check
+        </button>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={saveRows}
+          className={cn(
+            'text-[10px] px-2 py-0.5 rounded font-medium',
+            'bg-[color:var(--signal)] text-black hover:bg-[color:var(--signal-bright)]',
+            'disabled:opacity-40 disabled:cursor-not-allowed',
+          )}
+        >
+          {saving ? 'Saving…' : 'Save posture checks'}
+        </button>
+      </header>
+
+      {error && (
+        <p role="alert" className="m-3 text-xs text-[color:var(--danger)]">
+          {error}
+        </p>
+      )}
+
+      <div className="divide-y divide-[color:var(--border)]">
+        {rows.length === 0 && (
+          <div className="p-4 text-xs text-[color:var(--text-3)]">
+            No posture checks in this environment schedule.
+          </div>
+        )}
+        {rows.map((row, index) => (
+          <div key={index} className="p-3 grid gap-3 lg:grid-cols-[150px_minmax(180px,240px)_1fr_90px_110px_80px_auto] items-start">
+            <label className="space-y-1">
+              <span className="block text-[10px] font-mono-tabular uppercase tracking-[0.12em] text-[color:var(--text-3)]">
+                Profile
+              </span>
+              <select
+                aria-label="Profile"
+                value={row.profileID}
+                onChange={(e) => updateProfile(index, e.target.value)}
+                className="w-full rounded border border-[color:var(--border)] bg-[color:var(--bg-0)] px-2 py-1 text-xs text-[color:var(--text-1)]"
+              >
+                <option value="">Custom</option>
+                {row.profileID && !profiles.some((profile) => profile.id === row.profileID) && (
+                  <option value={row.profileID}>{row.profileID}</option>
+                )}
+                {profiles.map((profile) => (
+                  <option key={profile.id} value={profile.id}>
+                    {profile.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="block text-[10px] font-mono-tabular uppercase tracking-[0.12em] text-[color:var(--text-3)]">
+                Query name
+              </span>
+              <input
+                aria-label="Query name"
+                value={row.queryName}
+                onChange={(e) => updateRow(index, { queryName: e.target.value })}
+                className="w-full rounded border border-[color:var(--border)] bg-[color:var(--bg-0)] px-2 py-1 text-xs text-[color:var(--text-1)]"
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="block text-[10px] font-mono-tabular uppercase tracking-[0.12em] text-[color:var(--text-3)]">
+                Query
+              </span>
+              <textarea
+                aria-label="Query"
+                value={row.query}
+                onChange={(e) => updateRow(index, { query: e.target.value })}
+                rows={2}
+                className="w-full rounded border border-[color:var(--border)] bg-[color:var(--bg-0)] px-2 py-1 text-xs text-[color:var(--text-1)] font-mono-tabular"
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="block text-[10px] font-mono-tabular uppercase tracking-[0.12em] text-[color:var(--text-3)]">
+                Interval
+              </span>
+              <input
+                aria-label="Interval"
+                type="number"
+                min={0}
+                value={row.interval}
+                onChange={(e) => updateRow(index, { interval: Number(e.target.value) })}
+                className="w-full rounded border border-[color:var(--border)] bg-[color:var(--bg-0)] px-2 py-1 text-xs text-[color:var(--text-1)]"
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="block text-[10px] font-mono-tabular uppercase tracking-[0.12em] text-[color:var(--text-3)]">
+                Platform
+              </span>
+              <input
+                aria-label="Platform"
+                value={row.platform}
+                onChange={(e) => updateRow(index, { platform: e.target.value })}
+                className="w-full rounded border border-[color:var(--border)] bg-[color:var(--bg-0)] px-2 py-1 text-xs text-[color:var(--text-1)]"
+              />
+            </label>
+            <label className="flex items-center gap-2 pt-5 text-xs text-[color:var(--text-2)]">
+              <input
+                aria-label="Snapshot"
+                type="checkbox"
+                checked={row.snapshot}
+                onChange={(e) => updateRow(index, { snapshot: e.target.checked })}
+                className="accent-[color:var(--signal)]"
+              />
+              Snapshot
+            </label>
+            <button
+              type="button"
+              onClick={() => setRows((current) => current.filter((_, i) => i !== index))}
+              className="mt-5 text-[10px] px-2 py-1 rounded text-[color:var(--danger)] hover:bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)]"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function parsePostureSchedule(schedule: string, profiles: PostureProfile[]): {
+  entries: PostureScheduleEntry[];
+  error: string | null;
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(schedule || '{}');
+  } catch {
+    return { entries: [], error: 'Schedule must be a JSON object.' };
+  }
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
+    return { entries: [], error: 'Schedule must be a JSON object.' };
+  }
+  const entries = Object.entries(parsed as Record<string, unknown>)
+    .filter(([name]) => name.startsWith(POSTURE_QUERY_PREFIX))
+    .map(([queryName, raw]) => {
+      const value = raw && typeof raw === 'object' && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : {};
+      return {
+        profileID: typeof value.profile_id === 'string'
+          ? value.profile_id
+          : inferProfileID(queryName, value, profiles),
+        queryName,
+        query: typeof value.query === 'string' ? value.query : '',
+        interval: typeof value.interval === 'number' ? value.interval : Number(value.interval ?? 86400),
+        platform: typeof value.platform === 'string' ? value.platform : '',
+        snapshot: typeof value.snapshot === 'boolean' ? value.snapshot : true,
+      };
+    });
+  return { entries, error: null };
+}
+
+function inferProfileID(queryName: string, row: Record<string, unknown>, profiles: PostureProfile[]): string {
+  const query = typeof row.query === 'string' ? row.query : '';
+  for (const profile of profiles) {
+    for (const [category, profileQuery] of Object.entries(profile.queries)) {
+      const profileQueryName = profileQuery.query_name || POSTURE_QUERY_PREFIX + category;
+      if (profileQueryName === queryName && (!query || profileQuery.query === query)) {
+        return profile.id;
+      }
+    }
+  }
+  for (const profile of profiles) {
+    for (const [category, profileQuery] of Object.entries(profile.queries)) {
+      const profileQueryName = profileQuery.query_name || POSTURE_QUERY_PREFIX + category;
+      if (profileQueryName === queryName) {
+        return profile.id;
+      }
+    }
+  }
+  return '';
+}
+
+function buildScheduleWithPosture(schedule: string, rows: PostureScheduleEntry[]): string {
+  const parsed = JSON.parse(schedule || '{}') as Record<string, unknown>;
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
+    throw new Error('Schedule must be a JSON object.');
+  }
+  for (const key of Object.keys(parsed)) {
+    if (key.startsWith(POSTURE_QUERY_PREFIX)) {
+      delete parsed[key];
+    }
+  }
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const queryName = row.queryName.trim();
+    if (!queryName) throw new Error('Query name is required.');
+    if (!queryName.startsWith(POSTURE_QUERY_PREFIX)) {
+      throw new Error(`Query name must start with ${POSTURE_QUERY_PREFIX}.`);
+    }
+    if (seen.has(queryName)) throw new Error(`Duplicate posture query ${queryName}.`);
+    seen.add(queryName);
+    if (!row.query.trim()) throw new Error(`Query is required for ${queryName}.`);
+    if (!Number.isFinite(row.interval) || row.interval < 0) {
+      throw new Error(`Interval must be zero or greater for ${queryName}.`);
+    }
+    parsed[queryName] = {
+      query: row.query.trim(),
+      interval: row.interval,
+      ...(row.platform.trim() ? { platform: row.platform.trim() } : {}),
+      snapshot: row.snapshot,
+      ...(row.profileID.trim() ? { profile_id: row.profileID.trim() } : {}),
+    };
+  }
+  return JSON.stringify(parsed, null, 2);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/environments/postureSchedule.test.ts
+++ b/frontend/src/features/environments/postureSchedule.test.ts
@@ -36,13 +36,37 @@ describe('applyPostureProfileToSchedule', () => {
       query: 'SELECT username FROM users',
       interval: 3600,
       snapshot: true,
+      profile_id: 'linux-server',
     });
     expect(result['osctrl:posture:packages']).toEqual({
       query: 'SELECT name FROM deb_packages',
       interval: 3600,
       platform: 'linux',
       snapshot: true,
+      profile_id: 'linux-server',
     });
+  });
+
+  it('uses custom posture query names from the API', () => {
+    const custom = {
+      ...profile,
+      queries: {
+        users: {
+          ...profile.queries.users,
+          query_name: 'custom:posture:users',
+        },
+      },
+    };
+
+    const result = JSON.parse(applyPostureProfileToSchedule('{}', custom, 3600));
+
+    expect(result['custom:posture:users']).toEqual({
+      query: 'SELECT username FROM users',
+      interval: 3600,
+      snapshot: true,
+      profile_id: 'linux-server',
+    });
+    expect(result['osctrl:posture:users']).toBeUndefined();
   });
 
   it.each(['{"broken"', '[]', 'null', '"text"'])(

--- a/frontend/src/features/environments/postureSchedule.ts
+++ b/frontend/src/features/environments/postureSchedule.ts
@@ -19,11 +19,12 @@ export function applyPostureProfileToSchedule(
 
   const entries = parsed as Record<string, unknown>;
   for (const [name, query] of Object.entries(profile.queries)) {
-    entries[POSTURE_QUERY_PREFIX + name] = {
+    entries[query.query_name || POSTURE_QUERY_PREFIX + name] = {
       query: query.query,
       interval,
       snapshot: query.snapshot,
       ...(query.platform ? { platform: query.platform } : {}),
+      profile_id: profile.id,
     };
   }
   return JSON.stringify(entries, null, 2);

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -238,6 +238,53 @@ paths:
       summary: List audit logs
       tags:
         - audit
+  /api/v1/auth-providers/fetch-metadata:
+    post:
+      description: Fetches the SAML IdP metadata document from the given URL and
+        returns the XML.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: "{ \\"
+        required: true
+      responses:
+        "200":
+          description: '{ \"xml\": \"<EntityDescriptor ...>\" }'
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "502":
+          description: Fetch failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Fetch IdP metadata XML
+      tags:
+        - auth-providers
   /api/v1/auth/oidc/callback:
     get:
       description: Handles the OIDC authorization callback and creates an API session.
@@ -8972,6 +9019,8 @@ components:
         platform:
           type: string
         query:
+          type: string
+        query_name:
           type: string
         snapshot:
           type: boolean

--- a/pkg/posture/checks.go
+++ b/pkg/posture/checks.go
@@ -1,0 +1,336 @@
+package posture
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// PostureCheck is an admin-editable posture scheduled-query template.
+// ScoringRule selects a built-in evaluator; no executable logic is stored.
+type PostureCheck struct {
+	ID                 uint      `gorm:"primarykey" json:"id"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	ProfileID          string    `gorm:"type:varchar(64);uniqueIndex:idx_posture_check_profile_category" json:"profile_id"`
+	ProfileName        string    `gorm:"type:varchar(255)" json:"profile_name"`
+	ProfileDescription string    `gorm:"type:text" json:"profile_description"`
+	ProfilePlatform    string    `gorm:"type:varchar(64)" json:"profile_platform"`
+	Category           string    `gorm:"type:varchar(64);uniqueIndex:idx_posture_check_profile_category;index" json:"category"`
+	Name               string    `gorm:"type:varchar(255)" json:"name"`
+	Description        string    `gorm:"type:text" json:"description"`
+	QueryName          string    `gorm:"type:varchar(255)" json:"query_name"`
+	Query              string    `gorm:"type:text" json:"query"`
+	Interval           int       `json:"interval"`
+	Platform           string    `gorm:"type:varchar(64)" json:"platform"`
+	Snapshot           bool      `json:"snapshot"`
+	Enabled            bool      `gorm:"index" json:"enabled"`
+	ScoringRule        string    `gorm:"type:varchar(64);index" json:"scoring_rule"`
+	ControlID          string    `gorm:"type:varchar(64)" json:"control_id"`
+	Framework          Framework `gorm:"type:varchar(32)" json:"framework"`
+	Severity           Severity  `gorm:"type:varchar(32)" json:"severity"`
+	Weight             int       `json:"weight"`
+}
+
+func (PostureCheck) TableName() string { return "posture_checks" }
+
+// CheckPatch is the small PATCH/POST body used by the API. Pointer fields let
+// PATCH distinguish "unset" from zero values.
+type CheckPatch struct {
+	ProfileID          *string `json:"profile_id,omitempty"`
+	ProfileName        *string `json:"profile_name,omitempty"`
+	ProfileDescription *string `json:"profile_description,omitempty"`
+	ProfilePlatform    *string `json:"profile_platform,omitempty"`
+	Category           *string `json:"category,omitempty"`
+	Name               *string `json:"name,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	QueryName          *string `json:"query_name,omitempty"`
+	Query              *string `json:"query,omitempty"`
+	Interval           *int    `json:"interval,omitempty"`
+	Platform           *string `json:"platform,omitempty"`
+	Snapshot           *bool   `json:"snapshot,omitempty"`
+	Enabled            *bool   `json:"enabled,omitempty"`
+	ScoringRule        *string `json:"scoring_rule,omitempty"`
+	ControlID          *string `json:"control_id,omitempty"`
+	Framework          *string `json:"framework,omitempty"`
+	Severity           *string `json:"severity,omitempty"`
+	Weight             *int    `json:"weight,omitempty"`
+}
+
+func migratePostureChecks(db *gorm.DB) error {
+	return db.AutoMigrate(&PostureCheck{})
+}
+
+func (pm *PostureManager) SeedDefaultChecks() error {
+	for _, check := range defaultChecks() {
+		if err := pm.DB.Where("profile_id = ? AND category = ?", check.ProfileID, check.Category).
+			Attrs(check).
+			FirstOrCreate(&PostureCheck{}).Error; err != nil {
+			return fmt.Errorf("seed posture check %s/%s: %w", check.ProfileID, check.Category, err)
+		}
+	}
+	return nil
+}
+
+func (pm *PostureManager) ListChecks() ([]PostureCheck, error) {
+	var checks []PostureCheck
+	err := pm.DB.Order("profile_name ASC, category ASC, id ASC").Find(&checks).Error
+	return checks, err
+}
+
+func (pm *PostureManager) GetCheck(id uint) (*PostureCheck, error) {
+	var check PostureCheck
+	if err := pm.DB.First(&check, id).Error; err != nil {
+		return nil, err
+	}
+	return &check, nil
+}
+
+func (pm *PostureManager) CreateCheck(patch CheckPatch) (*PostureCheck, error) {
+	check := PostureCheck{Enabled: true, Snapshot: true, Interval: 86400}
+	applyCheckPatch(&check, patch)
+	if err := validateCheck(check); err != nil {
+		return nil, err
+	}
+	if err := pm.DB.Create(&check).Error; err != nil {
+		return nil, err
+	}
+	return &check, nil
+}
+
+func (pm *PostureManager) UpdateCheck(id uint, patch CheckPatch) (*PostureCheck, error) {
+	check, err := pm.GetCheck(id)
+	if err != nil {
+		return nil, err
+	}
+	applyCheckPatch(check, patch)
+	if err := validateCheck(*check); err != nil {
+		return nil, err
+	}
+	if err := pm.DB.Save(check).Error; err != nil {
+		return nil, err
+	}
+	return check, nil
+}
+
+func (pm *PostureManager) DeleteCheck(id uint) error {
+	return pm.DB.Delete(&PostureCheck{}, id).Error
+}
+
+func (pm *PostureManager) AllProfiles() ([]PostureProfile, error) {
+	var checks []PostureCheck
+	if err := pm.DB.Where("enabled = ?", true).Order("profile_name ASC, category ASC").Find(&checks).Error; err != nil {
+		return nil, err
+	}
+	profiles := map[string]*PostureProfile{}
+	for _, check := range checks {
+		profile := profiles[check.ProfileID]
+		if profile == nil {
+			profile = &PostureProfile{
+				ID:          check.ProfileID,
+				Name:        check.ProfileName,
+				Description: check.ProfileDescription,
+				Platform:    check.ProfilePlatform,
+				Queries:     map[string]ProfileQuery{},
+			}
+			profiles[check.ProfileID] = profile
+		}
+		profile.Queries[check.Category] = ProfileQuery{
+			QueryName: check.QueryName,
+			Query:     check.Query,
+			Interval:  check.Interval,
+			Platform:  check.Platform,
+			Snapshot:  check.Snapshot,
+		}
+	}
+	out := make([]PostureProfile, 0, len(profiles))
+	for _, profile := range profiles {
+		out = append(out, *profile)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (pm *PostureManager) GetProfile(id string) (*PostureProfile, error) {
+	profiles, err := pm.AllProfiles()
+	if err != nil {
+		return nil, err
+	}
+	for _, profile := range profiles {
+		if profile.ID == id {
+			return &profile, nil
+		}
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (pm *PostureManager) enabledChecks() ([]PostureCheck, error) {
+	var checks []PostureCheck
+	err := pm.DB.Where("enabled = ?", true).Order("scoring_rule ASC, category ASC, profile_id ASC").Find(&checks).Error
+	return checks, err
+}
+
+func (pm *PostureManager) Score(records []NodePosture) (PostureScore, error) {
+	checks, err := pm.enabledChecks()
+	if err != nil {
+		return PostureScore{}, err
+	}
+	return NewScoreCalculatorWithChecks(checks).Score(records), nil
+}
+
+func defaultChecks() []PostureCheck {
+	ruleByCategory := defaultRuleByCategory()
+	var checks []PostureCheck
+	for _, profile := range builtinProfiles() {
+		for category, query := range profile.Queries {
+			rule := ruleByCategory[category]
+			check := PostureCheck{
+				ProfileID:          profile.ID,
+				ProfileName:        profile.Name,
+				ProfileDescription: profile.Description,
+				ProfilePlatform:    profile.Platform,
+				Category:           category,
+				Name:               strings.TrimSpace(rule.Title),
+				Description:        strings.TrimSpace(rule.Description),
+				QueryName:          QueryPrefix + category,
+				Query:              query.Query,
+				Interval:           query.Interval,
+				Platform:           query.Platform,
+				Snapshot:           query.Snapshot,
+				Enabled:            true,
+				ScoringRule:        rule.RuleKey,
+				ControlID:          rule.ControlID,
+				Framework:          rule.Framework,
+				Severity:           rule.Severity,
+				Weight:             ruleWeight(rule),
+			}
+			if check.Name == "" {
+				check.Name = category
+			}
+			if check.Description == "" {
+				check.Description = profile.Description
+			}
+			checks = append(checks, check)
+		}
+	}
+	sort.Slice(checks, func(i, j int) bool {
+		if checks[i].ProfileID == checks[j].ProfileID {
+			return checks[i].Category < checks[j].Category
+		}
+		return checks[i].ProfileID < checks[j].ProfileID
+	})
+	return checks
+}
+
+func defaultRuleByCategory() map[string]ScoringRule {
+	out := map[string]ScoringRule{}
+	for _, rule := range defaultRules() {
+		for _, category := range rule.Categories {
+			out[category] = rule
+		}
+	}
+	return out
+}
+
+func applyCheckPatch(check *PostureCheck, patch CheckPatch) {
+	if patch.ProfileID != nil {
+		check.ProfileID = strings.TrimSpace(*patch.ProfileID)
+	}
+	if patch.ProfileName != nil {
+		check.ProfileName = strings.TrimSpace(*patch.ProfileName)
+	}
+	if patch.ProfileDescription != nil {
+		check.ProfileDescription = strings.TrimSpace(*patch.ProfileDescription)
+	}
+	if patch.ProfilePlatform != nil {
+		check.ProfilePlatform = strings.TrimSpace(*patch.ProfilePlatform)
+	}
+	if patch.Category != nil {
+		check.Category = strings.TrimSpace(*patch.Category)
+	}
+	if patch.Name != nil {
+		check.Name = strings.TrimSpace(*patch.Name)
+	}
+	if patch.Description != nil {
+		check.Description = strings.TrimSpace(*patch.Description)
+	}
+	if patch.QueryName != nil {
+		check.QueryName = strings.TrimSpace(*patch.QueryName)
+	}
+	if patch.Query != nil {
+		check.Query = strings.TrimSpace(*patch.Query)
+	}
+	if patch.Interval != nil {
+		check.Interval = *patch.Interval
+	}
+	if patch.Platform != nil {
+		check.Platform = strings.TrimSpace(*patch.Platform)
+	}
+	if patch.Snapshot != nil {
+		check.Snapshot = *patch.Snapshot
+	}
+	if patch.Enabled != nil {
+		check.Enabled = *patch.Enabled
+	}
+	if patch.ScoringRule != nil {
+		check.ScoringRule = strings.TrimSpace(*patch.ScoringRule)
+	}
+	if patch.ControlID != nil {
+		check.ControlID = strings.TrimSpace(*patch.ControlID)
+	}
+	if patch.Framework != nil {
+		check.Framework = Framework(strings.TrimSpace(*patch.Framework))
+	}
+	if patch.Severity != nil {
+		check.Severity = Severity(strings.TrimSpace(*patch.Severity))
+	}
+	if patch.Weight != nil {
+		check.Weight = *patch.Weight
+	}
+}
+
+func validateCheck(check PostureCheck) error {
+	switch {
+	case check.ProfileID == "":
+		return fmt.Errorf("profile_id is required")
+	case check.ProfileName == "":
+		return fmt.Errorf("profile_name is required")
+	case check.Category == "":
+		return fmt.Errorf("category is required")
+	case check.Name == "":
+		return fmt.Errorf("name is required")
+	case check.QueryName == "":
+		return fmt.Errorf("query_name is required")
+	case check.Query == "":
+		return fmt.Errorf("query is required")
+	case check.Interval < 0:
+		return fmt.Errorf("interval must be zero or greater")
+	case check.Weight < 0:
+		return fmt.Errorf("weight must be zero or greater")
+	}
+	if check.Severity != "" {
+		if _, ok := SeverityWeight[check.Severity]; !ok {
+			return fmt.Errorf("invalid severity %q", check.Severity)
+		}
+	}
+	if check.Framework != "" && check.Framework != FrameworkSOC2 && check.Framework != FrameworkISO27001 {
+		return fmt.Errorf("invalid framework %q", check.Framework)
+	}
+	if check.ScoringRule != "" && !knownScoringRules()[check.ScoringRule] {
+		return fmt.Errorf("unknown scoring_rule %q", check.ScoringRule)
+	}
+	return nil
+}
+
+func knownScoringRules() map[string]bool {
+	out := map[string]bool{}
+	for _, rule := range defaultRules() {
+		if rule.RuleKey != "" {
+			out[rule.RuleKey] = true
+		}
+	}
+	return out
+}

--- a/pkg/posture/posture.go
+++ b/pkg/posture/posture.go
@@ -89,6 +89,12 @@ func NewPostureManager(db *gorm.DB) *PostureManager {
 	if err := migrateNodePosture(db); err != nil {
 		log.Fatal().Err(err).Msg("Failed to AutoMigrate table (node_posture)")
 	}
+	if err := migratePostureChecks(db); err != nil {
+		log.Fatal().Err(err).Msg("Failed to AutoMigrate table (posture_checks)")
+	}
+	if err := pm.SeedDefaultChecks(); err != nil {
+		log.Fatal().Err(err).Msg("Failed to seed posture checks")
+	}
 	return pm
 }
 
@@ -451,7 +457,17 @@ func (pm *PostureManager) GetSummaryByNode(nodeUUID string) (*types.NodePostureS
 	if err != nil {
 		return nil, err
 	}
-	return SummaryFromRecords(records), nil
+	if len(records) == 0 {
+		return nil, nil
+	}
+	score, err := pm.Score(records)
+	if err != nil {
+		return nil, err
+	}
+	if score.RiskLevel == "" {
+		return nil, nil
+	}
+	return &types.NodePostureSummary{RiskLevel: score.RiskLevel}, nil
 }
 
 func (pm *PostureManager) GetSummaryByNodes(nodeUUIDs []string) (map[string]*types.NodePostureSummary, error) {
@@ -483,9 +499,15 @@ func (pm *PostureManager) GetSummaryByNodes(nodeUUIDs []string) (map[string]*typ
 	for _, record := range records {
 		grouped[record.NodeUUID] = append(grouped[record.NodeUUID], record)
 	}
+	checks, err := pm.enabledChecks()
+	if err != nil {
+		return nil, err
+	}
+	calculator := NewScoreCalculatorWithChecks(checks)
 	for nodeUUID, nodeRecords := range grouped {
-		if summary := SummaryFromRecords(nodeRecords); summary != nil {
-			out[nodeUUID] = summary
+		score := calculator.Score(nodeRecords)
+		if score.RiskLevel != "" {
+			out[nodeUUID] = &types.NodePostureSummary{RiskLevel: score.RiskLevel}
 		}
 	}
 	return out, nil

--- a/pkg/posture/posture_test.go
+++ b/pkg/posture/posture_test.go
@@ -235,6 +235,93 @@ func TestGetUptimeByNodesNormalizesUUIDs(t *testing.T) {
 	}
 }
 
+func TestPostureManagerSeedsDefaultChecksWithoutOverwritingAdminEdits(t *testing.T) {
+	pm := newTestManager(t)
+
+	checks, err := pm.ListChecks()
+	if err != nil {
+		t.Fatalf("list checks: %v", err)
+	}
+	if len(checks) == 0 {
+		t.Fatal("expected default posture checks to be seeded")
+	}
+
+	first := checks[0]
+	if err := pm.DB.Model(&PostureCheck{}).Where("id = ?", first.ID).Updates(map[string]interface{}{
+		"name":    "Admin edited",
+		"enabled": false,
+		"weight":  99,
+	}).Error; err != nil {
+		t.Fatalf("edit check: %v", err)
+	}
+	if err := pm.SeedDefaultChecks(); err != nil {
+		t.Fatalf("reseed checks: %v", err)
+	}
+
+	var edited PostureCheck
+	if err := pm.DB.First(&edited, first.ID).Error; err != nil {
+		t.Fatalf("load edited check: %v", err)
+	}
+	if edited.Name != "Admin edited" || edited.Enabled || edited.Weight != 99 {
+		t.Fatalf("seed overwrote admin edit: %+v", edited)
+	}
+}
+
+func TestPostureManagerBuildsProfilesFromEnabledDatabaseChecks(t *testing.T) {
+	pm := newTestManager(t)
+
+	if err := pm.DB.Model(&PostureCheck{}).
+		Where("profile_id = ? AND category = ?", "linux-server", "users").
+		Update("enabled", false).Error; err != nil {
+		t.Fatalf("disable check: %v", err)
+	}
+	profile, err := pm.GetProfile("linux-server")
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if _, ok := profile.Queries["users"]; ok {
+		t.Fatalf("disabled check still appears in profile: %+v", profile.Queries)
+	}
+	if _, ok := profile.Queries["packages_deb"]; !ok {
+		t.Fatalf("enabled check missing from profile: %+v", profile.Queries)
+	}
+}
+
+func TestPostureManagerScoresWithEnabledDatabaseCheckWeights(t *testing.T) {
+	pm := newTestManager(t)
+	if err := pm.DB.Model(&PostureCheck{}).Where("scoring_rule = ?", "listening_ports").Updates(map[string]interface{}{
+		"weight": 80,
+	}).Error; err != nil {
+		t.Fatalf("edit scoring check: %v", err)
+	}
+	if err := pm.DB.Model(&PostureCheck{}).Where("scoring_rule = ?", "software_inventory").Update("weight", 20).Error; err != nil {
+		t.Fatalf("edit inventory scoring check: %v", err)
+	}
+	if err := pm.DB.Model(&PostureCheck{}).Where("scoring_rule = ?", "disk_encryption").Update("enabled", false).Error; err != nil {
+		t.Fatalf("disable disk scoring check: %v", err)
+	}
+
+	score, err := pm.Score([]NodePosture{
+		postureRecord(t, "listening_ports", []map[string]interface{}{{"port": "3389"}}),
+		postureRecord(t, "packages_deb", debRows(3)),
+		postureRecord(t, "disk_encryption", []map[string]interface{}{{"name": "/dev/sda1", "encrypted": "0"}}),
+	})
+	if err != nil {
+		t.Fatalf("score: %v", err)
+	}
+	if score.TotalScore != 20 {
+		t.Fatalf("expected configured listening port weight in normalized score, got %d", score.TotalScore)
+	}
+	if score.RiskLevel != "medium" {
+		t.Fatalf("disabled critical disk rule should not escalate risk, got %s", score.RiskLevel)
+	}
+	for _, ctrl := range score.Controls {
+		if ctrl.Title == "Disk encryption at rest" {
+			t.Fatalf("disabled disk rule was evaluated: %+v", score.Controls)
+		}
+	}
+}
+
 type legacyNodePosture struct {
 	ID          uint `gorm:"primarykey"`
 	CreatedAt   time.Time

--- a/pkg/posture/scoring.go
+++ b/pkg/posture/scoring.go
@@ -117,6 +117,7 @@ type ScoreCalculator struct {
 
 // ScoringRule defines how to evaluate one control from posture data.
 type ScoringRule struct {
+	RuleKey string `json:"rule_key"`
 	// Categories lists every posture category that can provide evidence
 	// for this control. The rule is evaluated when at least one of them
 	// has been collected; mutually exclusive sources (deb vs rpm) belong
@@ -127,6 +128,7 @@ type ScoringRule struct {
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
 	Severity    Severity  `json:"severity"`
+	Weight      int       `json:"weight"`
 	// Evaluate receives the collected categories (only those present for
 	// the node) with their parsed rows and returns (status, detail).
 	// status is "pass", "warn", or "fail".
@@ -136,6 +138,57 @@ type ScoringRule struct {
 // NewScoreCalculator returns a calculator with all built-in rules.
 func NewScoreCalculator() *ScoreCalculator {
 	return &ScoreCalculator{rules: defaultRules()}
+}
+
+// NewScoreCalculatorWithChecks returns a calculator configured from enabled
+// DB checks. Checks without a built-in ScoringRule still collect posture data
+// but do not contribute to risk score.
+func NewScoreCalculatorWithChecks(checks []PostureCheck) *ScoreCalculator {
+	groups := map[string][]PostureCheck{}
+	for _, check := range checks {
+		if !check.Enabled || check.ScoringRule == "" {
+			continue
+		}
+		groups[check.ScoringRule] = append(groups[check.ScoringRule], check)
+	}
+	var rules []ScoringRule
+	for _, base := range defaultRules() {
+		checks := groups[base.RuleKey]
+		if len(checks) == 0 {
+			continue
+		}
+		sort.Slice(checks, func(i, j int) bool {
+			if checks[i].Category == checks[j].Category {
+				return checks[i].ProfileID < checks[j].ProfileID
+			}
+			return checks[i].Category < checks[j].Category
+		})
+		rule := base
+		rule.Categories = uniqueCheckCategories(checks)
+		first := checks[0]
+		if first.ControlID != "" {
+			rule.ControlID = first.ControlID
+		}
+		if first.Framework != "" {
+			rule.Framework = first.Framework
+		}
+		if first.Severity != "" {
+			rule.Severity = first.Severity
+		}
+		if first.Weight > 0 {
+			rule.Weight = first.Weight
+		}
+		if len(rule.Categories) == 1 {
+			if first.Name != "" {
+				rule.Title = first.Name
+			}
+			if first.Description != "" {
+				rule.Description = first.Description
+			}
+		}
+		rules = append(rules, rule)
+	}
+	return &ScoreCalculator{rules: rules}
 }
 
 // Score evaluates all posture records and returns the aggregate score.
@@ -193,7 +246,7 @@ func (sc *ScoreCalculator) Score(records []NodePosture) PostureScore {
 		}
 
 		status, detail := rule.Evaluate(data)
-		weight := SeverityWeight[rule.Severity]
+		weight := ruleWeight(rule)
 
 		result := ControlResult{
 			Category:    resultCategory,
@@ -228,6 +281,13 @@ func (sc *ScoreCalculator) Score(records []NodePosture) PostureScore {
 	}
 	score.RiskLevel = riskLevel(score.TotalScore, score.Controls)
 	return score
+}
+
+func ruleWeight(rule ScoringRule) int {
+	if rule.Weight > 0 {
+		return rule.Weight
+	}
+	return SeverityWeight[rule.Severity]
 }
 
 // riskLevel derives the risk level from the normalized score, escalated by
@@ -265,6 +325,7 @@ func defaultRules() []ScoringRule {
 		// macOS: "encrypted" flag) or BitLocker rows ("protection_status"),
 		// which Windows profiles store under the disk_encryption category.
 		{
+			RuleKey:    "disk_encryption",
 			Categories: []string{"disk_encryption", "bitlocker_info"},
 			ControlID:  "A.8.24", Framework: FrameworkISO27001,
 			Title:       "Disk encryption at rest",
@@ -314,6 +375,7 @@ func defaultRules() []ScoringRule {
 		// macOS), so an empty inapplicable source is not a finding: the
 		// control passes when any source has data.
 		{
+			RuleKey:    "software_inventory",
 			Categories: []string{"packages_deb", "packages_rpm", "packages_windows", "packages_apps", "packages_brew"},
 			ControlID:  "A.5.9", Framework: FrameworkISO27001,
 			Title:       "Software inventory",
@@ -346,6 +408,7 @@ func defaultRules() []ScoringRule {
 
 		// --- Users with real shells (A.8.2 / CC6.1) ---
 		{
+			RuleKey:    "users",
 			Categories: []string{"users"},
 			ControlID:  "A.8.2", Framework: FrameworkISO27001,
 			Title:       "Interactive user accounts",
@@ -375,6 +438,7 @@ func defaultRules() []ScoringRule {
 
 		// --- SSH authorized keys (A.5.17 / CC6.1) ---
 		{
+			RuleKey:    "ssh_keys",
 			Categories: []string{"ssh_keys"},
 			ControlID:  "A.5.17", Framework: FrameworkISO27001,
 			Title:       "SSH authorized keys",
@@ -405,6 +469,7 @@ func defaultRules() []ScoringRule {
 		// (RDP, SMB, SNMP, VNC) are a warning to review exposure, not a
 		// failure: RDP/SMB listen on effectively every Windows server.
 		{
+			RuleKey:    "listening_ports",
 			Categories: []string{"listening_ports"},
 			ControlID:  "A.8.20", Framework: FrameworkISO27001,
 			Title:       "Open listening ports",
@@ -451,6 +516,7 @@ func defaultRules() []ScoringRule {
 
 		// --- Patches / hotfixes (A.8.8 / CC7.1) ---
 		{
+			RuleKey:    "patches",
 			Categories: []string{"patches"},
 			ControlID:  "A.8.8", Framework: FrameworkISO27001,
 			Title:       "Security patches installed",
@@ -467,6 +533,7 @@ func defaultRules() []ScoringRule {
 
 		// --- SUID binaries (A.8.9 / CC7.4) ---
 		{
+			RuleKey:    "suid_binaries",
 			Categories: []string{"suid_binaries"},
 			ControlID:  "A.8.9", Framework: FrameworkISO27001,
 			Title:       "SUID binaries",
@@ -500,6 +567,7 @@ func defaultRules() []ScoringRule {
 
 		// --- Startup items (A.8.9 / CC8.1) ---
 		{
+			RuleKey:    "startup_items",
 			Categories: []string{"startup_items"},
 			ControlID:  "A.8.9", Framework: FrameworkISO27001,
 			Title:       "Startup items / autostart",
@@ -519,6 +587,7 @@ func defaultRules() []ScoringRule {
 
 		// --- Browser extensions (A.8.19 / CC6.6) ---
 		{
+			RuleKey:    "browser_extensions_chrome",
 			Categories: []string{"browser_extensions_chrome"},
 			ControlID:  "A.8.19", Framework: FrameworkISO27001,
 			Title:       "Chrome browser extensions",
@@ -536,6 +605,7 @@ func defaultRules() []ScoringRule {
 			},
 		},
 		{
+			RuleKey:    "browser_extensions_firefox",
 			Categories: []string{"browser_extensions_firefox"},
 			ControlID:  "A.8.19", Framework: FrameworkISO27001,
 			Title:       "Firefox browser add-ons",
@@ -555,6 +625,7 @@ func defaultRules() []ScoringRule {
 
 		// --- WiFi networks (A.8.21 / CC6.1) ---
 		{
+			RuleKey:    "wifi_networks",
 			Categories: []string{"wifi_networks"},
 			ControlID:  "A.8.21", Framework: FrameworkISO27001,
 			Title:       "Known WiFi networks",
@@ -581,6 +652,7 @@ func defaultRules() []ScoringRule {
 
 		// --- macOS sharing preferences (A.8.9 / CC6.1) ---
 		{
+			RuleKey:    "file_sharing",
 			Categories: []string{"file_sharing"},
 			ControlID:  "A.8.9", Framework: FrameworkISO27001,
 			Title:       "macOS sharing services",
@@ -607,6 +679,7 @@ func defaultRules() []ScoringRule {
 
 		// --- Kernel modules (A.8.9 / CC7.4) — Linux servers ---
 		{
+			RuleKey:    "kernel_modules",
 			Categories: []string{"kernel_modules"},
 			ControlID:  "A.8.9", Framework: FrameworkISO27001,
 			Title:       "Loaded kernel modules",
@@ -651,6 +724,22 @@ func dedupe(values []string) []string {
 		}
 		seen[v] = struct{}{}
 		out = append(out, v)
+	}
+	return out
+}
+
+func uniqueCheckCategories(checks []PostureCheck) []string {
+	seen := make(map[string]struct{}, len(checks))
+	out := make([]string, 0, len(checks))
+	for _, check := range checks {
+		if check.Category == "" {
+			continue
+		}
+		if _, ok := seen[check.Category]; ok {
+			continue
+		}
+		seen[check.Category] = struct{}{}
+		out = append(out, check.Category)
 	}
 	return out
 }

--- a/pkg/posture/templates.go
+++ b/pkg/posture/templates.go
@@ -19,10 +19,11 @@ type PostureProfile struct {
 
 // ProfileQuery is a single scheduled query within a posture profile.
 type ProfileQuery struct {
-	Query    string `json:"query"`
-	Interval int    `json:"interval"`
-	Platform string `json:"platform,omitempty"`
-	Snapshot bool   `json:"snapshot"`
+	QueryName string `json:"query_name,omitempty"`
+	Query     string `json:"query"`
+	Interval  int    `json:"interval"`
+	Platform  string `json:"platform,omitempty"`
+	Snapshot  bool   `json:"snapshot"`
 }
 
 const uptimeProfileQuery = "SELECT days, hours, minutes, seconds, total_seconds FROM uptime"
@@ -40,6 +41,10 @@ func uptimeCheck() ProfileQuery {
 func (p PostureProfile) ToScheduleEntries() (map[string]map[string]interface{}, error) {
 	out := make(map[string]map[string]interface{}, len(p.Queries))
 	for name, q := range p.Queries {
+		queryName := q.QueryName
+		if queryName == "" {
+			queryName = QueryPrefix + name
+		}
 		entry := map[string]interface{}{
 			"query":    q.Query,
 			"interval": q.Interval,
@@ -48,7 +53,7 @@ func (p PostureProfile) ToScheduleEntries() (map[string]map[string]interface{}, 
 		if q.Platform != "" {
 			entry["platform"] = q.Platform
 		}
-		out[QueryPrefix+name] = entry
+		out[queryName] = entry
 	}
 	return out, nil
 }
@@ -68,6 +73,12 @@ func (p PostureProfile) ToScheduleJSON() (string, error) {
 
 // AllProfiles returns every predefined posture profile, sorted by name.
 func AllProfiles() []PostureProfile {
+	profiles := builtinProfiles()
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+	return profiles
+}
+
+func builtinProfiles() []PostureProfile {
 	profiles := []PostureProfile{
 		WindowsServerProfile(),
 		LinuxServerProfile(),
@@ -75,7 +86,6 @@ func AllProfiles() []PostureProfile {
 		WindowsLaptopProfile(),
 		LinuxLaptopProfile(),
 	}
-	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
 	return profiles
 }
 


### PR DESCRIPTION
## Summary

- Added environment-scoped Posture configuration under the existing Configuration area, visible only when posture is enabled and the user can manage the environment.
- Restored the Schedule tab’s `Add posture checks` picker for adding profile-based posture checks with a selected interval.
- Added Posture tab editing for scheduled posture checks, including query name, query SQL, interval, platform, snapshot, and associated profile.
- Persisted posture profile association in schedule entries via `profile_id`, while keeping evaluation logic out of stored config.
- Added DB-backed posture check defaults/customization plumbing for names, query names, queries, descriptions, scores/weights, enabled state, and related metadata.
- Updated posture scoring/profile loading to use configurable check metadata where applicable.
- Added regression tests for posture schedule merging, profile metadata, environment Posture tab visibility, editing, and picker behavior.

## Validation

- `cd frontend && npm test -- EnvConfigPage.test.tsx postureSchedule.test.ts`
- `cd frontend && npm run check`
- `git diff --check`
- `GOCACHE=/tmp/osctrl-gocache go test ./pkg/posture ./cmd/api/handlers ./cmd/api ./cmd/tls/handlers ./cmd/cli`
- `make openapi-check`