### PR TITLE
Alerting system Stage 5: node-inactive / node-recovered watcher

### DIFF
--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -265,12 +265,14 @@ func osctrlService() {
 	// Alerting subsystem (disabled by default). The nil matcher means
 	// the ingest path never evaluates rules — zero cost when the
 	// feature is off. When enabled: manager + rule snapshot + Redis
-	// cooldown gate + channel dispatcher + async dispatch worker.
+	// cooldown gate + channel dispatcher + async dispatch worker +
+	// the node-inactive watcher.
 	var alertsMgr *alerts.Manager
 	var alertsStore *alerts.Store
 	var alertsState *alerts.State
 	var alertsWorker *alerts.Worker
 	var alertsDispatcher *alerts.Dispatcher
+	var alertsInactiveWatcher *alerts.InactiveWatcher
 	if flagParams.Service.AlertsEnabled {
 		alertsMgr = alerts.NewManager(db.Conn)
 		alertsStore = alerts.NewStore()
@@ -379,9 +381,21 @@ func osctrlService() {
 	// or direct DB changes) propagate without a restart. Channel
 	// sender caches reset alongside so channel edits are picked up.
 	var alertsRefreshStop chan struct{}
+	var alertsInactiveStop chan struct{}
 	if alertsStore != nil {
 		alertsRefreshStop = make(chan struct{})
 		go watchAlertRules(alertsRefreshStop, alertsMgr, alertsStore, alertsDispatcher)
+	}
+	// Node-inactive watcher: sweeps node liveness on a ticker and fires
+	// node_inactive / node_recovered rules on state transitions. State
+	// is tracked in Redis so restarts do not re-alert the fleet.
+	if alertsWorker != nil {
+		alertsInactiveStop = make(chan struct{})
+		alertsInactiveWatcher = alerts.NewInactiveWatcher(
+			newTLSNodeSource(nodesmgr, settingsmgr, envs),
+			alertsStore, alertsWorker, redis.Client)
+		go alertsInactiveWatcher.Run(alertsInactiveStop, alertsInactiveInterval)
+		log.Info().Msg("Alert node-inactive watcher started")
 	}
 	// Start the background sink-stats writer. It snapshots per-sink
 	// atomic counters (bytes sent, export count) from the live exporter
@@ -555,25 +569,33 @@ func osctrlService() {
 	case err := <-serverErr:
 		stopCommandWatcher()
 		sinkStatsWriter.Stop()
-		stopAlerts(alertsRefreshStop, alertsWorker)
+		stopAlerts(alertsRefreshStop, alertsInactiveStop, alertsWorker)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatal().Msgf("ListenAndServe: %v", err)
 		}
 	case <-restartCh:
 		stopCommandWatcher()
 		sinkStatsWriter.Stop()
-		stopAlerts(alertsRefreshStop, alertsWorker)
+		stopAlerts(alertsRefreshStop, alertsInactiveStop, alertsWorker)
 		log.Info().Msg("TLS service command consumed — exiting for restart")
 		os.Exit(1)
 	}
 }
 
+// alertsInactiveInterval is the node-inactive sweep cadence. Inactivity
+// is only observable on a clock, so this trades detection latency
+// against query load; 5 minutes matches the rule-refresh fallback.
+const alertsInactiveInterval = 5 * time.Minute
+
 // stopAlerts tears the alerting subsystem down on shutdown: stop the
-// snapshot refresher first (no new rules mid-drain), then drain the
-// dispatch queue. Both nil-safe for the feature-off path.
-func stopAlerts(refreshStop chan struct{}, worker *alerts.Worker) {
+// background loops first (no new rules mid-drain), then drain the
+// dispatch queue. All nil-safe for the feature-off path.
+func stopAlerts(refreshStop, inactiveStop chan struct{}, worker *alerts.Worker) {
 	if refreshStop != nil {
 		close(refreshStop)
+	}
+	if inactiveStop != nil {
+		close(inactiveStop)
 	}
 	if worker != nil {
 		worker.Close()

--- a/cmd/tls/tls_alerts.go
+++ b/cmd/tls/tls_alerts.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jmpsec/osctrl/pkg/alerts"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/settings"
+)
+
+// tls_alerts.go — adapters wiring pkg/alerts to the osctrl-tls managers.
+
+// tlsNodeSource adapts the nodes manager to the alert watcher's
+// NodeSource. Inactive thresholds are resolved per environment from the
+// settings manager, falling back to the global setting then the default.
+type tlsNodeSource struct {
+	nodes    *nodes.NodeManager
+	settings *settings.Settings
+	envs     *environments.EnvManager
+}
+
+// newTLSNodeSource builds the source over the package-level managers
+// wired in the TLS service.
+func newTLSNodeSource(nodesMgr *nodes.NodeManager, settingsMgr *settings.Settings, envsMgr *environments.EnvManager) *tlsNodeSource {
+	return &tlsNodeSource{nodes: nodesMgr, settings: settingsMgr, envs: envsMgr}
+}
+
+// threshold resolves the inactive-hours setting for an environment.
+func (s *tlsNodeSource) threshold(envID uint) int64 {
+	if s.settings != nil {
+		if h := s.settings.InactiveHours(envID); h > 0 {
+			return h
+		}
+	}
+	return settings.DefaultInactiveHours
+}
+
+// snapshotsByEnv runs the given target query per environment so the
+// inactive threshold applies correctly — a single global query would use
+// the wrong cutoff for environments with custom thresholds.
+func (s *tlsNodeSource) snapshotsByEnv(ctx context.Context, target string) ([]alerts.NodeSnapshot, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	all, err := s.envs.All()
+	if err != nil {
+		return nil, err
+	}
+	var out []alerts.NodeSnapshot
+	for _, env := range all {
+		threshold := s.threshold(env.ID)
+		nds, err := s.nodes.GetByEnv(env.Name, target, threshold)
+		if err != nil {
+			continue // one env failing must not drop the others
+		}
+		active := target == nodes.ActiveNodes
+		for _, n := range nds {
+			out = append(out, alerts.NodeSnapshot{
+				UUID:          n.UUID,
+				EnvironmentID: env.ID,
+				Environment:   env.Name,
+				Hostname:      n.Hostname,
+				Active:        active,
+				LastSeen:      n.LastSeen,
+			})
+		}
+	}
+	return out, nil
+}
+
+// InactiveNodes implements alerts.NodeSource.
+func (s *tlsNodeSource) InactiveNodes(ctx context.Context) ([]alerts.NodeSnapshot, error) {
+	return s.snapshotsByEnv(ctx, nodes.InactiveNodes)
+}
+
+// ActiveNodes implements alerts.NodeSource.
+func (s *tlsNodeSource) ActiveNodes(ctx context.Context) ([]alerts.NodeSnapshot, error) {
+	return s.snapshotsByEnv(ctx, nodes.ActiveNodes)
+}

--- a/pkg/alerts/inactive.go
+++ b/pkg/alerts/inactive.go
@@ -1,0 +1,279 @@
+package alerts
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/rs/zerolog/log"
+)
+
+// inactive.go — node-inactive / node-recovered watcher (Stage 5).
+//
+// A periodic sweep compares every node's last_seen against the
+// environment's inactive threshold and fires on *state transitions*:
+//   - active → inactive: one node_inactive hit per node (deduped by
+//     Redis state, not the per-hit cooldown key — the state IS the
+//     cooldown)
+//   - inactive → active: one node_recovered hit per node, but only when
+//     at least one node_recovered rule exists (recovery alerts are
+//     opt-in)
+//
+// Why sweep-based rather than log-arrival-based: inactivity is the
+// *absence* of traffic, so it can only be observed by a clock, never by
+// an event. The sweep runs on a ticker in osctrl-tls, batched per
+// environment, never on the ingest path.
+//
+// State lives in a Redis set per environment (UUID membership), so a
+// restart does not re-alert the whole fleet. On Redis errors the sweep
+// fails open like the cooldown gate: availability of alerting beats
+// perfect dedupe.
+
+// NodeSnapshot is one node's liveness state as seen by the sweep.
+type NodeSnapshot struct {
+	UUID string
+	// EnvironmentID / Environment identify the node's environment for
+	// rule scoping (ruleApplies) and hit attribution respectively.
+	EnvironmentID uint
+	Environment   string
+	Hostname      string
+	Active        bool
+	LastSeen      time.Time
+}
+
+// NodeSource produces node snapshots for the sweep. Implemented over
+// the nodes manager in osctrl-tls; tests substitute their own.
+type NodeSource interface {
+	// InactiveNodes returns every node whose last_seen is older than
+	// the given threshold, and the threshold itself is resolved per
+	// environment by the implementation.
+	InactiveNodes(ctx context.Context) ([]NodeSnapshot, error)
+	// ActiveNodes returns every currently-active node (used to detect
+	// recoveries of nodes previously marked inactive).
+	ActiveNodes(ctx context.Context) ([]NodeSnapshot, error)
+}
+
+// inactiveState is the persistence surface the watcher needs (Redis
+// set membership). *redis.Client satisfies it via the redisState
+// adapter; tests substitute an in-memory map.
+type inactiveState interface {
+	load(ctx context.Context) (map[string]bool, error)
+	save(ctx context.Context, inactive map[string]bool) error
+}
+
+// redisInactiveState adapts a Redis client to the inactiveState
+// interface using a single set key.
+type redisInactiveState struct {
+	client *redis.Client
+}
+
+func (s *redisInactiveState) load(ctx context.Context) (map[string]bool, error) {
+	members, err := s.client.SMembers(ctx, inactiveStateKey()).Result()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(members))
+	for _, m := range members {
+		out[m] = true
+	}
+	return out, nil
+}
+
+func (s *redisInactiveState) save(ctx context.Context, inactive map[string]bool) error {
+	pipe := s.client.TxPipeline()
+	pipe.Del(ctx, inactiveStateKey())
+	if len(inactive) > 0 {
+		members := make([]interface{}, 0, len(inactive))
+		for uuid := range inactive {
+			members = append(members, uuid)
+		}
+		pipe.SAdd(ctx, inactiveStateKey(), members...)
+	}
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// InactiveWatcher runs the sweep and emits hits to the dispatch worker.
+type InactiveWatcher struct {
+	source NodeSource
+	store  *Store
+	worker *Worker
+	state  inactiveState
+	// now is overridable for tests.
+	now func() time.Time
+}
+
+// NewInactiveWatcher builds the watcher. worker may be nil (feature
+// off mid-restart) — sweeps then no-op. A nil client builds a watcher
+// with no persistence: every sweep re-evaluates transitions from
+// scratch, so inactive nodes re-alert each pass (acceptable only for
+// tests; production always passes the Redis client).
+func NewInactiveWatcher(source NodeSource, store *Store, worker *Worker, client *redis.Client) *InactiveWatcher {
+	w := &InactiveWatcher{source: source, store: store, worker: worker, now: time.Now}
+	if client != nil {
+		w.state = &redisInactiveState{client: client}
+	}
+	return w
+}
+
+// newInactiveWatcherWithState injects a custom state store (tests).
+func newInactiveWatcherWithState(source NodeSource, store *Store, worker *Worker, state inactiveState) *InactiveWatcher {
+	return &InactiveWatcher{source: source, store: store, worker: worker, state: state, now: time.Now}
+}
+
+// stateKey is the Redis set of UUIDs currently flagged inactive.
+func inactiveStateKey() string {
+	return keyPrefix + "inactive"
+}
+
+// Sweep runs one detection pass: mark newly-inactive nodes, unmark
+// recovered ones, and enqueue hits for the transitions.
+func (w *InactiveWatcher) Sweep(ctx context.Context) {
+	if w == nil || w.worker == nil || w.store == nil {
+		return
+	}
+	rs := w.store.Snapshot()
+	if len(rs.nodeInactive) == 0 && len(rs.nodeRecovered) == 0 {
+		return // no node-state rules: nothing to do, skip the queries entirely
+	}
+
+	inactive, err := w.source.InactiveNodes(ctx)
+	if err != nil {
+		log.Err(err).Msg("alert inactive sweep: error listing inactive nodes")
+		return
+	}
+	// Only query actives when recovery rules exist.
+	var active []NodeSnapshot
+	if len(rs.nodeRecovered) > 0 {
+		active, err = w.source.ActiveNodes(ctx)
+		if err != nil {
+			log.Err(err).Msg("alert inactive sweep: error listing active nodes")
+			return
+		}
+	}
+
+	previouslyInactive, stateErr := w.loadState(ctx)
+	if stateErr != nil {
+		// Fail open: proceed with an empty prior-state view. Worst case
+		// on a Redis blip we re-alert nodes already flagged — the same
+		// posture as the cooldown gate.
+		log.Warn().Err(stateErr).Msg("alert inactive sweep: state unavailable, failing open")
+		previouslyInactive = map[string]bool{}
+	}
+
+	now := w.now()
+	var hits []Hit
+	newlyInactive := map[string]bool{}
+
+	// active → inactive transitions
+	for _, node := range inactive {
+		newlyInactive[node.UUID] = true
+		if previouslyInactive[node.UUID] {
+			continue
+		}
+		for i := range rs.nodeInactive {
+			r := &rs.nodeInactive[i]
+			if !r.ruleApplies(node.EnvironmentID) {
+				continue
+			}
+			hits = append(hits, Hit{
+				RuleID:          r.id,
+				RuleName:        r.name,
+				EnvironmentID:   node.EnvironmentID,
+				Environment:     node.Environment,
+				NodeUUID:        node.UUID,
+				Entity:          node.UUID,
+				Detail:          fmt.Sprintf("%s last seen %s", node.Hostname, humanSince(now, node.LastSeen)),
+				CooldownMinutes: r.cooldownMinutes,
+				Channels:        r.channels,
+			})
+		}
+	}
+
+	// inactive → active transitions (only when recovery rules exist)
+	if len(rs.nodeRecovered) > 0 {
+		for _, node := range active {
+			if !previouslyInactive[node.UUID] {
+				continue
+			}
+			for i := range rs.nodeRecovered {
+				r := &rs.nodeRecovered[i]
+				if !r.ruleApplies(node.EnvironmentID) {
+					continue
+				}
+				hits = append(hits, Hit{
+					RuleID:          r.id,
+					RuleName:        r.name,
+					EnvironmentID:   node.EnvironmentID,
+					Environment:     node.Environment,
+					NodeUUID:        node.UUID,
+					Entity:          node.UUID,
+					Detail:          fmt.Sprintf("%s seen again at %s", node.Hostname, node.LastSeen.Format(time.RFC3339)),
+					CooldownMinutes: r.cooldownMinutes,
+					Channels:        r.channels,
+				})
+			}
+		}
+	}
+
+	// Persist the new state (replace the set wholesale — nodes that
+	// recovered leave it).
+	if err := w.saveState(ctx, newlyInactive); err != nil {
+		log.Err(err).Msg("alert inactive sweep: error persisting state")
+	}
+
+	if len(hits) > 0 {
+		w.worker.Enqueue(hits)
+	}
+}
+
+// loadState reads the flagged-inactive UUID set.
+func (w *InactiveWatcher) loadState(ctx context.Context) (map[string]bool, error) {
+	if w.state == nil {
+		return map[string]bool{}, nil
+	}
+	return w.state.load(ctx)
+}
+
+// saveState replaces the flagged set with the current pass's inactive
+// UUIDs.
+func (w *InactiveWatcher) saveState(ctx context.Context, inactive map[string]bool) error {
+	if w.state == nil {
+		return nil
+	}
+	return w.state.save(ctx, inactive)
+}
+
+// Run blocks running the sweep on the interval until stop closes.
+func (w *InactiveWatcher) Run(stop <-chan struct{}, interval time.Duration) {
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			w.Sweep(context.Background())
+		}
+	}
+}
+
+// humanSince renders a coarse "x days / x hours ago" for hit details.
+func humanSince(now, lastSeen time.Time) string {
+	if lastSeen.IsZero() {
+		return "never"
+	}
+	d := now.Sub(lastSeen)
+	switch {
+	case d >= 48*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	}
+}

