### PR TITLE
New `osctrl-cli` functionality along with the new `osctrl-api` changes

### DIFF
--- a/cmd/cli/api-console.go
+++ b/cmd/cli/api-console.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strconv"
+
+	"github.com/jmpsec/osctrl/pkg/console"
+)
+
+// Console session + command API wrappers. These mirror the /console routes:
+//   POST   /api/v1/console/{env}/nodes/{uuid}/sessions
+//   GET    /api/v1/console/{env}/sessions/{session_id}
+//   DELETE /api/v1/console/{env}/sessions/{session_id}
+//   POST   /api/v1/console/{env}/sessions/{session_id}/commands
+//   GET    /api/v1/console/{env}/sessions/{session_id}/commands/{command_id}
+//   GET    /api/v1/console/{env}/sessions/{session_id}/commands/{command_id}/results
+
+// consoleNodeInfo mirrors the API's node_info projection for a console session.
+type consoleNodeInfo struct {
+	IPAddress       string `json:"ip_address"`
+	OsqueryUser     string `json:"osquery_user"`
+	OsqueryVersion  string `json:"osquery_version"`
+	Platform        string `json:"platform"`
+	PlatformVersion string `json:"platform_version"`
+}
+
+// ConsoleSessionResponse mirrors the create-session response (session + history + node info).
+type ConsoleSessionResponse struct {
+	Session  console.Session        `json:"session"`
+	History  []console.HistoryEntry `json:"history"`
+	NodeInfo consoleNodeInfo        `json:"node_info"`
+}
+
+// ConsoleCommandResponse mirrors the submit-command response.
+type ConsoleCommandResponse struct {
+	Command console.Command       `json:"command"`
+	Parsed  console.ParsedCommand `json:"parsed"`
+}
+
+// CreateConsoleSession opens a console session against a node.
+func (api *OsctrlAPI) CreateConsoleSession(env, uuid string) (ConsoleSessionResponse, error) {
+	var res ConsoleSessionResponse
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/console", env, "nodes", uuid, "sessions"))
+	raw, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return res, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return res, fmt.Errorf("can not parse body - %w", err)
+	}
+	return res, nil
+}
+
+// CloseConsoleSession closes a console session.
+func (api *OsctrlAPI) CloseConsoleSession(env string, sessionID uint) error {
+	var r struct {
+		Message string `json:"message"`
+	}
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/console", env, "sessions", strconv.FormatUint(uint64(sessionID), 10)))
+	raw, err := api.ReqGeneric("DELETE", reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return fmt.Errorf("can not parse body - %w", err)
+	}
+	return nil
+}
+
+// GetConsoleSession retrieves the current state of a console session.
+func (api *OsctrlAPI) GetConsoleSession(env string, sessionID uint) (console.Session, error) {
+	var session console.Session
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/console", env, "sessions", strconv.FormatUint(uint64(sessionID), 10)))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return session, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &session); err != nil {
+		return session, fmt.Errorf("can not parse body - %w", err)
+	}
+	return session, nil
+}
+
+// SubmitConsoleCommand sends a console command within a session.
+func (api *OsctrlAPI) SubmitConsoleCommand(env string, sessionID uint, input string, osqueryMode bool) (ConsoleCommandResponse, error) {
+	var res ConsoleCommandResponse
+	body := struct {
+		Input       string `json:"input"`
+		OsqueryMode bool   `json:"osquery_mode"`
+	}{Input: input, OsqueryMode: osqueryMode}
+	jsonMessage, err := json.Marshal(body)
+	if err != nil {
+		return res, fmt.Errorf("error marshaling data - %w", err)
+	}
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL,
+		path.Join(APIPath, "/console", env, "sessions", strconv.FormatUint(uint64(sessionID), 10), "commands"))
+	raw, err := api.PostGeneric(reqURL, bytes.NewReader(jsonMessage))
+	if err != nil {
+		return res, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return res, fmt.Errorf("can not parse body - %w", err)
+	}
+	return res, nil
+}
+
+// GetConsoleCommand retrieves the current state of a console command.
+func (api *OsctrlAPI) GetConsoleCommand(env string, sessionID, commandID uint) (console.Command, error) {
+	var cmd console.Command
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL,
+		path.Join(APIPath, "/console", env, "sessions", strconv.FormatUint(uint64(sessionID), 10),
+			"commands", strconv.FormatUint(uint64(commandID), 10)))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return cmd, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &cmd); err != nil {
+		return cmd, fmt.Errorf("can not parse body - %w", err)
+	}
+	return cmd, nil
+}
+
+// GetConsoleCommandResults retrieves the rows produced by a completed console command.
+func (api *OsctrlAPI) GetConsoleCommandResults(env string, sessionID, commandID uint) ([]map[string]any, error) {
+	var rows []map[string]any
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL,
+		path.Join(APIPath, "/console", env, "sessions", strconv.FormatUint(uint64(sessionID), 10),
+			"commands", strconv.FormatUint(uint64(commandID), 10), "results"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return rows, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return rows, fmt.Errorf("can not parse body - %w", err)
+	}
+	return rows, nil
+}

