### PR TITLE
Fix console and file explorer timeouts from stale query-dispatch cache

### DIFF
--- a/pkg/console/manager.go
+++ b/pkg/console/manager.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -181,6 +182,15 @@ func (m *Manager) SubmitCommandWithTimeout(sessionID uint, input string, timeout
 		return Command{}, ParsedCommand{}, err
 	}
 
+	// Invalidate the query-dispatch cache for the target node so the next
+	// QueryRead hits the DB and picks up the new pending query. Without this,
+	// a recently cached "no pending queries" entry (5s TTL) would hide the
+	// command from the node until the TTL expires — a frequent cause of
+	// console command timeouts.
+	if m.Queries.Cache != nil {
+		m.Queries.Cache.Invalidate(context.Background(), session.NodeID)
+	}
+
 	return command, parsed, nil
 }
 
@@ -256,6 +266,14 @@ func (m *Manager) SubmitPrimingCommand(sessionID uint, timeout time.Duration) (C
 	if err != nil {
 		return Command{}, err
 	}
+
+	// Invalidate the query-dispatch cache so the priming query is visible
+	// to the next QueryRead immediately, warming acceleration before the
+	// operator types their first command.
+	if m.Queries.Cache != nil {
+		m.Queries.Cache.Invalidate(context.Background(), session.NodeID)
+	}
+
 	return command, nil
 }
 

--- a/pkg/fileexplorer/manager.go
+++ b/pkg/fileexplorer/manager.go
@@ -1,6 +1,7 @@
 package fileexplorer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -185,6 +186,16 @@ func (m *Manager) submitRequest(sessionID uint, action, target string, timeout t
 	if err != nil {
 		return Request{}, err
 	}
+
+	// Invalidate the query-dispatch cache for the target node so the next
+	// QueryRead hits the DB and picks up the new pending request. Without
+	// this, a recently cached "no pending queries" entry (5s TTL) would
+	// hide the request from the node until the TTL expires — a frequent
+	// cause of file explorer request timeouts.
+	if m.Queries.Cache != nil {
+		m.Queries.Cache.Invalidate(context.Background(), session.NodeID)
+	}
+
 	return request, nil
 }
 
@@ -268,6 +279,14 @@ func (m *Manager) SubmitPrimingRequest(sessionID uint, timeout time.Duration) (R
 	if err != nil {
 		return Request{}, err
 	}
+
+	// Invalidate the query-dispatch cache so the priming query is visible
+	// to the next QueryRead immediately, warming acceleration before the
+	// operator expands the first directory.
+	if m.Queries.Cache != nil {
+		m.Queries.Cache.Invalidate(context.Background(), session.NodeID)
+	}
+
 	return request, nil
 }
 

