### PR TITLE
Add severity filter for status logs

### DIFF
--- a/cmd/api/handlers/log_reader_test.go
+++ b/cmd/api/handlers/log_reader_test.go
@@ -31,6 +31,7 @@ type fakeNodeLogsCall struct {
 	Since              time.Time
 	Limit              int
 	Search             string
+	Severity           string
 }
 
 type fakeQueryResultsCall struct {
@@ -39,8 +40,8 @@ type fakeQueryResultsCall struct {
 	Page, Size int
 }
 
-func (f *fakeLogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error) {
-	f.nodeLogsCalls = append(f.nodeLogsCalls, fakeNodeLogsCall{logType, env, uuid, since, limit, search})
+func (f *fakeLogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string, severity string) ([]map[string]any, error) {
+	f.nodeLogsCalls = append(f.nodeLogsCalls, fakeNodeLogsCall{logType, env, uuid, since, limit, search, severity})
 	if f.nodeLogsRows == nil {
 		return []map[string]any{}, nil
 	}
@@ -115,6 +116,31 @@ func TestNodeLogsHandlerUsesLogReader(t *testing.T) {
 	require.Equal(t, tc.envName, call.Env)
 	require.Equal(t, tc.nodeUUID, call.UUID)
 	require.Equal(t, 100, call.Limit)
+	require.Equal(t, "", call.Severity, "no severity param should pass empty string")
+}
+
+func TestNodeLogsHandlerPassesSeverityFilter(t *testing.T) {
+	tc := setupLogReaderTest(t)
+
+	fake := &fakeLogReader{
+		nodeLogsRows: []map[string]any{
+			{"line": "1", "message": "error", "uuid": tc.nodeUUID, "environment": tc.envName, "severity": "2"},
+		},
+	}
+	tc.h.LogReader = fake
+
+	req := consoleRequest(http.MethodGet, "/logs/status/env-uuid/NODE-UUID?severity=2", nil, "alice")
+	req.SetPathValue("type", "status")
+	req.SetPathValue("env", tc.envName)
+	req.SetPathValue("uuid", tc.nodeUUID)
+	rr := httptest.NewRecorder()
+
+	tc.h.NodeLogsHandler(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.Len(t, fake.nodeLogsCalls, 1)
+	call := fake.nodeLogsCalls[0]
+	require.Equal(t, "2", call.Severity, "severity query param should be passed to the reader")
 }
 
 func TestQueryResultsHandlerUsesLogReader(t *testing.T) {

--- a/cmd/api/handlers/logs.go
+++ b/cmd/api/handlers/logs.go
@@ -44,6 +44,8 @@ type NodeLogsResponse struct {
 // @Param uuid path string true "Node UUID"
 // @Param limit query int false "Maximum number of log rows"
 // @Param since query string false "RFC3339 lower bound"
+// @Param q query string false "Free-text search (substring, case-insensitive)"
+// @Param severity query string false "Severity filter for status logs (0=info, 1=warning, 2=error)"
 // @Success 200 {object} NodeLogsResponse
 // @Failure 400 {object} types.ApiErrorResponse "Bad request"
 // @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
@@ -121,9 +123,13 @@ func (h *HandlersApi) NodeLogsHandler(w http.ResponseWriter, r *http.Request) {
 	// operators can search the full history, not just the visible page.
 	search := strings.TrimSpace(q.Get("q"))
 
+	// Optional severity filter for status logs only. osquery severity is
+	// an integer: 0=info, 1=warning, 2=error. Ignored for result logs.
+	severity := strings.TrimSpace(q.Get("severity"))
+
 	// Use the node's canonical UUID (already upper-cased in the DB) from the
 	// verified node record, not the raw URL parameter.
-	items, err := h.logReader().NodeLogs(logType, env.Name, node.UUID, since, limit, search)
+	items, err := h.logReader().NodeLogs(logType, env.Name, node.UUID, since, limit, search, severity)
 	if err != nil {
 		apiErrorResponse(w, "failed to query logs", http.StatusInternalServerError, err)
 		return

--- a/frontend/src/api/nodes.ts
+++ b/frontend/src/api/nodes.ts
@@ -72,6 +72,7 @@ export function listNodeLogs(
   limit?: number,
   since?: string,
   q?: string,
+  severity?: string,
 ): Promise<NodeLogsResponse> {
   const params = new URLSearchParams();
   if (limit != null) params.set('limit', String(limit));
@@ -81,6 +82,9 @@ export function listNodeLogs(
   // line/message/filename; result rows match against name/action/columns.
   // Empty string is treated as "no filter" by the API.
   if (q && q.trim()) params.set('q', q.trim());
+  // Severity filter for status logs only (0=info, 1=warning, 2=error).
+  // Ignored by the backend for result logs.
+  if (severity) params.set('severity', severity);
 
   const qs = params.toString();
   return apiFetch<NodeLogsResponse>(

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -486,22 +486,26 @@ function LogsTab({
   // scratch so the page reflects only matching rows.
   const [searchQ, setSearchQ] = useState('');
 
+  // Severity filter for status logs only. '' = "all severities".
+  const [severity, setSeverity] = useState('');
+
   // Reset accumulator + search when tab type changes
   useEffect(() => {
     accumulatedRef.current = [];
     sinceRef.current = undefined;
     setSearchQ('');
+    setSeverity('');
   }, [type]);
 
   // Drop the running accumulator + since cursor whenever the (debounced)
-  // search term changes, so the next query starts fresh.
+  // search term or severity filter changes, so the next query starts fresh.
   useEffect(() => {
     accumulatedRef.current = [];
     sinceRef.current = undefined;
-  }, [searchQ]);
+  }, [searchQ, severity]);
 
   const { data, isLoading, isError, error, isFetching } = useQuery({
-    queryKey: ['node-logs', env, uuid, type, searchQ],
+    queryKey: ['node-logs', env, uuid, type, searchQ, severity],
     queryFn: async () => {
       const res = await listNodeLogs(
         env,
@@ -510,6 +514,7 @@ function LogsTab({
         100,
         sinceRef.current,
         searchQ || undefined,
+        type === 'status' && severity ? severity : undefined,
       );
       if (res.items.length > 0) {
         // API returns newest-first (ORDER BY created_at DESC); items[0] is the most recent.
@@ -536,13 +541,32 @@ function LogsTab({
   return (
     <div className="flex flex-col h-full min-h-0">
       {/* Search header — debounced via SearchInput's internal 300ms timer */}
-      <div className="px-4 py-2 border-b border-[color:var(--border)]">
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-[color:var(--border)]">
         <SearchInput
           id={`node-logs-search-${type}`}
           value={searchQ}
           onChange={setSearchQ}
           placeholder={`Search ${type} logs…`}
+          className="flex-1"
         />
+        {type === 'status' && (
+          <select
+            aria-label="Filter by severity"
+            value={severity}
+            onChange={(e) => setSeverity(e.target.value)}
+            className={cn(
+              'px-2 py-1.5 text-xs rounded-md border shrink-0',
+              'bg-[color:var(--bg-2)] text-[color:var(--text-1)]',
+              'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+              'border-[color:var(--border)]',
+            )}
+          >
+            <option value="">All severities</option>
+            <option value="0">Info</option>
+            <option value="1">Warning</option>
+            <option value="2">Error</option>
+          </select>
+        )}
       </div>
 
       {isLoading ? (
@@ -568,7 +592,7 @@ function LogsTab({
               <path d="M9 12h6M9 16h6M9 8h6M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z" />
             </svg>
           }
-          title={searchQ ? `No ${type} logs match “${searchQ}”.` : 'No log entries.'}
+          title={searchQ || severity ? `No ${type} logs match the current filters.` : 'No log entries.'}
         />
       ) : (
         <div className="overflow-auto" data-stale={isFetching ? 'true' : undefined}>

--- a/pkg/logging/db.go
+++ b/pkg/logging/db.go
@@ -267,7 +267,7 @@ func (logDB *LoggerDB) ResultLogsLimit(uuid, environment string, limit int) ([]O
 // The `LIKE` is unindexed today. If the result_data / status_data tables
 // grow large enough to make this slow, an operator-side workaround is to
 // narrow `since` first, which keeps the matched row count small.
-func GetNodeLogs(db *gorm.DB, logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error) {
+func GetNodeLogs(db *gorm.DB, logType, env, uuid string, since time.Time, limit int, search string, severity string) ([]map[string]any, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -305,6 +305,9 @@ func GetNodeLogs(db *gorm.DB, logType, env, uuid string, since time.Time, limit 
 				"LOWER(line) LIKE ? OR LOWER(message) LIKE ? OR LOWER(filename) LIKE ?",
 				lowerNeedle, lowerNeedle, lowerNeedle,
 			)
+		}
+		if severity != "" {
+			q = q.Where("severity = ?", severity)
 		}
 		if err := q.Order("created_at DESC").Limit(limit).Find(&rows).Error; err != nil {
 			return nil, err

--- a/pkg/logging/process_test.go
+++ b/pkg/logging/process_test.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/nodes"
@@ -80,5 +81,65 @@ func TestProcessLogQueryResultUpdatesStatusOnlyError(t *testing.T) {
 	}
 	if nodeQuery.Status != queries.DistributedQueryStatusError {
 		t.Fatalf("expected status-only query write to mark node query error, got %q", nodeQuery.Status)
+	}
+}
+
+func TestGetNodeLogsSeverityFilter(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&OsqueryStatusData{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	rows := []OsqueryStatusData{
+		{UUID: "NODE-UUID", Environment: "env", Message: "info msg", Severity: "0"},
+		{UUID: "NODE-UUID", Environment: "env", Message: "warn msg", Severity: "1"},
+		{UUID: "NODE-UUID", Environment: "env", Message: "error msg", Severity: "2"},
+	}
+	for _, r := range rows {
+		if err := db.Create(&r).Error; err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+
+	// No severity filter — all 3 rows
+	all, err := GetNodeLogs(db, types.StatusLog, "env", "node-uuid", time.Time{}, 100, "", "")
+	if err != nil {
+		t.Fatalf("GetNodeLogs: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 rows without filter, got %d", len(all))
+	}
+
+	// Filter by severity=2 (error) — only 1 row
+	errOnly, err := GetNodeLogs(db, types.StatusLog, "env", "node-uuid", time.Time{}, 100, "", "2")
+	if err != nil {
+		t.Fatalf("GetNodeLogs: %v", err)
+	}
+	if len(errOnly) != 1 {
+		t.Fatalf("expected 1 error row, got %d", len(errOnly))
+	}
+	if errOnly[0]["severity"] != "2" {
+		t.Fatalf("expected severity 2, got %v", errOnly[0]["severity"])
+	}
+
+	// Filter by severity=1 (warning) — only 1 row
+	warnOnly, err := GetNodeLogs(db, types.StatusLog, "env", "node-uuid", time.Time{}, 100, "", "1")
+	if err != nil {
+		t.Fatalf("GetNodeLogs: %v", err)
+	}
+	if len(warnOnly) != 1 {
+		t.Fatalf("expected 1 warning row, got %d", len(warnOnly))
+	}
+
+	// Filter by severity=0 (info) — only 1 row
+	infoOnly, err := GetNodeLogs(db, types.StatusLog, "env", "node-uuid", time.Time{}, 100, "", "0")
+	if err != nil {
+		t.Fatalf("GetNodeLogs: %v", err)
+	}
+	if len(infoOnly) != 1 {
+		t.Fatalf("expected 1 info row, got %d", len(infoOnly))
 	}
 }

--- a/pkg/logging/reader.go
+++ b/pkg/logging/reader.go
@@ -27,8 +27,11 @@ type LogReader interface {
 	// result), ordered by created_at DESC. since is exclusive; empty means
 	// no lower bound. limit is clamped to [1,1000] by the caller. search
 	// is an optional case-insensitive substring filter against the row's
-	// human-readable columns (best-effort for S3).
-	NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error)
+	// human-readable columns (best-effort for S3). severity is an optional
+	// filter for status logs only (osquery severity integers: 0=info,
+	// 1=warning, 2=error); "" or -1 means "no severity filter". Ignored
+	// for result logs.
+	NodeLogs(logType, env, uuid string, since time.Time, limit int, search string, severity string) ([]map[string]any, error)
 
 	// QueryResults returns rows of query result data (one per node) for a
 	// single query name, ordered by created_at ASC. env is the environment
@@ -57,8 +60,8 @@ func NewDBLogReader(db *gorm.DB) LogReader {
 	return &dbLogReader{db: db}
 }
 
-func (r *dbLogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error) {
-	return GetNodeLogs(r.db, logType, env, uuid, since, limit, search)
+func (r *dbLogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string, severity string) ([]map[string]any, error) {
+	return GetNodeLogs(r.db, logType, env, uuid, since, limit, search, severity)
 }
 
 func (r *dbLogReader) QueryResults(env, name string, since time.Time, page, pageSize int) ([]map[string]any, int64, error) {

--- a/pkg/logging/s3_reader.go
+++ b/pkg/logging/s3_reader.go
@@ -50,7 +50,7 @@ func NewS3LogReader(client *s3.Client, bucket string) LogReader {
 // prefix (node-scoped by key layout), applies the since/search filters
 // (best-effort — the search is applied against the decoded JSON body),
 // and returns up to `limit` rows ordered newest-first.
-func (r *s3LogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string) ([]map[string]any, error) {
+func (r *s3LogReader) NodeLogs(logType, env, uuid string, since time.Time, limit int, search string, severity string) ([]map[string]any, error) {
 	logTypePrefix, err := normalizeLogType(logType)
 	if err != nil {
 		return nil, err
@@ -101,6 +101,13 @@ func (r *s3LogReader) NodeLogs(logType, env, uuid string, since time.Time, limit
 		}
 		if search != "" && !nodeLogMatchesSearch(decoded, logType, search) {
 			continue
+		}
+		if severity != "" && logType == types.StatusLog {
+			if s, ok := decoded["severity"]; ok {
+				if fmt.Sprintf("%v", s) != severity {
+					continue
+				}
+			}
 		}
 		rows = append(rows, decoded)
 	}


### PR DESCRIPTION
## Add severity filter for status logs

### Problem

The status logs tab only had a free-text search bar. Operators investigating osquery issues had no way to quickly filter by severity (info, warning, error), forcing them to visually scan through all log entries or craft search terms that might match unrelated text.

### Change

Added a severity filter dropdown next to the existing search bar in the status logs tab, covering the full stack from backend to UI:

**Backend** (`pkg/logging`, `cmd/api/handlers`):
- Added a `severity` parameter to the `LogReader.NodeLogs` interface, `GetNodeLogs`, `dbLogReader`, and `s3LogReader`
- DB reader applies `WHERE severity = ?` for status logs when the param is non-empty; S3 reader filters decoded rows client-side by matching the `severity` field
- `NodeLogsHandler` reads `?severity=` from the query string and passes it through
- Updated Swagger annotation with the new `severity` param
- Ignored for result logs (no severity concept)

**Frontend API** (`frontend/src/api/nodes.ts`):
- Added optional `severity` parameter to `listNodeLogs()`, serialized as `?severity=` query param

**Frontend UI** (`frontend/src/features/nodes/NodeDetailPage.tsx`):
- Added a severity `<select>` dropdown next to the search bar in `LogsTab`, visible only for status logs
- Options: All severities (default), Info (0), Warning (1), Error (2) — matching the existing `severityBadge` mapping
- Search input set to `flex-1` so it and the dropdown together span the full width of the log entries below
- Changing the filter resets the accumulator and re-fetches, same as the search text behavior
- Included in the TanStack Query key so cache is per-severity

### Validation

- `go test ./pkg/logging/...` — `TestGetNodeLogsSeverityFilter` verifies DB-level filtering by severity 0/1/2
- `go test ./cmd/api/handlers/...` — `TestNodeLogsHandlerPassesSeverityFilter` verifies the handler passes `?severity=2` through to the LogReader
- `go test ./pkg/... ./cmd/...` — full Go test suite passes (no regressions)
- `npm run check` — TypeScript typecheck passes
- `npm run test` — 267 frontend tests pass (no regressions)