### PR TITLE
Publish `osctrl-frontend` as a release docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   GOLANG_VERSION: 1.26.5
+  NODE_VERSION: "22"
 
 jobs:
   release:
@@ -41,10 +42,28 @@ jobs:
           fi
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925efd2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ env.GOLANG_VERSION }}
           cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend bundle
+        shell: bash
+        run: make frontend
+
+      - name: Verify frontend bundle exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f frontend/dist/index.html
+          test -d frontend/dist/assets
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -105,7 +124,7 @@ jobs:
 
           image_tag="${RELEASE_TAG#v}"
 
-          for component in tls api cli; do
+          for component in tls api cli frontend; do
             image="${DOCKER_HUB_ORG}/osctrl-${component}"
             for tag in "${image_tag}" latest; do
               digest="$(retry 6 resolve_digest "${image}:${tag}")"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -150,6 +150,43 @@ dockers:
     extra_files:
       - dist/osctrl-api-linux-arm64
 
+  # osctrl-frontend — amd64
+  # No Go binary: the image ships the pre-built Vite bundle (frontend/dist/)
+  # produced before GoReleaser runs. ids is intentionally empty so GoReleaser
+  # does not try to stage a binary into the context; extra_files pulls in the
+  # bundle, nginx configs, and entrypoint the Dockerfile copies.
+  - image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-frontend:{{ .Version }}-amd64"
+    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-frontend
+    use: buildx
+    goos: linux
+    goarch: amd64
+    ids: []
+    skip_push: false
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    extra_files:
+      - frontend/dist
+      - deploy/cicd/nginx/frontend.conf
+      - deploy/cicd/nginx/frontend-tls.conf
+      - deploy/cicd/nginx/docker-entrypoint-frontend.sh
+  # osctrl-frontend — arm64
+  - image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-frontend:{{ .Version }}-arm64"
+    dockerfile: deploy/cicd/docker/Dockerfile-osctrl-frontend
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids: []
+    skip_push: false
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    extra_files:
+      - frontend/dist
+      - deploy/cicd/nginx/frontend.conf
+      - deploy/cicd/nginx/frontend-tls.conf
+      - deploy/cicd/nginx/docker-entrypoint-frontend.sh
+
   # osctrl-cli — amd64
   - image_templates:
       - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-amd64"
@@ -217,6 +254,17 @@ docker_manifests:
     image_templates:
       - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-amd64"
       - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-cli:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-frontend:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-frontend:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-frontend:{{ .Version }}-arm64"
+    skip_push: '{{ .IsSnapshot }}'
+  - name_template: "{{ .Env.DOCKER_HUB_ORG }}/osctrl-frontend:latest"
+    image_templates:
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-frontend:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKER_HUB_ORG }}/osctrl-frontend:{{ .Version }}-arm64"
     skip_push: '{{ .IsSnapshot }}'
 
 docker_signs:

--- a/deploy/cicd/docker/Dockerfile-osctrl-frontend
+++ b/deploy/cicd/docker/Dockerfile-osctrl-frontend
@@ -1,0 +1,49 @@
+# Release Docker image for osctrl-frontend.
+#
+# Serves the Vite-built React SPA through nginx and reverse-proxies /api/*
+# to osctrl-api on :9002 over the container network. The frontend bundle
+# is produced in CI before GoReleaser runs and dropped at frontend/dist/
+# in the build context — this Dockerfile does NOT run npm itself, so the
+# image stays small (nginx + ~5 MB of hashed assets) and the release
+# pipeline reuses the same artifact the frontend-build workflow validates.
+#
+# TLS is opt-in via OSCTRL_FRONTEND_TLS=1. When set, the entrypoint swaps
+# in frontend-tls.conf (HTTPS on :443 + HTTP→HTTPS redirect on :80) and
+# expects certificates mounted at /etc/ssl/osctrl/tls.crt and tls.key.
+# Default (unset/0) serves plain HTTP on :80 for use behind a TLS
+# terminator (ingress, load balancer, the osctrl-nginx pattern).
+#
+# Build context must contain:
+#   - frontend/dist/                           (the production bundle)
+#   - deploy/cicd/nginx/frontend.conf          (HTTP server block)
+#   - deploy/cicd/nginx/frontend-tls.conf      (HTTPS server block)
+#   - deploy/cicd/nginx/docker-entrypoint-frontend.sh
+
+FROM nginx:1.27-alpine
+
+RUN rm -f /etc/nginx/conf.d/default.conf && \
+    mkdir -p /usr/share/nginx/osctrl-frontend \
+             /etc/nginx/conf.d-available \
+             /etc/ssl/osctrl \
+             /run/nginx
+
+# Stage both server blocks outside conf.d so only the selected one is
+# symlinked into the active config directory at runtime.
+COPY deploy/cicd/nginx/frontend.conf     /etc/nginx/conf.d-available/osctrl-frontend.conf
+COPY deploy/cicd/nginx/frontend-tls.conf /etc/nginx/conf.d-available/osctrl-frontend-tls.conf
+COPY deploy/cicd/nginx/docker-entrypoint-frontend.sh /docker-entrypoint-frontend.sh
+
+COPY frontend/dist/ /usr/share/nginx/osctrl-frontend/
+
+RUN chmod +x /docker-entrypoint-frontend.sh && \
+    chown -R nginx:nginx /usr/share/nginx/osctrl-frontend /run/nginx
+
+# Default to HTTP; entrypoint flips the active config when TLS is enabled.
+ENV OSCTRL_FRONTEND_TLS=0
+
+USER nginx
+
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+
+ENTRYPOINT ["/docker-entrypoint-frontend.sh"]