--- a/pkg/alerts/inactive_test.go
+++ b/pkg/alerts/inactive_test.go
@@ -1,0 +1,311 @@
+package alerts
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeNodeSource serves scripted snapshots per sweep.
+type fakeNodeSource struct {
+	mu       sync.Mutex
+	inactive []NodeSnapshot
+	active   []NodeSnapshot
+	inactErr error
+	actErr   error
+}
+
+func (s *fakeNodeSource) InactiveNodes(_ context.Context) ([]NodeSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inactive, s.inactErr
+}
+
+func (s *fakeNodeSource) ActiveNodes(_ context.Context) ([]NodeSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active, s.actErr
+}
+
+func (s *fakeNodeSource) setInactive(nodes ...NodeSnapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inactive = nodes
+}
+
+func (s *fakeNodeSource) setActive(nodes ...NodeSnapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = nodes
+}
+
+// memInactiveState is an in-memory inactiveState for deterministic
+// transition tests.
+type memInactiveState struct {
+	mu   sync.Mutex
+	set  map[string]bool
+	fail bool
+}
+
+func (s *memInactiveState) load(_ context.Context) (map[string]bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fail {
+		return nil, fmt.Errorf("state down")
+	}
+	out := make(map[string]bool, len(s.set))
+	for k, v := range s.set {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (s *memInactiveState) save(_ context.Context, inactive map[string]bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fail {
+		return fmt.Errorf("state down")
+	}
+	s.set = make(map[string]bool, len(inactive))
+	for k := range inactive {
+		s.set[k] = true
+	}
+	return nil
+}
+
+func nodeStateRules(t *testing.T) (*Store, *Worker, *recordingSinkRef) {
+	t.Helper()
+	rs := &RuleSet{}
+	for _, r := range []AlertRule{
+		{Model: ruleWithID(1), Name: "offline", Source: SourceNodeInactive, Enabled: true, ChannelIDs: "[1]"},
+		{Model: ruleWithID(2), Name: "back", Source: SourceNodeRecovered, Enabled: true, ChannelIDs: "[1]"},
+	} {
+		cr, err := CompileRule(r)
+		if err != nil {
+			t.Fatalf("compile %q: %v", r.Name, err)
+		}
+		switch r.Source {
+		case SourceNodeInactive:
+			rs.nodeInactive = append(rs.nodeInactive, cr)
+		case SourceNodeRecovered:
+			rs.nodeRecovered = append(rs.nodeRecovered, cr)
+		}
+	}
+	store := NewStore()
+	store.Publish(rs)
+	sink := &recordingSinkRef{}
+	worker := NewSyncWorker(store, nil, nil, sink)
+	return store, worker, sink
+}
+
+// recordingSinkRef is a simple recording DispatchSink.
+type recordingSinkRef struct {
+	mu   sync.Mutex
+	hits []Hit
+}
+
+func (s *recordingSinkRef) Dispatch(_ context.Context, h Hit) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hits = append(s.hits, h)
+	return nil
+}
+
+func (s *recordingSinkRef) snapshot() []Hit {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Hit(nil), s.hits...)
+}
+
+func (s *recordingSinkRef) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hits = nil
+}
+
+// TestInactiveWatcherNoRulesNoQueries: with no node-state rules the
+// sweep must not produce hits (it also skips the source queries —
+// observable because the fake source returns nothing and nothing is
+// enqueued).
+func TestInactiveWatcherNoRulesNoQueries(t *testing.T) {
+	source := &fakeNodeSource{}
+	store, worker, sink := nodeStateRules(t)
+	store.Publish(&RuleSet{}) // empty the snapshot
+	w := newInactiveWatcherWithState(source, store, worker, &memInactiveState{})
+	w.Sweep(context.Background())
+	if len(sink.snapshot()) != 0 {
+		t.Fatalf("no rules must yield no hits: %+v", sink.snapshot())
+	}
+}
+
+// TestInactiveWatcherFireOncePerTransition covers the full lifecycle:
+// inactive fires once, an unchanged second sweep is silent, recovery
+// fires once, and a re-inactive transition fires again.
+func TestInactiveWatcherFireOncePerTransition(t *testing.T) {
+	source := &fakeNodeSource{}
+	store, worker, sink := nodeStateRules(t)
+	state := &memInactiveState{}
+	w := newInactiveWatcherWithState(source, store, worker, state)
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	w.now = func() time.Time { return now }
+
+	stale := now.Add(-96 * time.Hour)
+	source.setInactive(NodeSnapshot{UUID: "U-1", EnvironmentID: 7, Environment: "prod", Hostname: "host-1", Active: false, LastSeen: stale})
+
+	// Sweep 1: transition fires.
+	w.Sweep(context.Background())
+	hits := sink.snapshot()
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 inactive hit, got %d: %+v", len(hits), hits)
+	}
+	h := hits[0]
+	if h.RuleName != "offline" || h.NodeUUID != "U-1" || h.Environment != "prod" {
+		t.Fatalf("unexpected hit: %+v", h)
+	}
+	if h.Entity != "U-1" {
+		t.Fatalf("entity should be the uuid: %q", h.Entity)
+	}
+	if h.Detail == "" {
+		t.Fatal("detail should describe the staleness")
+	}
+
+	// Sweep 2: unchanged state is silent.
+	sink.reset()
+	w.Sweep(context.Background())
+	if hits := sink.snapshot(); len(hits) != 0 {
+		t.Fatalf("unchanged sweep must not re-fire: %+v", hits)
+	}
+
+	// Sweep 3: node recovers.
+	source.setInactive()
+	source.setActive(NodeSnapshot{UUID: "U-1", EnvironmentID: 7, Environment: "prod", Hostname: "host-1", Active: true, LastSeen: now})
+	sink.reset()
+	w.Sweep(context.Background())
+	hits = sink.snapshot()
+	if len(hits) != 1 || hits[0].RuleName != "back" {
+		t.Fatalf("expected 1 recovered hit, got %+v", hits)
+	}
+
+	// Sweep 4: recovery is not repeated.
+	sink.reset()
+	w.Sweep(context.Background())
+	if hits := sink.snapshot(); len(hits) != 0 {
+		t.Fatalf("recovered node must not re-fire: %+v", hits)
+	}
+
+	// Sweep 5: node goes inactive again → fires again.
+	source.setInactive(NodeSnapshot{UUID: "U-1", EnvironmentID: 7, Environment: "prod", Hostname: "host-1", LastSeen: stale})
+	source.setActive()
+	sink.reset()
+	w.Sweep(context.Background())
+	if hits := sink.snapshot(); len(hits) != 1 || hits[0].RuleName != "offline" {
+		t.Fatalf("re-inactive transition must fire again, got %+v", hits)
+	}
+}
+
+// TestInactiveWatcherEnvScoping: a node_inactive rule scoped to env 7
+// must not fire for nodes in other environments.
+func TestInactiveWatcherEnvScoping(t *testing.T) {
+	rs := &RuleSet{}
+	cr, err := CompileRule(AlertRule{Model: ruleWithID(9), Name: "prod-only", EnvironmentID: 7, Source: SourceNodeInactive})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	rs.nodeInactive = append(rs.nodeInactive, cr)
+	store := NewStore()
+	store.Publish(rs)
+	sink := &recordingSinkRef{}
+	worker := NewSyncWorker(store, nil, nil, sink)
+	source := &fakeNodeSource{}
+	w := newInactiveWatcherWithState(source, store, worker, &memInactiveState{})
+
+	source.setInactive(
+		NodeSnapshot{UUID: "U-PROD", EnvironmentID: 7, Environment: "prod", Hostname: "h1"},
+		NodeSnapshot{UUID: "U-DEV", EnvironmentID: 9, Environment: "dev", Hostname: "h2"},
+	)
+	w.Sweep(context.Background())
+	hits := sink.snapshot()
+	if len(hits) != 1 || hits[0].NodeUUID != "U-PROD" {
+		t.Fatalf("env-scoped rule must only hit prod node: %+v", hits)
+	}
+}
+
+// TestInactiveWatcherSourceErrors: a failing source logs and no-ops.
+func TestInactiveWatcherSourceErrors(t *testing.T) {
+	source := &fakeNodeSource{inactErr: fmt.Errorf("db down")}
+	store, worker, sink := nodeStateRules(t)
+	w := newInactiveWatcherWithState(source, store, worker, &memInactiveState{})
+	w.Sweep(context.Background())
+	if len(sink.snapshot()) != 0 {
+		t.Fatalf("source error must yield no hits: %+v", sink.snapshot())
+	}
+}
+
+// TestInactiveWatcherLiveRedis asserts the once-per-transition
+// guarantee against a real Redis (state set persistence).
+func TestInactiveWatcherLiveRedis(t *testing.T) {
+	client, ok := liveRedis(t)
+	if !ok {
+		t.Skip("REDIS_URL not set; live watcher test skipped")
+	}
+	ctx := context.Background()
+	_ = client.Del(ctx, inactiveStateKey()).Err()
+
+	source := &fakeNodeSource{}
+	store, worker, sink := nodeStateRules(t)
+	w := NewInactiveWatcher(source, store, worker, client)
+
+	stale := time.Now().Add(-96 * time.Hour)
+	source.setInactive(NodeSnapshot{UUID: "WATCH-U1", EnvironmentID: 0, Environment: "prod", Hostname: "host", LastSeen: stale})
+
+	// First sweep fires; second sweep with the same state must not.
+	w.Sweep(ctx)
+	if got := len(sink.snapshot()); got != 1 {
+		t.Fatalf("first sweep should fire once, got %d", got)
+	}
+	sink.reset()
+	w.Sweep(ctx)
+	if got := len(sink.snapshot()); got != 0 {
+		t.Fatalf("second sweep with unchanged state must not re-fire, got %d", got)
+	}
+
+	// Recovery: node leaves the inactive set and reappears active.
+	source.setInactive()
+	source.setActive(NodeSnapshot{UUID: "WATCH-U1", EnvironmentID: 0, Environment: "prod", Hostname: "host", Active: true})
+	sink.reset()
+	w.Sweep(ctx)
+	hits := sink.snapshot()
+	if len(hits) != 1 || hits[0].RuleName != "back" {
+		t.Fatalf("expected one recovery hit, got %+v", hits)
+	}
+	// And a subsequent inactive transition fires again.
+	sink.reset()
+	source.setInactive(NodeSnapshot{UUID: "WATCH-U1", EnvironmentID: 0, Environment: "prod", Hostname: "host", LastSeen: stale})
+	source.setActive()
+	w.Sweep(ctx)
+	if len(sink.snapshot()) != 1 {
+		t.Fatalf("re-inactive transition must fire again, got %+v", sink.snapshot())
+	}
+	_ = client.Del(ctx, inactiveStateKey()).Err()
+}
+
+// TestHumanSince pins the coarse rendering used in hit details.
+func TestHumanSince(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		last time.Time
+		want string
+	}{
+		{now.Add(-30 * time.Minute), "30m ago"},
+		{now.Add(-5 * time.Hour), "5h ago"},
+		{now.Add(-96 * time.Hour), "4d ago"},
+		{time.Time{}, "never"},
+	}
+	for _, c := range cases {
+		if got := humanSince(now, c.last); got != c.want {
+			t.Errorf("humanSince(%v) = %q, want %q", c.last, got, c.want)
+		}
+	}
+}