--- a/cmd/cli/api-extras.go
+++ b/cmd/cli/api-extras.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strconv"
+
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
+	"github.com/jmpsec/osctrl/pkg/posture"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+)
+
+// File explorer + posture + saved queries + node logs API wrappers.
+//
+// File explorer routes:
+//   POST /api/v1/file-explorer/{env}/nodes/{uuid}/sessions
+//   GET  /api/v1/file-explorer/{env}/sessions/{session_id}
+//   DEL  /api/v1/file-explorer/{env}/sessions/{session_id}
+//   POST /api/v1/file-explorer/{env}/sessions/{session_id}/list
+//   POST /api/v1/file-explorer/{env}/sessions/{session_id}/stat
+//   GET  /api/v1/file-explorer/{env}/sessions/{session_id}/requests/{request_id}
+//   GET  /api/v1/file-explorer/{env}/sessions/{session_id}/requests/{request_id}/results
+//
+// Posture routes:
+//   GET /api/v1/nodes/{env}/node/{uuid}/posture
+//   GET /api/v1/nodes/{env}/node/{uuid}/posture/score
+//   GET /api/v1/posture/profiles
+//
+// Saved queries routes:
+//   GET    /api/v1/saved-queries/{env}
+//   POST   /api/v1/saved-queries/{env}
+//   PATCH  /api/v1/saved-queries/{env}/{name}
+//   DELETE /api/v1/saved-queries/{env}/{name}
+//
+// Node logs routes:
+//   GET /api/v1/logs/{type}/{env}/{uuid}
+
+// fileExplorerSessionResponse mirrors the create-session response.
+type fileExplorerSessionResponse struct {
+	Session  fileexplorer.Session `json:"session"`
+	NodeInfo consoleNodeInfo      `json:"node_info"`
+}
+
+// CreateFileExplorerSession opens a file explorer session against a node.
+func (api *OsctrlAPI) CreateFileExplorerSession(env, uuid string) (fileExplorerSessionResponse, error) {
+	var res fileExplorerSessionResponse
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/file-explorer", env, "nodes", uuid, "sessions"))
+	raw, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return res, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return res, fmt.Errorf("can not parse body - %w", err)
+	}
+	return res, nil
+}
+
+// CloseFileExplorerSession closes a file explorer session.
+func (api *OsctrlAPI) CloseFileExplorerSession(env string, sessionID uint) error {
+	var r struct {
+		Message string `json:"message"`
+	}
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/file-explorer", env, "sessions", strconv.FormatUint(uint64(sessionID), 10)))
+	raw, err := api.ReqGeneric("DELETE", reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return fmt.Errorf("can not parse body - %w", err)
+	}
+	return nil
+}
+
+// SubmitFileExplorerList lists a directory path on the node.
+func (api *OsctrlAPI) SubmitFileExplorerList(env string, sessionID uint, target string) (fileexplorer.Request, error) {
+	return api.fileExplorerRequest(env, sessionID, "list", target)
+}
+
+// SubmitFileExplorerStat stats a path on the node.
+func (api *OsctrlAPI) SubmitFileExplorerStat(env string, sessionID uint, target string) (fileexplorer.Request, error) {
+	return api.fileExplorerRequest(env, sessionID, "stat", target)
+}
+
+func (api *OsctrlAPI) fileExplorerRequest(env string, sessionID uint, action, target string) (fileexplorer.Request, error) {
+	var req fileexplorer.Request
+	body := struct {
+		Path string `json:"path"`
+	}{Path: target}
+	jsonMessage, err := json.Marshal(body)
+	if err != nil {
+		return req, fmt.Errorf("error marshaling data - %w", err)
+	}
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL,
+		path.Join(APIPath, "/file-explorer", env, "sessions", strconv.FormatUint(uint64(sessionID), 10), action))
+	raw, err := api.PostGeneric(reqURL, bytes.NewReader(jsonMessage))
+	if err != nil {
+		return req, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return req, fmt.Errorf("can not parse body - %w", err)
+	}
+	return req, nil
+}
+
+// GetFileExplorerRequest retrieves the current state of a file explorer request.
+func (api *OsctrlAPI) GetFileExplorerRequest(env string, sessionID, requestID uint) (fileexplorer.Request, error) {
+	var req fileexplorer.Request
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL,
+		path.Join(APIPath, "/file-explorer", env, "sessions", strconv.FormatUint(uint64(sessionID), 10),
+			"requests", strconv.FormatUint(uint64(requestID), 10)))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return req, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return req, fmt.Errorf("can not parse body - %w", err)
+	}
+	return req, nil
+}
+
+// GetFileExplorerResults retrieves entries produced by a completed request.
+func (api *OsctrlAPI) GetFileExplorerResults(env string, sessionID, requestID uint) ([]fileexplorer.Entry, error) {
+	var entries []fileexplorer.Entry
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL,
+		path.Join(APIPath, "/file-explorer", env, "sessions", strconv.FormatUint(uint64(sessionID), 10),
+			"requests", strconv.FormatUint(uint64(requestID), 10), "results"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return entries, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return entries, fmt.Errorf("can not parse body - %w", err)
+	}
+	return entries, nil
+}
+
+// ─────────────────────────────── posture ───────────────────────────────
+
+// GetNodePosture retrieves all posture categories for a node.
+func (api *OsctrlAPI) GetNodePosture(env, uuid string) ([]posture.NodePosture, error) {
+	var records []posture.NodePosture
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APINodes, env, "node", uuid, "posture"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return records, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &records); err != nil {
+		return records, fmt.Errorf("can not parse body - %w", err)
+	}
+	return records, nil
+}
+
+// GetNodePostureScore retrieves the SOC2/ISO27001 risk score for a node.
+func (api *OsctrlAPI) GetNodePostureScore(env, uuid string) (posture.PostureScore, error) {
+	var score posture.PostureScore
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APINodes, env, "node", uuid, "posture", "score"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return score, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &score); err != nil {
+		return score, fmt.Errorf("can not parse body - %w", err)
+	}
+	return score, nil
+}
+
+// GetPostureProfiles lists the predefined posture profile templates.
+func (api *OsctrlAPI) GetPostureProfiles() ([]posture.PostureProfile, error) {
+	var profiles []posture.PostureProfile
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/posture", "profiles"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return profiles, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &profiles); err != nil {
+		return profiles, fmt.Errorf("can not parse body - %w", err)
+	}
+	return profiles, nil
+}
+
+// ─────────────────────────────── saved queries ───────────────────────────────
+
+// GetSavedQueries lists saved queries for an environment.
+func (api *OsctrlAPI) GetSavedQueries(env string) ([]types.SavedQueryView, error) {
+	var res types.SavedQueriesPagedResponse
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/saved-queries", env))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("can not parse body - %w", err)
+	}
+	return res.Items, nil
+}
+
+// CreateSavedQuery saves a new query in an environment.
+func (api *OsctrlAPI) CreateSavedQuery(env, name, query string) error {
+	body := types.SavedQueryCreateRequest{Name: name, Query: query}
+	jsonMessage, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("error marshaling data - %w", err)
+	}
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/saved-queries", env))
+	raw, err := api.PostGeneric(reqURL, bytes.NewReader(jsonMessage))
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return nil
+}
+
+// UpdateSavedQuery replaces the SQL body of an existing saved query.
+func (api *OsctrlAPI) UpdateSavedQuery(env, name, query string) error {
+	body := types.SavedQueryUpdateRequest{Query: query}
+	jsonMessage, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("error marshaling data - %w", err)
+	}
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/saved-queries", env, name))
+	raw, err := api.ReqGeneric("PATCH", reqURL, bytes.NewReader(jsonMessage))
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return nil
+}
+
+// DeleteSavedQuery removes a saved query by name.
+func (api *OsctrlAPI) DeleteSavedQuery(env, name string) error {
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/saved-queries", env, name))
+	raw, err := api.ReqGeneric("DELETE", reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return nil
+}
+
+// ─────────────────────────────── node logs ───────────────────────────────
+
+// GetNodeLogs retrieves recent result or status logs for a node.
+// logType is "result" or "status".
+func (api *OsctrlAPI) GetNodeLogs(env, logType, uuid string) (string, error) {
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/logs", logType, env, uuid))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return string(raw), nil
+}
+
+// ─────────────────────────────── query samples ───────────────────────────────
+
+// GetQuerySamples lists the built-in query sample templates.
+func (api *OsctrlAPI) GetQuerySamples() ([]queries.QuerySample, error) {
+	var samples []queries.QuerySample
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, APIQueries, "samples"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return samples, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &samples); err != nil {
+		return samples, fmt.Errorf("can not parse body - %w", err)
+	}
+	return samples, nil
+}
+
+// GetFeatures retrieves the deployment feature switches.
+func (api *OsctrlAPI) GetFeatures() (featuresResponse, error) {
+	var res featuresResponse
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/features"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return res, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return res, fmt.Errorf("can not parse body - %w", err)
+	}
+	return res, nil
+}
+
+// featuresResponse mirrors the /features deployment switches.
+type featuresResponse struct {
+	Posture       bool `json:"posture"`
+	ServiceConfig bool `json:"service_config"`
+	LogSinks      bool `json:"log_sinks"`
+	AuthProviders bool `json:"auth_providers"`
+	Accelerated   bool `json:"accelerated"`
+	Console       bool `json:"console"`
+	FileExplorer  bool `json:"file_explorer"`
+}