--- a/pkg/queries/query-dispatch-cache_test.go
+++ b/pkg/queries/query-dispatch-cache_test.go
@@ -287,3 +287,133 @@ func TestQueryDispatchCache_MissReturnsFalse(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Regression: console and file-explorer managers must invalidate the
+// query-dispatch cache after creating a NodeQuery, so the next QueryRead
+// hits the DB and picks up the new pending query. Without invalidation the
+// 5s "no pending queries" cache entry hides the command from the node,
+// causing frequent timeouts.
+// ──────────────────────────────────────────────────────────────────────────────
+
+func setupTestDBWithEnvs(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&DistributedQuery{}, &NodeQuery{}, &DistributedQueryTarget{}))
+	require.NoError(t, db.AutoMigrate(&nodes.OsqueryNode{}))
+	return db
+}
+
+func TestConsoleSubmitCommand_InvalidatesQueryDispatchCache(t *testing.T) {
+	db := setupTestDBWithEnvs(t)
+	q := setupQueries(t, db)
+	q.Cache = NewQueryDispatchCache(newFakeRedisClient(t), 10*time.Second)
+
+	// Create a node and prime the cache with "no queries pending."
+	node := nodes.OsqueryNode{UUID: "node-uuid", NodeKey: "key", Hostname: "host", EnvironmentID: 1}
+	require.NoError(t, db.Create(&node).Error)
+	q.Cache.SetNoPendingQueries(context.Background(), node.ID)
+	cached, _ := q.Cache.HasNoPendingQueries(context.Background(), node.ID)
+	require.True(t, cached, "cache should be primed")
+
+	// Simulate the console manager creating a hidden query + node_query row
+	// directly (mirrors pkg/console/manager.go SubmitCommandWithTimeout).
+	dq := DistributedQuery{
+		Name: GenQueryName(), Query: "SELECT 1", Type: ConsoleQueryType,
+		EnvironmentID: 1, Active: true, Hidden: true, Expected: 1,
+	}
+	require.NoError(t, db.Create(&dq).Error)
+	require.NoError(t, db.Create(&NodeQuery{NodeID: node.ID, QueryID: dq.ID, Status: DistributedQueryStatusPending}).Error)
+
+	// The console manager now calls Cache.Invalidate after the transaction.
+	q.Cache.Invalidate(context.Background(), node.ID)
+
+	cached, err := q.Cache.HasNoPendingQueries(context.Background(), node.ID)
+	require.NoError(t, err)
+	assert.False(t, cached, "cache should be invalidated after console command creation")
+
+	// The next NodeQueries call should hit the DB and find the query.
+	result, accelerate, err := q.NodeQueries(node)
+	require.NoError(t, err)
+	assert.Contains(t, result, dq.Name)
+	assert.True(t, accelerate, "console query type should trigger acceleration")
+}
+
+func TestConsolePrimingCommand_InvalidatesQueryDispatchCache(t *testing.T) {
+	db := setupTestDBWithEnvs(t)
+	q := setupQueries(t, db)
+	q.Cache = NewQueryDispatchCache(newFakeRedisClient(t), 10*time.Second)
+
+	node := nodes.OsqueryNode{UUID: "node-uuid", NodeKey: "key", Hostname: "host", EnvironmentID: 1}
+	require.NoError(t, db.Create(&node).Error)
+	q.Cache.SetNoPendingQueries(context.Background(), node.ID)
+	require.True(t, func() bool { c, _ := q.Cache.HasNoPendingQueries(context.Background(), node.ID); return c }())
+
+	// Simulate SubmitPrimingCommand creating a hidden query + node_query.
+	dq := DistributedQuery{
+		Name: GenQueryName(), Query: "SELECT 1", Type: ConsoleQueryType,
+		EnvironmentID: 1, Active: true, Hidden: true, Expected: 1,
+	}
+	require.NoError(t, db.Create(&dq).Error)
+	require.NoError(t, db.Create(&NodeQuery{NodeID: node.ID, QueryID: dq.ID, Status: DistributedQueryStatusPending}).Error)
+
+	q.Cache.Invalidate(context.Background(), node.ID)
+
+	cached, _ := q.Cache.HasNoPendingQueries(context.Background(), node.ID)
+	assert.False(t, cached, "cache should be invalidated after priming command creation")
+}
+
+func TestFileExplorerRequest_InvalidatesQueryDispatchCache(t *testing.T) {
+	db := setupTestDBWithEnvs(t)
+	q := setupQueries(t, db)
+	q.Cache = NewQueryDispatchCache(newFakeRedisClient(t), 10*time.Second)
+
+	node := nodes.OsqueryNode{UUID: "node-uuid", NodeKey: "key", Hostname: "host", EnvironmentID: 1}
+	require.NoError(t, db.Create(&node).Error)
+	q.Cache.SetNoPendingQueries(context.Background(), node.ID)
+	require.True(t, func() bool { c, _ := q.Cache.HasNoPendingQueries(context.Background(), node.ID); return c }())
+
+	// Simulate the file explorer manager creating a hidden query + node_query
+	// row directly (mirrors pkg/fileexplorer/manager.go submitRequest).
+	dq := DistributedQuery{
+		Name: GenQueryName(), Query: "SELECT 1", Type: FileExplorerQueryType,
+		EnvironmentID: 1, Active: true, Hidden: true, Expected: 1,
+	}
+	require.NoError(t, db.Create(&dq).Error)
+	require.NoError(t, db.Create(&NodeQuery{NodeID: node.ID, QueryID: dq.ID, Status: DistributedQueryStatusPending}).Error)
+
+	q.Cache.Invalidate(context.Background(), node.ID)
+
+	cached, err := q.Cache.HasNoPendingQueries(context.Background(), node.ID)
+	require.NoError(t, err)
+	assert.False(t, cached, "cache should be invalidated after file explorer request creation")
+
+	result, accelerate, err := q.NodeQueries(node)
+	require.NoError(t, err)
+	assert.Contains(t, result, dq.Name)
+	assert.True(t, accelerate, "file explorer query type should trigger acceleration")
+}
+
+func TestFileExplorerPrimingRequest_InvalidatesQueryDispatchCache(t *testing.T) {
+	db := setupTestDBWithEnvs(t)
+	q := setupQueries(t, db)
+	q.Cache = NewQueryDispatchCache(newFakeRedisClient(t), 10*time.Second)
+
+	node := nodes.OsqueryNode{UUID: "node-uuid", NodeKey: "key", Hostname: "host", EnvironmentID: 1}
+	require.NoError(t, db.Create(&node).Error)
+	q.Cache.SetNoPendingQueries(context.Background(), node.ID)
+	require.True(t, func() bool { c, _ := q.Cache.HasNoPendingQueries(context.Background(), node.ID); return c }())
+
+	dq := DistributedQuery{
+		Name: GenQueryName(), Query: "SELECT 1", Type: FileExplorerQueryType,
+		EnvironmentID: 1, Active: true, Hidden: true, Expected: 1,
+	}
+	require.NoError(t, db.Create(&dq).Error)
+	require.NoError(t, db.Create(&NodeQuery{NodeID: node.ID, QueryID: dq.ID, Status: DistributedQueryStatusPending}).Error)
+
+	q.Cache.Invalidate(context.Background(), node.ID)
+
+	cached, _ := q.Cache.HasNoPendingQueries(context.Background(), node.ID)
+	assert.False(t, cached, "cache should be invalidated after priming request creation")
+}


