### PR TITLE
Fix CI snapshot failure due to missing frontend files

### DIFF
--- a/.github/workflows/build_and_test_develop_merge.yml
+++ b/.github/workflows/build_and_test_develop_merge.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   GOLANG_VERSION: 1.26.5
+  NODE_VERSION: "22"
 
 jobs:
   validate:
@@ -71,6 +72,24 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
           cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend bundle
+        shell: bash
+        run: make frontend
+
+      - name: Verify frontend bundle exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f frontend/dist/index.html
+          test -d frontend/dist/assets
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/build_and_test_main_merge.yml
+++ b/.github/workflows/build_and_test_main_merge.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   GOLANG_VERSION: 1.26.5
+  NODE_VERSION: "22"
 
 jobs:
   validate:
@@ -71,6 +72,24 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
           cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend bundle
+        shell: bash
+        run: make frontend
+
+      - name: Verify frontend bundle exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f frontend/dist/index.html
+          test -d frontend/dist/assets
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0


### PR DESCRIPTION
## Fix CI snapshot failure: missing frontend bundle in GHCR publish jobs

### Problem

The `publish-ghcr` job in **CI - Develop** and **CI - Main** fails with:

docker build failed: failed to copy extra file 'frontend/dist':
lstat frontend/dist: no such file or directory

PR #1001 added `osctrl-frontend` to the GoReleaser `dockers` section, so every
`goreleaser release --snapshot --clean` invocation now requires the Vite
production bundle (`frontend/dist/`) in the build context. The CI snapshot
workflows never built it, while the tagged release workflow
(`release.yml:50-66`) does — with the exact steps this run was missing.

### Change

In both `.github/workflows/build_and_test_develop_merge.yml` and
`.github/workflows/build_and_test_main_merge.yml`:

- Add `NODE_VERSION: "22"` to the workflow `env` (mirrors `release.yml`)
- Add three steps to the `publish-ghcr` job, before the Docker/GoReleaser steps:
  - `Set up Node` (actions/setup-node@v7.0.0, npm cache on `frontend/package-lock.json`)
  - `Build frontend bundle` via `make frontend`
  - `Verify frontend bundle exists` (`test -f frontend/dist/index.html`, `test -d frontend/dist/assets`)

No changes to `.goreleaser.yml`, Dockerfiles, or release logic — the develop/main
snapshot jobs now reuse the same frontend build steps the tagged release
already runs.

### Validation

- Workflow YAML validated with `YAML.safe_load`
- Step ordering verified: frontend build runs after `Set up Go`, before QEMU/Buildx/GoReleaser
- Pattern is a 1:1 copy of the working `release.yml` flow (Node 22 + `make frontend` + same verification)
- Confirmed `build_and_test_pr.yml` is unaffected (uses `goreleaser build --snapshot`, which skips the `dockers` section)