--- a/deploy/cicd/nginx/docker-entrypoint-frontend.sh
+++ b/deploy/cicd/nginx/docker-entrypoint-frontend.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# osctrl-frontend container entrypoint.
+#
+# Selects between the HTTP-only and TLS nginx configs based on the
+# OSCTRL_FRONTEND_TLS env var, then execs the official nginx image
+# entrypoint so /docker-entrypoint.d/ scripts still run.
+#
+# TLS mode (OSCTRL_FRONTEND_TLS=1) expects certificates mounted at:
+#   /etc/ssl/osctrl/tls.crt
+#   /etc/ssl/osctrl/tls.key
+# The image never bakes certs in; operators mount them at runtime.
+set -eu
+
+CONF_DIR=/etc/nginx/conf.d
+HTTP_CONF=osctrl-frontend.conf
+TLS_CONF=osctrl-frontend-tls.conf
+
+# Remove any default nginx server block shipped by the base image.
+rm -f "$CONF_DIR/default.conf"
+
+if [ "${OSCTRL_FRONTEND_TLS:-0}" = "1" ]; then
+    if [ ! -f /etc/ssl/osctrl/tls.crt ] || [ ! -f /etc/ssl/osctrl/tls.key ]; then
+        echo "OSCTRL_FRONTEND_TLS=1 but /etc/ssl/osctrl/tls.crt or tls.key is missing." >&2
+        echo "Mount your certificate and key at those paths and retry." >&2
+        exit 1
+    fi
+    echo "OSCTRL_FRONTEND_TLS=1 — enabling HTTPS on :443 with HTTP→HTTPS redirect on :80"
+    ln -sf /etc/nginx/conf.d-available/$TLS_CONF "$CONF_DIR/$TLS_CONF"
+    rm -f "$CONF_DIR/$HTTP_CONF"
+else
+    echo "OSCTRL_FRONTEND_TLS not set — serving HTTP on :80 (use a reverse proxy for TLS)"
+    ln -sf /etc/nginx/conf.d-available/$HTTP_CONF "$CONF_DIR/$HTTP_CONF"
+    rm -f "$CONF_DIR/$TLS_CONF"
+fi
+
+exec nginx -g 'daemon off;'

