### PR TITLE
Add version field to the service configuration schema

### DIFF
--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
 )
 
 // osctrl-api reads its config either from flags/env vars or from a YAML
@@ -235,6 +237,9 @@ func TestSampleAPIConfigLoads(t *testing.T) {
 	}
 	params := loadedYAMLToServiceParams(cfg, "api.yml")
 
+	if cfg.Version != config.ConfigVersion {
+		t.Fatalf("sample api.yml version = %d, want %d — bump the file when the schema changes", cfg.Version, config.ConfigVersion)
+	}
 	if params.Osquery == nil {
 		t.Fatal("sample api.yml did not load osquery")
 	}
@@ -246,5 +251,24 @@ func TestSampleAPIConfigLoads(t *testing.T) {
 	}
 	if params.Carver == nil {
 		t.Fatal("sample api.yml did not load carver")
+	}
+}
+
+func TestConfigVersionMismatchDoesNotFailLoad(t *testing.T) {
+	// Version skew is a warning, not an error: a file from a newer
+	// osctrl release must still load so the service can start (the
+	// unknown fields are simply ignored), and a file with no version at
+	// all is every pre-existing deployment.
+	const body = `
+version: 999
+service:
+  auth: jwt
+`
+	cfg, err := loadYAMLConfiguration(writeTempConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration with newer version: %v", err)
+	}
+	if cfg.Version != 999 {
+		t.Fatalf("cfg.Version = %d, want 999", cfg.Version)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -179,6 +179,12 @@ func loadYAMLConfiguration(file string) (config.APIConfiguration, error) {
 	if err := v.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
+	// Warn when the file predates (or postdates) the schema this binary
+	// understands — usually new fields were added since the file was
+	// written and are silently missing from it.
+	if msg := config.ConfigVersionWarning(cfg.Version); msg != "" {
+		log.Warn().Msg(msg)
+	}
 	// Check if values are valid
 	if !validAuth[cfg.Service.Auth] {
 		return cfg, fmt.Errorf("invalid auth method: '%s'", cfg.Service.Auth)

--- a/cmd/tls/config_test.go
+++ b/cmd/tls/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
 )
 
 func writeTempTLSConfig(t *testing.T, body string) string {
@@ -101,6 +103,9 @@ func TestSampleTLSConfigLoads(t *testing.T) {
 	}
 	params := loadedYAMLToServiceParams(cfg, "tls.yml")
 
+	if cfg.Version != config.ConfigVersion {
+		t.Fatalf("sample tls.yml version = %d, want %d — bump the file when the schema changes", cfg.Version, config.ConfigVersion)
+	}
 	if params.BatchWriter == nil {
 		t.Fatal("sample tls.yml did not load batchWriter")
 	}
@@ -109,5 +114,28 @@ func TestSampleTLSConfigLoads(t *testing.T) {
 	}
 	if params.Osquery == nil {
 		t.Fatal("sample tls.yml did not load osquery")
+	}
+}
+
+func TestConfigVersionMismatchDoesNotFailLoad(t *testing.T) {
+	// Version skew is a warning, not an error: a file from a newer
+	// osctrl release must still load so the service can start (the
+	// unknown fields are simply ignored), and a file with no version at
+	// all is every pre-existing deployment.
+	const body = `
+version: 999
+service:
+  auth: none
+db:
+  type: postgres
+redis:
+  host: 127.0.0.1
+`
+	cfg, err := loadYAMLConfiguration(writeTempTLSConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration with newer version: %v", err)
+	}
+	if cfg.Version != 999 {
+		t.Fatalf("cfg.Version = %d, want 999", cfg.Version)
 	}
 }

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -105,6 +105,12 @@ func loadYAMLConfiguration(file string) (config.TLSConfiguration, error) {
 	if err := v.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
+	// Warn when the file predates (or postdates) the schema this binary
+	// understands — usually new fields were added since the file was
+	// written and are silently missing from it.
+	if msg := config.ConfigVersionWarning(cfg.Version); msg != "" {
+		log.Warn().Msg(msg)
+	}
 	if err := config.ValidateTLSConfigValues(cfg); err != nil {
 		return cfg, err
 	}

--- a/deploy/config/api.yml
+++ b/deploy/config/api.yml
@@ -2,6 +2,12 @@
 # This service is the authenticated REST API used by the React frontend,
 # osctrl-cli, and automation.
 
+# Version of the configuration schema this file targets. osctrl warns at
+# startup when this differs from the version the binary supports: a lower
+# number means fields were added since this file was written, a higher
+# number means the binary is older than this file. See pkg/config/version.go.
+version: 1
+
 # Main HTTP service behavior and shared service-level features.
 service:
   # Address to bind. Use 0.0.0.0 inside containers or behind a proxy.

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -2,6 +2,12 @@
 # This service implements the osquery remote API: enroll, config, logs,
 # distributed queries, and file carving.
 
+# Version of the configuration schema this file targets. osctrl warns at
+# startup when this differs from the version the binary supports: a lower
+# number means fields were added since this file was written, a higher
+# number means the binary is older than this file. See pkg/config/version.go.
+version: 1
+
 # Main HTTP service behavior and shared service-level features.
 service:
   # Address to bind. Use 0.0.0.0 inside containers or behind a proxy.

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -69,6 +69,9 @@ const (
 // minimal YAML file can omit them and the service falls back to DB-stored or
 // zero-valued defaults.
 type TLSConfiguration struct {
+	// Version of the configuration schema this file was written for.
+	// Checked against ConfigVersion at load time; see version.go.
+	Version int                      `mapstructure:"version"`
 	Service YAMLConfigurationService `mapstructure:"service"`
 	DB      YAMLConfigurationDB      `mapstructure:"db"`
 	Redis   YAMLConfigurationRedis   `mapstructure:"redis"`
@@ -89,6 +92,9 @@ type TLSConfiguration struct {
 // APIConfiguration to hold osctrl-api configuration values. Required sections
 // (service, db, redis) are value types; optional sections are pointers.
 type APIConfiguration struct {
+	// Version of the configuration schema this file was written for.
+	// Checked against ConfigVersion at load time; see version.go.
+	Version int                      `mapstructure:"version"`
 	Service YAMLConfigurationService `mapstructure:"service"`
 	DB      YAMLConfigurationDB      `mapstructure:"db"`
 	Redis   YAMLConfigurationRedis   `mapstructure:"redis"`

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -23,6 +23,7 @@ func (p *ServiceParameters) ConfigFilePath() string {
 // Helper to generate an example TLS configuration file
 func GenerateTLSConfigFile(path string, cfg *ServiceParameters, overwrite bool) error {
 	cfgTLS := TLSConfiguration{
+		Version:         ConfigVersion,
 		Service:         *cfg.Service,
 		DB:              *cfg.DB,
 		Redis:           *cfg.Redis,
@@ -43,15 +44,16 @@ func GenerateTLSConfigFile(path string, cfg *ServiceParameters, overwrite bool) 
 // Helper to generate an example API configuration file
 func GenerateAPIConfigFile(path string, cfg *ServiceParameters, overwrite bool) error {
 	cfgAPI := APIConfiguration{
-		Service: *cfg.Service,
-		DB:      *cfg.DB,
-		Redis:   *cfg.Redis,
-		Osquery: cfg.Osquery,
-		SAML:    cfg.SAML,
-		OIDC:    cfg.OIDC,
-		JWT:     cfg.JWT,
-		TLS:     cfg.TLS,
-		Logger:  cfg.Logger,
+		Version:    ConfigVersion,
+		Service:    *cfg.Service,
+		DB:         *cfg.DB,
+		Redis:      *cfg.Redis,
+		Osquery:    cfg.Osquery,
+		SAML:       cfg.SAML,
+		OIDC:       cfg.OIDC,
+		JWT:        cfg.JWT,
+		TLS:        cfg.TLS,
+		Logger:     cfg.Logger,
 		Carver:     cfg.Carver,
 		Debug:      cfg.Debug,
 		RateLimits: cfg.RateLimits,

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -1,0 +1,29 @@
+package config
+
+import "fmt"
+
+// ConfigVersion is the version of the YAML configuration schema this
+// binary understands. Bump it whenever a field is added, renamed, or
+// removed from any YAMLConfiguration* struct so services can warn
+// operators whose files predate the change. The sample files in
+// deploy/config and the files written by the config-generate
+// subcommands carry the same number in their top-level "version" field.
+const ConfigVersion = 1
+
+// ConfigVersionWarning returns a warning when the "version" field of a
+// YAML configuration file does not match ConfigVersion, or an empty
+// string when it does. A file without the field reads as 0 and counts
+// as predating versioned configuration. Version skew is never an error:
+// it is operator-visible information, not a reason to refuse starting.
+func ConfigVersionWarning(fileVersion int) string {
+	switch {
+	case fileVersion == ConfigVersion:
+		return ""
+	case fileVersion == 0:
+		return fmt.Sprintf("configuration file has no version field — fields added since the file was written may be missing; compare with config-generate output and add 'version: %d'", ConfigVersion)
+	case fileVersion < ConfigVersion:
+		return fmt.Sprintf("configuration file version %d is older than supported version %d — fields added since version %d may be missing; compare with config-generate output", fileVersion, ConfigVersion, fileVersion)
+	default:
+		return fmt.Sprintf("configuration file version %d is newer than supported version %d — fields this binary does not know are ignored; upgrade osctrl", fileVersion, ConfigVersion)
+	}
+}

--- a/pkg/config/version_test.go
+++ b/pkg/config/version_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestConfigVersionWarning(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileVersion int
+		wantEmpty   bool
+		wantSubstr  []string
+	}{
+		{
+			name:        "current version is silent",
+			fileVersion: ConfigVersion,
+			wantEmpty:   true,
+		},
+		{
+			name:        "missing version field warns",
+			fileVersion: 0,
+			wantSubstr:  []string{"no version field", fmt.Sprintf("'version: %d'", ConfigVersion)},
+		},
+		{
+			name:        "older version warns about missing fields",
+			fileVersion: -1,
+			wantSubstr: []string{
+				fmt.Sprintf("version -1 is older than supported version %d", ConfigVersion),
+				"may be missing",
+			},
+		},
+		{
+			name:        "newer version warns about stale binary",
+			fileVersion: ConfigVersion + 1,
+			wantSubstr: []string{
+				fmt.Sprintf("version %d is newer than supported version %d", ConfigVersion+1, ConfigVersion),
+				"upgrade",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConfigVersionWarning(tt.fileVersion)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Fatalf("ConfigVersionWarning(%d) = %q, want empty", tt.fileVersion, got)
+				}
+				return
+			}
+			for _, want := range tt.wantSubstr {
+				if !strings.Contains(got, want) {
+					t.Errorf("ConfigVersionWarning(%d) = %q, want substring %q", tt.fileVersion, got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Add a `version` field to the service configuration schema

### Problem
osctrl services silently accept YAML configuration files written for any
release. When fields are added, renamed, or removed, operators get no signal
that their file predates the binary — new options are simply missing and
fall back to defaults with no explanation. There is also no signal the other
way: an old binary loading a file from a newer release ignores unknown
fields quietly.

### Change
Introduce a top-level `version` integer on the YAML schema and emit a
startup warning when it does not match the version the binary supports.

- `pkg/config/version.go` (new): defines `ConfigVersion = 1` and
  `ConfigVersionWarning(fileVersion int) string`, which returns a
  human-readable message for missing (`0`), older, or newer file versions
  and an empty string when they match. Version skew is intentionally a
  warning, never a load error, so existing deployments without the field
  and files from future releases keep starting.
- `pkg/config/types.go`: add `Version int` to `TLSConfiguration` and
  `APIConfiguration`.
- `pkg/config/utils.go`: stamp generated config files
  (`GenerateTLSConfigFile`, `GenerateAPIConfigFile`) with `ConfigVersion`
  so `config-generate` output always carries the current schema number.
- `cmd/tls/main.go`, `cmd/api/main.go`: call `ConfigVersionWarning` right
  after `v.Unmarshal` and `log.Warn` the result, before value validation.
- `deploy/config/tls.yml`, `deploy/config/api.yml`: set `version: 1` with
  an explanatory comment.

### Tests
- `pkg/config/version_test.go` (new): table-driven coverage for the four
  branches of `ConfigVersionWarning` (current, missing, older, newer).
- `cmd/tls/config_test.go`, `cmd/api/config_test.go`:
  - `TestSampleTLSConfigLoads` / `TestSampleAPIConfigLoads` now assert the
    shipped sample file's `version` equals `ConfigVersion`, so a schema
    bump that forgets the sample file fails CI.
  - New `TestConfigVersionMismatchDoesNotFailLoad` verifies a file with
    `version: 999` still loads and parses, locking in the "warn, don't
    fail" contract.

### Validation
- `go test ./pkg/config ./cmd/tls ./cmd/api`
- `go test ./...`

### Risk / notes
- Additive and reversible: files without `version` continue to load and
  only produce a warning. No persistence, auth, or osquery-handler behavior
  changes.
- Future schema changes should bump `ConfigVersion` and update
  `deploy/config/*.yml` in the same PR; the sample-config tests enforce
  this.