### PR TITLE
Replace the failed-enrolls counter with reported osquery errors

### DIFF
--- a/cmd/api/handlers/stats.go
+++ b/cmd/api/handlers/stats.go
@@ -736,6 +736,7 @@ func (h *HandlersApi) OsqueryVersionsHandler(w http.ResponseWriter, r *http.Requ
 type activityReader interface {
 	ReadSeries(ctx context.Context, envUUID string, nodeUUIDs []string, end time.Time, days int) (map[string]activity.NodeTileSeries, error)
 	ReadEnvSeries(ctx context.Context, envUUID string, end time.Time, days int) (activity.EnvSeries, error)
+	TopErrorNodes(ctx context.Context, envUUID string, end time.Time, days, limit int) ([]activity.NodeErrorCount, error)
 }
 
 // activityTileDays parses and clamps the ?days query parameter for the
@@ -997,4 +998,84 @@ func (h *HandlersApi) EnvActivityTilesHandler(w http.ResponseWriter, r *http.Req
 	}
 	w.Header().Set("Cache-Control", "private, max-age=30")
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, out)
+}
+
+// errorNodesLimit caps the drill-down list. The tile answers "who is
+// erroring", not "give me every node" — an operator scanning a list longer
+// than this wants the Nodes table with a filter, not a dashboard popover.
+const errorNodesLimit = 10
+
+// ErrorNodeRow is one entry in the reported-errors drill-down.
+type ErrorNodeRow struct {
+	UUID     string `json:"uuid"`
+	Hostname string `json:"hostname"`
+	Errors   int64  `json:"errors"`
+}
+
+// EnvErrorNodesHandler — GET /api/v1/stats/activity/error-nodes/{env}
+//
+// Returns the nodes reporting the most ERROR-severity status logs in the
+// window, worst first. Backs the dashboard's reported-errors tile drill-down.
+// @Summary Top erroring nodes for an environment
+// @Description Returns nodes with the most ERROR-severity osquery status logs.
+// @Tags stats
+// @Produce json
+// @Param env path string true "Environment name or UUID"
+// @Param days query int false "Days of history (default 1)"
+// @Success 200 {array} ErrorNodeRow
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 503 {object} types.ApiErrorResponse "Service unavailable"
+// @Security ApiKeyAuth
+// @Router /api/v1/stats/activity/error-nodes/{env} [get]
+func (h *HandlersApi) EnvErrorNodesHandler(w http.ResponseWriter, r *http.Request) {
+	ctxVal := r.Context().Value(ContextKey(contextAPI))
+	if ctxVal == nil {
+		apiErrorResponse(w, "missing auth context", http.StatusUnauthorized, nil)
+		return
+	}
+	ctx := ctxVal.(ContextValue)
+	user := ctx[ctxUser]
+
+	envVar := r.PathValue("env")
+	if envVar == "" {
+		apiErrorResponse(w, "error with environment", http.StatusBadRequest, nil)
+		return
+	}
+	env, err := h.Envs.Get(envVar)
+	if err != nil {
+		apiErrorResponse(w, "error getting environment", http.StatusNotFound, err)
+		return
+	}
+	if !h.Users.CheckPermissions(user, users.UserLevel, env.UUID) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use API by user %s", user))
+		return
+	}
+	if h.Activity == nil {
+		apiErrorResponse(w, "activity store not configured", http.StatusServiceUnavailable, nil)
+		return
+	}
+
+	days := activityTileDays(r.URL.Query().Get("days"))
+	ranked, err := h.Activity.TopErrorNodes(r.Context(), env.UUID, time.Now(), days, errorNodesLimit)
+	if err != nil {
+		apiErrorResponse(w, "failed to load erroring nodes", http.StatusInternalServerError, err)
+		return
+	}
+
+	rows := make([]ErrorNodeRow, 0, len(ranked))
+	for _, entry := range ranked {
+		row := ErrorNodeRow{UUID: entry.NodeUUID, Errors: entry.Errors}
+		// Resolve the hostname for display. A node deleted since it last
+		// errored keeps its row — the errors were still real — it just
+		// shows by UUID.
+		if node, nerr := h.Nodes.GetByUUIDEnv(entry.NodeUUID, env.ID); nerr == nil {
+			row.Hostname = node.Hostname
+		}
+		rows = append(rows, row)
+	}
+
+	w.Header().Set("Cache-Control", "private, max-age=30")
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, rows)
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -752,6 +752,11 @@ func osctrlAPIService() {
 	muxAPI.Handle(
 		"GET "+_apiPath(apiStatsPath)+"/activity/env-tiles/{env}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvActivityTilesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	// API: nodes reporting the most osquery ERROR status logs (dashboard
+	// reported-errors drill-down).
+	muxAPI.Handle(
+		"GET "+_apiPath(apiStatsPath)+"/activity/error-nodes/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvErrorNodesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// API: queries by environment
 	if flagParams.Osquery.Query {
 		// Sample-templates library (post-auth). Pre-auth exposure

--- a/cmd/tls/handlers/activity_writer.go
+++ b/cmd/tls/handlers/activity_writer.go
@@ -2,11 +2,17 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/activity"
+	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/rs/zerolog/log"
 )
+
+// osquerySeverityError is osquery's ERROR level on the 0=INFO, 1=WARNING,
+// 2=ERROR status-log ladder.
+const osquerySeverityError types.StringInt = 2
 
 type activityStore interface {
 	IncrementMany(ctx context.Context, events []activity.Event) error
@@ -189,7 +195,15 @@ func resetTimer(timer *time.Timer, timeout time.Duration) {
 // request path. The counters feed the per-node/per-env activity heatmaps
 // surfaced in the admin frontend.
 func (h *HandlersTLS) recordActivity(envUUID, nodeUUID string, typ activity.EventType) {
-	if h == nil || h.ActivityWriter == nil || envUUID == "" || nodeUUID == "" {
+	h.recordActivityCount(envUUID, nodeUUID, typ, 1)
+}
+
+// recordActivityCount is recordActivity for counters that advance by more than
+// one per request — a single status POST carries a batch of log lines, so the
+// error counter moves by however many of them osquery flagged. Same
+// fire-and-forget contract: it can never block or fail the request path.
+func (h *HandlersTLS) recordActivityCount(envUUID, nodeUUID string, typ activity.EventType, count uint16) {
+	if h == nil || h.ActivityWriter == nil || envUUID == "" || nodeUUID == "" || count == 0 {
 		return
 	}
 	h.ActivityWriter.addEvent(activity.Event{
@@ -197,8 +211,42 @@ func (h *HandlersTLS) recordActivity(envUUID, nodeUUID string, typ activity.Even
 		NodeUUID: nodeUUID,
 		Type:     typ,
 		At:       time.Now(),
-		Count:    1,
+		Count:    count,
 	})
+}
+
+// countStatusErrors reports how many entries in a status-log batch osquery
+// flagged at ERROR severity.
+//
+// Only ERROR counts. osquery's severity ladder is 0=INFO, 1=WARNING,
+// 2=ERROR, and warnings are common enough in normal operation (a table that
+// is unavailable on this platform, a transient permission issue) that
+// counting them would keep the dashboard permanently amber and train
+// operators to ignore it.
+//
+// A malformed batch yields 0 rather than an error: this feeds a dashboard
+// counter, and losing a count is strictly better than failing log ingestion.
+// The parse is deliberately narrow — only the severity field is decoded, so
+// the cost is a fraction of the full ProcessLogs pass it runs alongside.
+func countStatusErrors(data json.RawMessage) uint16 {
+	var entries []struct {
+		Severity types.StringInt `json:"severity"`
+	}
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return 0
+	}
+	var errors int
+	for _, entry := range entries {
+		if entry.Severity == osquerySeverityError {
+			errors++
+		}
+	}
+	// Counters are uint16 in the rollup blob; saturate rather than wrap, so
+	// an implausibly large batch reads as "very many" instead of "a few".
+	if errors > int(^uint16(0)) {
+		return ^uint16(0)
+	}
+	return uint16(errors)
 }
 
 // logActivityType maps an osquery log type ("status"/"result") to its

--- a/cmd/tls/handlers/activity_writer_test.go
+++ b/cmd/tls/handlers/activity_writer_test.go
@@ -187,3 +187,86 @@ func TestLogActivityTypeMapping(t *testing.T) {
 		}
 	}
 }
+
+// countStatusErrors underpins the dashboard's error tile. Only osquery's
+// ERROR severity (2) counts — warnings are routine and would keep the tile
+// permanently lit.
+func TestCountStatusErrorsCountsOnlyErrors(t *testing.T) {
+	batch := []byte(`[
+		{"severity":0,"message":"info"},
+		{"severity":1,"message":"warning"},
+		{"severity":2,"message":"error one"},
+		{"severity":2,"message":"error two"}
+	]`)
+	if got := countStatusErrors(batch); got != 2 {
+		t.Fatalf("countStatusErrors = %d, want 2", got)
+	}
+}
+
+// osquery sends severity as a bare int or a quoted string depending on
+// version and logger plugin; types.StringInt absorbs both and the count must
+// not depend on which one arrived.
+func TestCountStatusErrorsAcceptsStringSeverity(t *testing.T) {
+	batch := []byte(`[{"severity":"2","message":"error"},{"severity":"0","message":"info"}]`)
+	if got := countStatusErrors(batch); got != 1 {
+		t.Fatalf("countStatusErrors = %d, want 1", got)
+	}
+}
+
+// A malformed or empty batch must yield zero rather than an error: this feeds
+// a counter, and losing a count beats failing log ingestion.
+func TestCountStatusErrorsToleratesBadInput(t *testing.T) {
+	for name, batch := range map[string]string{
+		"malformed":   `{"not":"an array"}`,
+		"empty array": `[]`,
+		"garbage":     `not json at all`,
+		"null":        `null`,
+	} {
+		if got := countStatusErrors([]byte(batch)); got != 0 {
+			t.Errorf("%s: countStatusErrors = %d, want 0", name, got)
+		}
+	}
+}
+
+// A batch carrying several errors advances the counter by that many, rather
+// than by one per request.
+func TestRecordActivityCountEmitsTheGivenCount(t *testing.T) {
+	store := &recordingActivityStore{notify: make(chan struct{}, 1)}
+	writer := NewActivityWriter(store, 1, time.Second, 4)
+	defer writer.close()
+
+	h := &HandlersTLS{ActivityWriter: writer}
+	h.recordActivityCount("ENV-UUID", "NODE-UUID", activity.EventStatusError, 4)
+
+	select {
+	case <-store.notify:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for activity flush")
+	}
+
+	events := store.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	got := events[0]
+	if got.Type != activity.EventStatusError || got.Count != 4 {
+		t.Fatalf("unexpected event: %+v", got)
+	}
+}
+
+// A batch with no errors must not emit an event at all, so a healthy fleet
+// does not write a rollup key on every check-in.
+func TestRecordActivityCountSkipsZero(t *testing.T) {
+	store := &recordingActivityStore{notify: make(chan struct{}, 1)}
+	writer := NewActivityWriter(store, 1, time.Second, 4)
+	defer writer.close()
+
+	h := &HandlersTLS{ActivityWriter: writer}
+	h.recordActivityCount("ENV-UUID", "NODE-UUID", activity.EventStatusError, 0)
+
+	select {
+	case <-store.notify:
+		t.Fatal("a zero count must not emit an event")
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -360,6 +360,14 @@ func (h *HandlersTLS) LogHandler(w http.ResponseWriter, r *http.Request) {
 			results := h.Logs.ProcessLogs(t.Data, t.LogType, env.ID, env.Name, utils.GetIP(r), len(body), env.DebugHTTP)
 			duration := time.Since(start).Seconds()
 			logProcessDuration.WithLabelValues(string(env.UUID), t.LogType).Observe(duration)
+			// Count ERROR-severity status logs into the activity rollup.
+			// Done here rather than at the sink so the counter is identical
+			// whatever logger.type is configured — with an external sink
+			// (S3, Splunk, Kafka) nothing lands in the database to count
+			// later. Inside this goroutine so it stays off the hot path.
+			if t.LogType == types.StatusLog {
+				h.recordActivityCount(env.UUID, node.UUID, activity.EventStatusError, countStatusErrors(t.Data))
+			}
 			// Ingest posture data from result logs (if enabled)
 			if h.Posture != nil && t.LogType == "result" {
 				h.ingestPosture(results, node.UUID, env.Name)

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -174,6 +174,12 @@ export interface NodeTileSeries {
   result: number[];
   query_read: number[];
   query_write: number[];
+  /**
+   * Status logs the node reported at osquery's ERROR severity. A subset of
+   * `status`, not a sibling — the same log increments both — so it is
+   * deliberately excluded from `total`.
+   */
+  status_error: number[];
   total: number[];
 }
 
@@ -183,7 +189,8 @@ export type TileCategory =
   | 'status'
   | 'result'
   | 'query_read'
-  | 'query_write';
+  | 'query_write'
+  | 'status_error';
 
 export const TILE_CATEGORIES: TileCategory[] = [
   'config',
@@ -191,6 +198,9 @@ export const TILE_CATEGORIES: TileCategory[] = [
   'result',
   'query_read',
   'query_write',
+  // Last on purpose: errors are the exception row, read after the normal
+  // endpoint traffic above them.
+  'status_error',
 ];
 
 export const TILE_CATEGORY_LABELS: Record<TileCategory, string> = {
@@ -199,6 +209,7 @@ export const TILE_CATEGORY_LABELS: Record<TileCategory, string> = {
   result: 'Result',
   query_read: 'Query read',
   query_write: 'Query write',
+  status_error: 'Errors',
 };
 
 export function getNodeActivityTiles(
@@ -268,4 +279,24 @@ export function tileCategoryTotal(series: NodeTileSeries, category: TileCategory
   let sum = 0;
   for (const c of counts) sum += c;
   return sum;
+}
+
+/** One node in the dashboard's reported-errors drill-down. */
+export interface ErrorNodeRow {
+  uuid: string;
+  /** Empty when the node has been deleted since it last errored. */
+  hostname: string;
+  errors: number;
+}
+
+/**
+ * Nodes reporting the most ERROR-severity osquery status logs, worst first.
+ * Capped server-side; backs the reported-errors tile drill-down.
+ */
+export function getEnvErrorNodes(env: string, days = 1): Promise<ErrorNodeRow[]> {
+  const sp = new URLSearchParams();
+  sp.set('days', String(days));
+  return apiFetch<ErrorNodeRow[]>(
+    `/api/v1/stats/activity/error-nodes/${encodeURIComponent(env)}?${sp.toString()}`,
+  );
 }

--- a/frontend/src/features/dashboard/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.test.tsx
@@ -10,13 +10,15 @@ import {
   Outlet,
 } from '@tanstack/react-router';
 import { DashboardPage } from './DashboardPage';
-import type { NodeTileSeries, StatsResponse } from '$/api/stats';
+import userEvent from '@testing-library/user-event';
+import type { NodeTileSeries, StatsResponse, ErrorNodeRow } from '$/api/stats';
 
 // ---------------------------------------------------------------------------
 // Mock the stats API module
 // ---------------------------------------------------------------------------
 const mockGetStats = vi.fn<() => Promise<StatsResponse>>();
 const mockGetEnvActivityTiles = vi.fn<(env: string, days?: number) => Promise<NodeTileSeries>>();
+const mockGetEnvErrorNodes = vi.fn<(env: string, days?: number) => Promise<ErrorNodeRow[]>>();
 
 vi.mock('$/api/stats', async () => {
   const actual = await vi.importActual<typeof import('$/api/stats')>('$/api/stats');
@@ -27,6 +29,7 @@ vi.mock('$/api/stats', async () => {
     // resolve to empty so the queries don't reject and trigger extra logs.
     getOsqueryVersionCounts: () => Promise.resolve([]),
     getEnvActivityTiles: (env: string, days?: number) => mockGetEnvActivityTiles(env, days),
+    getEnvErrorNodes: (env: string, days?: number) => mockGetEnvErrorNodes(env, days),
   };
 });
 
@@ -89,7 +92,7 @@ function makeStatsResponse(overrides: Partial<StatsResponse> = {}): StatsRespons
   };
 }
 
-function makeTileSeries(): NodeTileSeries {
+function makeTileSeries(overrides: Partial<NodeTileSeries> = {}): NodeTileSeries {
   const buckets = 24;
   const start = new Date(Date.now() - (buckets - 1) * 60 * 60 * 1000).toISOString();
   const zeros = () => Array.from({ length: buckets }, () => 0);
@@ -97,12 +100,14 @@ function makeTileSeries(): NodeTileSeries {
     start,
     bucket_seconds: 3600,
     enroll: zeros(),
+    status_error: zeros(),
     config: [...zeros().slice(0, buckets - 1), 3],
     status: [...zeros().slice(0, buckets - 2), 1, 2],
     result: [...zeros().slice(0, buckets - 3), 2, 1, 1],
     query_read: [...zeros().slice(0, buckets - 1), 1],
     query_write: [...zeros().slice(0, buckets - 1), 1],
     total: [...zeros().slice(0, buckets - 3), 2, 2, 7],
+    ...overrides,
   };
 }
 
@@ -169,6 +174,7 @@ describe('DashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetEnvActivityTiles.mockResolvedValue(makeTileSeries());
+    mockGetEnvErrorNodes.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -217,6 +223,100 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Inactive ≥ 72h')).toBeInTheDocument();
     expect(screen.getByText('Active Queries')).toBeInTheDocument();
     expect(screen.getByText('Forensic Carves')).toBeInTheDocument();
+  });
+
+  // The tile replaced a "Failed enrolls" counter that read the audit log.
+  // It now sums ERROR-severity status logs from the activity rollup, which is
+  // the only source that works whatever logger.type the deployment uses.
+  it('sums the last 24h of status errors into the reported-errors tile', async () => {
+    mockGetStats.mockResolvedValue(makeStatsResponse());
+    mockGetEnvActivityTiles.mockResolvedValue(
+      makeTileSeries({ status_error: [2, 0, 3] }),
+    );
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => expect(screen.getByText('Reported errors (24h)')).toBeInTheDocument());
+    expect(await screen.findByText('5 in 24h — see nodes')).toBeInTheDocument();
+    // The old tile must be gone, not merely relabeled.
+    expect(screen.queryByText('Failed enrolls (24h)')).not.toBeInTheDocument();
+  });
+
+  it('reads all clear when no errors were reported', async () => {
+    mockGetStats.mockResolvedValue(makeStatsResponse());
+    mockGetEnvActivityTiles.mockResolvedValue(makeTileSeries());
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => expect(screen.getByText('Reported errors (24h)')).toBeInTheDocument());
+    expect(screen.getByText('all clear')).toBeInTheDocument();
+  });
+
+  it('opens the erroring-nodes drill-down from the tile', async () => {
+    const user = userEvent.setup();
+    mockGetStats.mockResolvedValue(makeStatsResponse());
+    mockGetEnvActivityTiles.mockResolvedValue(makeTileSeries({ status_error: [4] }));
+    mockGetEnvErrorNodes.mockResolvedValue([
+      { uuid: 'NODE-1', hostname: 'web-01', errors: 3 },
+      // A node deleted since it errored keeps its row, shown by UUID.
+      { uuid: 'NODE-2', hostname: '', errors: 1 },
+    ]);
+    renderWithProviders(makeTestRouter());
+
+    const tile = await screen.findByRole('button', { name: /nodes reporting errors/i });
+    await user.click(tile);
+
+    expect(await screen.findByText('web-01')).toBeInTheDocument();
+    expect(screen.getByText('NODE-2')).toBeInTheDocument();
+    expect(mockGetEnvErrorNodes).toHaveBeenCalled();
+  });
+
+  // A tile with nothing behind it must not look clickable.
+  it('leaves the errors tile inert when there are no errors', async () => {
+    mockGetStats.mockResolvedValue(makeStatsResponse());
+    mockGetEnvActivityTiles.mockResolvedValue(makeTileSeries());
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => expect(screen.getByText('Reported errors (24h)')).toBeInTheDocument());
+    expect(
+      screen.queryByRole('button', { name: /nodes reporting errors/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an Errors row in endpoint health', async () => {
+    mockGetStats.mockResolvedValue(makeStatsResponse());
+    mockGetEnvActivityTiles.mockResolvedValue(makeTileSeries({ status_error: [7] }));
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => expect(screen.getByText('Errors')).toBeInTheDocument());
+  });
+
+  it('draws the errors line in the activity chart', async () => {
+    mockGetStats.mockResolvedValue(makeStatsResponse());
+    mockGetEnvActivityTiles.mockResolvedValue(
+      makeTileSeries({ status_error: [0, 2, 0, 5] }),
+    );
+    renderWithProviders(makeTestRouter());
+
+    const chart = await screen.findByRole('img', {
+      name: /Node activity by category/i,
+    });
+
+    // The chart element exists before the tiles query resolves, so wait on
+    // the drawn data rather than on the element — every path is d="" until
+    // the series arrives.
+    await waitFor(() => {
+      const errorLine = chart.querySelector('path[stroke="#ff4d4f"]');
+      expect(errorLine?.getAttribute('d')).toBeTruthy();
+    });
+
+    // One line per category, errors included and styled like the rest.
+    const strokes = Array.from(chart.querySelectorAll('path')).map((p) =>
+      p.getAttribute('stroke'),
+    );
+    expect(strokes).toContain('#ff4d4f');
+    expect(chart.querySelectorAll('circle')).toHaveLength(0);
+
+    // And it is recolourable like every other line.
+    expect(screen.getByLabelText('error color')).toBeInTheDocument();
   });
 
   it('uses the backend stats threshold for inactive labeling', async () => {

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -23,9 +23,11 @@ import {
   TILE_CATEGORY_LABELS,
   tileCategoryTotal,
   tileLastSeen,
+  getEnvErrorNodes,
 } from '$/api/stats';
 import type { PlatformCounts, NodeTileSeries, ActivityInterval, TileCategory } from '$/api/stats';
-import { listAuditLogs, LOG_TYPE, LOG_TYPE_LABELS } from '$/api/audit';
+import { ModalShell } from '$/components/feedback/ModalShell';
+import { listAuditLogs, LOG_TYPE_LABELS } from '$/api/audit';
 import { listNodes } from '$/api/nodes';
 import { listQueries } from '$/api/queries';
 import { listEnvironments } from '$/api/environments';
@@ -48,13 +50,14 @@ import { DEFAULT_INACTIVE_HOURS } from '$/lib/node-status';
 // When the tiles endpoint hasn't returned yet (or Redis is unavailable),
 // all-zero arrays are returned so the chart renders an empty frame.
 // ---------------------------------------------------------------------------
-export type ChartCategory = 'status' | 'result' | 'config' | 'query';
+export type ChartCategory = 'status' | 'result' | 'config' | 'query' | 'error';
 
 interface ActivitySeries {
   status: number[];
   result: number[];
   config: number[];
   query: number[];
+  statusError: number[];
   total: number[];
 }
 
@@ -64,6 +67,7 @@ function emptySeries(n: number): ActivitySeries {
     result: new Array<number>(n).fill(0),
     config: new Array<number>(n).fill(0),
     query: new Array<number>(n).fill(0),
+    statusError: new Array<number>(n).fill(0),
     total: new Array<number>(n).fill(0),
   };
 }
@@ -76,6 +80,8 @@ function tileSeriesToActivity(tiles: NodeTileSeries | undefined): ActivitySeries
     result: tiles.result.map((v) => v),
     config: tiles.config.map((v) => v),
     query: tiles.query_read.map((v) => v),
+    // Tolerate a server that predates the status_error counter.
+    statusError: (tiles.status_error ?? []).map((v) => v),
     total: tiles.total.map((v) => v),
   };
 }
@@ -194,6 +200,7 @@ const DEFAULT_PALETTE: ChartPalette = {
   result:  '#2bc4be', // signal teal — query results
   config:  '#a78bfa', // violet — config fetches (agent heartbeat)
   query:   '#4ade80', // green — distributed query reads
+  error:   '#ff4d4f', // bright red — ERROR-severity status logs
 };
 
 const PALETTE_STORAGE_KEY = 'osctrl.dashboard-chart-palette';
@@ -274,6 +281,8 @@ function LineChart({
     { key: 'result', data: series.result },
     { key: 'config', data: series.config },
     { key: 'query', data: series.query },
+    // Drawn last so it sits on top of the traffic lines it is a subset of.
+    { key: 'error', data: series.statusError },
   ];
 
   function linePath(data: number[]): string {
@@ -291,7 +300,7 @@ function LineChart({
         : ['-24h', '-20h', '-16h', '-12h', '-8h', '-4h', 'now'];
 
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-auto" role="img" aria-label="Node activity by category">
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-auto" role="img" aria-label="Node activity by category, including reported errors">
       {/* gridlines */}
       <g stroke="var(--border)" strokeDasharray="2 4" strokeWidth="1">
         {[0, 0.25, 0.5, 0.75, 1].map((t) => (
@@ -385,8 +394,16 @@ interface KpiCardProps {
   polarity?: 'up-good' | 'up-bad';
   /** Override the auto-computed delta label. */
   deltaLabel?: string;
+  /**
+   * Makes the card actionable. When set the card renders as a button so it
+   * is reachable by keyboard and announced as interactive, rather than a div
+   * with a click handler bolted on.
+   */
+  onClick?: () => void;
+  /** Accessible name for the action; required whenever onClick is set. */
+  actionLabel?: string;
 }
-function KpiCard({ label, value, sparkline, halo, polarity = 'up-good', deltaLabel }: KpiCardProps) {
+function KpiCard({ label, value, sparkline, halo, polarity = 'up-good', deltaLabel, onClick, actionLabel }: KpiCardProps) {
   const pct = computeDeltaPct(sparkline);
   const tone = deltaTone(pct, polarity);
   const text =
@@ -399,13 +416,23 @@ function KpiCard({ label, value, sparkline, halo, polarity = 'up-good', deltaLab
   const haloStyle: React.CSSProperties = {
     background: `radial-gradient(ellipse at top right, ${haloRgba[halo]} 0%, transparent 70%), var(--bg-1)`,
   };
+  const interactive = !!onClick;
+  const Tag = interactive ? 'button' : 'div';
   return (
-    <div
+    <Tag
+      type={interactive ? 'button' : undefined}
+      onClick={onClick}
+      aria-label={interactive ? actionLabel : undefined}
       className={cn(
         'relative rounded-xl border border-[color:var(--border)]',
         'px-5 pt-4 pb-4 min-h-[136px]',
         'transition-shadow duration-[120ms] hover:shadow-[0_0_0_1px_var(--signal)]',
         'flex flex-col',
+        interactive && [
+          'text-left cursor-pointer',
+          'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+          'focus-visible:outline-[color:var(--signal)]',
+        ],
       )}
       style={haloStyle}
     >
@@ -432,7 +459,7 @@ function KpiCard({ label, value, sparkline, halo, polarity = 'up-good', deltaLab
         </span>
         <InlineSparkline points={sparkline} color={sparkColor[halo]} width={84} height={26} />
       </div>
-    </div>
+    </Tag>
   );
 }
 
@@ -641,6 +668,79 @@ function ActivityRow({
 }
 
 // ---------------------------------------------------------------------------
+// Reported-errors drill-down — which nodes are erroring, worst first.
+// ---------------------------------------------------------------------------
+function ErrorNodesDialog({
+  env,
+  onClose,
+}: {
+  env: string;
+  onClose: () => void;
+}) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['dashboard-error-nodes', env],
+    queryFn: () => getEnvErrorNodes(env, 1),
+    staleTime: 30_000,
+    retry: 1,
+  });
+  const rows = data ?? [];
+
+  return (
+    <ModalShell
+      title="Nodes reporting errors (24h)"
+      titleId="error-nodes-title"
+      onClose={onClose}
+      panelClassName="max-w-lg"
+    >
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-9 w-full" />
+          ))}
+        </div>
+      ) : isError ? (
+        <p className="text-sm text-[color:var(--danger)]">
+          Could not load the erroring nodes.
+        </p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-[color:var(--text-3)]">
+          No node reported an error in the last 24 hours.
+        </p>
+      ) : (
+        <>
+          <p className="mb-3 text-xs text-[color:var(--text-3)]">
+            Counting osquery status logs at ERROR severity. Warnings are not
+            included.
+          </p>
+          <ul className="divide-y divide-[color:var(--border)] rounded-md border border-[color:var(--border)]">
+            {rows.map((row) => (
+              <li key={row.uuid} className="flex items-center justify-between gap-3 px-3 py-2">
+                <Link
+                  to="/_app/env/$env/nodes/$uuid"
+                  params={{ env, uuid: row.uuid }}
+                  onClick={onClose}
+                  className="min-w-0 text-xs text-[color:var(--text-1)] hover:text-[color:var(--signal)] truncate"
+                >
+                  {/* A node deleted since it errored has no hostname left;
+                      its UUID is still the honest identifier. */}
+                  {row.hostname || row.uuid}
+                </Link>
+                <span
+                  className="font-mono-tabular text-xs font-semibold tabular-nums flex-shrink-0"
+                  style={{ color: 'var(--error-bright)' }}
+                >
+                  {row.errors.toLocaleString()}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </ModalShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Endpoint health — selected-environment osquery endpoint activity.
 // ---------------------------------------------------------------------------
 const ENDPOINT_HEALTH_TONE: Record<TileCategory, string> = {
@@ -649,6 +749,9 @@ const ENDPOINT_HEALTH_TONE: Record<TileCategory, string> = {
   result: 'var(--signal)',
   query_read: 'var(--warning)',
   query_write: 'var(--signal)',
+  // Hotter than the --danger used elsewhere: every other row on this panel
+  // is normal traffic, so the errors row has to be unmistakable at a glance.
+  status_error: 'var(--error-bright)',
 };
 
 function EndpointHealthPanel({
@@ -708,10 +811,20 @@ function EndpointHealthPanel({
             </div>
             {rows.map((row) => {
               const label = TILE_CATEGORY_LABELS[row.category];
+              // The errors row goes fully red once there is something to
+              // report. At zero it stays neutral like every other row —
+              // a permanently red panel is one nobody reads.
+              const alarming = row.category === 'status_error' && row.total > 0;
+              const rowColor = alarming
+                ? 'var(--error-bright)'
+                : 'var(--text-1)';
               return (
                 <div
                   key={row.category}
-                  className="grid grid-cols-[1fr_auto_auto] gap-3 items-center py-2.5 border-b border-[color:var(--border)] last:border-0"
+                  className={cn(
+                    'grid grid-cols-[1fr_auto_auto] gap-3 items-center py-2.5 border-b border-[color:var(--border)] last:border-0',
+                    alarming && 'bg-[rgba(var(--error-bright-r),var(--error-bright-g),var(--error-bright-b),0.07)]',
+                  )}
                 >
                   <div className="flex items-center gap-2 min-w-0">
                     <span
@@ -719,11 +832,20 @@ function EndpointHealthPanel({
                       className="w-2 h-2 rounded-full flex-shrink-0"
                       style={{ background: ENDPOINT_HEALTH_TONE[row.category] }}
                     />
-                    <span className="text-[13px] font-medium text-[color:var(--text-1)] truncate">
+                    <span
+                      className="text-[13px] font-medium truncate"
+                      style={{ color: rowColor }}
+                    >
                       {label}
                     </span>
                   </div>
-                  <span className="font-mono-tabular text-[12px] text-[color:var(--text-1)] tabular-nums text-right">
+                  <span
+                    className={cn(
+                      'font-mono-tabular text-[12px] tabular-nums text-right',
+                      alarming && 'font-semibold',
+                    )}
+                    style={{ color: rowColor }}
+                  >
                     {row.total.toLocaleString()}
                   </span>
                   {row.lastSeen ? (
@@ -1248,26 +1370,6 @@ export function DashboardPage() {
     retry: 1,
   });
 
-  // ── Failed enrolls (24h) — Node-typed audit lines starting with
-  //    "failed enroll". Capped at 200 by the request; >= 200 → render "200+".
-  //    The since-timestamp is computed inside queryFn (not in the query key)
-  //    so it doesn't change on every render and trigger a refetch storm.
-  const { data: failedEnrollData } = useQuery({
-    queryKey: ['dashboard-failed-enrolls'],
-    queryFn: () => {
-      const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-      return listAuditLogs({ type: LOG_TYPE.Node, since, page_size: 200 });
-    },
-    refetchInterval: 5 * 60_000,
-    refetchIntervalInBackground: false,
-    retry: 1,
-  });
-  const failedEnrollItems = failedEnrollData?.items ?? [];
-  const failedEnrolls = failedEnrollItems.filter((it) =>
-    (it.line ?? '').startsWith('failed enroll'),
-  ).length;
-  const failedEnrollOverflow = failedEnrollItems.length >= 200;
-
   // ── Environments list (NEW) — enriches EnvStats rows with enroll_expire.
   //    May 401 / 403 for non-super-admins; we silently fall back to no expire.
   const { data: envList } = useQuery({
@@ -1332,6 +1434,7 @@ export function DashboardPage() {
       result: trim(rawSeries.result),
       config: trim(rawSeries.config),
       query: trim(rawSeries.query),
+      statusError: trim(rawSeries.statusError),
       total: trim(rawSeries.total),
     };
   })();
@@ -1348,9 +1451,22 @@ export function DashboardPage() {
       result: slice(trimmedSeries.result),
       config: slice(trimmedSeries.config),
       query: slice(trimmedSeries.query),
+      statusError: slice(trimmedSeries.statusError),
       total: slice(trimmedSeries.total),
     };
   })();
+  const [showErrorNodes, setShowErrorNodes] = useState(false);
+
+  // ── Reported errors (24h) — status logs the fleet sent at osquery's ERROR
+  //    severity, counted at ingest into the activity rollup. Always the last
+  //    24 hourly buckets regardless of which interval the chart is showing,
+  //    so the tile's meaning does not change when the chart selector does.
+  //    Scoped to the selected environment, like every other tile fed by this
+  //    series.
+  const reportedErrors = trimmedSeries.statusError
+    .slice(-24)
+    .reduce((sum, n) => sum + n, 0);
+
   const activityWindowLabel =
     activityInterval === '7d'
       ? 'Last 7 days'
@@ -1528,7 +1644,7 @@ export function DashboardPage() {
                 'text-xs text-[color:var(--text-2)]',
               )}
             >
-              {(['status', 'result', 'config', 'query'] as ChartCategory[]).map((key) => (
+              {(['status', 'result', 'config', 'query', 'error'] as ChartCategory[]).map((key) => (
                 <label key={key} className="flex items-center gap-1.5 cursor-pointer">
                   <input
                     type="color"
@@ -1611,20 +1727,29 @@ export function DashboardPage() {
                     : 'no nodes'
                 }
               />
-              {/* Failed enrolls (24h) — danger-tinted when >0. */}
+              {/* Reported errors (24h) — ERROR-severity status logs from the
+                  fleet, danger-tinted when >0. Warnings are excluded on
+                  purpose: they are routine enough that counting them would
+                  keep this tile permanently lit. */}
               <KpiCard
-                label="Failed enrolls (24h)"
-                value={failedEnrolls}
-                sparkline={chartSeries.result}
-                halo={failedEnrolls > 0 ? 'danger' : 'success'}
+                label="Reported errors (24h)"
+                value={reportedErrors}
+                sparkline={chartSeries.statusError}
+                halo={reportedErrors > 0 ? 'danger' : 'success'}
                 polarity="up-bad"
                 deltaLabel={
-                  failedEnrollOverflow
-                    ? '200+ in 24h'
-                    : failedEnrolls === 0
-                      ? 'all clear'
-                      : `${failedEnrolls} in 24h`
+                  reportedErrors === 0
+                    ? 'all clear'
+                    : `${reportedErrors} in 24h — see nodes`
                 }
+                // Only actionable when there is something to drill into, and
+                // only once an environment is resolved to scope the query.
+                onClick={
+                  reportedErrors > 0 && effectiveEnv
+                    ? () => setShowErrorNodes(true)
+                    : undefined
+                }
+                actionLabel="Show the nodes reporting errors"
               />
               <KpiCard
                 label="Active Queries"
@@ -1930,6 +2055,9 @@ export function DashboardPage() {
         )}
       </section>
 
+      {showErrorNodes && effectiveEnv && (
+        <ErrorNodesDialog env={effectiveEnv} onClose={() => setShowErrorNodes(false)} />
+      )}
     </div>
   );
 }

--- a/frontend/src/features/nodes/NodeDetailPage.merge.test.ts
+++ b/frontend/src/features/nodes/NodeDetailPage.merge.test.ts
@@ -27,6 +27,7 @@ describe('mergeNodeActivityBuckets', () => {
       start: '2026-07-02T10:00:00Z',
       bucket_seconds: 3600,
       enroll: [0, 0],
+      status_error: [0, 0],
       config: [0, 0],
       status: [0, 0],
       result: [0, 0],
@@ -38,5 +39,61 @@ describe('mergeNodeActivityBuckets', () => {
     const merged = mergeNodeActivityBuckets(buckets, tiles);
 
     expect(merged.map((b) => b.query)).toEqual([2, 3]);
+  });
+
+  // The errors row is fed from the Redis series, aligned the same way config
+  // is, and must not be folded into any other row.
+  it('folds status errors into their own heatmap row', () => {
+    const buckets: NodeActivityBucket[] = [
+      { bucket_start: '2026-07-02T10:00:00Z', status: 5, result: 0, query: 0, carve: 0, config: 0 },
+      { bucket_start: '2026-07-02T11:00:00Z', status: 7, result: 0, query: 0, carve: 0, config: 0 },
+    ];
+
+    const tiles: NodeTileSeries = {
+      start: '2026-07-02T10:00:00Z',
+      bucket_seconds: 3600,
+      enroll: [0, 0],
+      status_error: [2, 4],
+      config: [0, 0],
+      status: [5, 7],
+      result: [0, 0],
+      query_read: [0, 0],
+      query_write: [0, 0],
+      total: [5, 7],
+    };
+
+    const merged = mergeNodeActivityBuckets(buckets, tiles);
+
+    expect(merged.map((b) => b.error)).toEqual([2, 4]);
+    // The status row keeps reporting the node's own status count: errors are
+    // a subset of it, not extra traffic to add on top.
+    expect(merged.map((b) => b.status)).toEqual([5, 7]);
+    expect(merged.map((b) => b.query)).toEqual([0, 0]);
+  });
+
+  // A series from a server predating the counter omits the field entirely;
+  // the row must read zero rather than throw or shift the other rows.
+  it('reads zero errors when the series omits the counter', () => {
+    const buckets: NodeActivityBucket[] = [
+      { bucket_start: '2026-07-02T10:00:00Z', status: 1, result: 0, query: 0, carve: 0, config: 0 },
+    ];
+
+    const tiles = {
+      start: '2026-07-02T10:00:00Z',
+      bucket_seconds: 3600,
+      enroll: [0],
+      config: [3],
+      status: [1],
+      result: [0],
+      query_read: [0],
+      query_write: [0],
+      total: [1],
+    } as unknown as NodeTileSeries;
+
+    const merged = mergeNodeActivityBuckets(buckets, tiles);
+
+    expect(merged.map((b) => b.error)).toEqual([0]);
+    // The rest of the merge still works off the remaining series.
+    expect(merged.map((b) => b.config)).toEqual([3]);
   });
 });

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -289,6 +289,7 @@ describe('NodeDetailPage', () => {
       start: new Date(Date.now() - 23 * 3600_000).toISOString(),
       bucket_seconds: 3600,
       enroll: [],
+      status_error: [],
       config: [],
       status: [],
       result: [],
@@ -377,6 +378,37 @@ describe('NodeDetailPage', () => {
     });
 
     vi.unstubAllGlobals();
+  });
+
+  // The errors row sits alongside status/result/query/config in the node
+  // activity heatmap, with the count stated in text so it is not colour-only.
+  it('shows an errors row in the node activity heatmap', async () => {
+    // The Redis series is aligned onto the DB buckets by timestamp, so the
+    // fixture has to start where makeActivityBuckets() does or the errors
+    // land outside the window and correctly read zero.
+    mockGetNodeActivityTiles.mockResolvedValue({
+      start: '2026-06-17T10:00:00Z',
+      bucket_seconds: 3600,
+      enroll: [0, 0],
+      status_error: [3, 0],
+      config: [0, 0],
+      status: [9, 0],
+      result: [0, 0],
+      query_read: [0, 0],
+      query_write: [0, 0],
+      total: [9, 0],
+    });
+
+    renderWithProviders(makeTestRouter());
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Node activity heatmap')).toBeInTheDocument();
+    });
+    const heatmap = screen.getByLabelText('Node activity heatmap');
+    // The row label, alongside status/result/query/config.
+    expect(within(heatmap).getAllByText('errors').length).toBeGreaterThan(0);
+    // And the count stated in the header, not left to the colour alone.
+    expect(heatmap.textContent).toContain('3 errors');
   });
 
   it('shows posture data for the selected node', async () => {

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -50,6 +50,11 @@ interface NodeHeatmapBucket {
   result: number;
   query: number;
   config: number;
+  /**
+   * ERROR-severity status logs. A subset of the status traffic rather than
+   * additional events, so it is deliberately left out of the heatmap's total.
+   */
+  error: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -1676,6 +1681,9 @@ const NODE_ACTIVITY_CATEGORIES = [
   { key: 'result', label: 'result', cssVar: '--signal' },
   { key: 'query', label: 'query', cssVar: '--success' },
   { key: 'config', label: 'config', cssVar: '--warning' },
+  // Last, and the only row that is not ordinary traffic: these are the status
+  // logs osquery flagged ERROR.
+  { key: 'error', label: 'errors', cssVar: '--error-bright' },
 ] as const;
 
 type NodeActivityCategoryKey = (typeof NODE_ACTIVITY_CATEGORIES)[number]['key'];
@@ -1723,7 +1731,7 @@ function nodeFormatHHMM(iso: string): string {
 }
 
 // mergeNodeActivityBuckets aligns the hourly Redis config + query read/write
-// series onto the DB-backed activity grid (status/result/query). The DB grid
+// + status-error series onto the DB-backed activity grid (status/result/query). The DB grid
 // uses a window-scaled bucket so the heatmap always has 24 columns; the Redis
 // hourly series are folded into each cell by summing every hour that overlaps
 // the cell:
@@ -1742,21 +1750,33 @@ export function mergeNodeActivityBuckets(
   const config = tiles?.config;
   const queryRead = tiles?.query_read;
   const queryWrite = tiles?.query_write;
+  const statusError = tiles?.status_error;
   const cellMs =
     buckets.length >= 2
       ? Date.parse(buckets[1].bucket_start) - Date.parse(buckets[0].bucket_start)
       : 3600_000;
+  // Length is taken from whichever series is present rather than from config
+  // specifically, so a series that ships status_error without config (or vice
+  // versa) still aligns instead of silently reading zero.
+  const seriesLength = Math.max(
+    config?.length ?? 0,
+    queryRead?.length ?? 0,
+    queryWrite?.length ?? 0,
+    statusError?.length ?? 0,
+  );
   return buckets.map((b) => {
     let configCount = 0;
     let queryCount = b.query;
-    if (config && config.length > 0 && !Number.isNaN(startMs)) {
+    let errorCount = 0;
+    if (seriesLength > 0 && !Number.isNaN(startMs)) {
       const cellStart = Date.parse(b.bucket_start);
       const cellEnd = cellStart + cellMs;
       let h = Math.floor((cellStart - startMs) / hourMs);
-      while (h < config.length && startMs + h * hourMs < cellEnd) {
+      while (h < seriesLength && startMs + h * hourMs < cellEnd) {
         if (h >= 0) {
-          configCount += config[h];
+          configCount += config?.[h] ?? 0;
           queryCount += (queryRead?.[h] ?? 0) + (queryWrite?.[h] ?? 0);
+          errorCount += statusError?.[h] ?? 0;
         }
         h += 1;
       }
@@ -1767,6 +1787,7 @@ export function mergeNodeActivityBuckets(
       result: b.result,
       query: queryCount,
       config: configCount,
+      error: errorCount,
     };
   });
 }
@@ -1826,12 +1847,17 @@ function NodeActivityHeatmap({
     result: nodeMakeIntensityScale(buckets, 'result'),
     query: nodeMakeIntensityScale(buckets, 'query'),
     config: nodeMakeIntensityScale(buckets, 'config'),
+    error: nodeMakeIntensityScale(buckets, 'error'),
   };
 
+  // Errors are excluded on purpose: they are a subset of the status traffic
+  // already counted here, so adding them would report more events than the
+  // node actually sent.
   const totalEvents = buckets.reduce(
     (sum, b) => sum + b.status + b.result + b.query + b.config,
     0,
   );
+  const totalErrors = buckets.reduce((sum, b) => sum + b.error, 0);
   const isEmpty = !isLoading && n > 0 && totalEvents === 0;
 
   // 5 evenly-spaced HH:mm ticks under the grid. Rendered as a flex row that
@@ -1857,9 +1883,25 @@ function NodeActivityHeatmap({
     >
       {/* Header: title + interval picker */}
       <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-b border-[color:var(--border)]">
-        <h2 className="text-sm font-display font-semibold text-[color:var(--text-1)]">
-          Node activity · {NODE_INTERVAL_LABEL[interval]}
-        </h2>
+        <div className="flex items-center gap-2 min-w-0">
+          <h2 className="text-sm font-display font-semibold text-[color:var(--text-1)]">
+            Node activity · {NODE_INTERVAL_LABEL[interval]}
+          </h2>
+          {/* States the error count in text as well as colour, so the row is
+              not the only way to notice it. */}
+          {totalErrors > 0 && (
+            <span
+              className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-mono-tabular font-semibold border whitespace-nowrap"
+              style={{
+                color: 'var(--error-bright)',
+                borderColor: 'rgba(var(--error-bright-r),var(--error-bright-g),var(--error-bright-b),0.4)',
+                background: 'rgba(var(--error-bright-r),var(--error-bright-g),var(--error-bright-b),0.08)',
+              }}
+            >
+              {totalErrors.toLocaleString()} {totalErrors === 1 ? 'error' : 'errors'}
+            </span>
+          )}
+        </div>
         <div
           role="tablist"
           aria-label="Activity interval"
@@ -1991,6 +2033,10 @@ function NodeEndpointLastSeen({ series, isLoading }: NodeEndpointLastSeenProps) 
   const items: KvItem[] = TILE_CATEGORIES.map((cat: TileCategory) => {
     const total = series ? tileCategoryTotal(series, cat) : 0;
     const last = series ? tileLastSeen(series, cat) : null;
+    // Errors are the one category worth colouring: every other row is normal
+    // endpoint traffic where a number is just a number. Only once there is
+    // something to report — a permanently red row stops being a signal.
+    const alarming = cat === 'status_error' && total > 0;
     return {
       label: TILE_CATEGORY_LABELS[cat],
       value: isLoading ? (
@@ -1998,12 +2044,18 @@ function NodeEndpointLastSeen({ series, isLoading }: NodeEndpointLastSeenProps) 
       ) : (
         <span className="inline-flex items-baseline gap-2">
           <span
-            className="text-[color:var(--text-1)]"
+            className={alarming ? 'font-semibold' : 'text-[color:var(--text-1)]'}
+            style={alarming ? { color: 'var(--error-bright)' } : undefined}
             title={last ? `${formatAbsolute(last)} · ${total} events` : 'No activity in the last 24h'}
           >
             {last ? formatBucketAgo(last, bucketSeconds) : 'No activity'}
           </span>
-          <span className="text-[color:var(--text-3)]">{total} events in 24h</span>
+          <span
+            className={alarming ? 'font-semibold' : 'text-[color:var(--text-3)]'}
+            style={alarming ? { color: 'var(--error-bright)' } : undefined}
+          >
+            {total} {cat === 'status_error' ? 'errors' : 'events'} in 24h
+          </span>
         </span>
       ),
     };

--- a/frontend/src/features/nodes/NodesTablePage.test.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.test.tsx
@@ -144,6 +144,7 @@ function makeTileSeries(overrides: Partial<NodeTileSeries> = {}): NodeTileSeries
     start: '2026-07-31T00:00:00Z',
     bucket_seconds: 3600,
     enroll: new Array(48).fill(0),
+    status_error: new Array(48).fill(0),
     config: new Array(48).fill(0),
     status: new Array(48).fill(0),
     result: new Array(48).fill(0),
@@ -286,7 +287,37 @@ describe('NodesTablePage', () => {
       name: /Node activity over the last 24 hours, 5 events total/i,
     });
 
-    expect(heatmap.querySelectorAll('span')).toHaveLength(96);
+    // 5 lanes (status / result / config / queries / errors) x 24 hours.
+    expect(heatmap.querySelectorAll('span')).toHaveLength(120);
+  });
+
+  // The errors lane is what makes a misbehaving node visible while scanning
+  // the table, so its presence and its count are worth pinning.
+  it('surfaces reported errors in the node heatmap', async () => {
+    const status = new Array(48).fill(0);
+    const total = new Array(48).fill(0);
+    const statusError = new Array(48).fill(0);
+    status[47] = 3;
+    total[47] = 3;
+    statusError[47] = 2;
+
+    mockListNodes.mockResolvedValue(makeResponse());
+    mockGetNodeActivityTilesBatch.mockResolvedValue({
+      'abc12345-0000-0000-0000-000000000001': makeTileSeries({
+        start: '2026-07-30T00:00:00Z',
+        status,
+        total,
+        status_error: statusError,
+      }),
+    });
+
+    renderWithProviders(makeTestRouter());
+
+    // The accessible name calls the errors out rather than burying them in
+    // the total, so a screen-reader user gets the same signal as the colour.
+    expect(
+      await screen.findByRole('img', { name: /2 errors/i }),
+    ).toBeInTheDocument();
   });
 
   it('shows nothing except skeleton rows while loading', async () => {

--- a/frontend/src/features/nodes/NodesTablePage.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.tsx
@@ -293,7 +293,10 @@ interface HeatmapCellProps {
 
 /**
  * Per-row 5×24 mini activity heatmap from Redis-backed per-node tile data.
- *   - 5 rows of categories: status / result / config / query read / query write.
+ *   - 5 rows of categories: status / result / config / queries / errors.
+ *     The errors lane is ERROR-severity osquery status logs — a subset of the
+ *     status lane above it, not additional traffic — tinted bright red so a
+ *     misbehaving node is visible while scanning the table.
  *   - 24 columns, one per hour of the last 24h (left = oldest, right = now).
  *   - Intensity uses a global max across all visible nodes (passed via
  *     globalMax) so nodes with more activity show brighter than nodes with
@@ -330,6 +333,8 @@ function HeatmapCell({ tiles, globalMax, lastSeen }: HeatmapCellProps) {
       trimToNow(tiles!.result.map((v) => v)),
       trimToNow(tiles!.config.map((v) => v)),
       trimToNow(tiles!.query_read.map((v) => v)),
+      // Optional-chained: a server predating the counter omits the field.
+      trimToNow(tiles!.status_error?.map((v) => v)),
     ];
   } else {
     // Fallback: place a single config-row cell at the hour corresponding
@@ -340,6 +345,9 @@ function HeatmapCell({ tiles, globalMax, lastSeen }: HeatmapCellProps) {
     const status = new Array<number>(24).fill(0);
     const result = new Array<number>(24).fill(0);
     const query = new Array<number>(24).fill(0);
+    // No tile data means no evidence of errors — the lane stays dark rather
+    // than borrowing the last_seen signal the other lanes fall back to.
+    const errors = new Array<number>(24).fill(0);
     if (lastSeen) {
       const d = new Date(lastSeen);
       if (!isNaN(d.getTime())) {
@@ -352,7 +360,7 @@ function HeatmapCell({ tiles, globalMax, lastSeen }: HeatmapCellProps) {
         }
       }
     }
-    categoryHourly = [status, result, config, query];
+    categoryHourly = [status, result, config, query, errors];
   }
 
   const CATEGORIES = [
@@ -360,6 +368,7 @@ function HeatmapCell({ tiles, globalMax, lastSeen }: HeatmapCellProps) {
     { key: 'result', label: 'Result logs', baseVar: '--signal' },
     { key: 'config', label: 'Config fetches', baseVar: '--warning' },
     { key: 'query', label: 'Queries', baseVar: '--success' },
+    { key: 'error', label: 'Errors', baseVar: '--error-bright' },
   ] as const;
 
   function tintForStep(baseVar: string, step: 0 | 1 | 2 | 3 | 4): string {
@@ -378,15 +387,20 @@ function HeatmapCell({ tiles, globalMax, lastSeen }: HeatmapCellProps) {
   }
 
   const totalEvents = categoryHourly.flat().reduce((a, b) => a + b, 0);
+  const errorEvents = categoryHourly[4].reduce((a, b) => a + b, 0);
 
-  // 7px cells + 2px gaps → 24*7 + 23*2 = 214px wide, 4*7 + 3*2 = 34px tall.
+  // 7px cells + 2px gaps → 24*7 + 23*2 = 214px wide, 5*7 + 4*2 = 43px tall.
   // Fits in the dedicated 240px-wide column with room for px-4 padding (32px).
   return (
     <div
       className="inline-grid gap-[2px]"
-      style={{ gridTemplateColumns: 'repeat(24, 7px)', gridTemplateRows: 'repeat(4, 7px)' }}
+      style={{ gridTemplateColumns: 'repeat(24, 7px)', gridTemplateRows: 'repeat(5, 7px)' }}
       role="img"
-      aria-label={`Node activity over the last 24 hours, ${totalEvents} events total`}
+      aria-label={
+        errorEvents > 0
+          ? `Node activity over the last 24 hours, ${totalEvents} events total, ${errorEvents} errors`
+          : `Node activity over the last 24 hours, ${totalEvents} events total`
+      }
       title="Node activity · last 24h"
     >
       {CATEGORIES.map((cat, catIdx) =>
@@ -559,13 +573,14 @@ export function NodesTablePage() {
   // Without this, per-row normalization makes every node's busiest hour
   // look identical (all step-4) even when the counts differ 10x.
   const globalMax = (() => {
-    const max: Record<string, number> = { status: 0, result: 0, config: 0, query: 0 };
+    const max: Record<string, number> = { status: 0, result: 0, config: 0, query: 0, error: 0 };
     for (const tiles of Object.values(tilesByUuid ?? {})) {
       if (!tiles.total?.some((v) => v > 0)) continue;
       for (const v of tiles.status ?? []) { if (v > max.status) max.status = v; }
       for (const v of tiles.result ?? []) { if (v > max.result) max.result = v; }
       for (const v of tiles.config ?? []) { if (v > max.config) max.config = v; }
       for (const v of tiles.query_read ?? []) { if (v > max.query) max.query = v; }
+      for (const v of tiles.status_error ?? []) { if (v > max.error) max.error = v; }
     }
     return max;
   })();

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -33,10 +33,15 @@
   --success: #4ade80;
   --warning: #fbbf24;
   --danger: #f87171;
+  /* Reserved for reported osquery errors: deliberately hotter than
+     --danger so an erroring fleet is unmistakable next to the softer
+     warning/danger tones used for degraded-but-expected states. */
+  --error-bright: #ff4d4f;
   --info: #67c0ff;
   --success-r: 74; --success-g: 222; --success-b: 128;
   --warning-r: 251; --warning-g: 191; --warning-b: 36;
   --danger-r: 248; --danger-g: 113; --danger-b: 113;
+  --error-bright-r: 255; --error-bright-g: 77; --error-bright-b: 79;
   --info-r: 103; --info-g: 192; --info-b: 255;
 }
 
@@ -66,10 +71,14 @@
   --success: #16a34a;
   --warning: #d97706;
   --danger: #dc2626;
+  /* See the dark-theme note. Kept saturated rather than darkened so it
+     still reads as "bright red" against a light ground. */
+  --error-bright: #f01c1c;
   --info: #2563eb;
   --success-r: 22; --success-g: 163; --success-b: 74;
   --warning-r: 217; --warning-g: 119; --warning-b: 6;
   --danger-r: 220; --danger-g: 38; --danger-b: 38;
+  --error-bright-r: 240; --error-bright-g: 28; --error-bright-b: 28;
   --info-r: 37; --info-g: 99; --info-b: 235;
 }
 

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -6696,6 +6696,59 @@ paths:
       summary: Get environment activity tiles
       tags:
         - stats
+  "/api/v1/stats/activity/error-nodes/{env}":
+    get:
+      description: Returns nodes with the most ERROR-severity osquery status logs.
+      parameters:
+        - description: Environment name or UUID
+          in: path
+          name: env
+          required: true
+          schema:
+            type: string
+        - description: Days of history (default 1)
+          in: query
+          name: days
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/handlers.ErrorNodeRow"
+                type: array
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "503":
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Top erroring nodes for an environment
+      tags:
+        - stats
   "/api/v1/stats/activity/node-batch/{env}":
     get:
       description: Returns activity buckets for multiple nodes in an environment.
@@ -8401,6 +8454,10 @@ components:
           items:
             type: integer
           type: array
+        status_error:
+          items:
+            type: integer
+          type: array
         total:
           items:
             type: integer
@@ -8433,6 +8490,10 @@ components:
         start:
           type: string
         status:
+          items:
+            type: integer
+          type: array
+        status_error:
           items:
             type: integer
           type: array
@@ -8648,6 +8709,15 @@ components:
             is independent.
         total:
           type: integer
+        uuid:
+          type: string
+      type: object
+    handlers.ErrorNodeRow:
+      properties:
+        errors:
+          type: integer
+        hostname:
+          type: string
         uuid:
           type: string
       type: object

--- a/pkg/activity/redis.go
+++ b/pkg/activity/redis.go
@@ -3,6 +3,7 @@ package activity
 import (
 	"context"
 	"errors"
+	"sort"
 	"time"
 
 	redis "github.com/go-redis/redis/v8"
@@ -41,7 +42,13 @@ func (s *RedisStore) IncrementMany(ctx context.Context, events []Event) error {
 		offset int64
 	}
 
+	type rankCounterKey struct {
+		key      string
+		nodeUUID string
+	}
+
 	aggregated := make(map[counterKey]uint32)
+	ranked := make(map[rankCounterKey]int64)
 	for _, event := range events {
 		if event.EnvUUID == "" || event.Type >= EventTypeCount {
 			continue
@@ -65,9 +72,20 @@ func (s *RedisStore) IncrementMany(ctx context.Context, events []Event) error {
 			offset: offset,
 		}
 		aggregated[envKey] += uint32(event.Count)
+
+		// Errors additionally feed a per-env ranking so the dashboard can
+		// name the offending nodes without walking the whole fleet. Only
+		// errors pay this cost, and only when there are any.
+		if event.Type == EventStatusError && event.NodeUUID != "" {
+			rankKey := rankCounterKey{
+				key:      ErrorRankKey(s.prefix, event.EnvUUID, event.At),
+				nodeUUID: event.NodeUUID,
+			}
+			ranked[rankKey] += int64(event.Count)
+		}
 	}
 
-	if len(aggregated) == 0 {
+	if len(aggregated) == 0 && len(ranked) == 0 {
 		return nil
 	}
 
@@ -75,6 +93,10 @@ func (s *RedisStore) IncrementMany(ctx context.Context, events []Event) error {
 	expireKeys := make(map[string]struct{})
 	for key, count := range aggregated {
 		pipe.BitField(ctx, key.key, "OVERFLOW", "SAT", "INCRBY", "u16", key.offset, int64(count))
+		expireKeys[key.key] = struct{}{}
+	}
+	for key, count := range ranked {
+		pipe.ZIncrBy(ctx, key.key, float64(count), key.nodeUUID)
 		expireKeys[key.key] = struct{}{}
 	}
 	for key := range expireKeys {
@@ -136,24 +158,10 @@ func (s *RedisStore) ReadSeries(ctx context.Context, envUUID string, nodeUUIDs [
 
 		decoded := decodeDay(blob)
 		series := out[fetch.nodeUUID]
-		base := fetch.dayIndex * BucketsPerDay
-		for hour := 0; hour < BucketsPerDay; hour++ {
-			idx := base + hour
-			series.Enroll[idx] = decoded[EventEnroll][hour]
-			series.Config[idx] = decoded[EventConfig][hour]
-			series.Status[idx] = decoded[EventStatus][hour]
-			series.Result[idx] = decoded[EventResult][hour]
-			series.QueryRead[idx] = decoded[EventQueryRead][hour]
-			series.QueryWrite[idx] = decoded[EventQueryWrite][hour]
-			series.Total[idx] = saturatingSum(
-				decoded[EventEnroll][hour],
-				decoded[EventConfig][hour],
-				decoded[EventStatus][hour],
-				decoded[EventResult][hour],
-				decoded[EventQueryRead][hour],
-				decoded[EventQueryWrite][hour],
-			)
-		}
+		// Shared with ReadEnvSeries so a new event type only has to be
+		// wired into one place — this loop used to be duplicated here and
+		// silently missed counters added later.
+		fillSeries(&series, fetch.dayIndex*BucketsPerDay, decoded)
 		out[fetch.nodeUUID] = series
 	}
 
@@ -210,6 +218,7 @@ func newSeries(start time.Time, bucketCount int) NodeTileSeries {
 		Result:        make([]uint16, bucketCount),
 		QueryRead:     make([]uint16, bucketCount),
 		QueryWrite:    make([]uint16, bucketCount),
+		StatusError:   make([]uint16, bucketCount),
 		Total:         make([]uint16, bucketCount),
 	}
 }
@@ -223,6 +232,10 @@ func fillSeries(series *NodeTileSeries, base int, decoded [EventTypeCount][Bucke
 		series.Result[idx] = decoded[EventResult][hour]
 		series.QueryRead[idx] = decoded[EventQueryRead][hour]
 		series.QueryWrite[idx] = decoded[EventQueryWrite][hour]
+		series.StatusError[idx] = decoded[EventStatusError][hour]
+		// EventStatusError is intentionally absent from Total: it is a
+		// subset of EventStatus, and including it would count an erroring
+		// status log twice in the activity heatmap.
 		series.Total[idx] = saturatingSum(
 			decoded[EventEnroll][hour],
 			decoded[EventConfig][hour],
@@ -260,4 +273,66 @@ func saturatingSum(values ...uint16) uint16 {
 	}
 
 	return uint16(total)
+}
+
+// TopErrorNodes returns the nodes with the most ERROR-severity status logs in
+// the requested window, worst first, capped at limit.
+//
+// The window is expressed in whole UTC days because that is how the counters
+// are bucketed; a 24h view spans at most two of them. Each day's ranking is
+// read in full and merged here — bounded by the number of nodes that actually
+// errored, which is the small number in any fleet worth alerting on.
+func (s *RedisStore) TopErrorNodes(ctx context.Context, envUUID string, end time.Time, days, limit int) ([]NodeErrorCount, error) {
+	if days <= 0 {
+		days = 1
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	start := dayStart(end).Add(-time.Duration(days-1) * 24 * time.Hour)
+	pipe := s.client.Pipeline()
+	cmds := make([]*redis.ZSliceCmd, 0, days)
+	for dayIndex := 0; dayIndex < days; dayIndex++ {
+		day := start.Add(time.Duration(dayIndex) * 24 * time.Hour)
+		cmds = append(cmds, pipe.ZRevRangeWithScores(ctx, ErrorRankKey(s.prefix, envUUID, day), 0, -1))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && !errors.Is(err, redis.Nil) {
+		return nil, err
+	}
+
+	totals := make(map[string]int64)
+	for _, cmd := range cmds {
+		entries, err := cmd.Result()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				continue
+			}
+			return nil, err
+		}
+		for _, entry := range entries {
+			nodeUUID, ok := entry.Member.(string)
+			if !ok || nodeUUID == "" || entry.Score <= 0 {
+				continue
+			}
+			totals[nodeUUID] += int64(entry.Score)
+		}
+	}
+
+	out := make([]NodeErrorCount, 0, len(totals))
+	for nodeUUID, errCount := range totals {
+		out = append(out, NodeErrorCount{NodeUUID: nodeUUID, Errors: errCount})
+	}
+	// Worst first; ties broken by UUID so the list is stable between polls
+	// and does not shuffle under the operator's cursor.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Errors == out[j].Errors {
+			return out[i].NodeUUID < out[j].NodeUUID
+		}
+		return out[i].Errors > out[j].Errors
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }

--- a/pkg/activity/redis_test.go
+++ b/pkg/activity/redis_test.go
@@ -164,3 +164,102 @@ func TestStoreReadEnvSeries(t *testing.T) {
 		t.Fatalf("expected env key TTL to be 24h, got %s", got)
 	}
 }
+
+// TopErrorNodes powers the dashboard drill-down: which nodes are erroring.
+// It must rank worst-first, merge across the UTC day boundary the 24h window
+// straddles, and cap at the requested limit.
+func TestStoreTopErrorNodes(t *testing.T) {
+	client, _ := newTestRedisClient(t)
+	store := NewRedisStore(client, "nodeact:v1", 7, 24*time.Hour)
+	ctx := context.Background()
+
+	yesterday := time.Date(2026, 6, 14, 23, 20, 0, 0, time.UTC)
+	today := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	err := store.IncrementMany(ctx, []Event{
+		// NODE1 errors on both days — the two must be summed, not shadowed.
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventStatusError, At: yesterday, Count: 3},
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventStatusError, At: today, Count: 4},
+		{EnvUUID: "ENV1", NodeUUID: "NODE2", Type: EventStatusError, At: today, Count: 5},
+		{EnvUUID: "ENV1", NodeUUID: "NODE3", Type: EventStatusError, At: today, Count: 1},
+		// Non-error activity must never appear in the ranking.
+		{EnvUUID: "ENV1", NodeUUID: "NODE4", Type: EventStatus, At: today, Count: 99},
+		// Another environment must not leak in.
+		{EnvUUID: "ENV2", NodeUUID: "NODE9", Type: EventStatusError, At: today, Count: 50},
+	})
+	if err != nil {
+		t.Fatalf("increment failed: %v", err)
+	}
+
+	got, err := store.TopErrorNodes(ctx, "ENV1", today, 2, 10)
+	if err != nil {
+		t.Fatalf("TopErrorNodes failed: %v", err)
+	}
+
+	want := []NodeErrorCount{
+		{NodeUUID: "NODE1", Errors: 7},
+		{NodeUUID: "NODE2", Errors: 5},
+		{NodeUUID: "NODE3", Errors: 1},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d ranked nodes, got %+v", len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("rank %d: got %+v want %+v", i, got[i], want[i])
+		}
+	}
+
+	// The limit truncates the tail, keeping the worst offenders.
+	capped, err := store.TopErrorNodes(ctx, "ENV1", today, 2, 2)
+	if err != nil {
+		t.Fatalf("TopErrorNodes failed: %v", err)
+	}
+	if len(capped) != 2 || capped[0].NodeUUID != "NODE1" || capped[1].NodeUUID != "NODE2" {
+		t.Fatalf("expected the two worst nodes, got %+v", capped)
+	}
+}
+
+// An environment nobody has reported errors for must come back empty rather
+// than erroring — a healthy fleet is the common case.
+func TestStoreTopErrorNodesEmpty(t *testing.T) {
+	client, _ := newTestRedisClient(t)
+	store := NewRedisStore(client, "nodeact:v1", 7, 24*time.Hour)
+
+	got, err := store.TopErrorNodes(context.Background(), "QUIET-ENV", time.Now(), 1, 10)
+	if err != nil {
+		t.Fatalf("TopErrorNodes failed: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no ranked nodes, got %+v", got)
+	}
+}
+
+// The per-node series must carry the error counter too — it lives behind a
+// different code path than the env series and previously missed new types.
+func TestStoreReadSeriesIncludesStatusErrors(t *testing.T) {
+	client, _ := newTestRedisClient(t)
+	store := NewRedisStore(client, "nodeact:v1", 7, 24*time.Hour)
+	ctx := context.Background()
+	at := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	if err := store.IncrementMany(ctx, []Event{
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventStatus, At: at, Count: 6},
+		{EnvUUID: "ENV1", NodeUUID: "NODE1", Type: EventStatusError, At: at, Count: 2},
+	}); err != nil {
+		t.Fatalf("increment failed: %v", err)
+	}
+
+	out, err := store.ReadSeries(ctx, "ENV1", []string{"NODE1"}, at, 1)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	series := out["NODE1"]
+	if got := series.StatusError[10]; got != 2 {
+		t.Fatalf("StatusError at hour 10 = %d, want 2", got)
+	}
+	// Errors are a subset of status, so Total must not double-count them.
+	if got := series.Total[10]; got != 6 {
+		t.Fatalf("Total at hour 10 = %d, want 6 (errors must not be added twice)", got)
+	}
+}

--- a/pkg/activity/redis_test_helpers_test.go
+++ b/pkg/activity/redis_test_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,6 +23,7 @@ func newTestRedisClient(t *testing.T) (*redis.Client, *fakeRedisStore) {
 	store := &fakeRedisStore{
 		values:  make(map[string][]byte),
 		expires: make(map[string]time.Duration),
+		zsets:   make(map[string]map[string]float64),
 	}
 	client := redis.NewClient(&redis.Options{
 		Addr:     "fake-redis",
@@ -44,6 +46,7 @@ type fakeRedisStore struct {
 	mu      sync.Mutex
 	values  map[string][]byte
 	expires map[string]time.Duration
+	zsets   map[string]map[string]float64
 }
 
 func serveFakeRedis(conn net.Conn, store *fakeRedisStore) {
@@ -117,6 +120,36 @@ func handleFakeRedisCommand(conn net.Conn, store *fakeRedisStore, args []string)
 		}
 		_, err = conn.Write(append(value, []byte("\r\n")...))
 		return err
+
+	case "ZINCRBY":
+		if len(args) != 4 {
+			return fmt.Errorf("unexpected ZINCRBY args: %v", args)
+		}
+		delta, err := strconv.ParseFloat(args[2], 64)
+		if err != nil {
+			return err
+		}
+		total := store.zincrby(args[1], args[3], delta)
+		_, err = fmt.Fprintf(conn, "$%d\r\n%s\r\n", len(formatScore(total)), formatScore(total))
+		return err
+
+	case "ZREVRANGE":
+		// Only the WITHSCORES form over a full range is used.
+		if len(args) < 4 {
+			return fmt.Errorf("unexpected ZREVRANGE args: %v", args)
+		}
+		members := store.zrevrange(args[1])
+		if _, err := fmt.Fprintf(conn, "*%d\r\n", len(members)*2); err != nil {
+			return err
+		}
+		for _, m := range members {
+			score := formatScore(m.score)
+			if _, err := fmt.Fprintf(conn, "$%d\r\n%s\r\n$%d\r\n%s\r\n",
+				len(m.member), m.member, len(score), score); err != nil {
+				return err
+			}
+		}
+		return nil
 
 	case "PING":
 		_, err := conn.Write([]byte("+PONG\r\n"))
@@ -216,4 +249,43 @@ func readRESPArray(reader *bufio.Reader) ([]string, error) {
 	}
 
 	return args, nil
+}
+
+// --- sorted-set support, for the per-env error ranking ---
+
+type fakeZMember struct {
+	member string
+	score  float64
+}
+
+func formatScore(score float64) string {
+	return strconv.FormatFloat(score, 'g', -1, 64)
+}
+
+func (s *fakeRedisStore) zincrby(key, member string, delta float64) float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.zsets[key] == nil {
+		s.zsets[key] = make(map[string]float64)
+	}
+	s.zsets[key][member] += delta
+	return s.zsets[key][member]
+}
+
+// zrevrange returns every member, highest score first. The production code
+// only ever asks for the full range.
+func (s *fakeRedisStore) zrevrange(key string) []fakeZMember {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]fakeZMember, 0, len(s.zsets[key]))
+	for member, score := range s.zsets[key] {
+		out = append(out, fakeZMember{member: member, score: score})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].score == out[j].score {
+			return out[i].member < out[j].member
+		}
+		return out[i].score > out[j].score
+	})
+	return out
 }

--- a/pkg/activity/types.go
+++ b/pkg/activity/types.go
@@ -11,7 +11,13 @@ const (
 	DefaultRetentionDays = 7
 	BucketSeconds        = 3600
 	BucketsPerDay        = 24
-	EventTypeCount       = 6
+	// EventTypeCount sizes the per-day blob. New event types MUST be
+	// appended to the end of the EventType list: bitOffset is linear in the
+	// type index, so appending leaves every existing counter at the same
+	// offset and only grows the blob. decodeDay is bounds-safe, so blobs
+	// written before a new type existed simply decode it as zero — which is
+	// why adding one needs no key-prefix bump and loses no history.
+	EventTypeCount = 7
 )
 
 // EventType identifies the activity counter family stored in a bucket.
@@ -25,6 +31,11 @@ const (
 	EventResult
 	EventQueryRead
 	EventQueryWrite
+	// EventStatusError counts status logs the node reported at osquery's
+	// ERROR severity. It is a subset of EventStatus, not a sibling: the
+	// same log increments both, so it is deliberately left out of the
+	// Total series to avoid counting one log twice.
+	EventStatusError
 )
 
 // Event is one activity increment for a node at a specific point in time.
@@ -46,6 +57,7 @@ type NodeTileSeries struct {
 	Result        []uint16  `json:"result"`
 	QueryRead     []uint16  `json:"query_read"`
 	QueryWrite    []uint16  `json:"query_write"`
+	StatusError   []uint16  `json:"status_error"`
 	Total         []uint16  `json:"total"`
 }
 
@@ -55,6 +67,24 @@ type EnvSeries = NodeTileSeries
 // DayKey returns the Redis key for one node's UTC activity day blob.
 func DayKey(prefix, envUUID, nodeUUID string, day time.Time) string {
 	return fmt.Sprintf("%s:%s:%s:%s", prefix, envUUID, nodeUUID, day.UTC().Format("20060102"))
+}
+
+// ErrorRankKey returns the Redis key for one environment's UTC day sorted set
+// of per-node error counts.
+//
+// The hourly blobs are keyed per node, so answering "which nodes are erroring"
+// from them alone would mean reading every node in the environment. This
+// sorted set is the index for that question: ZINCRBY on write, ZREVRANGE on
+// read, so the cost of the dashboard drill-down scales with the number of
+// *erroring* nodes rather than the size of the fleet.
+func ErrorRankKey(prefix, envUUID string, day time.Time) string {
+	return fmt.Sprintf("%s:errs:%s:%s", prefix, envUUID, day.UTC().Format("20060102"))
+}
+
+// NodeErrorCount is one node's error tally over the requested window.
+type NodeErrorCount struct {
+	NodeUUID string `json:"node_uuid"`
+	Errors   int64  `json:"errors"`
 }
 
 // EnvDayKey returns the Redis key for one environment's UTC activity day blob.


### PR DESCRIPTION
# Replace the failed-enrolls counter with reported osquery errors

The dashboard's "Failed enrolls (24h)" tile read the *audit log* and filtered client-side for lines starting with `failed enroll`. It's replaced by "Reported errors (24h)" — status logs the fleet sent at osquery's ERROR severity — surfaced across the dashboard, the nodes table and the node detail page.

Errors only. osquery's ladder is 0=INFO, 1=WARNING, 2=ERROR, and warnings are routine enough (a table unavailable on the platform, a transient permission issue) that counting them would keep the tile permanently lit and train people to ignore it.

## Counted at ingest, not at read time

The obvious implementation — `COUNT(*) FROM osquery_status_data WHERE created_at > now()-24h AND severity != '0'` — breaks on three things:

1. **The logs may not be in the database.** With `logger.type` set to `s3`, `splunk`, `kafka`, `graylog` or `elastic`, that table is empty and the tile would read a permanent zero.
2. **No index supports it.** `OsqueryStatusData` indexes only `UUID`; `gorm.Model` doesn't index `CreatedAt`. That's a full scan of the highest-volume table, every dashboard load, every 5 minutes.
3. **`Severity` is stored as a string**, so `severity > '1'` is a string comparison — an easy silent bug.

Instead osctrl-tls tallies ERROR entries per status batch and increments the existing Redis activity rollup (`pkg/activity`). O(1) per log, correct under every log sink, and the dashboard read becomes O(1). The count runs inside the goroutine that already calls `ProcessLogs`, so it stays off the request hot path.

**No key migration.** `bitOffset` is linear in the event-type index and `decodeDay` is bounds-checked, so appending `EventStatusError` at index 6 leaves every existing counter at its offset — old blobs simply decode the new type as zero. `EventTypeCount` now carries a comment recording why new types must be appended, never inserted.

## Drill-down: which nodes are erroring

Reading every node's series to answer this would scale with fleet size, for a question whose answer is a handful of nodes. The write path also does a `ZINCRBY` into a per-env, per-day sorted set, so `TopErrorNodes` is a `ZREVRANGE` — cost scales with the number of *erroring* nodes. Only errors pay for it, and only when there are any.

`GET /api/v1/stats/activity/error-nodes/{env}` returns the worst 10 with hostnames resolved; a node deleted since it errored keeps its row and shows by UUID. Clicking the tile opens a dialog listing them, each linking to the node.

The tile only becomes a `<button>` when there's something behind it — keyboard-reachable and announced as interactive — and stays a plain `<div>` at zero.

## Where errors show up

| Surface | What was added |
| --- | --- |
| Dashboard tile | "Reported errors (24h)", clickable into the drill-down |
| Dashboard chart | A fifth line in bright red, in the existing recolourable palette |
| Endpoint health panel | An "Errors" row, red row wash when non-zero |
| All nodes table | A fifth heatmap lane, red, with its own intensity scale |
| Node detail heatmap | An `errors` row alongside status/result/query/config, plus a count badge in the header |
| Node detail "Endpoint last seen" | The Errors row goes red and reads "N errors in 24h" |

New `--error-bright` token (`#ff4d4f` dark / `#f01c1c` light), deliberately hotter than `--danger`, which is already used for softer degraded-but-expected states. Every red surface stays neutral at zero — a permanently red panel is one nobody reads.

Errors are excluded from every "total" (activity `Total` series, the heatmap's `totalEvents`): they're a subset of the status traffic already counted, so including them would claim the node sent more events than it did.

## Bugs caught during the work

- **`ReadSeries` had a duplicated fill loop.** The per-node path didn't share `fillSeries` with `ReadEnvSeries`, so per-node error counts would have silently read zero — and the drill-down is built on exactly that path. Both now share it.
- **The heatmap merge was gated on `config`.** `mergeNodeActivityBuckets` bounded its alignment loop by `config.length`; it now takes the max across all Redis series, so a payload with `status_error` but no `config` still aligns instead of reading zero.

## Changes

- `pkg/activity` — `EventStatusError`, `StatusError` series, `ErrorRankKey`, `TopErrorNodes`
- `cmd/tls/handlers` — `countStatusErrors`, `recordActivityCount`, wired into the log POST path
- `cmd/api/handlers/stats.go`, `cmd/api/main.go` — `EnvErrorNodesHandler` + route
- `frontend/` — API client, dashboard tile/chart/panel, nodes-table lane, node-detail row, `--error-bright`
- `osctrl-api.yaml` regenerated

## Testing

- Go: severity filtering (int and quoted-string forms — osquery sends both), malformed-batch tolerance (returns 0 rather than failing ingestion), batch counts advancing by N, zero counts emitting no event, ranking across the UTC day boundary a 24h window straddles, env isolation, non-error events staying out of the ranking, limit truncation, and `Total` not double-counting.
- Frontend: tile sum and label, inert-at-zero, drill-down dialog, chart line present with no markers, heatmap lane cell count (96 → 120, commented with the lane math), merge alignment including the omitted-field case.
- The fake Redis in `pkg/activity` tests gained `ZINCRBY`/`ZREVRANGE` support — it's a hand-rolled RESP server that only implemented the commands used so far.
- Full suite green: `go build`/`go vet`/`go test`, `make openapi-check`, frontend 265 tests, `tsc`.