--- a/cmd/cli/api.go
+++ b/cmd/cli/api.go
@@ -169,8 +169,9 @@ func (api *OsctrlAPI) ReqGeneric(reqType string, url string, body io.Reader) ([]
 	if err != nil {
 		return []byte{}, fmt.Errorf("can not read response - %w", err)
 	}
-	// Check response code
-	if resp.StatusCode != http.StatusOK {
+	// Check response code: any 2xx is success (201 Created, 204 No
+	// Content, etc.). Redirects are followed by the http client itself.
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return bodyBytes, fmt.Errorf("HTTP Code %d", resp.StatusCode)
 	}
 	return bodyBytes, nil

--- a/cmd/cli/api_extras_test.go
+++ b/cmd/cli/api_extras_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
+	"github.com/jmpsec/osctrl/pkg/posture"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+)
+
+// newTestAPI spins an httptest server answering the console / file-explorer /
+// posture / saved-queries routes, returning the wired client.
+func newTestAPI(t *testing.T) *OsctrlAPI {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Console routes
+	mux.HandleFunc("POST /api/v1/console/{env}/nodes/{uuid}/sessions", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("env") != "dev" || r.PathValue("uuid") != "UUID1" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer testtoken" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ConsoleSessionResponse{
+			Session:  console.Session{ID: 7, NodeUUID: "UUID1", CWD: "/", Platform: "linux"},
+			NodeInfo: consoleNodeInfo{OsqueryVersion: "5.23.1"},
+		})
+	})
+	mux.HandleFunc("DELETE /api/v1/console/{env}/sessions/{session_id}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("session_id") != "7" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(types.ApiGenericResponse{Message: "console session closed"})
+	})
+	mux.HandleFunc("GET /api/v1/console/{env}/sessions/{session_id}", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(console.Session{ID: 7, CWD: "/etc"})
+	})
+	mux.HandleFunc("POST /api/v1/console/{env}/sessions/{session_id}/commands", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Input       string `json:"input"`
+			OsqueryMode bool   `json:"osquery_mode"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ConsoleCommandResponse{
+			Command: console.Command{ID: 42, Input: body.Input, Status: console.StatusCompleted},
+			Parsed:  console.ParsedCommand{Kind: console.CommandRemote, Command: "sql"},
+		})
+	})
+	mux.HandleFunc("GET /api/v1/console/{env}/sessions/{session_id}/commands/{command_id}", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(console.Command{ID: 42, Status: console.StatusCompleted})
+	})
+	mux.HandleFunc("GET /api/v1/console/{env}/sessions/{session_id}/commands/{command_id}/results", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"hostname": "box1"}})
+	})
+
+	// File explorer routes
+	mux.HandleFunc("POST /api/v1/file-explorer/{env}/nodes/{uuid}/sessions", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(fileExplorerSessionResponse{
+			Session: fileexplorer.Session{ID: 9, Root: "/"},
+		})
+	})
+	mux.HandleFunc("DELETE /api/v1/file-explorer/{env}/sessions/{session_id}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("session_id") != "9" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(types.ApiGenericResponse{Message: "file explorer session closed"})
+	})
+	mux.HandleFunc("POST /api/v1/file-explorer/{env}/sessions/{session_id}/list", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Path string `json:"path"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(fileexplorer.Request{ID: 11, Action: "list", Path: body.Path, Status: fileexplorer.StatusCompleted})
+	})
+	mux.HandleFunc("POST /api/v1/file-explorer/{env}/sessions/{session_id}/stat", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(fileexplorer.Request{ID: 12, Action: "stat", Status: fileexplorer.StatusCompleted})
+	})
+	mux.HandleFunc("GET /api/v1/file-explorer/{env}/sessions/{session_id}/requests/{request_id}", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(fileexplorer.Request{ID: 11, Status: fileexplorer.StatusCompleted})
+	})
+	mux.HandleFunc("GET /api/v1/file-explorer/{env}/sessions/{session_id}/requests/{request_id}/results", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]fileexplorer.Entry{{Filename: "passwd", Directory: "/etc", Type: "regular"}})
+	})
+
+	// Posture routes
+	mux.HandleFunc("GET /api/v1/nodes/{env}/node/{uuid}/posture", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]posture.NodePosture{{Category: "osquery_info", Summary: `[{"version":"5.23.1"}]`}})
+	})
+	mux.HandleFunc("GET /api/v1/nodes/{env}/node/{uuid}/posture/score", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(posture.PostureScore{
+			TotalScore: 12,
+			RiskLevel:  "medium",
+			PassCount:  3,
+			WarnCount:  1,
+			FailCount:  0,
+		})
+	})
+	mux.HandleFunc("GET /api/v1/posture/profiles", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]posture.PostureProfile{{ID: "linux-server", Name: "Linux Server"}})
+	})
+
+	// Saved queries routes
+	mux.HandleFunc("GET /api/v1/saved-queries/{env}", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(types.SavedQueriesPagedResponse{
+			Items: []types.SavedQueryView{{Name: "uptime", Query: "select * from uptime"}},
+		})
+	})
+	mux.HandleFunc("POST /api/v1/saved-queries/{env}", func(w http.ResponseWriter, r *http.Request) {
+		var body types.SavedQueryCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" || body.Query == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+	mux.HandleFunc("PATCH /api/v1/saved-queries/{env}/{name}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("name") != "uptime" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var body types.SavedQueryUpdateRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(types.SavedQueryView{Name: "uptime", Query: body.Query})
+	})
+	mux.HandleFunc("DELETE /api/v1/saved-queries/{env}/{name}", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(types.ApiGenericResponse{Message: "deleted"})
+	})
+
+	// Query samples + node logs
+	mux.HandleFunc("GET /api/v1/queries/samples", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(queries.QuerySamples)
+	})
+	mux.HandleFunc("GET /api/v1/logs/{type}/{env}/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"type":%q,"env":%q,"uuid":%q}`, r.PathValue("type"), r.PathValue("env"), r.PathValue("uuid"))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return CreateAPI(JSONConfigurationAPI{URL: srv.URL, Token: "testtoken"}, false)
+}
+
+func TestConsoleClientRoundTrip(t *testing.T) {
+	api := newTestAPI(t)
+
+	res, err := api.CreateConsoleSession("dev", "UUID1")
+	if err != nil {
+		t.Fatalf("CreateConsoleSession: %v", err)
+	}
+	if res.Session.ID != 7 || res.Session.CWD != "/" || res.NodeInfo.OsqueryVersion != "5.23.1" {
+		t.Fatalf("unexpected session response: %+v", res)
+	}
+
+	resp, err := api.SubmitConsoleCommand("dev", 7, "select * from uptime", false)
+	if err != nil {
+		t.Fatalf("SubmitConsoleCommand: %v", err)
+	}
+	if resp.Command.ID != 42 || resp.Parsed.Kind != console.CommandRemote {
+		t.Fatalf("unexpected command response: %+v", resp)
+	}
+
+	cmd, err := api.GetConsoleCommand("dev", 7, 42)
+	if err != nil {
+		t.Fatalf("GetConsoleCommand: %v", err)
+	}
+	if cmd.Status != console.StatusCompleted {
+		t.Fatalf("expected completed, got %s", cmd.Status)
+	}
+
+	rows, err := api.GetConsoleCommandResults("dev", 7, 42)
+	if err != nil {
+		t.Fatalf("GetConsoleCommandResults: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["hostname"] != "box1" {
+		t.Fatalf("unexpected rows: %+v", rows)
+	}
+
+	sess, err := api.GetConsoleSession("dev", 7)
+	if err != nil {
+		t.Fatalf("GetConsoleSession: %v", err)
+	}
+	if sess.CWD != "/etc" {
+		t.Fatalf("expected cwd /etc, got %s", sess.CWD)
+	}
+
+	if err := api.CloseConsoleSession("dev", 7); err != nil {
+		t.Fatalf("CloseConsoleSession: %v", err)
+	}
+}
+
+func TestFileExplorerClientRoundTrip(t *testing.T) {
+	api := newTestAPI(t)
+
+	res, err := api.CreateFileExplorerSession("dev", "UUID1")
+	if err != nil {
+		t.Fatalf("CreateFileExplorerSession: %v", err)
+	}
+	if res.Session.ID != 9 {
+		t.Fatalf("unexpected session id: %d", res.Session.ID)
+	}
+
+	req, err := api.SubmitFileExplorerList("dev", 9, "/etc")
+	if err != nil {
+		t.Fatalf("SubmitFileExplorerList: %v", err)
+	}
+	if req.ID != 11 || req.Path != "/etc" {
+		t.Fatalf("unexpected request: %+v", req)
+	}
+
+	got, err := api.GetFileExplorerRequest("dev", 9, 11)
+	if err != nil {
+		t.Fatalf("GetFileExplorerRequest: %v", err)
+	}
+	if got.Status != fileexplorer.StatusCompleted {
+		t.Fatalf("expected completed, got %s", got.Status)
+	}
+
+	entries, err := api.GetFileExplorerResults("dev", 9, 11)
+	if err != nil {
+		t.Fatalf("GetFileExplorerResults: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Filename != "passwd" {
+		t.Fatalf("unexpected entries: %+v", entries)
+	}
+
+	if _, err := api.SubmitFileExplorerStat("dev", 9, "/etc/passwd"); err != nil {
+		t.Fatalf("SubmitFileExplorerStat: %v", err)
+	}
+
+	if err := api.CloseFileExplorerSession("dev", 9); err != nil {
+		t.Fatalf("CloseFileExplorerSession: %v", err)
+	}
+}
+
+func TestPostureClientRoundTrip(t *testing.T) {
+	api := newTestAPI(t)
+
+	records, err := api.GetNodePosture("dev", "UUID1")
+	if err != nil {
+		t.Fatalf("GetNodePosture: %v", err)
+	}
+	if len(records) != 1 || records[0].Category != "osquery_info" {
+		t.Fatalf("unexpected records: %+v", records)
+	}
+
+	score, err := api.GetNodePostureScore("dev", "UUID1")
+	if err != nil {
+		t.Fatalf("GetNodePostureScore: %v", err)
+	}
+	if score.RiskLevel != "medium" || score.TotalScore != 12 {
+		t.Fatalf("unexpected score: %+v", score)
+	}
+
+	profiles, err := api.GetPostureProfiles()
+	if err != nil {
+		t.Fatalf("GetPostureProfiles: %v", err)
+	}
+	if len(profiles) != 1 || profiles[0].ID != "linux-server" {
+		t.Fatalf("unexpected profiles: %+v", profiles)
+	}
+}
+
+func TestSavedQueriesClientRoundTrip(t *testing.T) {
+	api := newTestAPI(t)
+
+	items, err := api.GetSavedQueries("dev")
+	if err != nil {
+		t.Fatalf("GetSavedQueries: %v", err)
+	}
+	if len(items) != 1 || items[0].Name != "uptime" {
+		t.Fatalf("unexpected items: %+v", items)
+	}
+
+	if err := api.CreateSavedQuery("dev", "uptime", "select * from uptime"); err != nil {
+		t.Fatalf("CreateSavedQuery: %v", err)
+	}
+
+	if err := api.UpdateSavedQuery("dev", "uptime", "select * from system_info"); err != nil {
+		t.Fatalf("UpdateSavedQuery: %v", err)
+	}
+
+	if err := api.DeleteSavedQuery("dev", "uptime"); err != nil {
+		t.Fatalf("DeleteSavedQuery: %v", err)
+	}
+}
+
+func TestQuerySamplesAndNodeLogs(t *testing.T) {
+	api := newTestAPI(t)
+
+	samples, err := api.GetQuerySamples()
+	if err != nil {
+		t.Fatalf("GetQuerySamples: %v", err)
+	}
+	if len(samples) == 0 {
+		t.Fatalf("expected non-empty sample library")
+	}
+
+	body, err := api.GetNodeLogs("dev", "result", "UUID1")
+	if err != nil {
+		t.Fatalf("GetNodeLogs: %v", err)
+	}
+	var parsed struct {
+		Type string `json:"type"`
+		Env  string `json:"env"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("logs body not JSON: %v", err)
+	}
+	if parsed.Type != "result" || parsed.Env != "dev" {
+		t.Fatalf("unexpected logs body: %s", body)
+	}
+}
+
+func TestStoreCastErrors(t *testing.T) {
+	// dbStore does not implement the console/posture/saved surfaces.
+	store := newDBStore()
+	if _, err := storeConsole(store); err == nil {
+		t.Fatal("expected storeConsole to reject dbStore")
+	}
+	if _, err := storePosture(store); err == nil {
+		t.Fatal("expected storePosture to reject dbStore")
+	}
+	if _, err := storeSaved(store); err == nil {
+		t.Fatal("expected storeSaved to reject dbStore")
+	}
+}
+
+func TestAPIStoreImplementsExtraSurfaces(t *testing.T) {
+	api := newTestAPI(t)
+	store := newAPIStore(api)
+	if _, err := storeConsole(store); err != nil {
+		t.Fatalf("apiStore should implement consoleStore: %v", err)
+	}
+	if _, err := storePosture(store); err != nil {
+		t.Fatalf("apiStore should implement postureStore: %v", err)
+	}
+	if _, err := storeSaved(store); err != nil {
+		t.Fatalf("apiStore should implement savedStore: %v", err)
+	}
+}
+
+func TestColumnKeysAndIndent(t *testing.T) {
+	keys := columnKeys(map[string]any{"b": 1, "a": 2, "c": 3})
+	if len(keys) != 3 || keys[0] != "a" || keys[2] != "c" {
+		t.Fatalf("columnKeys not sorted: %v", keys)
+	}
+	if got := indentLines("x\ny", "  "); got != "  x\n  y" {
+		t.Fatalf("indentLines: %q", got)
+	}
+}
+
+func TestConsoleURLPaths(t *testing.T) {
+	// Sanity-check the URL shape the client builds matches the server route
+	// table (path.Join collapses leading slashes but preserves ordering).
+	want := "/api/v1/console/dev/sessions/7/commands/42/results"
+	got := path.Join(APIPath, "/console", "dev", "sessions", strconv.FormatUint(uint64(7), 10),
+		"commands", strconv.FormatUint(uint64(42), 10), "results")
+	if got != want {
+		t.Fatalf("path mismatch: got %s want %s", got, want)
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -250,6 +250,12 @@ func init() {
 			Action:  cliWrapper(runShell),
 		},
 		{
+			Name:    "tui",
+			Aliases: []string{"dashboard"},
+			Usage:   "Full-screen TUI dashboard — fleet health, platforms, environments, queries, audit",
+			Action:  cliWrapper(runTUIDashboard),
+		},
+		{
 			Name:   "audit-logs",
 			Usage:  "Get all audit logs for actions performed in osctrl",
 			Action: cliWrapper(auditLogs),

--- a/cmd/cli/shell_commands.go
+++ b/cmd/cli/shell_commands.go
@@ -27,7 +27,11 @@ func (s *shellState) buildModules() {
 	}
 	add(&shellModule{name: "nodes", label: "nodes", desc: "enrolled osquery nodes", cmds: nodesCommands()})
 	add(&shellModule{name: "queries", label: "queries", desc: "on-demand distributed queries", cmds: queriesCommands()})
+	add(&shellModule{name: "saved", label: "saved", desc: "saved queries + template library", cmds: savedCommands()})
 	add(&shellModule{name: "carves", label: "carves", desc: "file carves", cmds: carvesCommands()})
+	add(&shellModule{name: "console", label: "console", desc: "live interactive node console", cmds: consoleCommands()})
+	add(&shellModule{name: "file-explorer", label: "fex", desc: "live remote file explorer", cmds: fileExplorerCommands()})
+	add(&shellModule{name: "posture", label: "posture", desc: "node posture + compliance scoring", cmds: postureCommands()})
 	add(&shellModule{name: "environments", label: "env", desc: "TLS environments", cmds: envCommands()})
 	add(&shellModule{name: "tags", label: "tags", desc: "node tags", cmds: tagsCommands()})
 	add(&shellModule{name: "users", label: "users", desc: "users and permissions", cmds: usersCommands()})
@@ -214,13 +218,18 @@ func (s *shellState) argCandidates(tokens []string, line string, cursor int) ([]
 	// resource-name completion for the active module's primary key
 	switch s.ctx {
 	case "nodes":
-		if cmd == "show" || cmd == "delete" || cmd == "tag" {
+		if cmd == "show" || cmd == "delete" || cmd == "tag" || cmd == "logs" {
 			c := filterPrefix(s.nodeKeys, currentWord(line, cursor))
 			return c, longestCommonPrefix(c)
 		}
 	case "queries":
 		if cmd == "show" || cmd == "results" || cmd == "complete" || cmd == "expire" || cmd == "delete" {
 			c := filterPrefix(s.queryNames, currentWord(line, cursor))
+			return c, longestCommonPrefix(c)
+		}
+	case "console", "file-explorer", "posture":
+		if cmd == "open" || cmd == "show" || cmd == "score" {
+			c := filterPrefix(s.nodeKeys, currentWord(line, cursor))
 			return c, longestCommonPrefix(c)
 		}
 	}

--- a/cmd/cli/shell_module_extras.go
+++ b/cmd/cli/shell_module_extras.go
@@ -1,0 +1,636 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
+	"github.com/jmpsec/osctrl/pkg/posture"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+)
+
+// shell_module_extras.go — console, file explorer, posture, saved-queries
+// modules for the interactive shell. Console and file explorer are live
+// experiences: they open a session against a node and poll command
+// results until the node answers (or the request expires), rendering
+// rows as a table the moment they land.
+
+// consoleStatusTimeout is how long a submitted command waits for the node
+// to report before we stop polling.
+const consoleStatusTimeout = 90 * time.Second
+
+// ─────────────────────────────── console module ───────────────────────────────
+
+func consoleCommands() []shellCmd {
+	return []shellCmd{
+		{name: "open", args: "<uuid|hostname>", help: "open an interactive console session to a node", min: 1, fn: shConsoleOpen},
+	}
+}
+
+// shConsoleOpen opens a live console session: submits commands, polls for
+// results, and renders them. 'exit' closes the session.
+func shConsoleOpen(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	cs, err := storeConsole(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	n, err := spinGet("🖥️  Resolving node", func() (nodeRow, error) { return s.store.Node(s.env, args[0]) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	res, err := spinGet("⌨️  Opening console session", func() (ConsoleSessionResponse, error) { return cs.CreateConsoleSession(s.env, n.UUID) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	session := res.Session
+	fmt.Printf("%s session #%d → %s (%s %s)\n",
+		paint(cGreen+cBold, "⌨️  console"),
+		session.ID, n.Hostname, session.Platform, res.NodeInfo.OsqueryVersion)
+	fmt.Printf("%s type SQL, or shell-style commands (ls, cd, pwd, get <path>, tables, help). 'exit' to close.\n",
+		paint(cGray, "     "))
+	if len(res.History) > 0 {
+		fmt.Printf("%s %d history entries restored\n", paint(cGray, "     "), len(res.History))
+	}
+	sessionID := session.ID
+	cwd := session.CWD
+	defer func() {
+		_ = cs.CloseConsoleSession(s.env, sessionID)
+	}()
+	for {
+		prompt := paint(cCyan+cBold, "osctrl") + " " +
+			paint(cMagenta, "("+n.Hostname+":"+cwd+")") + paint(cGreen, "> ")
+		line, err := s.rl.readline(prompt)
+		if err != nil {
+			fmt.Println()
+			return
+		}
+		input := strings.TrimSpace(line)
+		if input == "" {
+			continue
+		}
+		if input == "exit" || input == "quit" || input == "q" {
+			return
+		}
+		resp, err := cs.SubmitConsoleCommand(s.env, sessionID, input, false)
+		if err != nil {
+			errf("%v", err)
+			continue
+		}
+		if resp.Parsed.Message != "" {
+			fmt.Printf("  %s\n", resp.Parsed.Message)
+		}
+		if resp.Parsed.Output != "" {
+			fmt.Println(indentLines(resp.Parsed.Output, "  "))
+		}
+		if rows := s.pollConsoleResults(cs, sessionID, resp.Command.ID); rows != nil {
+			printResultRows(rows)
+		}
+		// 'cd' mutates the session cwd server-side — refetch so the
+		// prompt tracks where the node really is.
+		if resp.Parsed.Kind == console.CommandRemote && resp.Parsed.Command == "cd" {
+			if sess, err := cs.GetConsoleSession(s.env, sessionID); err == nil {
+				cwd = sess.CWD
+			}
+		}
+	}
+}
+
+// pollConsoleResults waits for a command to complete and returns its rows.
+// Prints an inline status so the operator sees the node answering.
+func (s *shellState) pollConsoleResults(cs consoleStore, sessionID, commandID uint) []map[string]any {
+	deadline := time.Now().Add(consoleStatusTimeout)
+	for {
+		cmd, err := cs.GetConsoleCommand(s.env, sessionID, commandID)
+		if err != nil {
+			errf("%v", err)
+			return nil
+		}
+		switch cmd.Status {
+		case console.StatusCompleted:
+			fmt.Printf("\r\x1b[K")
+			rows, err := cs.GetConsoleCommandResults(s.env, sessionID, commandID)
+			if err != nil {
+				errf("%v", err)
+				return nil
+			}
+			return rows
+		case console.StatusError:
+			fmt.Printf("\r\x1b[K")
+			errf("command failed: %s", cmd.Error)
+			return nil
+		case console.StatusExpired:
+			fmt.Printf("\r\x1b[K")
+			fmt.Printf("  %s node did not report in time\n", paint(cYellow, "⏱"))
+			return nil
+		}
+		if time.Now().After(deadline) {
+			fmt.Printf("\r\x1b[K")
+			fmt.Printf("  %s timed out waiting for node\n", paint(cYellow, "⏱"))
+			return nil
+		}
+		fmt.Printf("\r  %s waiting for node…%s",
+			paint(cCyan, spinnerFrames[int(time.Now().Unix()%int64(len(spinnerFrames)))]),
+			paint(cGray, strings.Repeat(" ", 8)))
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// ─────────────────────────────── file explorer module ───────────────────────────────
+
+func fileExplorerCommands() []shellCmd {
+	return []shellCmd{
+		{name: "open", args: "<uuid|hostname>", help: "open an interactive file explorer session to a node", min: 1, fn: shFexploreOpen},
+	}
+}
+
+func shFexploreOpen(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	cs, err := storeConsole(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	n, err := spinGet("🖥️  Resolving node", func() (nodeRow, error) { return s.store.Node(s.env, args[0]) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	res, err := spinGet("🗂️  Opening file explorer session", func() (fileExplorerSessionResponse, error) { return cs.CreateFileExplorerSession(s.env, n.UUID) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	session := res.Session
+	root := session.Root
+	if root == "" {
+		root = "/"
+	}
+	fmt.Printf("%s session #%d → %s (%s)\n",
+		paint(cGreen+cBold, "🗂️  file explorer"), session.ID, n.Hostname, session.Platform)
+	fmt.Printf("%s 'ls <path>', 'stat <path>', 'cd <dir>' (re-roots), 'exit' to close. root: %s\n",
+		paint(cGray, "     "), root)
+	sessionID := session.ID
+	defer func() {
+		_ = cs.CloseFileExplorerSession(s.env, sessionID)
+	}()
+	for {
+		prompt := paint(cCyan+cBold, "osctrl") + " " +
+			paint(cMagenta, "(fex:"+n.Hostname+")") + paint(cGreen, "> ")
+		line, err := s.rl.readline(prompt)
+		if err != nil {
+			fmt.Println()
+			return
+		}
+		input := strings.TrimSpace(line)
+		if input == "" {
+			continue
+		}
+		if input == "exit" || input == "quit" || input == "q" {
+			return
+		}
+		tokens := strings.Fields(input)
+		cmd, arg := tokens[0], ""
+		if len(tokens) > 1 {
+			arg = tokens[1]
+		}
+		switch cmd {
+		case "ls", "list", "dir":
+			s.fexploreRequest(cs, sessionID, "list", arg)
+		case "stat":
+			s.fexploreRequest(cs, sessionID, "stat", arg)
+		case "cd":
+			if arg != "" {
+				root = arg
+				okf("root: %s", root)
+			}
+		default:
+			errf("unknown file explorer command: %s (ls, stat, cd, exit)", cmd)
+		}
+	}
+}
+
+func (s *shellState) fexploreRequest(cs consoleStore, sessionID uint, action, target string) {
+	var req fileexplorer.Request
+	var err error
+	if action == "stat" {
+		req, err = cs.SubmitFileExplorerStat(s.env, sessionID, target)
+	} else {
+		req, err = cs.SubmitFileExplorerList(s.env, sessionID, target)
+	}
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	deadline := time.Now().Add(consoleStatusTimeout)
+	for {
+		req, err = cs.GetFileExplorerRequest(s.env, sessionID, req.ID)
+		if err != nil {
+			errf("%v", err)
+			return
+		}
+		if req.Status == fileexplorer.StatusCompleted || req.Status == fileexplorer.StatusError || req.Status == fileexplorer.StatusExpired {
+			fmt.Printf("\r\x1b[K")
+			break
+		}
+		if time.Now().After(deadline) {
+			fmt.Printf("\r\x1b[K")
+			fmt.Printf("  %s timed out waiting for node\n", paint(cYellow, "⏱"))
+			return
+		}
+		fmt.Printf("\r  %s waiting for node…%s",
+			paint(cCyan, spinnerFrames[int(time.Now().Unix()%int64(len(spinnerFrames)))]),
+			paint(cGray, strings.Repeat(" ", 8)))
+		time.Sleep(500 * time.Millisecond)
+	}
+	if req.Status != fileexplorer.StatusCompleted {
+		if req.Error != "" {
+			errf("%s", req.Error)
+		} else {
+			errf("request %s", req.Status)
+		}
+		return
+	}
+	entries, err := cs.GetFileExplorerResults(s.env, sessionID, req.ID)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(entries))
+	for _, e := range entries {
+		rows = append(rows, []string{e.Type, e.Mode, e.Filename, e.Directory, strconv.FormatInt(e.Size, 10)})
+	}
+	fmt.Printf("%d entries\n", len(entries))
+	printTable([]string{"Type", "Mode", "Name", "Directory", "Size"}, rows)
+}
+
+// ─────────────────────────────── posture module ───────────────────────────────
+
+func postureCommands() []shellCmd {
+	return []shellCmd{
+		{name: "show", args: "<uuid|hostname>", help: "show posture data for a node", min: 1, fn: shPostureShow},
+		{name: "score", args: "<uuid|hostname>", help: "show SOC2/ISO27001 risk score for a node", min: 1, fn: shPostureScore},
+		{name: "profiles", aliases: "ls", args: "", help: "list posture profile templates", fn: shPostureProfiles},
+	}
+}
+
+func shPostureShow(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ps, err := storePosture(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	n, err := spinGet("🖥️  Resolving node", func() (nodeRow, error) { return s.store.Node(s.env, args[0]) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	records, err := spinGet("🛡️  Fetching posture", func() ([]posture.NodePosture, error) { return ps.NodePosture(s.env, n.UUID) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	if len(records) == 0 {
+		fmt.Printf("no posture data for %s — has a posture profile been assigned?\n", n.Hostname)
+		return
+	}
+	for _, r := range records {
+		fmt.Printf("%s (%d rows, last seen %s)\n", paint(cCyan+cBold, r.Category), r.RowCount, shortTime(r.LastSeen))
+		var rows []map[string]any
+		if err := json.Unmarshal([]byte(r.Summary), &rows); err != nil || len(rows) == 0 {
+			fmt.Printf("  %s\n", paint(cGray, "(no rows)"))
+			fmt.Println()
+			continue
+		}
+		printResultRows(rows)
+		fmt.Println()
+	}
+}
+
+func shPostureScore(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ps, err := storePosture(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	n, err := spinGet("🖥️  Resolving node", func() (nodeRow, error) { return s.store.Node(s.env, args[0]) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	score, err := spinGet("🛡️  Scoring posture", func() (posture.PostureScore, error) { return ps.NodePostureScore(s.env, n.UUID) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	color := cGreen
+	switch score.RiskLevel {
+	case "medium":
+		color = cYellow
+	case "high", "critical":
+		color = cRed
+	}
+	fmt.Printf("%s %s  %s %s/100  pass %s  warn %s  fail %s\n",
+		paint(cCyan+cBold, "🛡️  "+n.Hostname),
+		paint(color+cBold, strings.ToUpper(score.RiskLevel)),
+		paint(cCyan, "score"), strconv.Itoa(score.TotalScore),
+		paint(cGreen, strconv.Itoa(score.PassCount)),
+		paint(cYellow, strconv.Itoa(score.WarnCount)),
+		paint(cRed, strconv.Itoa(score.FailCount)))
+	rows := make([][]string, 0, len(score.Controls))
+	for _, c := range score.Controls {
+		rows = append(rows, []string{string(c.Framework), c.ControlID, c.Title, c.Status, string(c.Severity), c.Detail})
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		order := map[string]int{"fail": 0, "warn": 1, "pass": 2}
+		return order[rows[i][3]] < order[rows[j][3]]
+	})
+	printTable([]string{"Framework", "Control", "Title", "Status", "Severity", "Detail"}, rows)
+}
+
+func shPostureProfiles(s *shellState, _ []string) {
+	ps, err := storePosture(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	profiles, err := spinGet("🛡️  Fetching profiles", func() ([]posture.PostureProfile, error) { return ps.PostureProfiles() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(profiles))
+	for _, p := range profiles {
+		rows = append(rows, []string{p.ID, p.Name, p.Platform, p.Description, strconv.Itoa(len(p.Queries))})
+	}
+	printTable([]string{"ID", "Name", "Platform", "Description", "Checks"}, rows)
+}
+
+// ─────────────────────────────── saved queries module ───────────────────────────────
+
+func savedCommands() []shellCmd {
+	return []shellCmd{
+		{name: "list", aliases: "ls", args: "", help: "list saved queries in the active env", fn: shSavedList},
+		{name: "show", args: "<name>", help: "show a saved query", min: 1, fn: shSavedShow},
+		{name: "save", args: "<name> <sql>", help: "save a new query", min: 2, fn: shSavedSave},
+		{name: "update", args: "<name> <sql>", help: "update a saved query body", min: 2, fn: shSavedUpdate},
+		{name: "delete", aliases: "rm", args: "<name>", help: "delete a saved query", min: 1, fn: shSavedDelete},
+		{name: "run", args: "<name>", help: "dispatch a saved query (uses set options)", min: 1, fn: shSavedRun},
+		{name: "samples", args: "", help: "browse the built-in query template library", fn: shSavedSamples},
+	}
+}
+
+func shSavedList(s *shellState, _ []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ss, err := storeSaved(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	items, err := spinGet("💾 Fetching saved queries", func() ([]types.SavedQueryView, error) { return ss.SavedQueries(s.env) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(items))
+	for _, q := range items {
+		rows = append(rows, []string{q.Name, q.Creator, q.Query, shortTime(q.UpdatedAt)})
+	}
+	fmt.Printf("%d saved queries in %s\n", len(items), s.env)
+	printTable([]string{"Name", "Creator", "Query", "Updated"}, rows)
+}
+
+func shSavedShow(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ss, err := storeSaved(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	items, err := spinGet("💾 Fetching saved queries", func() ([]types.SavedQueryView, error) { return ss.SavedQueries(s.env) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	for _, q := range items {
+		if q.Name == args[0] {
+			fmt.Printf("Name:    %s\n", q.Name)
+			fmt.Printf("Creator: %s\n", q.Creator)
+			fmt.Printf("Created: %s\n", shortTime(q.CreatedAt))
+			fmt.Printf("Updated: %s\n", shortTime(q.UpdatedAt))
+			fmt.Printf("Query:\n%s\n", q.Query)
+			return
+		}
+	}
+	errf("saved query not found: %s", args[0])
+}
+
+func shSavedSave(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ss, err := storeSaved(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	sql := strings.Join(args[1:], " ")
+	if err := ss.SaveQuery(s.env, args[0], sql); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("saved query %s in %s", args[0], s.env)
+}
+
+func shSavedUpdate(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ss, err := storeSaved(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	sql := strings.Join(args[1:], " ")
+	if err := ss.UpdateSavedQuery(s.env, args[0], sql); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("updated saved query %s", args[0])
+}
+
+func shSavedDelete(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ss, err := storeSaved(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	if !s.confirm(fmt.Sprintf("Delete saved query %s?", args[0])) {
+		fmt.Println("aborted")
+		return
+	}
+	if err := ss.DeleteSavedQuery(s.env, args[0]); err != nil {
+		errf("%v", err)
+		return
+	}
+	okf("deleted saved query %s", args[0])
+}
+
+func shSavedRun(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ss, err := storeSaved(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	items, err := spinGet("💾 Fetching saved queries", func() ([]types.SavedQueryView, error) { return ss.SavedQueries(s.env) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	for _, q := range items {
+		if q.Name == args[0] {
+			req := s.buildRunReq(q.Query)
+			if err := spinDo("🔍 Dispatching query", func() error { return s.store.RunQuery(req) }); err != nil {
+				errf("%v", err)
+				return
+			}
+			okf("dispatched saved query %s", args[0])
+			return
+		}
+	}
+	errf("saved query not found: %s", args[0])
+}
+
+func shSavedSamples(s *shellState, _ []string) {
+	ss, err := storeSaved(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	samples, err := spinGet("💾 Fetching samples", func() ([]queries.QuerySample, error) { return ss.QuerySamples() })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	rows := make([][]string, 0, len(samples))
+	for _, smp := range samples {
+		rows = append(rows, []string{smp.Name, string(smp.Category), strings.Join(platformsOf(smp), ","), smp.Description})
+	}
+	fmt.Printf("%d sample templates\n", len(samples))
+	printTable([]string{"Name", "Category", "Platforms", "Description"}, rows)
+}
+
+func platformsOf(s queries.QuerySample) []string {
+	out := make([]string, 0, len(s.Platforms))
+	for _, p := range s.Platforms {
+		out = append(out, string(p))
+	}
+	return out
+}
+
+// ─────────────────────────────── node logs (nodes module extension) ───────────────────────────────
+
+func shNodeLogs(s *shellState, args []string) {
+	if !s.requireEnv() {
+		return
+	}
+	ss, err := storeSaved(s.store)
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	logType := "result"
+	if len(args) > 1 {
+		logType = args[1]
+	}
+	if logType != "result" && logType != "status" {
+		errf("log type must be 'result' or 'status'")
+		return
+	}
+	n, err := spinGet("🖥️  Resolving node", func() (nodeRow, error) { return s.store.Node(s.env, args[0]) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	body, err := spinGet("📜 Fetching logs", func() (string, error) { return ss.NodeLogs(s.env, logType, n.UUID) })
+	if err != nil {
+		errf("%v", err)
+		return
+	}
+	fmt.Println(body)
+}
+
+// ─────────────────────────────── row rendering helpers ───────────────────────────────
+
+// columnKeys returns the sorted keys of a result-row map for table headers.
+func columnKeys(row map[string]any) []string {
+	keys := make([]string, 0, len(row))
+	for k := range row {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// printResultRows renders arbitrary query-result rows as a table.
+func printResultRows(rows []map[string]any) {
+	if len(rows) == 0 {
+		fmt.Printf("  %s\n", paint(cGray, "(no rows)"))
+		return
+	}
+	headers := columnKeys(rows[0])
+	table := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		cells := make([]string, 0, len(headers))
+		for _, h := range headers {
+			v, ok := r[h]
+			if !ok {
+				cells = append(cells, "")
+				continue
+			}
+			cells = append(cells, fmt.Sprintf("%v", v))
+		}
+		table = append(table, cells)
+	}
+	printTable(headers, table)
+}
+
+// indentLines prefixes every line with pad.
+func indentLines(s, pad string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		if l != "" {
+			lines[i] = pad + l
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/cmd/cli/shell_modules.go
+++ b/cmd/cli/shell_modules.go
@@ -20,6 +20,7 @@ func nodesCommands() []shellCmd {
 		{name: "list", aliases: "ls", args: "[active|inactive|all]", help: "list nodes in the active env (default: all)", fn: shNodesList},
 		{name: "search", args: "<query>", help: "search nodes by hostname/uuid/ip/user", min: 1, fn: shNodesSearch},
 		{name: "show", args: "<uuid|hostname>", help: "show node detail", min: 1, fn: shNodesShow},
+		{name: "logs", args: "<uuid|hostname> [result|status]", help: "show recent logs for a node (api mode)", min: 1, fn: shNodeLogs},
 		{name: "delete", aliases: "rm", args: "<uuid>", help: "delete (archive) a node", min: 1, fn: shNodesDelete},
 		{name: "tag", args: "<uuid> <tag>", help: "apply a tag to a node", min: 2, fn: shNodesTag},
 	}

--- a/cmd/cli/shell_store_extras.go
+++ b/cmd/cli/shell_store_extras.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
+	"github.com/jmpsec/osctrl/pkg/posture"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+)
+
+// shell_store_extras.go — additional DataStore surface covering the newer
+// osctrl-api additions: console sessions, file explorer sessions, node
+// posture, saved queries, node logs, and query samples. These are
+// API-centric features (the console/file-explorer services live behind
+// osctrl-api), so dbStore returns a clear "API mode" error for each.
+
+// consoleStore is the API-backed surface for interactive per-node access.
+type consoleStore interface {
+	CreateConsoleSession(env, uuid string) (ConsoleSessionResponse, error)
+	GetConsoleSession(env string, sessionID uint) (console.Session, error)
+	CloseConsoleSession(env string, sessionID uint) error
+	SubmitConsoleCommand(env string, sessionID uint, input string, osqueryMode bool) (ConsoleCommandResponse, error)
+	GetConsoleCommand(env string, sessionID, commandID uint) (console.Command, error)
+	GetConsoleCommandResults(env string, sessionID, commandID uint) ([]map[string]any, error)
+
+	CreateFileExplorerSession(env, uuid string) (fileExplorerSessionResponse, error)
+	CloseFileExplorerSession(env string, sessionID uint) error
+	SubmitFileExplorerList(env string, sessionID uint, path string) (fileexplorer.Request, error)
+	SubmitFileExplorerStat(env string, sessionID uint, path string) (fileexplorer.Request, error)
+	GetFileExplorerRequest(env string, sessionID, requestID uint) (fileexplorer.Request, error)
+	GetFileExplorerResults(env string, sessionID, requestID uint) ([]fileexplorer.Entry, error)
+}
+
+// postureStore covers posture reads.
+type postureStore interface {
+	NodePosture(env, uuid string) ([]posture.NodePosture, error)
+	NodePostureScore(env, uuid string) (posture.PostureScore, error)
+	PostureProfiles() ([]posture.PostureProfile, error)
+}
+
+// savedStore covers saved-query CRUD.
+type savedStore interface {
+	SavedQueries(env string) ([]types.SavedQueryView, error)
+	SaveQuery(env, name, query string) error
+	UpdateSavedQuery(env, name, query string) error
+	DeleteSavedQuery(env, name string) error
+	QuerySamples() ([]queries.QuerySample, error)
+	NodeLogs(env, logType, uuid string) (string, error)
+}
+
+// storeConsole casts the active store to the console surface when available.
+func storeConsole(s DataStore) (consoleStore, error) {
+	if cs, ok := s.(consoleStore); ok {
+		return cs, nil
+	}
+	return nil, fmt.Errorf("console requires API mode")
+}
+
+// storePosture casts the active store to the posture surface when available.
+func storePosture(s DataStore) (postureStore, error) {
+	if ps, ok := s.(postureStore); ok {
+		return ps, nil
+	}
+	return nil, fmt.Errorf("posture requires API mode")
+}
+
+// storeSaved casts the active store to the saved-query surface when available.
+func storeSaved(s DataStore) (savedStore, error) {
+	if ss, ok := s.(savedStore); ok {
+		return ss, nil
+	}
+	return nil, fmt.Errorf("saved queries require API mode")
+}
+
+// ─────────────────────────────── apiStore implementations ───────────────────────────────
+
+func (s *apiStore) CreateConsoleSession(env, uuid string) (ConsoleSessionResponse, error) {
+	return s.api.CreateConsoleSession(env, uuid)
+}
+
+func (s *apiStore) GetConsoleSession(env string, sessionID uint) (console.Session, error) {
+	return s.api.GetConsoleSession(env, sessionID)
+}
+
+func (s *apiStore) CloseConsoleSession(env string, sessionID uint) error {
+	return s.api.CloseConsoleSession(env, sessionID)
+}
+
+func (s *apiStore) SubmitConsoleCommand(env string, sessionID uint, input string, osqueryMode bool) (ConsoleCommandResponse, error) {
+	return s.api.SubmitConsoleCommand(env, sessionID, input, osqueryMode)
+}
+
+func (s *apiStore) GetConsoleCommand(env string, sessionID, commandID uint) (console.Command, error) {
+	return s.api.GetConsoleCommand(env, sessionID, commandID)
+}
+
+func (s *apiStore) GetConsoleCommandResults(env string, sessionID, commandID uint) ([]map[string]any, error) {
+	return s.api.GetConsoleCommandResults(env, sessionID, commandID)
+}
+
+func (s *apiStore) CreateFileExplorerSession(env, uuid string) (fileExplorerSessionResponse, error) {
+	return s.api.CreateFileExplorerSession(env, uuid)
+}
+
+func (s *apiStore) CloseFileExplorerSession(env string, sessionID uint) error {
+	return s.api.CloseFileExplorerSession(env, sessionID)
+}
+
+func (s *apiStore) SubmitFileExplorerList(env string, sessionID uint, path string) (fileexplorer.Request, error) {
+	return s.api.SubmitFileExplorerList(env, sessionID, path)
+}
+
+func (s *apiStore) SubmitFileExplorerStat(env string, sessionID uint, path string) (fileexplorer.Request, error) {
+	return s.api.SubmitFileExplorerStat(env, sessionID, path)
+}
+
+func (s *apiStore) GetFileExplorerRequest(env string, sessionID, requestID uint) (fileexplorer.Request, error) {
+	return s.api.GetFileExplorerRequest(env, sessionID, requestID)
+}
+
+func (s *apiStore) GetFileExplorerResults(env string, sessionID, requestID uint) ([]fileexplorer.Entry, error) {
+	return s.api.GetFileExplorerResults(env, sessionID, requestID)
+}
+
+func (s *apiStore) NodePosture(env, uuid string) ([]posture.NodePosture, error) {
+	return s.api.GetNodePosture(env, uuid)
+}
+
+func (s *apiStore) NodePostureScore(env, uuid string) (posture.PostureScore, error) {
+	return s.api.GetNodePostureScore(env, uuid)
+}
+
+func (s *apiStore) PostureProfiles() ([]posture.PostureProfile, error) {
+	return s.api.GetPostureProfiles()
+}
+
+func (s *apiStore) SavedQueries(env string) ([]types.SavedQueryView, error) {
+	return s.api.GetSavedQueries(env)
+}
+
+func (s *apiStore) SaveQuery(env, name, query string) error {
+	return s.api.CreateSavedQuery(env, name, query)
+}
+
+func (s *apiStore) UpdateSavedQuery(env, name, query string) error {
+	return s.api.UpdateSavedQuery(env, name, query)
+}
+
+func (s *apiStore) DeleteSavedQuery(env, name string) error {
+	return s.api.DeleteSavedQuery(env, name)
+}
+
+func (s *apiStore) QuerySamples() ([]queries.QuerySample, error) {
+	return s.api.GetQuerySamples()
+}
+
+func (s *apiStore) NodeLogs(env, logType, uuid string) (string, error) {
+	return s.api.GetNodeLogs(env, logType, uuid)
+}

--- a/cmd/cli/shell_ui.go
+++ b/cmd/cli/shell_ui.go
@@ -135,8 +135,16 @@ func moduleIcon(name string) string {
 		return "🖥️"
 	case "queries":
 		return "🔍"
+	case "saved":
+		return "💾"
 	case "carves":
 		return "📦"
+	case "console":
+		return "⌨️"
+	case "file-explorer":
+		return "🗂️"
+	case "posture":
+		return "🛡️"
 	case "environments":
 		return "🌐"
 	case "tags":

--- a/cmd/cli/tui_dashboard.go
+++ b/cmd/cli/tui_dashboard.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	ui "github.com/gizak/termui/v3"
+	"github.com/gizak/termui/v3/widgets"
+
+	"github.com/jmpsec/osctrl/pkg/version"
+	"github.com/urfave/cli/v3"
+)
+
+// tui_dashboard.go — full-screen TUI dashboard (osctrl-cli tui).
+//
+// Renders a live view of the deployment using termui: fleet gauges,
+// platform breakdown, and a detail pane switchable between environments,
+// recent queries, and the audit log. Data comes from the same DataStore
+// the interactive shell uses, so it works in both --api and --db modes.
+//
+// Keys: q / Ctrl-C quit · r refresh · 1 environments · 2 queries · 3 audit.
+
+const tuiRefreshSeconds = 30
+
+const (
+	paneEnvironments = iota
+	paneQueries
+	paneAudit
+)
+
+// tuiModel holds the dashboard state between refreshes.
+type tuiModel struct {
+	store DataStore
+	pane  int
+
+	stats tuiStats
+	audit []auditRow
+
+	footer *widgets.Paragraph
+}
+
+// runTUIDashboard is the action behind the `tui` CLI command.
+func runTUIDashboard(cctx context.Context, cmd *cli.Command) error {
+	var store DataStore
+	switch {
+	case dbFlag:
+		store = newDBStore()
+	case apiFlag:
+		store = newAPIStore(osctrlAPI)
+	default:
+		return fmt.Errorf("enable --db or --api to use the dashboard")
+	}
+	if dbFlag {
+		if err := db.Check(); err != nil {
+			return fmt.Errorf("db check: %w", err)
+		}
+	} else {
+		if err := osctrlAPI.CheckAPI(); err != nil {
+			return fmt.Errorf("api check: %w", err)
+		}
+	}
+	model := &tuiModel{store: store}
+	if err := model.refresh(); err != nil {
+		return err
+	}
+	return model.loop()
+}
+
+func (m *tuiModel) loop() error {
+	if err := ui.Init(); err != nil {
+		return fmt.Errorf("termui init: %w", err)
+	}
+	defer ui.Close()
+
+	grid := m.render()
+	ui.Render(grid)
+
+	events := ui.PollEvents()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	remaining := tuiRefreshSeconds
+	for {
+		select {
+		case e := <-events:
+			switch e.ID {
+			case "q", "<C-c>":
+				return nil
+			case "r":
+				if err := m.refresh(); err != nil {
+					return err
+				}
+				remaining = tuiRefreshSeconds
+			case "1":
+				m.pane = paneEnvironments
+			case "2":
+				m.pane = paneQueries
+			case "3":
+				m.pane = paneAudit
+			case "<Resize>":
+			}
+			ui.Clear()
+			grid = m.render()
+			ui.Render(grid)
+		case <-ticker.C:
+			remaining--
+			if remaining <= 0 {
+				if err := m.refresh(); err != nil {
+					return err
+				}
+				remaining = tuiRefreshSeconds
+			}
+			ui.Clear()
+			grid = m.render()
+			ui.Render(grid)
+		}
+	}
+}
+
+// refresh pulls the latest snapshot from the store.
+func (m *tuiModel) refresh() error {
+	stats, err := m.store.Stats()
+	if err != nil {
+		return err
+	}
+	m.stats = stats
+	// Audit pane is optional: some deployments disable the audit log.
+	if audit, err := m.store.AuditLogs(); err == nil {
+		m.audit = audit
+	}
+	return nil
+}
+
+// footerText renders the bottom help bar.
+func (m *tuiModel) footerText(remaining int) string {
+	return fmt.Sprintf(" [1] environments  [2] queries  [3] audit  [r] refresh  [q] quit · next refresh in %ds ", remaining)
+}
+
+// render builds the grid for the current state.
+func (m *tuiModel) render() *ui.Grid {
+	header := widgets.NewParagraph()
+	header.Title = " 🛡  osctrl-cli dashboard "
+	header.Text = fmt.Sprintf(" v%s · %s mode · %s ", version.OsctrlVersion, m.store.Mode(), time.Now().Format("15:04:05"))
+	header.BorderStyle = ui.NewStyle(ui.ColorCyan)
+	header.TextStyle = ui.NewStyle(ui.ColorWhite, ui.ColorClear, ui.ModifierBold)
+
+	// Fleet health gauge: percentage of nodes active.
+	activePercent := 0
+	if m.stats.TotalNodes > 0 {
+		activePercent = int(float64(m.stats.ActiveNodes) / float64(m.stats.TotalNodes) * 100)
+	}
+	fleet := widgets.NewGauge()
+	fleet.Title = fmt.Sprintf(" Fleet health — %d/%d active ", m.stats.ActiveNodes, m.stats.TotalNodes)
+	fleet.Percent = activePercent
+	fleetColor := ui.ColorGreen
+	switch {
+	case activePercent < 50:
+		fleetColor = ui.ColorRed
+	case activePercent < 80:
+		fleetColor = ui.ColorYellow
+	}
+	fleet.BarColor = fleetColor
+	fleet.BorderStyle = ui.NewStyle(fleetColor)
+	fleet.LabelStyle = ui.NewStyle(ui.ColorBlack, fleetColor, ui.ModifierBold)
+
+	// Activity gauge: queries + carves in flight.
+	workload := widgets.NewGauge()
+	workload.Title = fmt.Sprintf(" In flight — %d queries · %d carves ", m.stats.TotalActiveQueries, m.stats.TotalActiveCarves)
+	workloadPercent := (m.stats.TotalActiveQueries + m.stats.TotalActiveCarves) % 101
+	workload.Percent = workloadPercent
+	workload.BarColor = ui.ColorMagenta
+	workload.BorderStyle = ui.NewStyle(ui.ColorMagenta)
+	workload.LabelStyle = ui.NewStyle(ui.ColorBlack, ui.ColorMagenta, ui.ModifierBold)
+
+	// Platform breakdown.
+	platforms := widgets.NewBarChart()
+	platforms.Title = " Platforms "
+	platforms.Data = []float64{
+		float64(m.stats.Platforms.Linux),
+		float64(m.stats.Platforms.Darwin),
+		float64(m.stats.Platforms.Windows),
+		float64(m.stats.Platforms.Other),
+	}
+	platforms.Labels = []string{"linux", "darwin", "win", "other"}
+	platforms.BarColors = []ui.Color{ui.ColorCyan, ui.ColorCyan, ui.ColorCyan, ui.ColorWhite}
+	platforms.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorWhite)}
+	platforms.NumStyles = []ui.Style{ui.NewStyle(ui.ColorBlack, ui.ColorCyan, ui.ModifierBold)}
+	platforms.BorderStyle = ui.NewStyle(ui.ColorCyan)
+
+	// Detail pane.
+	var detail *widgets.Table
+	var paneTitle string
+	switch m.pane {
+	case paneQueries:
+		paneTitle = " Active queries by environment "
+		detail = m.queriesTable()
+	case paneAudit:
+		paneTitle = " Recent audit entries "
+		detail = m.auditTable()
+	default:
+		paneTitle = " Environments "
+		detail = m.environmentsTable()
+	}
+	detail.Title = paneTitle
+	detail.BorderStyle = ui.NewStyle(ui.ColorYellow)
+	detail.TextStyle = ui.NewStyle(ui.ColorWhite)
+	detail.RowSeparator = false
+	detail.RowStyles = map[int]ui.Style{
+		0: ui.NewStyle(ui.ColorBlack, ui.ColorYellow, ui.ModifierBold),
+	}
+
+	footer := widgets.NewParagraph()
+	footer.Text = m.footerText(tuiRefreshSeconds)
+	footer.BorderStyle = ui.NewStyle(ui.ColorMagenta)
+	footer.TextStyle = ui.NewStyle(ui.ColorWhite)
+	m.footer = footer
+
+	grid := ui.NewGrid()
+	grid.Set(
+		ui.NewRow(1.0/10.0, header),
+		ui.NewRow(2.0/10.0,
+			ui.NewCol(0.5, fleet),
+			ui.NewCol(0.5, workload),
+		),
+		ui.NewRow(3.0/10.0, platforms),
+		ui.NewRow(3.0/10.0, detail),
+		ui.NewRow(1.0/10.0, footer),
+	)
+	return grid
+}
+
+// environmentsTable renders per-env node/query/carve counts.
+func (m *tuiModel) environmentsTable() *widgets.Table {
+	t := widgets.NewTable()
+	rows := [][]string{{"Env", "Active", "Inactive", "Total", "Queries", "Carves"}}
+	envs := make([]tuiEnvStats, len(m.stats.Environments))
+	copy(envs, m.stats.Environments)
+	sort.Slice(envs, func(i, j int) bool { return envs[i].Name < envs[j].Name })
+	for _, e := range envs {
+		rows = append(rows, []string{
+			e.Name,
+			strconv.FormatInt(e.Active, 10),
+			strconv.FormatInt(e.Inactive, 10),
+			strconv.FormatInt(e.Total, 10),
+			strconv.Itoa(e.ActiveQueries),
+			strconv.Itoa(e.ActiveCarves),
+		})
+	}
+	t.Rows = rows
+	return t
+}
+
+// queriesTable shows the summary line for query activity per env.
+func (m *tuiModel) queriesTable() *widgets.Table {
+	t := widgets.NewTable()
+	rows := [][]string{{"Env", "Active queries", "Active carves", "Linux", "Darwin", "Windows"}}
+	envs := make([]tuiEnvStats, len(m.stats.Environments))
+	copy(envs, m.stats.Environments)
+	sort.Slice(envs, func(i, j int) bool { return envs[i].Name < envs[j].Name })
+	for _, e := range envs {
+		rows = append(rows, []string{
+			e.Name,
+			strconv.Itoa(e.ActiveQueries),
+			strconv.Itoa(e.ActiveCarves),
+			strconv.FormatInt(e.Platforms.Linux, 10),
+			strconv.FormatInt(e.Platforms.Darwin, 10),
+			strconv.FormatInt(e.Platforms.Windows, 10),
+		})
+	}
+	t.Rows = rows
+	return t
+}
+
+// auditTable renders the most recent audit entries (newest first, capped).
+func (m *tuiModel) auditTable() *widgets.Table {
+	t := widgets.NewTable()
+	rows := [][]string{{"When", "User", "Type", "Entry"}}
+	entries := make([]auditRow, len(m.audit))
+	copy(entries, m.audit)
+	// audit rows arrive newest-first from the API; show the top slice.
+	const cap = 20
+	if len(entries) > cap {
+		entries = entries[:cap]
+	}
+	for _, a := range entries {
+		line := a.Line
+		if len(line) > 60 {
+			line = line[:57] + "..."
+		}
+		rows = append(rows, []string{a.When, a.Username, a.LogType, line})
+	}
+	t.Rows = rows
+	return t
+}


### PR DESCRIPTION
## Refresh osctrl-cli with new osctrl-api functionality + TUI dashboard

### Problem

osctrl-cli lagged behind osctrl-api. The interactive shell covered the core
surface (nodes, queries, carves, environments, tags, users, audit, settings)
but none of the newer API additions: the per-node console, the file explorer,
node posture + compliance scoring, saved queries, the query template library,
or node log retrieval. There was also no at-a-glance fleet view from the
terminal.

### Change

**New API client wrappers**
- `cmd/cli/api-console.go` — console sessions (create/show/close), command
  submit, command status, command results (`/api/v1/console/...`)
- `cmd/cli/api-extras.go` — file explorer (sessions, `list`/`stat`, request
  status, entries), posture (node records, SOC2/ISO27001 risk score, profile
  templates), saved queries (list/create/update/delete), query samples, and
  node logs (`result`/`status`)
- `cmd/cli/api.go` — `ReqGeneric` now accepts any 2xx (not just 200) since the
  new POST routes return `201 Created`

**New interactive shell modules** (`cmd/cli/shell_module_extras.go`,
backed by `cmd/cli/shell_store_extras.go`):
- `use console` → `open <node>`: live per-node REPL. Shell-style commands
  (`ls`, `cd`, `pwd`, `get`, `tables`) and SQL, inline spinner while the node
  answers, result rows rendered as tables, server-side `cd` tracking,
  session history restored on open
- `use file-explorer` → `open <node>`: live remote browsing (`ls`, `stat`,
  `cd` re-root) with polling and entry tables
- `use posture` → `show`, `score` (color-coded risk level + control table
  sorted fail → warn → pass), `profiles`
- `use saved` → `list`, `show`, `save`, `update`, `delete`, `run` (dispatches
  with existing `set` targeting options), `samples` (template library)
- `use nodes` gains `logs <node> [result|status]`
- New surfaces are exposed via optional interfaces (`consoleStore`,
  `postureStore`, `savedStore`) so `--db` mode fails cleanly with
  "requires API mode" instead of crashing; tab completion and module help
  cover the new modules

**Full-screen TUI dashboard** (`cmd/cli/tui_dashboard.go`)
- New `osctrl-cli tui` (alias `dashboard`) command using termui (already a
  dependency)
- Fleet-health and in-flight queries/carves gauges, platform bar chart,
  detail pane switchable between environments / queries / audit
- Auto-refresh every 30s, `r` force-refresh, `q`/Ctrl-C quit
- Works in both `--api` and `--db` modes through the existing `DataStore`
  façade

### Validation

- `go build ./...`, `go vet ./cmd/cli/`, `gofmt` clean
- `golangci-lint run ./cmd/cli/...` — 0 issues
- `go test ./cmd/cli/ ./pkg/console/ ./pkg/fileexplorer/ ./pkg/posture/` — pass
- New `cmd/cli/api_extras_test.go`: httptest round-trip tests for every new
  endpoint (console session lifecycle, command submit/poll/results, file
  explorer list/stat/results, posture records/score/profiles, saved-query
  CRUD, samples, node logs), store-cast regression tests asserting dbStore
  rejects and apiStore implements the new surfaces, and a URL-shape test
  asserting the client paths match the server route table