### PR TITLE
Alerting system Stage 4: management API, instant hot-reload, and CLI

### DIFF
--- a/cmd/api/handlers/alerts.go
+++ b/cmd/api/handlers/alerts.go
@@ -1,0 +1,752 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/alerts"
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+// alerts.go — management API for the alerting subsystem: rules CRUD,
+// channels CRUD, history read, channel type registry, and the apply
+// (hot-reload) command. Mirrors the log-sinks handler surface.
+
+const alertsCommandTTL = logSinksCommandTTL
+
+// alertRuleDTO is the JSON shape returned to clients.
+type alertRuleDTO struct {
+	ID              uint   `json:"id"`
+	CreatedAt       string `json:"created_at"`
+	UpdatedAt       string `json:"updated_at"`
+	Name            string `json:"name"`
+	EnvironmentID   uint   `json:"environment_id"`
+	Source          string `json:"source"`
+	MatchType       string `json:"match_type"`
+	MatchField      string `json:"match_field"`
+	MatchValue      string `json:"match_value"`
+	StatusSeverity  string `json:"status_severity"`
+	CooldownMinutes int    `json:"cooldown_minutes"`
+	ChannelIDs      []uint `json:"channel_ids"`
+	Enabled         bool   `json:"enabled"`
+	Info            string `json:"info"`
+}
+
+func toAlertRuleDTO(r alerts.AlertRule) alertRuleDTO {
+	ids, _ := alerts.DecodeChannelIDs(r.ChannelIDs)
+	return alertRuleDTO{
+		ID:              r.ID,
+		CreatedAt:       r.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:       r.UpdatedAt.Format(time.RFC3339),
+		Name:            r.Name,
+		EnvironmentID:   r.EnvironmentID,
+		Source:          r.Source,
+		MatchType:       r.MatchType,
+		MatchField:      r.MatchField,
+		MatchValue:      r.MatchValue,
+		StatusSeverity:  r.StatusSeverity,
+		CooldownMinutes: r.CooldownMinutes,
+		ChannelIDs:      ids,
+		Enabled:         r.Enabled,
+		Info:            r.Info,
+	}
+}
+
+// alertChannelDTO is the JSON shape returned to clients. Config is a
+// decoded object with secrets redacted unless reveal=1.
+type alertChannelDTO struct {
+	ID            uint            `json:"id"`
+	CreatedAt     string          `json:"created_at"`
+	UpdatedAt     string          `json:"updated_at"`
+	Name          string          `json:"name"`
+	EnvironmentID uint            `json:"environment_id"`
+	Type          string          `json:"type"`
+	Enabled       bool            `json:"enabled"`
+	Config        json.RawMessage `json:"config"`
+	Info          string          `json:"info"`
+}
+
+func toAlertChannelDTO(c alerts.AlertChannel, reveal bool) alertChannelDTO {
+	cfg := c.Config
+	if !reveal {
+		cfg = alerts.RedactedChannelConfig(c.Type, c.Config)
+	}
+	return alertChannelDTO{
+		ID:            c.ID,
+		CreatedAt:     c.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:     c.UpdatedAt.Format(time.RFC3339),
+		Name:          c.Name,
+		EnvironmentID: c.EnvironmentID,
+		Type:          c.Type,
+		Enabled:       c.Enabled,
+		Config:        json.RawMessage(cfg),
+		Info:          c.Info,
+	}
+}
+
+func (h *HandlersApi) requireAlertsAdmin(w http.ResponseWriter, r *http.Request) (string, bool) {
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use alerts API by user %s", ctx[ctxUser]))
+		return "", false
+	}
+	return ctx[ctxUser], true
+}
+
+func (h *HandlersApi) alertsMgr(w http.ResponseWriter) (*alerts.Manager, bool) {
+	if h.Alerts == nil {
+		apiErrorResponse(w, "alerts not enabled", http.StatusServiceUnavailable, nil)
+		return nil, false
+	}
+	return h.Alerts, true
+}
+
+// ─────────────────────────────── rules ───────────────────────────────
+
+// AlertRulesListHandler — GET /api/v1/alerts/rules?env={id}
+//
+// @Summary List alert rules
+// @Description Returns alert rule rows, optionally filtered by environment.
+// @Tags alerts
+// @Produce json
+// @Param env query int false "Environment ID; omit to list all"
+// @Success 200 {array} alertRuleDTO
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/rules [get]
+func (h *HandlersApi) AlertRulesListHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	envID, err := parseEnvFilter(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid env filter", http.StatusBadRequest, err)
+		return
+	}
+	rows, err := mgr.ListRules(envID)
+	if err != nil {
+		apiErrorResponse(w, "error listing alert rules", http.StatusInternalServerError, err)
+		return
+	}
+	out := make([]alertRuleDTO, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toAlertRuleDTO(row))
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, out)
+}
+
+// AlertRuleGetHandler — GET /api/v1/alerts/rules/{id}
+//
+// @Summary Get one alert rule
+// @Description Returns a single alert rule by ID.
+// @Tags alerts
+// @Produce json
+// @Param id path int true "Rule ID"
+// @Success 200 {object} alertRuleDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/rules/{id} [get]
+func (h *HandlersApi) AlertRuleGetHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	id, err := parseAlertID(r, "id")
+	if err != nil {
+		apiErrorResponse(w, "invalid rule id", http.StatusBadRequest, err)
+		return
+	}
+	row, err := mgr.GetRule(id)
+	if err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toAlertRuleDTO(row))
+}
+
+// AlertRulesCreateHandler — POST /api/v1/alerts/rules
+//
+// @Summary Create an alert rule
+// @Description Creates a new alert rule for the given environment (or global when environment_id is 0).
+// @Tags alerts
+// @Accept json
+// @Produce json
+// @Param request body types.AlertRuleCreateRequest true "Request body"
+// @Success 201 {object} alertRuleDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 409 {object} types.ApiErrorResponse "Conflict"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/rules [post]
+func (h *HandlersApi) AlertRulesCreateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	var body types.AlertRuleCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	row, err := mgr.CreateRule(alerts.AlertRule{
+		Name:            body.Name,
+		EnvironmentID:   body.EnvironmentID,
+		Source:          body.Source,
+		MatchType:       body.MatchType,
+		MatchField:      body.MatchField,
+		MatchValue:      body.MatchValue,
+		StatusSeverity:  body.StatusSeverity,
+		CooldownMinutes: body.CooldownMinutes,
+		ChannelIDs:      alerts.EncodeChannelIDs(body.ChannelIDs),
+		Enabled:         body.Enabled,
+		Info:            body.Info,
+	})
+	if err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("created alert rule %q (source %s, env %d)", row.Name, row.Source, row.EnvironmentID), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, toAlertRuleDTO(row))
+}
+
+// AlertRulesUpdateHandler — PUT /api/v1/alerts/rules/{id}
+//
+// @Summary Update an alert rule
+// @Description Replaces an existing alert rule's mutable fields.
+// @Tags alerts
+// @Accept json
+// @Produce json
+// @Param id path int true "Rule ID"
+// @Param request body types.AlertRuleCreateRequest true "Request body"
+// @Success 200 {object} alertRuleDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/rules/{id} [put]
+func (h *HandlersApi) AlertRulesUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	id, err := parseAlertID(r, "id")
+	if err != nil {
+		apiErrorResponse(w, "invalid rule id", http.StatusBadRequest, err)
+		return
+	}
+	var body types.AlertRuleCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	row, err := mgr.UpdateRule(id, alerts.AlertRule{
+		Name:            body.Name,
+		EnvironmentID:   body.EnvironmentID,
+		Source:          body.Source,
+		MatchType:       body.MatchType,
+		MatchField:      body.MatchField,
+		MatchValue:      body.MatchValue,
+		StatusSeverity:  body.StatusSeverity,
+		CooldownMinutes: body.CooldownMinutes,
+		ChannelIDs:      alerts.EncodeChannelIDs(body.ChannelIDs),
+		Enabled:         body.Enabled,
+		Info:            body.Info,
+	})
+	if err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("updated alert rule %q (env %d)", row.Name, row.EnvironmentID), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toAlertRuleDTO(row))
+}
+
+// AlertRulesDeleteHandler — DELETE /api/v1/alerts/rules/{id}
+//
+// @Summary Delete an alert rule
+// @Description Deletes an alert rule by ID. Deletion takes effect on the next alert reload.
+// @Tags alerts
+// @Produce json
+// @Param id path int true "Rule ID"
+// @Success 204 "No content"
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/rules/{id} [delete]
+func (h *HandlersApi) AlertRulesDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	id, err := parseAlertID(r, "id")
+	if err != nil {
+		apiErrorResponse(w, "invalid rule id", http.StatusBadRequest, err)
+		return
+	}
+	if err := mgr.DeleteRule(id); err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("deleted alert rule %d", id), strings.Split(r.RemoteAddr, ":")[0])
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ─────────────────────────────── channels ───────────────────────────────
+
+// AlertChannelsListHandler — GET /api/v1/alerts/channels?env={id}&reveal={0|1}
+//
+// @Summary List alert channels
+// @Description Returns alert channel rows. Secrets are redacted unless reveal=1 is passed by an admin.
+// @Tags alerts
+// @Produce json
+// @Param env query int false "Environment ID; omit to list all"
+// @Param reveal query int false "Pass 1 to include secret fields (admin only)"
+// @Success 200 {array} alertChannelDTO
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/channels [get]
+func (h *HandlersApi) AlertChannelsListHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	envID, err := parseEnvFilter(r)
+	if err != nil {
+		apiErrorResponse(w, "invalid env filter", http.StatusBadRequest, err)
+		return
+	}
+	rows, err := mgr.ListChannels(envID)
+	if err != nil {
+		apiErrorResponse(w, "error listing alert channels", http.StatusInternalServerError, err)
+		return
+	}
+	reveal := parseReveal(r)
+	out := make([]alertChannelDTO, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toAlertChannelDTO(row, reveal))
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, out)
+}
+
+// AlertChannelsTypesHandler — GET /api/v1/alerts/channels/types
+//
+// @Summary List supported alert channel types
+// @Description Returns the channel type registry: type, description, whether the config carries secrets, and which JSON keys hold them.
+// @Tags alerts
+// @Produce json
+// @Success 200 {array} types.AlertChannelTypeSpec
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/channels/types [get]
+func (h *HandlersApi) AlertChannelsTypesHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	if _, ok := h.requireAlertsAdmin(w, r); !ok {
+		return
+	}
+	specs := make([]types.AlertChannelTypeSpec, 0, len(alerts.ChannelRegistry))
+	for _, typ := range alerts.SupportedChannelTypes() {
+		spec := alerts.ChannelRegistry[typ]
+		fields := make([]types.AlertFieldSpec, 0, len(spec.Fields))
+		for _, f := range spec.Fields {
+			fields = append(fields, types.AlertFieldSpec{
+				Name:        f.Name,
+				Label:       f.Label,
+				Type:        f.Type,
+				Required:    f.Required,
+				Placeholder: f.Placeholder,
+				Help:        f.Help,
+				Default:     f.Default,
+			})
+		}
+		specs = append(specs, types.AlertChannelTypeSpec{
+			Type:         spec.Type,
+			Description:  spec.Description,
+			HasSecret:    spec.HasSecret,
+			SecretFields: spec.SecretFields,
+			Fields:       fields,
+		})
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, specs)
+}
+
+// AlertChannelsGetHandler — GET /api/v1/alerts/channels/{id}?reveal={0|1}
+//
+// @Summary Get one alert channel
+// @Description Returns a single alert channel by ID. Secrets are redacted unless reveal=1.
+// @Tags alerts
+// @Produce json
+// @Param id path int true "Channel ID"
+// @Param reveal query int false "Pass 1 to include secret fields (admin only)"
+// @Success 200 {object} alertChannelDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/channels/{id} [get]
+func (h *HandlersApi) AlertChannelsGetHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	id, err := parseAlertID(r, "id")
+	if err != nil {
+		apiErrorResponse(w, "invalid channel id", http.StatusBadRequest, err)
+		return
+	}
+	row, err := mgr.GetChannel(id)
+	if err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toAlertChannelDTO(row, parseReveal(r)))
+}
+
+// AlertChannelsCreateHandler — POST /api/v1/alerts/channels
+//
+// @Summary Create an alert channel
+// @Description Creates a new notification channel. Config is validated against the channel type registry.
+// @Tags alerts
+// @Accept json
+// @Produce json
+// @Param request body types.AlertChannelCreateRequest true "Request body"
+// @Success 201 {object} alertChannelDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 409 {object} types.ApiErrorResponse "Conflict"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/channels [post]
+func (h *HandlersApi) AlertChannelsCreateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	var body types.AlertChannelCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	row, err := mgr.CreateChannel(alerts.AlertChannel{
+		Name:          body.Name,
+		EnvironmentID: body.EnvironmentID,
+		Type:          body.Type,
+		Enabled:       body.Enabled,
+		Config:        string(body.Config),
+		Info:          body.Info,
+	})
+	if err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("created alert channel %q (type %s, env %d)", row.Name, row.Type, row.EnvironmentID), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, toAlertChannelDTO(row, true))
+}
+
+// AlertChannelsUpdateHandler — PUT /api/v1/alerts/channels/{id}
+//
+// @Summary Update an alert channel
+// @Description Replaces an existing channel's mutable fields. A secret field set to "***" is merged from the previously stored value.
+// @Tags alerts
+// @Accept json
+// @Produce json
+// @Param id path int true "Channel ID"
+// @Param request body types.AlertChannelCreateRequest true "Request body"
+// @Success 200 {object} alertChannelDTO
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/channels/{id} [put]
+func (h *HandlersApi) AlertChannelsUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	id, err := parseAlertID(r, "id")
+	if err != nil {
+		apiErrorResponse(w, "invalid channel id", http.StatusBadRequest, err)
+		return
+	}
+	var body types.AlertChannelCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	prev, err := mgr.GetChannel(id)
+	if err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	merged, err := alerts.MergeChannelSecrets(prev.Type, prev.Config, string(body.Config))
+	if err != nil {
+		apiErrorResponse(w, "error merging channel secrets", http.StatusBadRequest, err)
+		return
+	}
+	row, err := mgr.UpdateChannel(id, alerts.AlertChannel{
+		Name:          body.Name,
+		EnvironmentID: body.EnvironmentID,
+		Type:          body.Type,
+		Enabled:       body.Enabled,
+		Config:        merged,
+		Info:          body.Info,
+	})
+	if err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("updated alert channel %q (type %s, env %d)", row.Name, row.Type, row.EnvironmentID), strings.Split(r.RemoteAddr, ":")[0])
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, toAlertChannelDTO(row, true))
+}
+
+// AlertChannelsDeleteHandler — DELETE /api/v1/alerts/channels/{id}
+//
+// @Summary Delete an alert channel
+// @Description Deletes an alert channel by ID. Rules referencing it keep the dangling ID and the dispatcher skips it; deletion takes effect on the next alert reload.
+// @Tags alerts
+// @Produce json
+// @Param id path int true "Channel ID"
+// @Success 204 "No content"
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 404 {object} types.ApiErrorResponse "Not found"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/channels/{id} [delete]
+func (h *HandlersApi) AlertChannelsDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	id, err := parseAlertID(r, "id")
+	if err != nil {
+		apiErrorResponse(w, "invalid channel id", http.StatusBadRequest, err)
+		return
+	}
+	if err := mgr.DeleteChannel(id); err != nil {
+		respondAlertsErr(w, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("deleted alert channel %d", id), strings.Split(r.RemoteAddr, ":")[0])
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ─────────────────────────────── history + apply ───────────────────────────────
+
+// AlertHistoryHandler — GET /api/v1/alerts/history?limit={n}
+//
+// @Summary Recent alert history
+// @Description Returns the most recent dispatched alerts, newest first, capped at 500.
+// @Tags alerts
+// @Produce json
+// @Param limit query int false "Maximum rows (default 100, max 500)"
+// @Success 200 {array} alerts.AlertHistory
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/history [get]
+func (h *HandlersApi) AlertHistoryHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	rows, err := mgr.RecentHistory(limit)
+	if err != nil {
+		apiErrorResponse(w, "error listing alert history", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.Visit(user, r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, rows)
+}
+
+// AlertsApplyHandler — POST /api/v1/alerts/apply
+//
+// @Summary Apply alert changes (hot reload)
+// @Description Queues a reload-alerts service command for osctrl-tls. The TLS process reloads its alert rule snapshot and resets the channel sender cache without restarting. The snapshot swap is atomic; in-flight matches finish against the old ruleset.
+// @Tags alerts
+// @Produce json
+// @Success 202 {object} types.ServiceConfigApplyResponse "Reload requested"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled or service commands unavailable"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/apply [post]
+func (h *HandlersApi) AlertsApplyHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	if h.Alerts == nil {
+		apiErrorResponse(w, "alerts not enabled", http.StatusServiceUnavailable, nil)
+		return
+	}
+	if h.ServiceCommands == nil {
+		apiErrorResponse(w, "service commands not available", http.StatusServiceUnavailable, nil)
+		return
+	}
+	cmd, err := h.ServiceCommands.Request(config.ServiceTLS, servicecommands.ActionReloadAlerts, user, strings.Split(r.RemoteAddr, ":")[0], alertsCommandTTL)
+	if err != nil {
+		apiErrorResponse(w, "error requesting tls alerts reload", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("apply alerts reload command %s", cmd.CommandID), strings.Split(r.RemoteAddr, ":")[0])
+	log.Info().Str("command", cmd.CommandID).Msgf("TLS alerts reload requested by %s", user)
+	resp := serviceCommandResponse(cmd)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusAccepted, types.ServiceConfigApplyResponse{
+		Service: config.ServiceTLS,
+		Message: "Reload requested. osctrl-tls will reload its alert rule snapshot and channel sender cache after consuming the service command.",
+		Command: &resp,
+	})
+}
+
+// ─────────────────────────────── helpers ───────────────────────────────
+
+func parseAlertID(r *http.Request, name string) (uint, error) {
+	v := r.PathValue(name)
+	if v == "" {
+		return 0, fmt.Errorf("missing %s", name)
+	}
+	n, err := strconv.ParseUint(v, 10, strconv.IntSize)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	return uint(n), nil
+}
+
+func respondAlertsErr(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, alerts.ErrRuleNotFound), errors.Is(err, alerts.ErrChannelNotFound):
+		apiErrorResponse(w, "not found", http.StatusNotFound, err)
+	case errors.Is(err, alerts.ErrRuleExists), errors.Is(err, alerts.ErrChannelExists):
+		apiErrorResponse(w, "already exists", http.StatusConflict, err)
+	case errors.Is(err, alerts.ErrInvalidSource), errors.Is(err, alerts.ErrInvalidChannelType), errors.Is(err, alerts.ErrInvalidChannelConfig):
+		apiErrorResponse(w, "invalid value", http.StatusBadRequest, err)
+	case errors.Is(err, alerts.ErrTooManyRules):
+		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		apiErrorResponse(w, "not found", http.StatusNotFound, err)
+	default:
+		apiErrorResponse(w, "error", http.StatusInternalServerError, err)
+	}
+}

