### PR TITLE
Better error handling for cache connections

### DIFF
--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -185,6 +185,49 @@ rateLimits:
 	}
 }
 
+func TestLoadedYAMLCarriesRedisConfig(t *testing.T) {
+	const body = `
+service:
+  auth: jwt
+db:
+  type: postgres
+redis:
+  host: redis.internal
+  port: 6380
+  password: cache-secret
+  connectionString: redis://:url-secret@redis-url.internal:6381/4
+  db: 3
+  connRetry: 4
+`
+	cfg, err := loadYAMLConfiguration(writeTempConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration: %v", err)
+	}
+	params := loadedYAMLToServiceParams(cfg, "api.yml")
+
+	if params.Redis == nil {
+		t.Fatal("Redis params are nil")
+	}
+	if got, want := params.Redis.Host, "redis.internal"; got != want {
+		t.Errorf("Redis.Host = %q, want %q", got, want)
+	}
+	if got, want := params.Redis.Port, 6380; got != want {
+		t.Errorf("Redis.Port = %d, want %d", got, want)
+	}
+	if got, want := params.Redis.Password, "cache-secret"; got != want {
+		t.Errorf("Redis.Password = %q, want %q", got, want)
+	}
+	if got, want := params.Redis.ConnectionString, "redis://:url-secret@redis-url.internal:6381/4"; got != want {
+		t.Errorf("Redis.ConnectionString = %q, want %q", got, want)
+	}
+	if got, want := params.Redis.DB, 3; got != want {
+		t.Errorf("Redis.DB = %d, want %d", got, want)
+	}
+	if got, want := params.Redis.ConnRetry, 4; got != want {
+		t.Errorf("Redis.ConnRetry = %d, want %d", got, want)
+	}
+}
+
 func TestSampleAPIConfigLoads(t *testing.T) {
 	cfg, err := loadYAMLConfiguration(filepath.Join("..", "..", "deploy", "config", "api.yml"))
 	if err != nil {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -161,21 +161,22 @@ var validAuth = map[string]bool{
 // Function to load the configuration from a single YAML file
 func loadYAMLConfiguration(file string) (config.APIConfiguration, error) {
 	var cfg config.APIConfiguration
+	v := viper.New()
 	// saml.forceAuthn defaults to true — same as the --saml-force-authn
 	// flag. Without this the YAML path would silently land on false for
 	// any config file that omits the key, which most operators read as
 	// "logout didn't work" (the IdP silently re-auths from its own SSO
 	// cookie). A zero-value bool can't distinguish "absent" from
 	// "explicitly false", so the default has to live here.
-	viper.SetDefault("saml.forceAuthn", true)
+	v.SetDefault("saml.forceAuthn", true)
 	// Load file and read config
-	viper.SetConfigFile(file)
-	viper.SetConfigType(config.YAMLConfigType)
-	if err := viper.ReadInConfig(); err != nil {
+	v.SetConfigFile(file)
+	v.SetConfigType(config.YAMLConfigType)
+	if err := v.ReadInConfig(); err != nil {
 		return cfg, err
 	}
 	// Unmarshal into struct
-	if err := viper.Unmarshal(&cfg); err != nil {
+	if err := v.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
 	// Check if values are valid

--- a/cmd/tls/config_test.go
+++ b/cmd/tls/config_test.go
@@ -51,6 +51,49 @@ rateLimits:
 	}
 }
 
+func TestLoadedYAMLCarriesRedisConfig(t *testing.T) {
+	const body = `
+service:
+  auth: none
+db:
+  type: postgres
+redis:
+  host: redis.internal
+  port: 6380
+  password: cache-secret
+  connectionString: redis://:url-secret@redis-url.internal:6381/4
+  db: 3
+  connRetry: 4
+`
+	cfg, err := loadYAMLConfiguration(writeTempTLSConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration: %v", err)
+	}
+	params := loadedYAMLToServiceParams(cfg, "tls.yml")
+
+	if params.Redis == nil {
+		t.Fatal("Redis params are nil")
+	}
+	if got, want := params.Redis.Host, "redis.internal"; got != want {
+		t.Errorf("Redis.Host = %q, want %q", got, want)
+	}
+	if got, want := params.Redis.Port, 6380; got != want {
+		t.Errorf("Redis.Port = %d, want %d", got, want)
+	}
+	if got, want := params.Redis.Password, "cache-secret"; got != want {
+		t.Errorf("Redis.Password = %q, want %q", got, want)
+	}
+	if got, want := params.Redis.ConnectionString, "redis://:url-secret@redis-url.internal:6381/4"; got != want {
+		t.Errorf("Redis.ConnectionString = %q, want %q", got, want)
+	}
+	if got, want := params.Redis.DB, 3; got != want {
+		t.Errorf("Redis.DB = %d, want %d", got, want)
+	}
+	if got, want := params.Redis.ConnRetry, 4; got != want {
+		t.Errorf("Redis.ConnRetry = %d, want %d", got, want)
+	}
+}
+
 func TestSampleTLSConfigLoads(t *testing.T) {
 	cfg, err := loadYAMLConfiguration(filepath.Join("..", "..", "deploy", "config", "tls.yml"))
 	if err != nil {

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -94,14 +94,15 @@ var (
 // Function to load the configuration from a single YAML file
 func loadYAMLConfiguration(file string) (config.TLSConfiguration, error) {
 	var cfg config.TLSConfiguration
+	v := viper.New()
 	// Load file and read config
-	viper.SetConfigFile(file)
-	viper.SetConfigType(config.YAMLConfigType)
-	if err := viper.ReadInConfig(); err != nil {
+	v.SetConfigFile(file)
+	v.SetConfigType(config.YAMLConfigType)
+	if err := v.ReadInConfig(); err != nil {
 		return cfg, err
 	}
 	// Unmarshal into struct
-	if err := viper.Unmarshal(&cfg); err != nil {
+	if err := v.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
 	if err := config.ValidateTLSConfigValues(cfg); err != nil {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	redis "github.com/go-redis/redis/v8"
 	"github.com/jmpsec/osctrl/pkg/config"
@@ -47,7 +49,20 @@ func CreateRedisManager(cfg config.YAMLConfigurationRedis) (*RedisManager, error
 	rm.Config = &cfg
 	rm.Client = rm.GetRedis()
 	if err := rm.Check(); err != nil {
-		return nil, err
+		return nil, redisConnectionError(cfg, err)
 	}
 	return rm, nil
+}
+
+func redisConnectionError(cfg config.YAMLConfigurationRedis, err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "AUTH <password> called without any password configured") {
+		if cfg.ConnectionString != "" {
+			return fmt.Errorf("redis auth rejected: redis.connectionString includes credentials, but Redis has no password configured; remove credentials from redis.connectionString or configure a Redis password: %w", err)
+		}
+		return fmt.Errorf("redis auth rejected: redis.password is set, but Redis has no password configured; clear redis.password or configure a Redis password: %w", err)
+	}
+	return err
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,42 @@
+package cache
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+)
+
+func TestRedisConnectionErrorExplainsPasswordWithoutServerAuth(t *testing.T) {
+	baseErr := errors.New("ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?")
+
+	err := redisConnectionError(config.YAMLConfigurationRedis{Password: "secret"}, baseErr)
+	if !errors.Is(err, baseErr) {
+		t.Fatal("wrapped error does not preserve original Redis error")
+	}
+	if !strings.Contains(err.Error(), "redis.password is set") {
+		t.Fatalf("error = %q, want redis.password hint", err)
+	}
+}
+
+func TestRedisConnectionErrorExplainsConnectionStringCredentialsWithoutServerAuth(t *testing.T) {
+	baseErr := errors.New("ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?")
+
+	err := redisConnectionError(config.YAMLConfigurationRedis{ConnectionString: "redis://:secret@127.0.0.1:6379/0"}, baseErr)
+	if !errors.Is(err, baseErr) {
+		t.Fatal("wrapped error does not preserve original Redis error")
+	}
+	if !strings.Contains(err.Error(), "redis.connectionString includes credentials") {
+		t.Fatalf("error = %q, want redis.connectionString hint", err)
+	}
+}
+
+func TestRedisConnectionErrorLeavesOtherErrorsAlone(t *testing.T) {
+	baseErr := errors.New("dial tcp 127.0.0.1:6379: connect: connection refused")
+
+	err := redisConnectionError(config.YAMLConfigurationRedis{}, baseErr)
+	if err != baseErr {
+		t.Fatalf("error = %v, want original error", err)
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -199,12 +199,12 @@ type YAMLConfigurationDB struct {
 
 // YAMLConfigurationRedis to hold all redis configuration values
 type YAMLConfigurationRedis struct {
-	Host             string `yaml:"host"`
-	Port             int    `yaml:"port"`
-	Password         string `yaml:"password"`
-	ConnectionString string `yaml:"connectionString"`
-	DB               int    `yaml:"db"`
-	ConnRetry        int    `yaml:"connRetry"`
+	Host             string `yaml:"host" mapstructure:"host"`
+	Port             int    `yaml:"port" mapstructure:"port"`
+	Password         string `yaml:"password" mapstructure:"password"`
+	ConnectionString string `yaml:"connectionString" mapstructure:"connectionString"`
+	DB               int    `yaml:"db" mapstructure:"db"`
+	ConnRetry        int    `yaml:"connRetry" mapstructure:"connRetry"`
 }
 
 // YAMLConfigurationOsquery to hold the osquery configuration values


### PR DESCRIPTION
## Summary

- Added explicit `mapstructure` tags for Redis YAML config fields so Viper decoding is pinned to the documented YAML keys.
- Switched API/TLS YAML config loading to use isolated Viper instances instead of the package-global Viper state.
- Improved Redis connection errors for the common mismatch where osctrl sends a password but Redis has no password configured.
- Added regression coverage for Redis YAML loading in both `osctrl-api` and `osctrl-tls`.
- Added unit coverage for the Redis auth-mismatch error wrapper.

## Notes

The original Redis error indicates the service is sending an AUTH password, but the Redis server is not configured with one. Operators should either clear `redis.password` / credentials in `redis.connectionString`, or configure Redis with the matching password.

## Validation

- `git diff --check`

Could not run `gofmt` or `go test` in this sandbox because the host Go toolchain was blocked with `operation not permitted`.