--- a/deploy/cicd/nginx/frontend-tls.conf
+++ b/deploy/cicd/nginx/frontend-tls.conf
@@ -1,0 +1,122 @@
+# osctrl-frontend — production nginx config (TLS variant) for the release
+# Docker image.
+#
+# Activated by the entrypoint when OSCTRL_FRONTEND_TLS=1. Terminates TLS on
+# :443 with certificates mounted at /etc/ssl/osctrl/tls.crt and
+# /etc/ssl/osctrl/tls.key, and redirects :80 → https. The HTTP server block
+# is intentionally minimal — only the redirect — so no SPA bytes leave the
+# container over plaintext.
+#
+# Security headers are duplicated per location because nginx's add_header
+# does NOT inherit into child locations that declare add_header of their own.
+
+upstream osctrl_api {
+    server osctrl-api:9002;
+    keepalive 16;
+}
+
+# HTTP → HTTPS redirect only. No SPA, no API proxying on plaintext.
+server {
+    listen 80;
+    server_name _;
+    server_tokens off;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name _;
+
+    server_tokens off;
+
+    ssl_certificate /etc/ssl/osctrl/tls.crt;
+    ssl_certificate_key /etc/ssl/osctrl/tls.key;
+
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 5m;
+
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+
+    root /usr/share/nginx/osctrl-frontend;
+    index index.html;
+
+    location ^~ /assets/ {
+        access_log off;
+        expires 30d;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        try_files $uri =404;
+    }
+
+    location ^~ /monaco/ {
+        access_log off;
+        expires 30d;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        try_files $uri =404;
+    }
+
+    location /api/ {
+        proxy_pass http://osctrl_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+
+        proxy_buffering off;
+        client_max_body_size 64m;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        try_files /index.html =404;
+    }
+
+    location / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/cicd/nginx/frontend.conf
+++ b/deploy/cicd/nginx/frontend.conf
@@ -1,0 +1,94 @@
+# osctrl-frontend — production nginx config for the release Docker image.
+#
+# Serves the Vite-built React SPA from /usr/share/nginx/osctrl-frontend/ and
+# reverse-proxies /api/* to osctrl-api on :9002 over the docker network.
+# Mirrors deploy/nginx/frontend.conf.example and the dev stack
+# (deploy/docker/conf/nginx/frontend-dev.conf) — security headers are
+# duplicated per location because nginx's add_header does NOT inherit into
+# child locations that declare add_header of their own.
+
+upstream osctrl_api {
+    server osctrl-api:9002;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    server_tokens off;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+
+    root /usr/share/nginx/osctrl-frontend;
+    index index.html;
+
+    location ^~ /assets/ {
+        access_log off;
+        expires 30d;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        try_files $uri =404;
+    }
+
+    location ^~ /monaco/ {
+        access_log off;
+        expires 30d;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        try_files $uri =404;
+    }
+
+    location /api/ {
+        proxy_pass http://osctrl_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+
+        proxy_buffering off;
+        client_max_body_size 64m;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        try_files /index.html =404;
+    }
+
+    location / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Publish `osctrl-frontend` as a release Docker image

### Problem
Every tagged release publishes `osctrl-tls`, `osctrl-api`, and `osctrl-cli`
to Docker Hub, but the React admin SPA has no release image. With
`osctrl-admin` now archived, operators have no prebuilt, shippable frontend
artifact — they must build the Vite bundle themselves and wire up nginx from
the example config. The dev stack (`Dockerfile-dev-frontend`) exists but is
unsuitable for releases (runs Node + air in-container, no production nginx
config, no TLS path).

### Change
Add a fourth release image, `osctrl-frontend`, built and published alongside
the existing components on every tagged release. It is a plain nginx image
serving the pre-built Vite bundle and reverse-proxying `/api/*` to
`osctrl-api:9002` — one process per container, no Node at runtime, no Go
binary. TLS is opt-in so the same image works behind an external terminator
or as a self-contained HTTPS endpoint.

**New files**
- `deploy/cicd/docker/Dockerfile-osctrl-frontend` — `nginx:1.27-alpine` base.
  Stages both HTTP and TLS server blocks into `/etc/nginx/conf.d-available/`
  (outside the active `conf.d`), copies the Vite bundle to
  `/usr/share/nginx/osctrl-frontend/`, and runs an entrypoint that selects
  the active config at startup. Exposes 80 and 443. `ENV OSCTRL_FRONTEND_TLS=0`.
- `deploy/cicd/nginx/frontend.conf` — HTTP-only server block on :80.
  Long-cached `/assets/` + `/monaco/`, SPA fallback, `/api/` reverse-proxy,
  full security headers re-stated per location (nginx `add_header` does not
  inherit). Mirrors the dev-stack `frontend-dev.conf` and the example in
  `deploy/nginx/frontend.conf`.
- `deploy/cicd/nginx/frontend-tls.conf` — HTTPS on :443 with certs at
  `/etc/ssl/osctrl/tls.{crt,key}`, HTTP→HTTPS redirect on :80, HSTS added to
  every header set. Same location structure as the HTTP variant.
- `deploy/cicd/nginx/docker-entrypoint-frontend.sh` — symlinks the chosen
  config into `/etc/nginx/conf.d/` based on `OSCTRL_FRONTEND_TLS`; fails
  fast if TLS is enabled but certs are missing; execs
  `nginx -g 'daemon off;'`.

**`.goreleaser.yml`**
- Two new `dockers` entries (amd64 + arm64) with `ids: []` (no Go binary to
  stage) and `extra_files` listing `frontend/dist`, both nginx configs, and
  the entrypoint script.
- Two new `docker_manifests` entries (`:<version>` + `:latest`), gated by
  `skip_push: '{{ .IsSnapshot }}'` like the other components.

**`.github/workflows/release.yml`**
- Added `NODE_VERSION: "22"` env.
- Added `setup-node` (with npm cache) + `make frontend` + a sanity check
  that `frontend/dist/index.html` and `/assets/` exist, before GoReleaser
  runs. The bundle is produced once and copied into the image — the
  Dockerfile does not run npm.
- Added `frontend` to the cosign verify loop so the new image is signed and
  verified like `tls`/`api`/`cli`.

### Usage
```bash
# Default — HTTP on :80, behind a TLS terminator
docker run -p 80:80 <org>/osctrl-frontend

# Self-contained TLS — HTTPS on :443, HTTP→HTTPS on :80
docker run -p 80:80 -p 443:443 \
  -v /path/tls.crt:/etc/ssl/osctrl/tls.crt:ro \
  -v /path/tls.key:/etc/ssl/osctrl/tls.key:ro \
  -e OSCTRL_FRONTEND_TLS=1 \
  <org>/osctrl-frontend
```