### PR TITLE
Bump docker base image for all docker releases

### DIFF
--- a/deploy/cicd/docker/Dockerfile-osctrl-api
+++ b/deploy/cicd/docker/Dockerfile-osctrl-api
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG COMPONENT=api
 ARG GOOS=linux

--- a/deploy/cicd/docker/Dockerfile-osctrl-cli
+++ b/deploy/cicd/docker/Dockerfile-osctrl-cli
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG COMPONENT=cli
 ARG GOOS=linux

--- a/deploy/cicd/docker/Dockerfile-osctrl-frontend
+++ b/deploy/cicd/docker/Dockerfile-osctrl-frontend
@@ -19,7 +19,7 @@
 #   - deploy/cicd/nginx/frontend-tls.conf      (HTTPS server block)
 #   - deploy/cicd/nginx/docker-entrypoint-frontend.sh
 
-FROM nginx:1.27-alpine
+FROM nginx:1.31-alpine
 
 RUN rm -f /etc/nginx/conf.d/default.conf && \
     mkdir -p /usr/share/nginx/osctrl-frontend \

--- a/deploy/cicd/docker/Dockerfile-osctrl-tls
+++ b/deploy/cicd/docker/Dockerfile-osctrl-tls
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG COMPONENT=tls
 ARG GOOS=linux


### PR DESCRIPTION
Bump base image to Ubuntu 24.04 for all docker releases.