### PR TITLE
Log sink categories: route different data classes to different sinks

### DIFF
--- a/cmd/api/handlers/log_sinks.go
+++ b/cmd/api/handlers/log_sinks.go
@@ -41,6 +41,7 @@ type logSinkDTO struct {
 	Info          string          `json:"info"`
 	BytesSent     int64           `json:"bytes_sent"`
 	ExportsCount  int64           `json:"exports_count"`
+	Categories    []string        `json:"categories"`
 }
 
 func toLogSinkDTO(s logsinks.LogSink, reveal bool) logSinkDTO {
@@ -62,6 +63,7 @@ func toLogSinkDTO(s logsinks.LogSink, reveal bool) logSinkDTO {
 		Info:          s.Info,
 		BytesSent:     s.BytesSent,
 		ExportsCount:  s.ExportsCount,
+		Categories:    logsinks.DecodeCategories(s.Categories),
 	}
 }
 
@@ -177,6 +179,7 @@ func (h *HandlersApi) LogSinksTypesHandler(w http.ResponseWriter, r *http.Reques
 			HasSecret:    spec.HasSecret,
 			SecretFields: spec.SecretFields,
 			Fields:       fields,
+			Categories:   logsinks.AllCategories,
 		})
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, specs)
@@ -260,7 +263,7 @@ func (h *HandlersApi) LogSinksCreateHandler(w http.ResponseWriter, r *http.Reque
 		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
 		return
 	}
