### PR TITLE
Fixes to adapt `provision.sh` to Ubuntu 26.04

### DIFF
--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -410,7 +410,8 @@ function prepare_deployment() {
   fi
 
   log "Installing required packages"
-  packages git sudo curl wget gcc make openssl tmux bc rsync yq
+  packages git sudo curl wget gcc make openssl tmux bc rsync
+  install_yq
   install_nvm
 
   # Install go 1.26.5 if not present
@@ -471,6 +472,9 @@ function install_yq() {
     __arch="amd64"
   elif [[ "$__arch" == "aarch64" ]]; then
     __arch="arm64"
+  # Default to x86_64
+  else
+    __arch="amd64"
   fi
   local __file="yq_linux_$__arch"
   local __url="https://github.com/mikefarah/yq/releases/latest/download/$__file"

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -560,7 +560,7 @@ function provision_postgresql() {
       POSTGRES_SERVICE="postgresql"
       POSTGRES_PSQL="/usr/lib/postgresql/18/bin/psql"
     # Ubuntu 24.04 uses postgresql 16
-    if [[ "$(lsb_release -r | cut -f2 | cut -d'.' -f1)" == "24" ]]; then
+    elif [[ "$(lsb_release -r | cut -f2 | cut -d'.' -f1)" == "24" ]]; then
       package postgresql-16
       package postgresql-contrib
       package postgresql-client-16

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -618,4 +618,7 @@ function provision_redis() {
 
   # Configure Redis with password
   configure_redis "$REDIS_CONF" "$REDIS_SERVICE" "$REDIS_ETC" "$__password"
+
+  # Restart Redis service to apply changes
+  sudo systemctl restart "$REDIS_SERVICE"
 }

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -423,7 +423,7 @@ function prepare_deployment() {
 # Install go 1.26.5 from tgz
 function install_go_26() {
   local __version="1.26.5"
-  local __arch="$(uname -i)"
+  local __arch="$(uname -m)"
   if [[ "$__arch" == "x86_64" ]]; then
     __arch="amd64"
   elif [[ "$__arch" == "aarch64" ]]; then
@@ -467,7 +467,7 @@ function install_go_26() {
 
 # Install yq from releases (https://github.com/mikefarah/yq)
 function install_yq() {
-  local __arch="$(uname -i)"
+  local __arch="$(uname -m)"
   if [[ "$__arch" == "x86_64" ]]; then
     __arch="amd64"
   elif [[ "$__arch" == "aarch64" ]]; then

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -410,8 +410,7 @@ function prepare_deployment() {
   fi
 
   log "Installing required packages"
-  packages git sudo curl wget gcc make openssl tmux bc rsync
-  install_yq
+  packages git sudo curl wget gcc make openssl tmux bc rsync yq
   install_nvm
 
   # Install go 1.26.5 if not present
@@ -553,6 +552,13 @@ function provision_postgresql() {
   local POSTGRES_PSQL="$__psql"
 
   if [[ "$__distro" == "ubuntu" ]]; then
+    # Ubuntu 26.04 uses postgresql 18
+    if [[ "$(lsb_release -r | cut -f2 | cut -d'.' -f1)" == "26" ]]; then
+      package postgresql-18
+      package postgresql-contrib
+      package postgresql-client-18
+      POSTGRES_SERVICE="postgresql"
+      POSTGRES_PSQL="/usr/lib/postgresql/18/bin/psql"
     # Ubuntu 24.04 uses postgresql 16
     if [[ "$(lsb_release -r | cut -f2 | cut -d'.' -f1)" == "24" ]]; then
       package postgresql-16

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -643,7 +643,7 @@ else
   __osctrl_crt="/etc/nginx/certs/osctrl.crt"
 
   # Create admin user
-  if [[ "$ADMIN" == true ]]; then
+  if [[ -n "$_ADMIN_PASS" ]]; then
     log "Creating admin user"
     "$DEST_PATH"/bin/osctrl-cli --db -D "$__db_conf" user add -u "$_ADMIN_USER" -p "$_ADMIN_PASS" -a -e "$ENVIRONMENT" -n "Admin"
   fi
@@ -695,7 +695,7 @@ fi
 if [[ "$UPGRADE" == false ]]; then
   echo
   log " -> https://$_A_HOST:$_A_PUB_PORT"
-  if [[ "$ADMIN" == true ]]; then
+  if [[ -n "$_ADMIN_PASS" ]]; then
     log " -> 🔐 Credentials: $_ADMIN_USER / $_ADMIN_PASS"
   fi
   echo

--- a/deploy/redis/redis.conf
+++ b/deploy/redis/redis.conf
@@ -2,6 +2,7 @@ bind 127.0.0.1
 daemonize no
 supervised systemd
 requirepass REDIS_PASSWORD
+dir /var/lib/redis
 
 # This limit will depend on the memory available in your system
 maxmemory 1G


### PR DESCRIPTION
Some adjustments to make sure the `provision.sh` script works well in Ubuntu 26.04