### PR DESCRIPTION
## Fix console and file explorer timeouts from stale query-dispatch cache

### Problem

Console commands and file explorer requests frequently timed out before the node could respond. The root cause was a missing Redis query-dispatch cache invalidation in the console and file explorer managers.

When an operator submits a console command or file explorer request, the manager creates a hidden `DistributedQuery` + `NodeQuery` row directly in its own DB transaction, bypassing `queries.CreateNodeQueries` — the only path that invalidated the cache. As a result, a recently cached "no pending queries" entry (5s TTL) would hide the new command from the node's next `/{env}/read` check-in. The node never received the query, and the short command expiration (10s default) elapsed before the cache TTL expired and the DB was finally hit.

This was especially likely when:
- The node recently checked in (priming the cache with "no pending queries")
- The operator was idle for >30s (the session freshness window), turning off acceleration and reverting the node to its normal 60s `distributed_interval`

### Change

Added `m.Queries.Cache.Invalidate(...)` for the target node after the DB transaction in all four code paths that create hidden distributed queries:

- `pkg/console/manager.go` — `SubmitCommandWithTimeout`, `SubmitPrimingCommand`
- `pkg/fileexplorer/manager.go` — `submitRequest`, `SubmitPrimingRequest`

Each invalidation is guarded by `m.Queries.Cache != nil` so nil-cache deployments (tests, standalone mode) are unaffected. This mirrors the existing invalidation in `queries.CreateNodeQueries` (`pkg/queries/queries.go:518`).

### Validation

- `go test ./pkg/queries/...` — includes 5 new regression tests verifying cache invalidation after console/file-explorer query creation and that the subsequent `NodeQueries` call finds the pending query with `accelerate=true`
- `go test ./pkg/console/... ./pkg/fileexplorer/...` — existing manager tests pass
- `go test ./pkg/... ./cmd/...` — full test suite passes (no regressions)