--- a/pkg/alerts/manager.go
+++ b/pkg/alerts/manager.go
@@ -300,9 +300,10 @@ func (m *Manager) LoadSnapshot(store *Store) error {
 			rs.status = append(rs.status, cr)
 		case SourceQueryLog:
 			rs.query = append(rs.query, cr)
-		default:
-			// node_inactive / node_recovered rules are evaluated by the
-			// sweep, not the log matcher; nothing to compile.
+		case SourceNodeInactive:
+			rs.nodeInactive = append(rs.nodeInactive, cr)
+		case SourceNodeRecovered:
+			rs.nodeRecovered = append(rs.nodeRecovered, cr)
 		}
 	}
 	store.Publish(rs)

--- a/pkg/alerts/rules.go
+++ b/pkg/alerts/rules.go
@@ -52,6 +52,11 @@ type RuleSet struct {
 	result []compiledRule
 	status []compiledRule
 	query  []compiledRule
+	// nodeInactive / nodeRecovered are evaluated by the inactive-node
+	// sweep (Stage 5), not the log matcher. They carry only identity +
+	// cooldown + channels — no pattern.
+	nodeInactive  []compiledRule
+	nodeRecovered []compiledRule
 }
 
 // counts returns the number of compiled rules per bucket (test helper).
@@ -61,7 +66,8 @@ func (rs *RuleSet) counts() (result, status, query int) {
 
 // empty reports whether the snapshot has no rules at all.
 func (rs *RuleSet) empty() bool {
-	return len(rs.result) == 0 && len(rs.status) == 0 && len(rs.query) == 0
+	return len(rs.result) == 0 && len(rs.status) == 0 && len(rs.query) == 0 &&
+		len(rs.nodeInactive) == 0 && len(rs.nodeRecovered) == 0
 }
 
 // Store publishes rule snapshots. Safe for concurrent use; readers pull


### PR DESCRIPTION
## Alerting system Stage 5: node-inactive / node-recovered watcher

### Problem

Stages 1–4 cover alerting on log content — matches in result, status, and
distributed-query logs — but not on *absence* of traffic. "Alert when a node
has gone silent" was one of the two original alert classes and cannot be
observed from an event stream: only a clock can detect that a node stopped
reporting. This PR adds the sweep-based watcher for `node_inactive` and
`node_recovered` rules.

### Change

**Watcher — new `pkg/alerts/inactive.go`**
- Periodic sweep with **state-transition semantics**: an active→inactive
  transition fires `node_inactive` once per node; an inactive→active
  transition fires `node_recovered` once (only when a `node_recovered` rule
  exists — recovery alerts are opt-in); an unchanged sweep is silent
- Redis set (`osctrl:alert:inactive`) records flagged UUIDs so a restart
  does not re-alert the whole fleet; the set is replaced wholesale each pass
  so recovered nodes drop out
- State access is behind a small `inactiveState` interface (Redis adapter in
  production, in-memory map in tests); load/save failures fail **open** —
  same posture as the cooldown gate (alert availability beats perfect
  dedupe on a Redis blip)
- Zero-cost guards: no node-state rules in the snapshot → the sweep returns
  before any source query; the active-node query runs only when recovery
  rules exist
- `Run(stop, interval)` ticker loop, 5-minute default cadence

**Snapshot extension — `pkg/alerts/rules.go`, `manager.go`**
- `RuleSet` gains `nodeInactive` / `nodeRecovered` buckets; `LoadSnapshot`
  routes the sources so hot-reload (Stage 4's `reload-alerts` command)
  covers them too
- Env scoping identical to the log matchers: global rules (env 0) fire
  everywhere, scoped rules only in their environment — enforced per node
  via `ruleApplies(envID)`

**osquery-facing source — new `cmd/tls/tls_alerts.go`**
- `tlsNodeSource` adapts the nodes manager to the watcher's `NodeSource`
- Queries are batched **per environment** so each environment's
  `inactive_hours` setting applies correctly (global setting then the
  72h default as fallbacks) — a single global query would use the wrong
  cutoff for environments with custom thresholds
- One environment's query failure does not drop the others

**Wiring — `cmd/tls/main.go`**
- Watcher constructed and started behind `--alerts-enabled` (5-minute
  interval), stopped on shutdown/restart via the reworked `stopAlerts`
  (now closes the watcher loop before draining the dispatch queue)

### Validation

- `go build ./...`, `go vet`, `gofmt` — clean
- `golangci-lint run ./pkg/alerts/... ./cmd/tls/...` — 0 issues
- New tests, all passing:
  - Full lifecycle with in-memory state + synthetic clock: inactive fires
    once → unchanged second sweep silent → recovery fires once → not
    repeated → re-inactive fires again
  - Env scoping: an env-7 rule hits only the prod node, not the dev node
  - No-rules no-work (no hits, no source queries); source errors no-op
  - `humanSince` rendering table (never / 30m / 5h / 4d)
  - Live-Redis variant asserts the same lifecycle through the real Redis
    set (auto-skipped without `REDIS_URL`)
- Full affected suites green: `pkg/alerts`, `cmd/tls`, `cmd/tls/handlers`,
  `cmd/api/handlers`

### Performance

- The sweep never touches the ingest path; it runs on its own ticker
- Per-env batched queries (one `GetByEnv` per environment per pass) — no
  per-node lookups; the Stage-0 design target of "batched SQL, not
  per-node queries" is met
- No-rules deployments pay zero queries; recovery detection costs one
  extra query per env only when recovery rules exist configured

### Roadmap position

Stage 5 of 7 (`alerts-inactive`). Both original alert classes are now
live: log-content matching (Stages 1–4) and node liveness (this stage),
both manageable via the Stage-4 API/CLI and hot-reloadable. Remaining:
Stage 6 (SPA "Alerts" section), Stage 7 (load hardening + alert-history
retention sweep).