--- a/cmd/api/handlers/alerts_test.go
+++ b/cmd/api/handlers/alerts_test.go
@@ -1,0 +1,253 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/alerts"
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/servicecommands"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupAlertsHandler(t *testing.T) *HandlersApi {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&alerts.AlertRule{}, &alerts.AlertChannel{}, &alerts.AlertHistory{}))
+	userManager := users.CreateUserManager(db)
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "alice", Admin: true}))
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "bob"})) // non-admin
+	auditLog, err := auditlog.CreateAuditLogManager(db, "osctrl-api", false)
+	require.NoError(t, err)
+	h := CreateHandlersApi(
+		WithUsers(userManager),
+		WithAuditLog(auditLog),
+		WithDebugHTTP(&config.YAMLConfigurationDebug{}),
+		WithAlerts(&alerts.Manager{DB: db}),
+		WithServiceCommands(servicecommands.NewManager(db)),
+	)
+	return h
+}
+
+func alertsCtx(user string) context.Context {
+	return context.WithValue(context.Background(), ContextKey(contextAPI), ContextValue{ctxUser: user})
+}
+
+// call executes a handler with the admin context and a JSON body.
+func call(t *testing.T, h http.HandlerFunc, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	return callPathValue(t, h, method, path, body, nil)
+}
+
+// callWithID executes a handler with the admin context and the {id}
+// path variable set.
+func callWithID(t *testing.T, h http.HandlerFunc, method, path string, id uint, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	return callPathValue(t, h, method, path, body, map[string]string{"id": strconv.FormatUint(uint64(id), 10)})
+}
+
+func callPathValue(t *testing.T, h http.HandlerFunc, method, path string, body any, vars map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(raw)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, reader).WithContext(alertsCtx("alice"))
+	for k, v := range vars {
+		req.SetPathValue(k, v)
+	}
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	return rr
+}
+
+func callAs(t *testing.T, h http.HandlerFunc, user, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil).WithContext(alertsCtx(user))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	return rr
+}
+
+func ruleBody() map[string]any {
+	return map[string]any{
+		"name": "sudoers-write", "environment_id": 0, "source": "result_log",
+		"match_type": "substring", "match_value": "/etc/sudoers",
+		"cooldown_minutes": 30, "channel_ids": []uint{1}, "enabled": true,
+	}
+}
+
+func TestAlertsRejectNonAdmin(t *testing.T) {
+	h := setupAlertsHandler(t)
+	require.Equal(t, http.StatusForbidden, callAs(t, h.AlertRulesListHandler, "bob", http.MethodGet, "/api/v1/alerts/rules").Code)
+	require.Equal(t, http.StatusForbidden, callAs(t, h.AlertChannelsListHandler, "bob", http.MethodGet, "/api/v1/alerts/channels").Code)
+}
+
+func TestAlertsDisabledReturns503(t *testing.T) {
+	h := setupAlertsHandler(t)
+	h.Alerts = nil
+	require.Equal(t, http.StatusServiceUnavailable, callAs(t, h.AlertRulesListHandler, "alice", http.MethodGet, "/api/v1/alerts/rules").Code)
+}
+
+func TestAlertRuleCRUDRoundTrip(t *testing.T) {
+	h := setupAlertsHandler(t)
+
+	// create
+	rr := call(t, h.AlertRulesCreateHandler, http.MethodPost, "/api/v1/alerts/rules", ruleBody())
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var created alertRuleDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+	require.Equal(t, "sudoers-write", created.Name)
+	require.Equal(t, []uint{1}, created.ChannelIDs)
+
+	// duplicate → 409
+	rr = call(t, h.AlertRulesCreateHandler, http.MethodPost, "/api/v1/alerts/rules", ruleBody())
+	require.Equal(t, http.StatusConflict, rr.Code)
+
+	// list
+	rr = call(t, h.AlertRulesListHandler, http.MethodGet, "/api/v1/alerts/rules", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var list []alertRuleDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &list))
+	require.Len(t, list, 1)
+
+	// get
+	rr = callWithID(t, h.AlertRuleGetHandler, http.MethodGet, "/api/v1/alerts/rules/{id}", created.ID, nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// update
+	rr = callWithID(t, h.AlertRulesUpdateHandler, http.MethodPut, "/api/v1/alerts/rules/{id}", created.ID, map[string]any{
+		"name": "sudoers-write", "environment_id": 0, "source": "result_log",
+		"match_type": "substring", "match_value": "/etc/sudoers.d",
+		"cooldown_minutes": 60, "enabled": false,
+	})
+	require.Equal(t, http.StatusOK, rr.Code)
+	var updated alertRuleDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &updated))
+	require.Equal(t, "/etc/sudoers.d", updated.MatchValue)
+	require.False(t, updated.Enabled)
+
+	// delete
+	rr = callWithID(t, h.AlertRulesDeleteHandler, http.MethodDelete, "/api/v1/alerts/rules/{id}", created.ID, nil)
+	require.Equal(t, http.StatusNoContent, rr.Code)
+
+	// get after delete → 404
+	rr = callWithID(t, h.AlertRuleGetHandler, http.MethodGet, "/api/v1/alerts/rules/{id}", created.ID, nil)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestAlertRuleCreateRejectsInvalidSource(t *testing.T) {
+	h := setupAlertsHandler(t)
+	body := map[string]any{
+		"name": "bad", "source": "carrier_pigeon",
+		"match_type": "substring", "match_value": "x",
+	}
+	rr := call(t, h.AlertRulesCreateHandler, http.MethodPost, "/api/v1/alerts/rules", body)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestAlertChannelCRUDRoundTrip(t *testing.T) {
+	h := setupAlertsHandler(t)
+
+	body := map[string]any{
+		"name": "soc-hook", "environment_id": 0, "type": "webhook", "enabled": true,
+		"config": map[string]any{"url": "https://hooks.example.com/x", "secret": "hunter2"},
+	}
+	// create
+	rr := call(t, h.AlertChannelsCreateHandler, http.MethodPost, "/api/v1/alerts/channels", body)
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var created alertChannelDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+	require.Equal(t, "soc-hook", created.Name)
+
+	// list without reveal → secret redacted
+	rr = call(t, h.AlertChannelsListHandler, http.MethodGet, "/api/v1/alerts/channels", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var list []alertChannelDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &list))
+	require.Len(t, list, 1)
+	var cfg map[string]any
+	require.NoError(t, json.Unmarshal(list[0].Config, &cfg))
+	require.Equal(t, "***", cfg["secret"])
+	require.Equal(t, "https://hooks.example.com/x", cfg["url"])
+
+	// list with reveal → secret visible
+	rr = call(t, h.AlertChannelsListHandler, http.MethodGet, "/api/v1/alerts/channels?reveal=1", nil)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &list))
+	require.NoError(t, json.Unmarshal(list[0].Config, &cfg))
+	require.Equal(t, "hunter2", cfg["secret"])
+
+	// update with redacted placeholder → secret preserved
+	rr = callWithID(t, h.AlertChannelsUpdateHandler, http.MethodPut, "/api/v1/alerts/channels/{id}", created.ID, map[string]any{
+		"name": "soc-hook", "environment_id": 0, "type": "webhook", "enabled": true,
+		"config": map[string]any{"url": "https://hooks.example.com/y", "secret": "***"},
+	})
+	require.Equal(t, http.StatusOK, rr.Code)
+	var updated alertChannelDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &updated))
+	require.NoError(t, json.Unmarshal(updated.Config, &cfg))
+	require.Equal(t, "https://hooks.example.com/y", cfg["url"])
+	require.Equal(t, "hunter2", cfg["secret"], "placeholder must merge the stored secret")
+}
+
+func TestAlertChannelRejectsBadConfig(t *testing.T) {
+	h := setupAlertsHandler(t)
+	body := map[string]any{
+		"name": "broken", "type": "webhook", "enabled": true,
+		"config": "{not json",
+	}
+	rr := call(t, h.AlertChannelsCreateHandler, http.MethodPost, "/api/v1/alerts/channels", body)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestAlertChannelTypesHandler(t *testing.T) {
+	h := setupAlertsHandler(t)
+	rr := call(t, h.AlertChannelsTypesHandler, http.MethodGet, "/api/v1/alerts/channels/types", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var specs []struct {
+		Type         string   `json:"type"`
+		HasSecret    bool     `json:"has_secret"`
+		SecretFields []string `json:"secret_fields"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &specs))
+	require.Len(t, specs, 2)
+}
+
+func TestAlertHistoryHandler(t *testing.T) {
+	h := setupAlertsHandler(t)
+	require.NoError(t, h.Alerts.RecordHistory(alerts.AlertHistory{RuleName: "r", Entity: "e", Detail: "d"}))
+	rr := call(t, h.AlertHistoryHandler, http.MethodGet, "/api/v1/alerts/history", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var rows []alerts.AlertHistory
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	require.Equal(t, "r", rows[0].RuleName)
+}
+
+func TestAlertsApplyQueuesServiceCommand(t *testing.T) {
+	h := setupAlertsHandler(t)
+	rr := call(t, h.AlertsApplyHandler, http.MethodPost, "/api/v1/alerts/apply", nil)
+	require.Equal(t, http.StatusAccepted, rr.Code)
+
+	// The command must be consumable by osctrl-tls.
+	cmd, ok, err := h.ServiceCommands.ConsumeNext(config.ServiceTLS, "osctrl-tls", time.Now())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, servicecommands.ActionReloadAlerts, cmd.Action)
+}

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/jmpsec/osctrl/pkg/alerts"
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/authproviders"
 	"github.com/jmpsec/osctrl/pkg/backend"
@@ -54,6 +55,10 @@ type HandlersApi struct {
 	// enabled. nil when ServiceConfigEnabled is false — the routes are
 	// not registered in that case.
 	LogSinks *logsinks.LogSinksManager
+	// Alerts manages the alert_rules / alert_channels / alert_history
+	// tables when --alerts-enabled is set. nil otherwise — the alert
+	// routes are not registered in that case.
+	Alerts *alerts.Manager
 	// AuthProviders holds the live multi-provider registry (OIDC + SAML).
 	AuthProviders        *AuthProviderRegistry
 	AuthProviderMgr      *authproviders.AuthProviderManager
@@ -204,6 +209,15 @@ func WithServiceConfig(mgr *serviceconfig.ServiceConfigManager) HandlersOption {
 func WithLogSinks(mgr *logsinks.LogSinksManager) HandlersOption {
 	return func(h *HandlersApi) {
 		h.LogSinks = mgr
+	}
+}
+
+// WithAlerts wires the alerts manager. Only meaningful when
+// AlertsEnabled is also true; the routes are gated on that flag in
+// cmd/api/main.go.
+func WithAlerts(mgr *alerts.Manager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.Alerts = mgr
 	}
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -109,6 +109,7 @@ const (
 	apiServiceConfigPath = "/service-config"
 	// API log sinks path
 	apiLogSinksPath      = "/log-sinks"
+	apiAlertsPath        = "/alerts"
 	apiAuthProvidersPath = "/auth-providers"
 	// API features path
 	apiFeaturesPath = "/features"
@@ -368,10 +369,10 @@ func osctrlAPIService() {
 	}
 	// Alerting subsystem (disabled by default). When disabled the
 	// alert tables are not created and the alert API routes are not
-	// registered. Stage 4 wires the rule/channel CRUD handlers here.
+	// registered.
+	var alertsMgr *alerts.Manager
 	if flagParams.Service.AlertsEnabled {
-		alertsMgr := alerts.NewManager(db.Conn)
-		_ = alertsMgr // consumed by the alert routes in Stage 4
+		alertsMgr = alerts.NewManager(db.Conn)
 		log.Info().Msg("Alerting system enabled")
 	} else {
 		log.Info().Msg("Alerting system disabled (enable with --alerts-enabled)")
@@ -578,6 +579,7 @@ func osctrlAPIService() {
 		handlers.WithSettings(settingsmgr),
 		handlers.WithServiceConfig(serviceConfigMgr),
 		handlers.WithLogSinks(logSinksMgr),
+		handlers.WithAlerts(alertsMgr),
 		handlers.WithAuthProviders(authProviderRegistry, authProvidersMgr),
 		handlers.WithServiceConfigEnabled(flagParams.Service.ServiceConfigEnabled),
 		handlers.WithLogSinksEnabled(logSinksEnabled),
@@ -1120,6 +1122,52 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"POST "+_apiPath(apiLogSinksPath)+"/apply",
 			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.LogSinksApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
+	}
+
+	// API: alerting. Gated by --alerts-enabled; when the flag is off the
+	// routes are absent and the tables were never created. The apply
+	// endpoint reuses the restart rate limiter — an alerts reload is the
+	// same class of privileged service-command operation.
+	if alertsMgr != nil {
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAlertsPath)+"/rules",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertRulesListHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAlertsPath)+"/rules/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertRuleGetHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiAlertsPath)+"/rules",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertRulesCreateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"PUT "+_apiPath(apiAlertsPath)+"/rules/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertRulesUpdateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"DELETE "+_apiPath(apiAlertsPath)+"/rules/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertRulesDeleteHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAlertsPath)+"/channels",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsListHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAlertsPath)+"/channels/types",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsTypesHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAlertsPath)+"/channels/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsGetHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiAlertsPath)+"/channels",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsCreateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"PUT "+_apiPath(apiAlertsPath)+"/channels/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsUpdateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"DELETE "+_apiPath(apiAlertsPath)+"/channels/{id}",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsDeleteHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"GET "+_apiPath(apiAlertsPath)+"/history",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertHistoryHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
+			"POST "+_apiPath(apiAlertsPath)+"/apply",
+			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.AlertsApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
 	}
 
 	// API: auth providers. Independently gated by

--- a/cmd/cli/alert.go
+++ b/cmd/cli/alert.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/jmpsec/osctrl/pkg/alerts"
+	"github.com/olekukonko/tablewriter"
+	"github.com/urfave/cli/v3"
+)
+
+// alert.go — actions behind the `alert` CLI command group (API mode only).
+
+func requireAPI() error {
+	if dbFlag || !apiFlag {
+		return fmt.Errorf("alert management requires --api mode (run against osctrl-api)")
+	}
+	return nil
+}
+
+func alertRulesList(ctx context.Context, cmd *cli.Command) error {
+	if err := requireAPI(); err != nil {
+		return err
+	}
+	rules, err := osctrlAPI.GetAlertRules()
+	if err != nil {
+		return fmt.Errorf("❌ %w", err)
+	}
+	header := []string{"ID", "Name", "Env", "Source", "Match", "Field", "Pattern", "Cooldown", "Channels", "Enabled"}
+	switch formatFlag {
+	case jsonFormat:
+		raw, err := json.Marshal(rules)
+		if err != nil {
+			return fmt.Errorf("error marshaling - %w", err)
+		}
+		fmt.Println(string(raw))
+	case csvFormat:
+		data := [][]string{header}
+		for _, r := range rules {
+			data = append(data, ruleToRow(r, false))
+		}
+		w := csv.NewWriter(os.Stdout)
+		if err := w.WriteAll(data); err != nil {
+			return fmt.Errorf("error writing csv - %w", err)
+		}
+	default:
+		table := tablewriter.NewWriter(os.Stdout)
+		table.Header(stringSliceToAnySlice(header)...)
+		if len(rules) > 0 {
+			fmt.Printf("Existing alert rules (%d):\n", len(rules))
+			for _, r := range rules {
+				if err := table.Append(ruleToRow(r, true)); err != nil {
+					return fmt.Errorf("❌ error appending row - %w", err)
+				}
+			}
+		} else {
+			fmt.Println("No alert rules")
+		}
+		if err := table.Render(); err != nil {
+			return fmt.Errorf("❌ error rendering table - %w", err)
+		}
+	}
+	return nil
+}
+
+func ruleToRow(r alertRuleJSON, _ bool) []string {
+	return []string{
+		strconv.FormatUint(uint64(r.ID), 10),
+		r.Name,
+		strconv.FormatUint(uint64(r.EnvironmentID), 10),
+		r.Source,
+		r.MatchType,
+		r.MatchField,
+		r.MatchValue,
+		strconv.Itoa(r.CooldownMinutes),
+		strings.Join(uintsToStrings(r.ChannelIDs), ","),
+		boolTag(r.Enabled),
+	}
+}
+
+func uintsToStrings(ids []uint) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, strconv.FormatUint(uint64(id), 10))
+	}
+	return out
+}
+
+func alertRuleCreate(ctx context.Context, cmd *cli.Command) error {
+	if err := requireAPI(); err != nil {
+		return err
+	}
+	name := cmd.String("name")
+	source := cmd.String("source")
+	matchValue := cmd.String("match-value")
+	if name == "" || source == "" || matchValue == "" {
+		return fmt.Errorf("❌ --name, --source and --match-value are required")
+	}
+	var channelIDs []uint
+	for _, part := range strings.Split(cmd.String("channels"), ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		id, err := strconv.ParseUint(part, 10, strconv.IntSize)
+		if err != nil {
+			return fmt.Errorf("❌ invalid channel id %q", part)
+		}
+		channelIDs = append(channelIDs, uint(id))
+	}
+	rule := alerts.AlertRule{
+		Name:            name,
+		Source:          source,
+		MatchType:       cmd.String("match-type"),
+		MatchField:      cmd.String("match-field"),
+		MatchValue:      matchValue,
+		CooldownMinutes: int(cmd.Int("cooldown")),
+		ChannelIDs:      alerts.EncodeChannelIDs(channelIDs),
+		Enabled:         cmd.Bool("enabled"),
+	}
+	if err := osctrlAPI.CreateAlertRule(rule); err != nil {
+		return fmt.Errorf("❌ %w", err)
+	}
+	fmt.Printf("✅ Created alert rule %q — run `osctrl-cli alert apply` to hot-reload osctrl-tls\n", name)
+	return nil
+}
+
+func alertRuleDelete(ctx context.Context, cmd *cli.Command) error {
+	if err := requireAPI(); err != nil {
+		return err
+	}
+	id := cmd.Uint("id")
+	if id == 0 {
+		return fmt.Errorf("❌ --id is required")
+	}
+	if err := osctrlAPI.DeleteAlertRule(id); err != nil {
+		return fmt.Errorf("❌ %w", err)
+	}
+	fmt.Printf("✅ Deleted alert rule %d — run `osctrl-cli alert apply` to hot-reload osctrl-tls\n", id)
+	return nil
+}
+
+func alertChannelsList(ctx context.Context, cmd *cli.Command) error {
+	if err := requireAPI(); err != nil {
+		return err
+	}
+	channels, err := osctrlAPI.GetAlertChannels()
+	if err != nil {
+		return fmt.Errorf("❌ %w", err)
+	}
+	header := []string{"ID", "Name", "Env", "Type", "Enabled", "Config"}
+	switch formatFlag {
+	case jsonFormat:
+		raw, err := json.Marshal(channels)
+		if err != nil {
+			return fmt.Errorf("error marshaling - %w", err)
+		}
+		fmt.Println(string(raw))
+	case csvFormat:
+		data := [][]string{header}
+		for _, c := range channels {
+			data = append(data, channelToRow(c))
+		}
+		w := csv.NewWriter(os.Stdout)
+		if err := w.WriteAll(data); err != nil {
+			return fmt.Errorf("error writing csv - %w", err)
+		}
+	default:
+		table := tablewriter.NewWriter(os.Stdout)
+		table.Header(stringSliceToAnySlice(header)...)
+		if len(channels) > 0 {
+			fmt.Printf("Existing alert channels (%d):\n", len(channels))
+			for _, c := range channels {
+				if err := table.Append(channelToRow(c)); err != nil {
+					return fmt.Errorf("❌ error appending row - %w", err)
+				}
+			}
+		} else {
+			fmt.Println("No alert channels")
+		}
+		if err := table.Render(); err != nil {
+			return fmt.Errorf("❌ error rendering table - %w", err)
+		}
+	}
+	return nil
+}
+
+func channelToRow(c alertChannelJSON) []string {
+	return []string{
+		strconv.FormatUint(uint64(c.ID), 10),
+		c.Name,
+		strconv.FormatUint(uint64(c.EnvironmentID), 10),
+		c.Type,
+		boolTag(c.Enabled),
+		string(c.Config),
+	}
+}
+
+func alertChannelCreate(ctx context.Context, cmd *cli.Command) error {
+	if err := requireAPI(); err != nil {
+		return err
+	}
+	name := cmd.String("name")
+	typ := cmd.String("type")
+	configJSON := cmd.String("config")
+	if name == "" || typ == "" || configJSON == "" {
+		return fmt.Errorf("❌ --name, --type and --config are required")
+	}
+	if err := alerts.ValidateChannelConfig(typ, configJSON); err != nil {
+		return fmt.Errorf("❌ %w", err)
+	}
+	if err := osctrlAPI.CreateAlertChannel(name, typ, configJSON, 0, cmd.Bool("enabled")); err != nil {
+		return fmt.Errorf("❌ %w", err)
+	}
+	fmt.Printf("✅ Created alert channel %q — run `osctrl-cli alert apply` to hot-reload osctrl-tls\n", name)
+	return nil
+}
+
+func alertChannelDelete(ctx context.Context, cmd *cli.Command) error {
+	if err := requireAPI(); err != nil {
+		return err
+	}
+	id := cmd.Uint("id")
+	if id == 0 {
+		return fmt.Errorf("❌ --id is required")
+	}
+	if err := osctrlAPI.DeleteAlertChannel(id); err != nil {
+		return fmt.Errorf("❌ %w", err)
+	}
+	fmt.Printf("✅ Deleted alert channel %d — run `osctrl-cli alert apply` to hot-reload osctrl-tls\n", id)
+	return nil
+}
+
+func alertsApply(ctx context.Context, cmd *cli.Command) error {
+	if err := requireAPI(); err != nil {
+		return err
+	}
+	if err := osctrlAPI.ApplyAlerts(); err != nil {
+		return fmt.Errorf("❌ %w", err)
+	}
+	fmt.Println("✅ Alert reload requested — osctrl-tls will pick up the changes")
+	return nil
+}

--- a/cmd/cli/api-alerts.go
+++ b/cmd/cli/api-alerts.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strconv"
+
+	"github.com/jmpsec/osctrl/pkg/alerts"
+)
+
+// api-alerts.go — REST wrappers for the alerts management API.
+//
+// Routes:
+//   GET    /api/v1/alerts/rules[?env={id}]
+//   GET    /api/v1/alerts/rules/{id}
+//   POST   /api/v1/alerts/rules
+//   PUT    /api/v1/alerts/rules/{id}
+//   DELETE /api/v1/alerts/rules/{id}
+//   GET    /api/v1/alerts/channels[?env={id}&reveal={0|1}]
+//   GET    /api/v1/alerts/channels/types
+//   GET    /api/v1/alerts/channels/{id}
+//   POST   /api/v1/alerts/channels
+//   PUT    /api/v1/alerts/channels/{id}
+//   DELETE /api/v1/alerts/channels/{id}
+//   GET    /api/v1/alerts/history[?limit={n}]
+//   POST   /api/v1/alerts/apply
+
+// alertRuleJSON mirrors the API DTO.
+type alertRuleJSON struct {
+	ID              uint   `json:"id"`
+	Name            string `json:"name"`
+	EnvironmentID   uint   `json:"environment_id"`
+	Source          string `json:"source"`
+	MatchType       string `json:"match_type"`
+	MatchField      string `json:"match_field"`
+	MatchValue      string `json:"match_value"`
+	StatusSeverity  string `json:"status_severity"`
+	CooldownMinutes int    `json:"cooldown_minutes"`
+	ChannelIDs      []uint `json:"channel_ids"`
+	Enabled         bool   `json:"enabled"`
+	Info            string `json:"info"`
+}
+
+// alertChannelJSON mirrors the API DTO (config decoded).
+type alertChannelJSON struct {
+	ID            uint            `json:"id"`
+	Name          string          `json:"name"`
+	EnvironmentID uint            `json:"environment_id"`
+	Type          string          `json:"type"`
+	Enabled       bool            `json:"enabled"`
+	Config        json.RawMessage `json:"config"`
+	Info          string          `json:"info"`
+}
+
+// GetAlertRules lists alert rules.
+func (api *OsctrlAPI) GetAlertRules() ([]alertRuleJSON, error) {
+	var rules []alertRuleJSON
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "rules"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return rules, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &rules); err != nil {
+		return rules, fmt.Errorf("can not parse body - %w", err)
+	}
+	return rules, nil
+}
+
+// CreateAlertRule creates an alert rule.
+func (api *OsctrlAPI) CreateAlertRule(rule alerts.AlertRule) error {
+	body := struct {
+		Name            string `json:"name"`
+		EnvironmentID   uint   `json:"environment_id"`
+		Source          string `json:"source"`
+		MatchType       string `json:"match_type"`
+		MatchField      string `json:"match_field,omitempty"`
+		MatchValue      string `json:"match_value"`
+		StatusSeverity  string `json:"status_severity,omitempty"`
+		CooldownMinutes int    `json:"cooldown_minutes,omitempty"`
+		ChannelIDs      []uint `json:"channel_ids,omitempty"`
+		Enabled         bool   `json:"enabled"`
+		Info            string `json:"info,omitempty"`
+	}{
+		Name: rule.Name, EnvironmentID: rule.EnvironmentID, Source: rule.Source,
+		MatchType: rule.MatchType, MatchField: rule.MatchField, MatchValue: rule.MatchValue,
+		StatusSeverity: rule.StatusSeverity, CooldownMinutes: rule.CooldownMinutes,
+		ChannelIDs: alerts.DecodeChannelIDsOrEmpty(rule.ChannelIDs), Enabled: rule.Enabled, Info: rule.Info,
+	}
+	jsonMessage, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("error marshaling data - %w", err)
+	}
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "rules"))
+	raw, err := api.PostGeneric(reqURL, bytes.NewReader(jsonMessage))
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return nil
+}
+
+// DeleteAlertRule removes an alert rule by ID.
+func (api *OsctrlAPI) DeleteAlertRule(id uint) error {
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "rules", strconv.FormatUint(uint64(id), 10)))
+	raw, err := api.ReqGeneric("DELETE", reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return nil
+}
+
+// GetAlertChannels lists alert channels.
+func (api *OsctrlAPI) GetAlertChannels() ([]alertChannelJSON, error) {
+	var channels []alertChannelJSON
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "channels"))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return channels, fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	if err := json.Unmarshal(raw, &channels); err != nil {
+		return channels, fmt.Errorf("can not parse body - %w", err)
+	}
+	return channels, nil
+}
+
+// CreateAlertChannel creates a notification channel.
+func (api *OsctrlAPI) CreateAlertChannel(name, typ, configJSON string, envID uint, enabled bool) error {
+	body := struct {
+		Name          string          `json:"name"`
+		EnvironmentID uint            `json:"environment_id"`
+		Type          string          `json:"type"`
+		Enabled       bool            `json:"enabled"`
+		Config        json.RawMessage `json:"config"`
+	}{
+		Name: name, EnvironmentID: envID, Type: typ, Enabled: enabled,
+		Config: json.RawMessage(configJSON),
+	}
+	jsonMessage, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("error marshaling data - %w", err)
+	}
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "channels"))
+	raw, err := api.PostGeneric(reqURL, bytes.NewReader(jsonMessage))
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return nil
+}
+
+// DeleteAlertChannel removes a channel by ID.
+func (api *OsctrlAPI) DeleteAlertChannel(id uint) error {
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "channels", strconv.FormatUint(uint64(id), 10)))
+	raw, err := api.ReqGeneric("DELETE", reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return nil
+}
+
+// ApplyAlerts queues the reload-alerts service command for osctrl-tls.
+func (api *OsctrlAPI) ApplyAlerts() error {
+	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "apply"))
+	raw, err := api.PostGeneric(reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("error api request - %w - %s", err, string(raw))
+	}
+	return nil
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -261,6 +261,75 @@ func init() {
 			Action: cliWrapper(auditLogs),
 		},
 		{
+			Name:  "alert",
+			Usage: "Commands for the alerting system",
+			Commands: []*cli.Command{
+				{
+					Name:    "rules",
+					Aliases: []string{"r"},
+					Usage:   "List alert rules",
+					Action:  cliWrapper(alertRulesList),
+				},
+				{
+					Name:    "rule-create",
+					Aliases: []string{"rc"},
+					Usage:   "Create an alert rule",
+					Flags: []cli.Flag{
+						&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Usage: "Rule name"},
+						&cli.StringFlag{Name: "source", Aliases: []string{"s"}, Usage: "Source: result_log | status_log | query_log | node_inactive | node_recovered"},
+						&cli.StringFlag{Name: "match-type", Aliases: []string{"m"}, Value: "substring", Usage: "Match type: substring | regex"},
+						&cli.StringFlag{Name: "match-field", Usage: "Field to match (empty = any field)"},
+						&cli.StringFlag{Name: "match-value", Aliases: []string{"v"}, Usage: "Pattern to match"},
+						&cli.IntFlag{Name: "cooldown", Value: 0, Usage: "Cooldown minutes between repeat alerts"},
+						&cli.StringFlag{Name: "channels", Usage: "Comma-separated channel IDs"},
+						&cli.BoolFlag{Name: "enabled", Value: true, Usage: "Create the rule enabled"},
+					},
+					Action: cliWrapper(alertRuleCreate),
+				},
+				{
+					Name:    "rule-delete",
+					Aliases: []string{"rd"},
+					Usage:   "Delete an alert rule by ID",
+					Flags: []cli.Flag{
+						&cli.UintFlag{Name: "id", Usage: "Rule ID"},
+					},
+					Action: cliWrapper(alertRuleDelete),
+				},
+				{
+					Name:    "channels",
+					Aliases: []string{"c"},
+					Usage:   "List alert channels",
+					Action:  cliWrapper(alertChannelsList),
+				},
+				{
+					Name:    "channel-create",
+					Aliases: []string{"cc"},
+					Usage:   "Create an alert channel",
+					Flags: []cli.Flag{
+						&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Usage: "Channel name"},
+						&cli.StringFlag{Name: "type", Aliases: []string{"t"}, Usage: "Channel type: webhook | email"},
+						&cli.StringFlag{Name: "config", Usage: "Channel config as JSON"},
+						&cli.BoolFlag{Name: "enabled", Value: true, Usage: "Create the channel enabled"},
+					},
+					Action: cliWrapper(alertChannelCreate),
+				},
+				{
+					Name:    "channel-delete",
+					Aliases: []string{"cd"},
+					Usage:   "Delete an alert channel by ID",
+					Flags: []cli.Flag{
+						&cli.UintFlag{Name: "id", Usage: "Channel ID"},
+					},
+					Action: cliWrapper(alertChannelDelete),
+				},
+				{
+					Name:   "apply",
+					Usage:  "Apply alert changes (hot-reload rules and channels in osctrl-tls)",
+					Action: cliWrapper(alertsApply),
+				},
+			},
+		},
+		{
 			Name:  "carve",
 			Usage: "Commands for file carves",
 			Commands: []*cli.Command{

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -540,7 +540,7 @@ func osctrlService() {
 		srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
 	}
 	watchCtx, stopCommandWatcher := context.WithCancel(context.Background())
-	go watchServiceCommands(watchCtx, serviceCommandMgr, serviceConfigMgr, logSinksMgr, loggerTLS, settingsmgr, auditLog, restartCh)
+	go watchServiceCommands(watchCtx, serviceCommandMgr, serviceConfigMgr, logSinksMgr, loggerTLS, settingsmgr, auditLog, alertsReloadFn(alertsMgr, alertsStore, alertsDispatcher), restartCh)
 	serverErr := make(chan error, 1)
 	go func() {
 		log.Info().Msgf("%s v%s - HTTP%s listening %s", serviceName, buildVersion, map[bool]string{true: "S", false: ""}[flagParams.TLS.Termination], serviceListener)
@@ -604,7 +604,24 @@ func watchAlertRules(stop <-chan struct{}, mgr *alerts.Manager, store *alerts.St
 	}
 }
 
-func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfgMgr *serviceconfig.ServiceConfigManager, sinksMgr *logsinks.LogSinksManager, logTLS *logging.LoggerTLS, settingsMgr *settings.Settings, auditLog *auditlog.AuditLogManager, restartCh chan<- struct{}) {
+// alertsReloadFn returns a no-arg reload closure for the alerting
+// subsystem, or nil when alerts are disabled (the service-command
+// watcher then ignores reload-alerts commands).
+func alertsReloadFn(mgr *alerts.Manager, store *alerts.Store, dispatcher *alerts.Dispatcher) func() {
+	if mgr == nil || store == nil {
+		return nil
+	}
+	return func() {
+		if err := mgr.LoadSnapshot(store); err != nil {
+			log.Err(err).Msg("error reloading alert rule snapshot")
+		}
+		if dispatcher != nil {
+			dispatcher.Reset()
+		}
+	}
+}
+
+func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfgMgr *serviceconfig.ServiceConfigManager, sinksMgr *logsinks.LogSinksManager, logTLS *logging.LoggerTLS, settingsMgr *settings.Settings, auditLog *auditlog.AuditLogManager, reloadAlerts func(), restartCh chan<- struct{}) {
 	ticker := time.NewTicker(serviceCommandPollInterval)
 	defer ticker.Stop()
 	for {
@@ -658,6 +675,17 @@ func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfg
 				logTLS.ReplaceExporters(newExporters)
 				auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls reload-log-sinks command %s consumed", cmd.CommandID), "local")
 				log.Info().Str("command", cmd.CommandID).Msg("Hot-reloaded log sinks")
+			case servicecommands.ActionReloadAlerts:
+				// Hot-reload alert rules + channel sender cache. The
+				// snapshot swap is atomic; in-flight matches finish
+				// against the old ruleset.
+				if reloadAlerts == nil {
+					log.Warn().Str("command", cmd.CommandID).Msg("reload-alerts ignored — alerting is disabled")
+					continue
+				}
+				reloadAlerts()
+				auditLog.SettingsAction(cmd.RequestedBy, fmt.Sprintf("tls reload-alerts command %s consumed", cmd.CommandID), "local")
+				log.Info().Str("command", cmd.CommandID).Msg("Hot-reloaded alert rules")
 			default:
 				log.Warn().Str("command", cmd.CommandID).Msgf("Ignoring unknown TLS service command action %q", cmd.Action)
 			}

--- a/pkg/alerts/channels.go
+++ b/pkg/alerts/channels.go
@@ -121,19 +121,23 @@ func ValidateChannelType(typ string) bool {
 func ValidateChannelConfig(typ, cfgJSON string) error {
 	spec, ok := ChannelRegistry[normalizeChannelType(typ)]
 	if !ok {
-		return ErrInvalidChannelType
+		return fmt.Errorf("%w: %q", ErrInvalidChannelType, typ)
 	}
 	if cfgJSON == "" {
 		cfgJSON = "{}"
 	}
 	if _, err := spec.Decode(json.RawMessage(cfgJSON)); err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrInvalidChannelConfig, err)
 	}
 	return nil
 }
 
 // ErrInvalidChannelType is returned for unregistered channel types.
 var ErrInvalidChannelType = fmt.Errorf("invalid channel type")
+
+// ErrInvalidChannelConfig is returned when the config JSON fails to
+// decode against the registered type.
+var ErrInvalidChannelConfig = fmt.Errorf("invalid channel configuration")
 
 func normalizeChannelType(typ string) string {
 	return strings.ToLower(strings.TrimSpace(typ))
@@ -152,4 +156,69 @@ func decodeTyped[T any]() func(json.RawMessage) (any, error) {
 		}
 		return &cfg, nil
 	}
+}
+
+// secretPlaceholder is what redacted secret fields read back as.
+const secretPlaceholder = "***"
+
+// RedactedChannelConfig returns the Config JSON with secret fields
+// replaced by "***" for the channel Type. Non-secret types return the
+// raw config unchanged. Best-effort: undecodable configs pass through.
+func RedactedChannelConfig(typ, cfgJSON string) string {
+	spec, ok := ChannelRegistry[normalizeChannelType(typ)]
+	if !ok || !spec.HasSecret || len(spec.SecretFields) == 0 {
+		return cfgJSON
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(cfgJSON), &obj); err != nil {
+		return cfgJSON
+	}
+	for _, key := range spec.SecretFields {
+		if _, present := obj[key]; present {
+			obj[key] = secretPlaceholder
+		}
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return cfgJSON
+	}
+	return string(out)
+}
+
+// MergeChannelSecrets replaces "***" placeholder values in newCfg with
+// the corresponding values from prevCfg, so an API update that did not
+// touch a secret preserves the stored one instead of writing the
+// placeholder.
+func MergeChannelSecrets(typ, prevCfgJSON, newCfgJSON string) (string, error) {
+	spec, ok := ChannelRegistry[normalizeChannelType(typ)]
+	if !ok || !spec.HasSecret || len(spec.SecretFields) == 0 {
+		return newCfgJSON, nil
+	}
+	var prev, next map[string]any
+	if err := json.Unmarshal([]byte(prevCfgJSON), &prev); err != nil {
+		return "", fmt.Errorf("decode prev config: %w", err)
+	}
+	if err := json.Unmarshal([]byte(newCfgJSON), &next); err != nil {
+		return "", fmt.Errorf("decode new config: %w", err)
+	}
+	for _, key := range spec.SecretFields {
+		v, ok := next[key]
+		if !ok {
+			continue
+		}
+		s, isStr := v.(string)
+		if !isStr {
+			continue
+		}
+		if s == secretPlaceholder || s == "" {
+			if pv, pok := prev[key]; pok {
+				next[key] = pv
+			}
+		}
+	}
+	out, err := json.Marshal(next)
+	if err != nil {
+		return "", fmt.Errorf("encode merged config: %w", err)
+	}
+	return string(out), nil
 }

--- a/pkg/alerts/validate.go
+++ b/pkg/alerts/validate.go
@@ -59,6 +59,28 @@ func ValidateRule(rule AlertRule) error {
 	return nil
 }
 
+// DecodeChannelIDs parses the JSON channel-ID array. Empty string /
+// null decodes to nil.
+func DecodeChannelIDs(raw string) ([]uint, error) {
+	return decodeChannels(raw)
+}
+
+// EncodeChannelIDs serializes channel IDs for storage.
+func EncodeChannelIDs(ids []uint) string {
+	return encodeChannels(ids)
+}
+
+// DecodeChannelIDsOrEmpty parses the channel-ID array and returns an
+// empty slice on any error — a convenience for API clients that only
+// need display values.
+func DecodeChannelIDsOrEmpty(raw string) []uint {
+	ids, err := decodeChannels(raw)
+	if err != nil || ids == nil {
+		return []uint{}
+	}
+	return ids
+}
+
 // decodeChannels parses the JSON channel-ID array. Empty string / null
 // decodes to nil.
 func decodeChannels(raw string) ([]uint, error) {

--- a/pkg/servicecommands/servicecommands.go
+++ b/pkg/servicecommands/servicecommands.go
@@ -31,6 +31,11 @@ const (
 	// it in without restarting. Users mid-login may see a transient
 	// error and can retry.
 	ActionReloadAuthProviders = "reload-auth-providers"
+	// ActionReloadAlerts asks osctrl-tls to reload its alert rule
+	// snapshot and reset the channel sender cache without restarting.
+	// The swap is atomic (copy-on-write snapshot), so in-flight matches
+	// finish against the old ruleset while new logs pick up the new one.
+	ActionReloadAlerts = "reload-alerts"
 
 	StatusPending   = "pending"
 	StatusConsumed  = "consumed"
@@ -51,6 +56,7 @@ var validActions = map[string]struct{}{
 	ActionPersistConfig:       {},
 	ActionReloadLogSinks:      {},
 	ActionReloadAuthProviders: {},
+	ActionReloadAlerts:        {},
 }
 
 // ServiceCommand is a one-shot control request for another osctrl service.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -718,3 +718,54 @@ type LogSinkCloneRequest struct {
 	TargetEnvironmentID uint `json:"target_environment_id"`
 	Overwrite           bool `json:"overwrite"`
 }
+
+// ─────────────────────────────── alerts ───────────────────────────────
+
+// AlertRuleCreateRequest is the body for POST /api/v1/alerts/rules and
+// PUT /api/v1/alerts/rules/{id}. All fields are required on update.
+type AlertRuleCreateRequest struct {
+	Name            string `json:"name"`
+	EnvironmentID   uint   `json:"environment_id"`
+	Source          string `json:"source"`
+	MatchType       string `json:"match_type"`
+	MatchField      string `json:"match_field,omitempty"`
+	MatchValue      string `json:"match_value"`
+	StatusSeverity  string `json:"status_severity,omitempty"`
+	CooldownMinutes int    `json:"cooldown_minutes,omitempty"`
+	ChannelIDs      []uint `json:"channel_ids,omitempty"`
+	Enabled         bool   `json:"enabled"`
+	Info            string `json:"info,omitempty"`
+}
+
+// AlertChannelCreateRequest is the body for POST /api/v1/alerts/channels
+// and PUT /api/v1/alerts/channels/{id}. A secret field set to "***" on
+// update is merged from the previously stored value by the handler.
+type AlertChannelCreateRequest struct {
+	Name          string          `json:"name"`
+	EnvironmentID uint            `json:"environment_id"`
+	Type          string          `json:"type"`
+	Enabled       bool            `json:"enabled"`
+	Config        json.RawMessage `json:"config"`
+	Info          string          `json:"info,omitempty"`
+}
+
+// AlertFieldSpec is one field in an alert channel type's config schema.
+type AlertFieldSpec struct {
+	Name        string `json:"name"`
+	Label       string `json:"label"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+	Placeholder string `json:"placeholder,omitempty"`
+	Help        string `json:"help,omitempty"`
+	Default     any    `json:"default,omitempty"`
+}
+
+// AlertChannelTypeSpec is one entry in the GET /api/v1/alerts/channels/types
+// response.
+type AlertChannelTypeSpec struct {
+	Type         string           `json:"type"`
+	Description  string           `json:"description"`
+	HasSecret    bool             `json:"has_secret"`
+	SecretFields []string         `json:"secret_fields,omitempty"`
+	Fields       []AlertFieldSpec `json:"fields,omitempty"`
+}


### PR DESCRIPTION
## Alerting system Stage 4: management API, instant hot-reload, and CLI

### Problem

Stages 1–3 delivered the full alerting pipeline (ingest → match → cooldown →
deliver → history) gated behind `--alerts-enabled`, but rules and channels
could only be changed by direct database edits, and those edits waited on the
5-minute snapshot refresh ticker. This PR makes the subsystem operator-manageable:
a full CRUD API in osctrl-api, a service command that turns rule/channel edits
into an instant hot-reload in osctrl-tls, and a CLI command group.

### Change

**Management API — new `cmd/api/handlers/alerts.go`** (mirrors the log-sinks
handler surface):
- Rules: list / get / create / update / delete —
  `GET|POST /api/v1/alerts/rules`, `GET|PUT|DELETE /api/v1/alerts/rules/{id}`
- Channels: list / get / types / create / update / delete —
  `GET /api/v1/alerts/channels[...]", `POST ...`, etc., plus
  `/channels/types` serving the registry so the SPA can render channel forms
  generically
- History: `GET /api/v1/alerts/history?limit=` (newest first, capped at 500)
- Secret handling identical to log sinks: channel configs redacted to `***`
  in reads unless an admin passes `reveal=1`; an update that submits the
  `***` placeholder merges the previously stored secret
- All routes admin-only, audit-logged, and registered only when
  `--alerts-enabled` is set (nil manager → routes absent; direct handler
  calls → 503). The apply endpoint reuses the restart rate limiter — an
  alerts reload is the same class of privileged service-command operation
- Request/response shapes added to `pkg/types`
  (`AlertRuleCreateRequest`, `AlertChannelCreateRequest`,
  `AlertChannelTypeSpec`, `AlertFieldSpec`)

**Instant hot-reload — service command plumbing**:
- `pkg/servicecommands`: new `reload-alerts` action in the allowlist
- `cmd/api`: `POST /api/v1/alerts/apply` queues the command for osctrl-tls
  (202 + command ID, same response shape as log-sinks apply)
- `cmd/tls`: the existing service-command watcher consumes the action —
  reloads the alert rule snapshot and resets the channel sender cache
  atomically (copy-on-write, in-flight matches finish against the old
  ruleset); warns and no-ops when alerting is disabled. The 5-minute ticker
  remains as a fallback path

**CLI — new `osctrl-cli alert` command group**:
- `rules` / `rule-create` / `rule-delete`, `channels` / `channel-create` /
  `channel-delete`, `apply` (trigger hot-reload)
- json / csv / pretty output consistent with the rest of the CLI;
  channel configs validated client-side against the registry before the
  POST; db-mode attempts fail with a clear "requires --api" error

**Supporting changes in `pkg/alerts`**:
- Exported `DecodeChannelIDs` / `EncodeChannelIDs` for API and CLI use
- `RedactedChannelConfig` + `MergeChannelSecrets` (channel-registry
  equivalents of the logsinks helpers)
- `ErrInvalidChannelConfig` sentinel, mapped to 400 by the API error router

### Validation

- `go build ./...`, `go vet`, `gofmt` — clean
- `golangci-lint` on all touched packages — 0 new issues (5 pre-existing in
  untouched files)
- 10 new handler tests, all passing: non-admin 403 (rules + channels),
  disabled 503, full rule CRUD round-trip (create → 409 duplicate → list →
  get → update → delete → 404), invalid source 400, channel CRUD with
  redaction / reveal / secret-merge round-trip, malformed config 400, types
  endpoint, history listing, and apply → command consumable by osctrl-tls
  (asserted via the real servicecommands manager)
- Full affected suites green: `cmd/api/handlers`, `cmd/api`, `cmd/cli`,
  `cmd/alerts`, `cmd/tls`, `pkg/servicecommands`
- CLI smoke: `osctrl-cli alert --help` renders the full group

### Roadmap position

Stage 4 of 7 (`alerts-api`). The alerting system is now fully operable
end-to-end: rules and channels are managed via API/CLI, edits hot-reload into
osctrl-tls within one poll cycle, and delivery lands in email/webhooks with
per-channel audit history. Remaining: Stage 5 (node-inactive watcher),
Stage 6 (SPA "Alerts" section), Stage 7 (load hardening + retention sweep).