-	row, err := h.LogSinks.Create(body.Name, body.Type, body.Enabled, body.Order, string(body.Config), body.EnvironmentID, body.Info)
+	row, err := h.LogSinks.Create(body.Name, body.Type, body.Enabled, body.Order, string(body.Config), body.EnvironmentID, body.Info, body.Categories)
 	if err != nil {
 		respondLogSinksErr(w, err)
 		return
@@ -322,7 +325,7 @@ func (h *HandlersApi) LogSinksUpdateHandler(w http.ResponseWriter, r *http.Reque
 		apiErrorResponse(w, "error merging sink secrets", http.StatusBadRequest, err)
 		return
 	}
-	row, err := h.LogSinks.Update(id, body.Name, body.Type, body.Enabled, body.Order, merged, body.Info)
+	row, err := h.LogSinks.Update(id, body.Name, body.Type, body.Enabled, body.Order, merged, body.Info, body.Categories)
 	if err != nil {
 		respondLogSinksErr(w, err)
 		return

--- a/cmd/api/handlers/log_sinks_test.go
+++ b/cmd/api/handlers/log_sinks_test.go
@@ -57,7 +57,7 @@ func TestLogSinksListRejectsNonAdmin(t *testing.T) {
 
 func TestLogSinksListRedactsSecretsByDefault(t *testing.T) {
 	h := setupLogSinksHandler(t)
-	_, err := h.LogSinks.Create("prod-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"supersecret","host":"h","index":"i"}`, 0, "")
+	_, err := h.LogSinks.Create("prod-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"supersecret","host":"h","index":"i"}`, 0, "", nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/log-sinks", nil).WithContext(logSinksCtx("alice"))
@@ -76,7 +76,7 @@ func TestLogSinksListRedactsSecretsByDefault(t *testing.T) {
 
 func TestLogSinksListRevealsSecretsWithRevealFlag(t *testing.T) {
 	h := setupLogSinksHandler(t)
-	_, err := h.LogSinks.Create("prod-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"supersecret","host":"h","index":"i"}`, 0, "")
+	_, err := h.LogSinks.Create("prod-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"supersecret","host":"h","index":"i"}`, 0, "", nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/log-sinks?reveal=1", nil).WithContext(logSinksCtx("alice"))
@@ -121,7 +121,7 @@ func TestLogSinksCreateRejectsInvalidType(t *testing.T) {
 
 func TestLogSinksUpdateMergesSecretPlaceholder(t *testing.T) {
 	h := setupLogSinksHandler(t)
-	row, err := h.LogSinks.Create("s", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"real-secret","host":"h","index":"i"}`, 0, "")
+	row, err := h.LogSinks.Create("s", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"real-secret","host":"h","index":"i"}`, 0, "", nil)
 	require.NoError(t, err)
 
 	body, _ := json.Marshal(types.LogSinkUpdateRequest{
@@ -145,7 +145,7 @@ func TestLogSinksUpdateMergesSecretPlaceholder(t *testing.T) {
 
 func TestLogSinksDelete(t *testing.T) {
 	h := setupLogSinksHandler(t)
-	row, err := h.LogSinks.Create("s", config.LoggingNone, true, 0, `{}`, 0, "")
+	row, err := h.LogSinks.Create("s", config.LoggingNone, true, 0, `{}`, 0, "", nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/log-sinks/"+itoa(row.ID), nil).WithContext(logSinksCtx("alice"))
@@ -164,7 +164,7 @@ func TestLogSinksDelete(t *testing.T) {
 
 func TestLogSinksClone(t *testing.T) {
 	h := setupLogSinksHandler(t)
-	_, err := h.LogSinks.Create("g", config.LoggingNone, true, 0, `{}`, 0, "")
+	_, err := h.LogSinks.Create("g", config.LoggingNone, true, 0, `{}`, 0, "", nil)
 	require.NoError(t, err)
 
 	body, _ := json.Marshal(types.LogSinkCloneRequest{SourceEnvironmentID: 0, TargetEnvironmentID: 5, Overwrite: false})

--- a/cmd/tls/handlers/carves.go
+++ b/cmd/tls/handlers/carves.go
@@ -1,8 +1,11 @@
 package handlers
 
 import (
+	"encoding/json"
+
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/logsinks"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/rs/zerolog/log"
 )
@@ -70,6 +73,18 @@ func (h *HandlersTLS) ProcessCarveWrite(req types.QueryCarveScheduled, queryName
 		log.Err(err).Msg("error creating CarvedFile")
 		return err
 	}
+	// Emit carve.meta event so external sinks can track the carve lifecycle.
+	h.emitCarveMetaEvent(node.EnvironmentID, environment, node.UUID, map[string]any{
+		"event":       "scheduled",
+		"carve_id":    req.CarveGUID,
+		"request_id":  req.RequestID,
+		"query_name":  queryName,
+		"path":        req.Path,
+		"node_uuid":   node.UUID,
+		"environment": environment,
+		"status":      carves.StatusScheduled,
+		"carver":      h.Carves.Carver,
+	})
 	return nil
 }
 
@@ -79,6 +94,23 @@ func (h *HandlersTLS) ProcessCarveInit(req types.CarveInitRequest, sessionid, en
 	if err := h.Carves.InitCarve(req, sessionid); err != nil {
 		log.Err(err).Msg("error creating CarvedFile")
 		return err
+	}
+	// Emit carve.meta event for the init lifecycle step.
+	carve, err := h.Carves.GetBySession(sessionid)
+	if err == nil {
+		h.emitCarveMetaEvent(carve.EnvironmentID, environment, carve.UUID, map[string]any{
+			"event":       "init",
+			"carve_id":    carve.CarveID,
+			"request_id":  req.RequestID,
+			"session_id":  sessionid,
+			"carve_size":  req.CarveSize,
+			"block_count": req.BlockCount,
+			"block_size":  req.BlockSize,
+			"node_uuid":   carve.UUID,
+			"environment": environment,
+			"status":      carves.StatusInProgress,
+			"carver":      h.Carves.Carver,
+		})
 	}
 	return nil
 }
@@ -92,6 +124,17 @@ func (h *HandlersTLS) ProcessCarveBlock(req types.CarveBlockRequest, environment
 	if err := h.Carves.CreateBlock(block, uuid, req.Data); err != nil {
 		log.Err(err).Msg("error creating CarvedBlock")
 	}
+	// Emit carve.data event with block metadata (not the block payload).
+	h.emitCarveDataEvent(envid, environment, uuid, map[string]any{
+		"event":       "block",
+		"session_id":  req.SessionID,
+		"request_id":  req.RequestID,
+		"block_id":    req.BlockID,
+		"block_size":  len(req.Data),
+		"node_uuid":   uuid,
+		"environment": environment,
+		"carver":      h.Carves.Carver,
+	})
 	// Bump block completion
 	if err := h.Carves.CompleteBlock(req.SessionID); err != nil {
 		log.Err(err).Msg("error completing block")
@@ -118,9 +161,56 @@ func (h *HandlersTLS) ProcessCarveBlock(req types.CarveBlockRequest, environment
 		} else if err := h.syncCompletedCarveQuery(req.SessionID); err != nil {
 			log.Err(err).Msg("error syncing completed carve query")
 		}
+		// Emit carve.meta completion event.
+		if carve, err := h.Carves.GetBySession(req.SessionID); err == nil {
+			h.emitCarveMetaEvent(carve.EnvironmentID, environment, uuid, map[string]any{
+				"event":            "completed",
+				"carve_id":         carve.CarveID,
+				"request_id":       req.RequestID,
+				"session_id":       req.SessionID,
+				"node_uuid":        uuid,
+				"environment":      environment,
+				"status":           carves.StatusCompleted,
+				"carver":           h.Carves.Carver,
+				"total_blocks":     carve.TotalBlocks,
+				"completed_blocks": carve.CompletedBlocks,
+				"carve_size":       carve.CarveSize,
+			})
+		}
 	} else {
 		if err := h.Carves.ChangeStatus(carves.StatusInProgress, req.SessionID); err != nil {
 			log.Err(err).Msg("error progressing carve")
 		}
 	}
+}
+
+// emitCarveMetaEvent dispatches a carve.meta lifecycle event through the
+// log sink fan-out. Sinks configured with the "carve.meta" category
+// (or "all") will receive it.
+func (h *HandlersTLS) emitCarveMetaEvent(envID uint, environment, uuid string, payload map[string]any) {
+	if h.Logs == nil {
+		return
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		log.Err(err).Msg("error marshaling carve.meta event")
+		return
+	}
+	h.Logs.LogWithEnv(logsinks.CatCarveMeta, data, envID, environment, uuid, false)
+}
+
+// emitCarveDataEvent dispatches a carve.data block event through the
+// log sink fan-out. Sinks configured with the "carve.data" category
+// (or "all") will receive it. The event carries block metadata only,
+// not the raw block payload — that is stored by pkg/carves.
+func (h *HandlersTLS) emitCarveDataEvent(envID uint, environment, uuid string, payload map[string]any) {
+	if h.Logs == nil {
+		return
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		log.Err(err).Msg("error marshaling carve.data event")
+		return
+	}
+	h.Logs.LogWithEnv(logsinks.CatCarveData, data, envID, environment, uuid, false)
 }

--- a/frontend/src/api/log-sinks.ts
+++ b/frontend/src/api/log-sinks.ts
@@ -25,6 +25,8 @@ export interface LogSink {
   info: string;
   bytes_sent: number;
   exports_count: number;
+  /** Data categories this sink receives. null/empty = all categories. */
+  categories: string[] | null;
 }
 
 /** One field in a sink type's config schema. Drives the dynamic form. */
@@ -50,6 +52,8 @@ export interface LogSinkTypeSpec {
   /** Typed field schema the SPA renders as a dynamic form. Absent for
    * sink types with no config (none, stdout). */
   fields?: LogSinkFieldSpec[];
+  /** All valid category strings the SPA can offer as checkboxes. */
+  categories: string[];
 }
 
 /** GET /api/v1/log-sinks?env={id}&reveal={0|1}. */
@@ -84,6 +88,8 @@ export interface LogSinkCreateRequest {
   config: unknown;
   environment_id: number;
   info?: string;
+  /** Data categories. Empty/omitted = all categories. */
+  categories?: string[];
 }
 
 /** POST /api/v1/log-sinks. */
@@ -103,6 +109,8 @@ export interface LogSinkUpdateRequest {
   order: number;
   config: unknown;
   info?: string;
+  /** Data categories. Empty/omitted = all categories. */
+  categories?: string[];
 }
 
 /** PUT /api/v1/log-sinks/{id}. */

--- a/frontend/src/features/log-sinks/LogSinksPage.test.tsx
+++ b/frontend/src/features/log-sinks/LogSinksPage.test.tsx
@@ -81,9 +81,12 @@ function makeSink(overrides: Partial<LogSink> = {}): LogSink {
     info: '',
     bytes_sent: 0,
     exports_count: 0,
+    categories: null,
     ...overrides,
   };
 }
+
+const ALL_CATS = ['status', 'result', 'query', 'carve.meta', 'carve.data'];
 
 const splunkType: LogSinkTypeSpec = {
   type: 'splunk',
@@ -96,11 +99,13 @@ const splunkType: LogSinkTypeSpec = {
     { name: 'host', label: 'Host', type: 'string', required: false, secret: false, placeholder: 'osctrl' },
     { name: 'index', label: 'Index', type: 'string', required: false, secret: false, placeholder: 'main' },
   ],
+  categories: ALL_CATS,
 };
 const noneType: LogSinkTypeSpec = {
   type: 'none',
   description: 'Discard',
   has_secret: false,
+  categories: ALL_CATS,
 };
 const kafkaType: LogSinkTypeSpec = {
   type: 'kafka',
@@ -116,6 +121,7 @@ const kafkaType: LogSinkTypeSpec = {
     { name: 'sasl.username', label: 'SASL username', type: 'string', required: false, secret: false, placeholder: '' },
     { name: 'sasl.password', label: 'SASL password', type: 'password', required: false, secret: true, placeholder: '' },
   ],
+  categories: ALL_CATS,
 };
 
 function renderPage() {

--- a/frontend/src/features/log-sinks/LogSinksPage.tsx
+++ b/frontend/src/features/log-sinks/LogSinksPage.tsx
@@ -121,6 +121,23 @@ function sinkTypeIcon(type: string): ReactNode {
   return SINK_TYPE_ICONS[type] ?? SINK_TYPE_ICONS.file;
 }
 
+function categoryColor(cat: string): string {
+  switch (cat) {
+    case 'status':
+      return 'text-[color:var(--info)] border-[color:var(--info)]/30 bg-[color:var(--info)]/10';
+    case 'result':
+      return 'text-[color:var(--signal)] border-[color:var(--signal)]/30 bg-[color:var(--signal)]/10';
+    case 'query':
+      return 'text-[color:var(--warning)] border-[color:var(--warning)]/30 bg-[color:var(--warning)]/10';
+    case 'carve.meta':
+      return 'text-[color:var(--text-2)] border-[color:var(--border)] bg-[color:var(--bg-3)]';
+    case 'carve.data':
+      return 'text-[color:var(--danger)] border-[color:var(--danger)]/30 bg-[color:var(--danger)]/10';
+    default:
+      return 'text-[color:var(--text-3)] border-[color:var(--border)] bg-[color:var(--bg-3)]';
+  }
+}
+
 type ModalMode =
   | { kind: 'closed' }
   | { kind: 'create' } // step 1: type picker
@@ -440,6 +457,9 @@ export function LogSinksPage() {
               <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide">
                 Type
               </th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide">
+                Destination
+              </th>
               <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-[color:var(--text-2)] uppercase tracking-wide w-24">
                 Enabled
               </th>
@@ -457,11 +477,11 @@ export function LogSinksPage() {
           </thead>
           <tbody>
             {isLoading &&
-              Array.from({ length: 4 }).map((_, i) => <SkeletonRow key={i} cells={8} />)}
+              Array.from({ length: 4 }).map((_, i) => <SkeletonRow key={i} cells={9} />)}
 
             {isError && !isLoading && (
               <tr>
-                <td colSpan={8}>
+                <td colSpan={9}>
                   <EmptyState
                     icon={
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -486,7 +506,7 @@ export function LogSinksPage() {
 
             {!isLoading && !isError && sorted.length === 0 && (
               <tr>
-                <td colSpan={8}>
+                <td colSpan={9}>
                   <EmptyState
                     icon={
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -547,6 +567,27 @@ export function LogSinksPage() {
                       </span>
                       <span className="tabular-nums">{s.type}</span>
                     </span>
+                  </td>
+                  <td className="px-4 py-3 text-xs">
+                    {s.categories === null || s.categories.length === 0 ? (
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono-tabular font-medium bg-[color:var(--bg-3)] text-[color:var(--text-2)] border border-[color:var(--border)]">
+                        all
+                      </span>
+                    ) : (
+                      <span className="flex flex-wrap gap-1">
+                        {s.categories.map((cat) => (
+                          <span
+                            key={cat}
+                            className={cn(
+                              'inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono-tabular font-medium border',
+                              categoryColor(cat),
+                            )}
+                          >
+                            {cat}
+                          </span>
+                        ))}
+                      </span>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-xs">
                     {s.enabled ? (
@@ -771,6 +812,11 @@ function SinkEditor({
   const [info, setInfo] = useState(existing?.info ?? '');
   const [err, setErr] = useState<string | null>(null);
 
+  // Categories: null/empty means "all". When editing, pre-fill from the
+  // existing sink. When creating, default to all (null).
+  const allCats = types[0]?.categories ?? ['status', 'result', 'query', 'carve.meta', 'carve.data'];
+  const [categories, setCategories] = useState<string[] | null>(existing?.categories ?? null);
+
   const spec = useMemo(
     () => types.find((t) => t.type === sinkType),
     [types, sinkType],
@@ -814,6 +860,11 @@ function SinkEditor({
       const trimmedName = name.trim();
       if (!trimmedName) throw new Error('Name is required.');
       const config = buildConfig(spec, fieldValues);
+      // Normalize: when all categories are selected, send empty array
+      // (meaning "all") so the stored value stays clean.
+      const cats = categories && categories.length > 0 && categories.length < allCats.length
+        ? categories
+        : [];
       if (mode === 'create') {
         const body: LogSinkCreateRequest = {
           name: trimmedName,
@@ -823,6 +874,7 @@ function SinkEditor({
           config,
           environment_id: envID,
           info: info.trim() || undefined,
+          categories: cats,
         };
         return createLogSink(body);
       }
@@ -833,6 +885,7 @@ function SinkEditor({
         order,
         config,
         info: info.trim() || undefined,
+        categories: cats,
       });
     },
     onSuccess: () => {
@@ -950,6 +1003,63 @@ function SinkEditor({
           onChange={setFieldValues}
           inputClass={inputClass}
         />
+
+        {/* Categories — which data classes this sink receives. All
+            checked (default) means "all categories" and the form
+            submits an empty array so the stored value stays clean. */}
+        <fieldset>
+          <legend className="block text-xs font-semibold text-[color:var(--text-2)] mb-1.5">
+            Categories
+          </legend>
+          <div className="flex flex-wrap gap-2">
+            <label className="flex items-center gap-1.5 text-xs text-[color:var(--text-1)]">
+              <input
+                type="checkbox"
+                checked={categories === null || categories.length === allCats.length}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setCategories(null);
+                  } else {
+                    setCategories([]);
+                  }
+                }}
+                className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+              />
+              <span className="font-medium">All</span>
+            </label>
+            {allCats.map((cat) => {
+              const isAll = categories === null || categories.length === allCats.length;
+              const checked = isAll || (categories?.includes(cat) ?? false);
+              return (
+                <label
+                  key={cat}
+                  className="flex items-center gap-1.5 text-xs text-[color:var(--text-1)]"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={isAll}
+                    onChange={(e) => {
+                      if (isAll) return;
+                      if (e.target.checked) {
+                        setCategories([...(categories ?? []), cat]);
+                      } else {
+                        setCategories((categories ?? []).filter((c) => c !== cat));
+                      }
+                    }}
+                    className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+                  />
+                  <span className="tabular-nums">{cat}</span>
+                </label>
+              );
+            })}
+          </div>
+          <p className="mt-1 text-xs text-[color:var(--text-3)]">
+            {categories === null || categories.length === allCats.length
+              ? 'This sink receives all data categories (status, result, query, carve metadata, carve data).'
+              : 'This sink receives only the selected categories. Uncheck "All" to customize.'}
+          </p>
+        </fieldset>
 
         <div>
           <label

--- a/pkg/logging/exporter.go
+++ b/pkg/logging/exporter.go
@@ -78,10 +78,13 @@ func (c *CountedExporter) Stats() *SinkStats { return c.stats }
 // exporters from receiving the same payload. It also holds per-exporter
 // SinkStats counters so the background stats writer can snapshot them
 // and persist bytes/count to the log_sinks table without touching the
-// hot path.
+// hot path. Each exporter carries an optional category list; an exporter
+// whose categories don't match the incoming logType is skipped.
 type MultiExporter struct {
 	exporters []DataExporter
 	stats     []*SinkStats
+	// categories parallels exporters; nil/empty means "all categories".
+	categories [][]string
 }
 
 // NewMultiExporter creates a composite exporter from the provided
@@ -94,22 +97,29 @@ func NewMultiExporter(exporters ...DataExporter) *MultiExporter {
 // NewMultiExporterWithStats creates a composite exporter where each
 // exporter is wrapped in a CountedExporter linked to its SinkStats.
 // The returned stats slice can be snapshotted by a background writer.
+// Each entry's Categories are carried through so Export can skip
+// exporters that don't match the incoming logType.
 func NewMultiExporterWithStats(entries []ExporterEntry) *MultiExporter {
 	exporters := make([]DataExporter, 0, len(entries))
 	stats := make([]*SinkStats, 0, len(entries))
+	categories := make([][]string, 0, len(entries))
 	for _, e := range entries {
 		s := &SinkStats{SinkID: e.SinkID}
 		ce := NewCountedExporter(e.Exporter, s)
 		exporters = append(exporters, ce)
 		stats = append(stats, s)
+		categories = append(categories, e.Categories)
 	}
-	return &MultiExporter{exporters: exporters, stats: stats}
+	return &MultiExporter{exporters: exporters, stats: stats, categories: categories}
 }
 
-// ExporterEntry pairs a sink DB row ID with its built DataExporter.
+// ExporterEntry pairs a sink DB row ID with its built DataExporter
+// and the categories it should receive. Empty Categories means "all
+// categories" (backwards-compatible default).
 type ExporterEntry struct {
-	SinkID   uint
-	Exporter DataExporter
+	SinkID     uint
+	Exporter   DataExporter
+	Categories []string
 }
 
 // Stats returns the per-exporter SinkStats slice, or nil if the
@@ -164,14 +174,23 @@ func (m *MultiExporter) IsEnabled() bool {
 	return false
 }
 
-// Export sends data to every enabled destination.
+// Export sends data to every enabled destination whose categories
+// match the incoming logType. An exporter with empty categories
+// receives all logTypes (backwards-compatible default).
 func (m *MultiExporter) Export(logType string, data []byte, params ExportParams) error {
 	if m == nil {
 		return nil
 	}
 	var errs []error
-	for _, exporter := range m.exporters {
+	for i, exporter := range m.exporters {
 		if exporter == nil || !exporter.IsEnabled() {
+			continue
+		}
+		var cats []string
+		if i < len(m.categories) {
+			cats = m.categories[i]
+		}
+		if !matchesCategory(cats, logType) {
 			continue
 		}
 		if err := exporter.Export(logType, data, params); err != nil {
@@ -180,6 +199,20 @@ func (m *MultiExporter) Export(logType string, data []byte, params ExportParams)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// matchesCategory returns true if the category list is empty (all
+// categories) or contains the given logType.
+func matchesCategory(categories []string, logType string) bool {
+	if len(categories) == 0 {
+		return true
+	}
+	for _, c := range categories {
+		if c == logType {
+			return true
+		}
+	}
+	return false
 }
 
 // Close closes every contained exporter. Errors are collected and

--- a/pkg/logging/exporter_test.go
+++ b/pkg/logging/exporter_test.go
@@ -152,3 +152,53 @@ func TestCreateExportersDoesNotDuplicateAlwaysLogDB(t *testing.T) {
 		t.Fatalf("exporter names: got %#v want %#v", got, want)
 	}
 }
+
+func TestMultiExporterCategoryFiltering(t *testing.T) {
+	statusOnly := &recordingExporter{name: "status-only", enabled: true}
+	allSink := &recordingExporter{name: "all-sink", enabled: true}
+	queryAndResult := &recordingExporter{name: "query-result", enabled: true}
+
+	entries := []ExporterEntry{
+		{SinkID: 1, Exporter: statusOnly, Categories: []string{"status"}},
+		{SinkID: 2, Exporter: allSink, Categories: nil}, // nil = all
+		{SinkID: 3, Exporter: queryAndResult, Categories: []string{"query", "result"}},
+	}
+	multi := NewMultiExporterWithStats(entries)
+	params := ExportParams{Environment: "env", UUID: "node-1"}
+
+	// Send a status log — statusOnly and allSink should receive it.
+	_ = multi.Export("status", []byte(`{"msg":"info"}`), params)
+	if len(statusOnly.calls) != 1 {
+		t.Fatalf("status-only should receive status, got %d calls", len(statusOnly.calls))
+	}
+	if len(allSink.calls) != 1 {
+		t.Fatalf("all-sink should receive status, got %d calls", len(allSink.calls))
+	}
+	if len(queryAndResult.calls) != 0 {
+		t.Fatalf("query-result should NOT receive status, got %d calls", len(queryAndResult.calls))
+	}
+
+	// Send a query log — allSink and queryAndResult should receive it.
+	_ = multi.Export("query", []byte(`{"msg":"result"}`), params)
+	if len(statusOnly.calls) != 1 {
+		t.Fatalf("status-only should NOT receive query, got %d calls", len(statusOnly.calls))
+	}
+	if len(allSink.calls) != 2 {
+		t.Fatalf("all-sink should receive query, got %d calls", len(allSink.calls))
+	}
+	if len(queryAndResult.calls) != 1 {
+		t.Fatalf("query-result should receive query, got %d calls", len(queryAndResult.calls))
+	}
+
+	// Send a carve.meta event — only allSink should receive it.
+	_ = multi.Export("carve.meta", []byte(`{"event":"scheduled"}`), params)
+	if len(statusOnly.calls) != 1 {
+		t.Fatalf("status-only should NOT receive carve.meta, got %d calls", len(statusOnly.calls))
+	}
+	if len(allSink.calls) != 3 {
+		t.Fatalf("all-sink should receive carve.meta, got %d calls", len(allSink.calls))
+	}
+	if len(queryAndResult.calls) != 1 {
+		t.Fatalf("query-result should NOT receive carve.meta, got %d calls", len(queryAndResult.calls))
+	}
+}

--- a/pkg/logsinks/categories.go
+++ b/pkg/logsinks/categories.go
@@ -1,0 +1,119 @@
+package logsinks
+
+// Data categories that can be routed to individual log sinks. Each
+// category corresponds to a class of osquery data that osctrl-tls
+// receives and dispatches through the exporter fan-out.
+const (
+	// CatStatus is osquery daemon status logs (INFO/WARN/ERROR),
+	// received via POST /{env}/log with logType=status.
+	CatStatus = "status"
+	// CatResult is scheduled-query result logs, received via
+	// POST /{env}/log with logType=result.
+	CatResult = "result"
+	// CatQuery is on-demand distributed-query results, received via
+	// POST /{env}/write.
+	CatQuery = "query"
+	// CatCarveMeta is carve lifecycle metadata (scheduling, init,
+	// completion). Emitted by the carve handlers as a small JSON
+	// event so external sinks can track carve lifecycle without
+	// reading the osctrl DB.
+	CatCarveMeta = "carve.meta"
+	// CatCarveData is carve block metadata (block ID, session ID,
+	// size). Emitted per block so external sinks know a carve is
+	// progressing. The raw block payload is NOT sent through the
+	// fan-out — it is stored by pkg/carves in the DB or S3 directly.
+	CatCarveData = "carve.data"
+)
+
+// AllCategories is the complete set of valid category strings, used for
+// validation and UI defaults.
+var AllCategories = []string{
+	CatStatus,
+	CatResult,
+	CatQuery,
+	CatCarveMeta,
+	CatCarveData,
+}
+
+// allCategoriesSet is a set for O(1) validation lookups.
+var allCategoriesSet = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(AllCategories))
+	for _, c := range AllCategories {
+		m[c] = struct{}{}
+	}
+	return m
+}()
+
+// IsValidCategory returns true if cat is a known category string.
+func IsValidCategory(cat string) bool {
+	_, ok := allCategoriesSet[cat]
+	return ok
+}
+
+// ValidateCategories returns nil if every entry in cats is a known
+// category string. Otherwise it returns the first unknown entry as an
+// error.
+func ValidateCategories(cats []string) error {
+	for _, c := range cats {
+		if !IsValidCategory(c) {
+			return &invalidCategoryError{Category: c}
+		}
+	}
+	return nil
+}
+
+// MatchesCategory returns true if the sink should receive the given
+// category. An empty categories list means "all categories"
+// (backwards-compatible default when a single sink is configured).
+func MatchesCategory(categories []string, cat string) bool {
+	if len(categories) == 0 {
+		return true
+	}
+	for _, c := range categories {
+		if c == cat {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAllCategories returns true when categories is empty or nil, meaning
+// the sink receives every category. Used by the API to normalize the
+// stored value: an explicit list of all five categories is collapsed to
+// empty so the stored value stays clean.
+func IsAllCategories(categories []string) bool {
+	return len(categories) == 0
+}
+
+// NormalizeCategories collapses an explicit "all" list (all five
+// categories) to empty so the stored value stays clean. A subset is
+// returned as-is. Unknown entries are rejected.
+func NormalizeCategories(cats []string) ([]string, error) {
+	if len(cats) == 0 {
+		return nil, nil
+	}
+	if err := ValidateCategories(cats); err != nil {
+		return nil, err
+	}
+	if len(cats) == len(AllCategories) {
+		all := true
+		for _, c := range cats {
+			if !IsValidCategory(c) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return nil, nil
+		}
+	}
+	return cats, nil
+}
+
+type invalidCategoryError struct {
+	Category string
+}
+
+func (e *invalidCategoryError) Error() string {
+	return "invalid log sink category: " + e.Category
+}

--- a/pkg/logsinks/categories_test.go
+++ b/pkg/logsinks/categories_test.go
@@ -1,0 +1,75 @@
+package logsinks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchesCategoryEmptyMeansAll(t *testing.T) {
+	assert.True(t, MatchesCategory(nil, CatStatus))
+	assert.True(t, MatchesCategory(nil, CatResult))
+	assert.True(t, MatchesCategory(nil, CatQuery))
+	assert.True(t, MatchesCategory(nil, CatCarveMeta))
+	assert.True(t, MatchesCategory(nil, CatCarveData))
+	assert.True(t, MatchesCategory([]string{}, CatStatus))
+}
+
+func TestMatchesCategoryExplicit(t *testing.T) {
+	cats := []string{CatStatus, CatQuery}
+	assert.True(t, MatchesCategory(cats, CatStatus))
+	assert.True(t, MatchesCategory(cats, CatQuery))
+	assert.False(t, MatchesCategory(cats, CatResult))
+	assert.False(t, MatchesCategory(cats, CatCarveMeta))
+	assert.False(t, MatchesCategory(cats, CatCarveData))
+}
+
+func TestValidateCategories(t *testing.T) {
+	require.NoError(t, ValidateCategories(nil))
+	require.NoError(t, ValidateCategories([]string{}))
+	require.NoError(t, ValidateCategories([]string{CatStatus, CatResult}))
+	require.NoError(t, ValidateCategories(AllCategories))
+
+	err := ValidateCategories([]string{"bogus"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bogus")
+}
+
+func TestNormalizeCategories(t *testing.T) {
+	// Empty stays empty
+	out, err := NormalizeCategories(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	// Subset stays as-is
+	out, err = NormalizeCategories([]string{CatStatus, CatQuery})
+	require.NoError(t, err)
+	assert.Equal(t, []string{CatStatus, CatQuery}, out)
+
+	// All five collapses to nil
+	out, err = NormalizeCategories(AllCategories)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	// Unknown is rejected
+	_, err = NormalizeCategories([]string{"bogus"})
+	require.Error(t, err)
+}
+
+func TestEncodeDecodeCategories(t *testing.T) {
+	// Empty encodes as ""
+	assert.Equal(t, "", encodeCategories(nil))
+	assert.Equal(t, "", encodeCategories([]string{}))
+
+	// Non-empty encodes as JSON array
+	encoded := encodeCategories([]string{CatStatus, CatQuery})
+	assert.Equal(t, `["status","query"]`, encoded)
+
+	// Decode round-trips
+	decoded := DecodeCategories(encoded)
+	assert.Equal(t, []string{CatStatus, CatQuery}, decoded)
+
+	// Decode empty returns nil
+	assert.Nil(t, DecodeCategories(""))
+}

--- a/pkg/logsinks/logsinks.go
+++ b/pkg/logsinks/logsinks.go
@@ -51,7 +51,9 @@ const NoEnvironmentID uint = 0
 // LogSink stores one osquery log destination for one environment (or
 // global when EnvironmentID is NoEnvironmentID). The Config field is a
 // JSON-encoded blob whose shape is determined by Type and validated
-// against the Registry.
+// against the Registry. Categories is a JSON-encoded array of data
+// category strings (status, result, query, carve.meta, carve.data);
+// empty/null means "all categories" (backwards-compatible default).
 type LogSink struct {
 	gorm.Model
 	Name          string `gorm:"uniqueIndex:idx_log_sinks_unique"`
@@ -62,6 +64,10 @@ type LogSink struct {
 	Config        string `gorm:"type:text"`
 	Source        string // "service" (seeded) or "db" (operator-edited)
 	Info          string
+	// Categories is a JSON-encoded array of data category strings. Empty
+	// string means "all categories" — the backwards-compatible default.
+	// See pkg/logsinks/categories.go for the valid set.
+	Categories string `gorm:"type:text"`
 	// BytesSent and ExportsCount are maintained by the background stats
 	// writer (SinkStatsWriter), which snapshots the in-process atomic
 	// counters from the live MultiExporter and flushes them here
@@ -487,11 +493,17 @@ func ValidateSink(name, typ, cfgJSON string) error {
 	return nil
 }
 
-// Create inserts a new sink row.
-func (m *LogSinksManager) Create(name, typ string, enabled bool, order int, cfgJSON string, envID uint, info string) (LogSink, error) {
+// Create inserts a new sink row. categories is a list of data category
+// strings; empty/nil means "all categories". Unknown entries return an
+// error.
+func (m *LogSinksManager) Create(name, typ string, enabled bool, order int, cfgJSON string, envID uint, info string, categories []string) (LogSink, error) {
 	name = normalizeName(name)
 	typ = normalizeType(typ)
 	if err := ValidateSink(name, typ, cfgJSON); err != nil {
+		return LogSink{}, err
+	}
+	normalized, err := NormalizeCategories(categories)
+	if err != nil {
 		return LogSink{}, err
 	}
 	row := LogSink{
@@ -503,6 +515,7 @@ func (m *LogSinksManager) Create(name, typ string, enabled bool, order int, cfgJ
 		Config:        cfgJSON,
 		Source:        SourceDB,
 		Info:          info,
+		Categories:    encodeCategories(normalized),
 	}
 	if err := m.DB.Create(&row).Error; err != nil {
 		return LogSink{}, fmt.Errorf("create log sink: %w", err)
@@ -513,10 +526,16 @@ func (m *LogSinksManager) Create(name, typ string, enabled bool, order int, cfgJ
 // Update replaces an existing sink row's mutable fields. Config is
 // re-validated against the existing Type (Type can be changed in the
 // same call as long as the new Config decodes against the new Type).
-func (m *LogSinksManager) Update(id uint, name, typ string, enabled bool, order int, cfgJSON string, info string) (LogSink, error) {
+// categories is a list of data category strings; empty/nil means "all
+// categories". Unknown entries return an error.
+func (m *LogSinksManager) Update(id uint, name, typ string, enabled bool, order int, cfgJSON string, info string, categories []string) (LogSink, error) {
 	name = normalizeName(name)
 	typ = normalizeType(typ)
 	if err := ValidateSink(name, typ, cfgJSON); err != nil {
+		return LogSink{}, err
+	}
+	normalized, err := NormalizeCategories(categories)
+	if err != nil {
 		return LogSink{}, err
 	}
 	row, err := m.Get(id)
@@ -524,13 +543,14 @@ func (m *LogSinksManager) Update(id uint, name, typ string, enabled bool, order 
 		return LogSink{}, err
 	}
 	if err := m.DB.Model(&row).Updates(map[string]any{
-		"name":    name,
-		"type":    typ,
-		"enabled": enabled,
-		"order":   order,
-		"config":  cfgJSON,
-		"info":    info,
-		"source":  SourceDB,
+		"name":       name,
+		"type":       typ,
+		"enabled":    enabled,
+		"order":      order,
+		"config":     cfgJSON,
+		"info":       info,
+		"source":     SourceDB,
+		"categories": encodeCategories(normalized),
 	}).Error; err != nil {
 		return LogSink{}, fmt.Errorf("update log sink: %w", err)
 	}
@@ -688,6 +708,7 @@ func (m *LogSinksManager) CloneEnvironment(sourceEnvID, targetEnvID uint, overwr
 				Config:        r.Config,
 				Source:        SourceDB,
 				Info:          r.Info,
+				Categories:    r.Categories,
 			}
 			if err := tx.Create(&newRow).Error; err != nil {
 				return fmt.Errorf("create cloned sink %q: %w", newRow.Name, err)
@@ -953,6 +974,33 @@ func RedactedConfig(typ, cfgJSON string) string {
 	return string(out)
 }
 
+// encodeCategories serializes a category list to the JSON string stored
+// in the Categories column. nil/empty produces "" (empty string), which
+// means "all categories" — the backwards-compatible default.
+func encodeCategories(cats []string) string {
+	if len(cats) == 0 {
+		return ""
+	}
+	raw, err := json.Marshal(cats)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+// DecodeCategories parses the stored Categories string back into a
+// slice. An empty string returns nil (meaning "all categories").
+func DecodeCategories(stored string) []string {
+	if stored == "" {
+		return nil
+	}
+	var cats []string
+	if err := json.Unmarshal([]byte(stored), &cats); err != nil {
+		return nil
+	}
+	return cats
+}
+
 // MergeSecrets replaces any "***" placeholder values in newCfgJSON with
 // the corresponding values from prevCfgJSON. Used by the API Update
 // handler so an edit that did not touch a secret field preserves the
@@ -1023,7 +1071,11 @@ func BuildExporters(rows []LogSink, smgr *settings.Settings) *logging.MultiExpor
 			log.Error().Err(err).Str("sink", row.Name).Msg("build sink exporter, skipping")
 			continue
 		}
-		entries = append(entries, logging.ExporterEntry{SinkID: row.ID, Exporter: exp})
+		entries = append(entries, logging.ExporterEntry{
+			SinkID:     row.ID,
+			Exporter:   exp,
+			Categories: DecodeCategories(row.Categories),
+		})
 	}
 	return logging.NewMultiExporterWithStats(entries)
 }

--- a/pkg/logsinks/logsinks_test.go
+++ b/pkg/logsinks/logsinks_test.go
@@ -70,7 +70,7 @@ func TestValidateTypeIsStrictCase(t *testing.T) {
 
 func TestCreateNormalizesTypeCase(t *testing.T) {
 	m := newTestManager(t)
-	row, err := m.Create("ci", "SPLUNK", true, 0, `{"url":"","token":"","host":"","index":""}`, 0, "")
+	row, err := m.Create("ci", "SPLUNK", true, 0, `{"url":"","token":"","host":"","index":""}`, 0, "", nil)
 	if err != nil {
 		t.Fatalf("create with upper-case type: %v", err)
 	}
@@ -82,26 +82,26 @@ func TestCreateNormalizesTypeCase(t *testing.T) {
 func TestCreateValidatesTypeAndConfig(t *testing.T) {
 	m := newTestManager(t)
 
-	if _, err := m.Create("good", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, ""); err != nil {
+	if _, err := m.Create("good", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, "", nil); err != nil {
 		t.Fatalf("valid create: %v", err)
 	}
 
-	if _, err := m.Create("bad-type", "nope", true, 0, `{}`, 0, ""); !errors.Is(err, ErrInvalidSinkType) {
+	if _, err := m.Create("bad-type", "nope", true, 0, `{}`, 0, "", nil); !errors.Is(err, ErrInvalidSinkType) {
 		t.Fatalf("bad type: got %v, want ErrInvalidSinkType", err)
 	}
 
-	if _, err := m.Create("bad-config", config.LoggingSplunk, true, 0, `{not json}`, 0, ""); !errors.Is(err, ErrInvalidSinkConfig) {
+	if _, err := m.Create("bad-config", config.LoggingSplunk, true, 0, `{not json}`, 0, "", nil); !errors.Is(err, ErrInvalidSinkConfig) {
 		t.Fatalf("bad config: got %v, want ErrInvalidSinkConfig", err)
 	}
 
-	if _, err := m.Create("", config.LoggingNone, true, 0, `{}`, 0, ""); err == nil {
+	if _, err := m.Create("", config.LoggingNone, true, 0, `{}`, 0, "", nil); err == nil {
 		t.Fatalf("empty name should error")
 	}
 }
 
 func TestCreateAndRoundTrip(t *testing.T) {
 	m := newTestManager(t)
-	row, err := m.Create("prod-splunk", config.LoggingSplunk, true, 1, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, "prod")
+	row, err := m.Create("prod-splunk", config.LoggingSplunk, true, 1, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, "prod", nil)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -124,11 +124,11 @@ func TestCreateAndRoundTrip(t *testing.T) {
 
 func TestUpdatePreservesAndMerges(t *testing.T) {
 	m := newTestManager(t)
-	row, err := m.Create("s", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"secret","host":"h","index":"i"}`, 0, "")
+	row, err := m.Create("s", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"secret","host":"h","index":"i"}`, 0, "", nil)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	updated, err := m.Update(row.ID, "s2", config.LoggingSplunk, false, 5, `{"url":"http://y","token":"***","host":"h2","index":"j"}`, "note")
+	updated, err := m.Update(row.ID, "s2", config.LoggingSplunk, false, 5, `{"url":"http://y","token":"***","host":"h2","index":"j"}`, "note", nil)
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -145,9 +145,74 @@ func TestUpdatePreservesAndMerges(t *testing.T) {
 	}
 }
 
+func TestCreateWithCategories(t *testing.T) {
+	m := newTestManager(t)
+	cats := []string{CatStatus, CatQuery}
+	row, err := m.Create("cat-sink", config.LoggingNone, true, 0, `{}`, 0, "", cats)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	decoded := DecodeCategories(row.Categories)
+	if len(decoded) != 2 || decoded[0] != CatStatus || decoded[1] != CatQuery {
+		t.Fatalf("categories not stored correctly: got %v", decoded)
+	}
+
+	// All categories collapses to empty
+	rowAll, err := m.Create("all-sink", config.LoggingNone, true, 1, `{}`, 0, "", AllCategories)
+	if err != nil {
+		t.Fatalf("create all: %v", err)
+	}
+	if rowAll.Categories != "" {
+		t.Fatalf("all categories should collapse to empty, got %q", rowAll.Categories)
+	}
+}
+
+func TestUpdateWithCategories(t *testing.T) {
+	m := newTestManager(t)
+	row, err := m.Create("s", config.LoggingNone, true, 0, `{}`, 0, "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	updated, err := m.Update(row.ID, "s", config.LoggingNone, true, 0, `{}`, "", []string{CatResult})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	decoded := DecodeCategories(updated.Categories)
+	if len(decoded) != 1 || decoded[0] != CatResult {
+		t.Fatalf("categories not updated: got %v", decoded)
+	}
+}
+
+func TestCreateRejectsInvalidCategory(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.Create("bad", config.LoggingNone, true, 0, `{}`, 0, "", []string{"bogus"})
+	if err == nil {
+		t.Fatal("expected error for invalid category")
+	}
+}
+
+func TestClonePreservesCategories(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.Create("g-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, "", []string{CatStatus, CatResult})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cloned, err := m.CloneEnvironment(0, 5, false)
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	if len(cloned) != 1 {
+		t.Fatalf("expected 1 cloned sink, got %d", len(cloned))
+	}
+	decoded := DecodeCategories(cloned[0].Categories)
+	if len(decoded) != 2 || decoded[0] != CatStatus || decoded[1] != CatResult {
+		t.Fatalf("cloned categories not preserved: got %v", decoded)
+	}
+}
+
 func TestDelete(t *testing.T) {
 	m := newTestManager(t)
-	row, err := m.Create("s", config.LoggingNone, true, 0, `{}`, 0, "")
+	row, err := m.Create("s", config.LoggingNone, true, 0, `{}`, 0, "", nil)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -162,7 +227,7 @@ func TestDelete(t *testing.T) {
 func TestRevertToService(t *testing.T) {
 	m := newTestManager(t)
 	// Create a sink (Source defaults to "db").
-	row, err := m.Create("s", config.LoggingNone, true, 0, `{}`, 0, "")
+	row, err := m.Create("s", config.LoggingNone, true, 0, `{}`, 0, "", nil)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -192,13 +257,13 @@ func TestRevertToService(t *testing.T) {
 
 func TestListByEnvironmentAndEffectiveFor(t *testing.T) {
 	m := newTestManager(t)
-	if _, err := m.Create("g-none", config.LoggingNone, true, 0, `{}`, 0, ""); err != nil {
+	if _, err := m.Create("g-none", config.LoggingNone, true, 0, `{}`, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.Create("g-splunk", config.LoggingSplunk, false, 1, `{"url":"","token":"","host":"","index":""}`, 0, ""); err != nil {
+	if _, err := m.Create("g-splunk", config.LoggingSplunk, false, 1, `{"url":"","token":"","host":"","index":""}`, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.Create("env5-stdout", config.LoggingStdout, true, 0, `{}`, 5, ""); err != nil {
+	if _, err := m.Create("env5-stdout", config.LoggingStdout, true, 0, `{}`, 5, "", nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -227,10 +292,10 @@ func TestListByEnvironmentAndEffectiveFor(t *testing.T) {
 
 func TestCloneEnvironment(t *testing.T) {
 	m := newTestManager(t)
-	if _, err := m.Create("g-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, ""); err != nil {
+	if _, err := m.Create("g-splunk", config.LoggingSplunk, true, 0, `{"url":"http://x","token":"t","host":"h","index":"i"}`, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.Create("g-none", config.LoggingNone, true, 1, `{}`, 0, ""); err != nil {
+	if _, err := m.Create("g-none", config.LoggingNone, true, 1, `{}`, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -297,7 +362,7 @@ func TestSeedIdempotent(t *testing.T) {
 
 	// Re-seed: must NOT create duplicates or overwrite existing rows.
 	// Mutate one row to source=db first to prove it survives.
-	if _, err := m.Update(rows[0].ID, rows[0].Name, rows[0].Type, rows[0].Enabled, rows[0].Order, rows[0].Config, rows[0].Info); err != nil {
+	if _, err := m.Update(rows[0].ID, rows[0].Name, rows[0].Type, rows[0].Enabled, rows[0].Order, rows[0].Config, rows[0].Info, nil); err != nil {
 		t.Fatalf("mark row as db: %v", err)
 	}
 	gotUpdated, _ := m.Get(rows[0].ID)
@@ -636,7 +701,7 @@ func TestMergeSecretsAcceptsNewSecretValue(t *testing.T) {
 
 func TestBuildExportersSkipsDisabledAndUnknown(t *testing.T) {
 	m := newTestManager(t)
-	if _, err := m.Create("off", config.LoggingNone, false, 0, `{}`, 0, ""); err != nil {
+	if _, err := m.Create("off", config.LoggingNone, false, 0, `{}`, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
 	// Build directly from a row slice with an unknown type and a disabled row.
@@ -656,10 +721,10 @@ func TestBuildExportersSkipsDisabledAndUnknown(t *testing.T) {
 
 func TestBuildExportersForEnvironmentsGroupsByEnv(t *testing.T) {
 	m := newTestManager(t)
-	if _, err := m.Create("g", config.LoggingNone, true, 0, `{}`, 0, ""); err != nil {
+	if _, err := m.Create("g", config.LoggingNone, true, 0, `{}`, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.Create("e5", config.LoggingStdout, true, 0, `{}`, 5, ""); err != nil {
+	if _, err := m.Create("e5", config.LoggingStdout, true, 0, `{}`, 5, "", nil); err != nil {
 		t.Fatal(err)
 	}
 	got, err := m.BuildExportersForEnvironments(nil)
@@ -679,8 +744,8 @@ func TestBuildExportersForEnvironmentsGroupsByEnv(t *testing.T) {
 
 func TestBuildExportersTracksStatsPerSink(t *testing.T) {
 	m := newTestManager(t)
-	row1, _ := m.Create("s1", config.LoggingNone, true, 0, `{}`, 0, "")
-	row2, _ := m.Create("s2", config.LoggingStdout, true, 1, `{}`, 0, "")
+	row1, _ := m.Create("s1", config.LoggingNone, true, 0, `{}`, 0, "", nil)
+	row2, _ := m.Create("s2", config.LoggingStdout, true, 1, `{}`, 0, "", nil)
 
 	multi := BuildExporters([]LogSink{row1, row2}, nil)
 	stats := multi.Stats()

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -681,6 +681,7 @@ type LogSinkTypeSpec struct {
 	HasSecret    bool               `json:"has_secret"`
 	SecretFields []string           `json:"secret_fields,omitempty"`
 	Fields       []LogSinkFieldSpec `json:"fields,omitempty"`
+	Categories   []string           `json:"categories"`
 }
 
 // LogSinkCreateRequest is the body for POST /api/v1/log-sinks.
@@ -692,6 +693,7 @@ type LogSinkCreateRequest struct {
 	Config        json.RawMessage `json:"config"`
 	EnvironmentID uint            `json:"environment_id"`
 	Info          string          `json:"info,omitempty"`
+	Categories    []string        `json:"categories,omitempty"`
 }
 
 // LogSinkUpdateRequest is the body for PUT /api/v1/log-sinks/{id}. All
@@ -699,12 +701,13 @@ type LogSinkCreateRequest struct {
 // previously stored value by the handler so the SPA can submit a form
 // without re-entering every secret.
 type LogSinkUpdateRequest struct {
-	Name    string          `json:"name"`
-	Type    string          `json:"type"`
-	Enabled bool            `json:"enabled"`
-	Order   int             `json:"order"`
-	Config  json.RawMessage `json:"config"`
-	Info    string          `json:"info,omitempty"`
+	Name       string          `json:"name"`
+	Type       string          `json:"type"`
+	Enabled    bool            `json:"enabled"`
+	Order      int             `json:"order"`
+	Config     json.RawMessage `json:"config"`
+	Info       string          `json:"info,omitempty"`
+	Categories []string        `json:"categories,omitempty"`
 }
 
 // LogSinkCloneRequest is the body for POST /api/v1/log-sinks/clone.


### PR DESCRIPTION
## Log sink categories: route different data classes to different sinks

### Problem

Every configured log sink received every type of osquery data — status logs, scheduled-query results, on-demand query results, and carve lifecycle events. Operators could not say "send status logs to Splunk but keep results in the DB" or "route carve metadata to Kafka only." Adding a second sink meant both got the full firehose.

### Change

Added per-sink **category routing** so operators choose which data classes each sink receives. Five categories are supported:

| Category | Data |
|---|---|
| `status` | osquery daemon status logs |
| `result` | Scheduled-query result logs |
| `query` | On-demand distributed-query results |
| `carve.meta` | Carve lifecycle metadata (scheduled, init, completed) |
| `carve.data` | Carve block metadata (block ID, session ID, size) |

**Backend**:

- `pkg/logsinks/categories.go` (new): category constants, `MatchesCategory`, `ValidateCategories`, `NormalizeCategories` (collapses explicit "all five" to empty), `DecodeCategories`/`encodeCategories` helpers
- `pkg/logsinks/logsinks.go`: Added `Categories` text column to `LogSink` model (JSON-encoded array; empty = all). `Create`/`Update` accept and validate categories. `CloneEnvironment` copies them. `BuildExporters` passes them to `ExporterEntry`
- `pkg/logging/exporter.go`: Added `Categories` to `ExporterEntry`. `MultiExporter` stores a parallel categories slice and skips exporters whose categories don't match the incoming `logType` in `Export` (nil/empty = all, backwards-compatible)
- `cmd/tls/handlers/carves.go`: `ProcessCarveWrite`/`ProcessCarveInit`/`ProcessCarveBlock` now emit `carve.meta` and `carve.data` events via `LoggerTLS.LogWithEnv` so external sinks can track carve lifecycle. Raw block data is NOT sent through the fan-out — it stays in the DB/S3 via `pkg/carves`
- `pkg/types/types.go`: Added `Categories` to `LogSinkCreateRequest`, `LogSinkUpdateRequest`, `LogSinkTypeSpec`
- `cmd/api/handlers/log_sinks.go`: Added `Categories` to `logSinkDTO`; create/update handlers pass categories through; types endpoint advertises `AllCategories`

**Frontend**:

- `frontend/src/api/log-sinks.ts`: Added `categories` to `LogSink`, create/update request types, and `LogSinkTypeSpec`
- `frontend/src/features/log-sinks/LogSinksPage.tsx`: Categories checkbox section in the sink editor (All checkbox + individual category toggles). New **Destination** column in the table showing color-coded category badges per sink — "all" badge when unscoped, individual badges when categories are explicitly set

**Migration**: `Categories` is a new nullable text column added by `AutoMigrate`. Existing rows get `""` = all categories — no behavior change. No YAML changes; seeded sinks get empty categories. Rollback by clearing the column.

### Validation

- `go test ./pkg/logsinks/...` — `TestMatchesCategory*`, `TestValidateCategories`, `TestNormalizeCategories`, `TestEncodeDecodeCategories`, `TestCreateWithCategories`, `TestUpdateWithCategories`, `TestCreateRejectsInvalidCategory`, `TestClonePreservesCategories`
- `go test ./pkg/logging/...` — `TestMultiExporterCategoryFiltering` verifies status-only, all, and query+result sinks receive the correct logTypes
- `go test ./pkg/... ./cmd/...` — full Go test suite passes (no regressions)
- `npm run check` — TypeScript typecheck passes
- `npm run test` — 292 frontend tests pass (no regressions)