### PR TITLE
Alerting system Stage 6: SPA 'Alerts' section

### DIFF
--- a/cmd/api/handlers/features.go
+++ b/cmd/api/handlers/features.go
@@ -17,7 +17,11 @@ type FeaturesResponse struct {
 	// alongside the service-config routes.
 	LogSinks      bool `json:"log_sinks"`
 	AuthProviders bool `json:"auth_providers"`
-	Accelerated   bool `json:"accelerated"`
+	// Alerts gates the Alerts section in the SPA. Tied to
+	// --alerts-enabled — when false the /api/v1/alerts routes are not
+	// registered and the alert tables are not created.
+	Alerts       bool `json:"alerts"`
+	Accelerated  bool `json:"accelerated"`
 	Console      bool `json:"console"`
 	FileExplorer bool `json:"file_explorer"`
 }
@@ -32,6 +36,7 @@ func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 		ServiceConfig: h.ServiceConfigEnabled,
 		LogSinks:      h.LogSinksEnabled,
 		AuthProviders: h.AuthProvidersEnabled,
+		Alerts:        h.Alerts != nil,
 		Accelerated:   h.OsqueryValues.Accelerated,
 		Console:       h.OsqueryValues.Query && h.OsqueryValues.Console,
 		FileExplorer:  h.OsqueryValues.Query && h.OsqueryValues.FileExplorer,

--- a/cmd/api/handlers/features_test.go
+++ b/cmd/api/handlers/features_test.go
@@ -29,6 +29,11 @@ func TestFeaturesHandlerReportsPostureDisabledByDefault(t *testing.T) {
 	if resp.Accelerated {
 		t.Fatalf("accelerated feature: got true want false")
 	}
+	// Alerts defaults off: a nil manager (feature flag disabled) must
+	// advertise the SPA-hiding switch.
+	if resp.Alerts {
+		t.Fatalf("alerts feature: got true want false with nil manager")
+	}
 }
 
 func TestFeaturesHandlerReportsServiceConfigEnabled(t *testing.T) {

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -1,0 +1,198 @@
+/**
+ * Alerts API client.
+ *
+ * Access to the alerting subsystem: rules (what to watch), channels
+ * (where notifications go), recent history (what was sent), and the
+ * apply command that hot-reloads osctrl-tls. Channel configs redact
+ * secret fields unless reveal=1; an update submitting the "***"
+ * placeholder preserves the stored secret server-side.
+ */
+import { apiFetch } from './client';
+import type { ServiceCommand } from './service-config';
+
+/** Wire shape matching handlers.alertRuleDTO. */
+export interface AlertRule {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  name: string;
+  environment_id: number;
+  source: string;
+  match_type: string;
+  match_field: string;
+  match_value: string;
+  status_severity: string;
+  cooldown_minutes: number;
+  channel_ids: number[];
+  enabled: boolean;
+  info: string;
+}
+
+/** Wire shape matching handlers.alertChannelDTO. */
+export interface AlertChannel {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  name: string;
+  environment_id: number;
+  type: string;
+  enabled: boolean;
+  config: unknown;
+  info: string;
+}
+
+/** Wire shape matching alerts.AlertHistory. */
+export interface AlertHistoryEntry {
+  id: number;
+  created_at: string;
+  rule_id: number;
+  rule_name: string;
+  channel_id: number;
+  channel_name: string;
+  environment: string;
+  node_uuid: string;
+  entity: string;
+  detail: string;
+}
+
+/** One field in a channel type's config schema. Drives the dynamic form. */
+export interface AlertFieldSpec {
+  name: string;
+  label: string;
+  /** string | integer | boolean | secret */
+  type: string;
+  required: boolean;
+  placeholder?: string;
+  help?: string;
+  default?: unknown;
+}
+
+/** One entry in the GET /api/v1/alerts/channels/types registry response. */
+export interface AlertChannelTypeSpec {
+  type: string;
+  description: string;
+  has_secret: boolean;
+  secret_fields?: string[];
+  fields?: AlertFieldSpec[];
+}
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+
+export interface AlertRuleRequest {
+  name: string;
+  environment_id: number;
+  source: string;
+  match_type: string;
+  match_field?: string;
+  match_value: string;
+  status_severity?: string;
+  cooldown_minutes?: number;
+  channel_ids?: number[];
+  enabled: boolean;
+  info?: string;
+}
+
+/** GET /api/v1/alerts/rules?env={id}. */
+export function listAlertRules(opts?: { env?: number }): Promise<AlertRule[]> {
+  const params = new URLSearchParams();
+  if (opts?.env !== undefined) params.set('env', String(opts.env));
+  const qs = params.toString();
+  return apiFetch<AlertRule[]>(`/api/v1/alerts/rules${qs ? `?${qs}` : ''}`);
+}
+
+/** POST /api/v1/alerts/rules. */
+export function createAlertRule(body: AlertRuleRequest): Promise<AlertRule> {
+  return apiFetch<AlertRule>('/api/v1/alerts/rules', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** PUT /api/v1/alerts/rules/{id}. */
+export function updateAlertRule(id: number, body: AlertRuleRequest): Promise<AlertRule> {
+  return apiFetch<AlertRule>(`/api/v1/alerts/rules/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** DELETE /api/v1/alerts/rules/{id}. Returns 204 No Content. */
+export function deleteAlertRule(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/alerts/rules/${id}`, { method: 'DELETE' });
+}
+
+// ---------------------------------------------------------------------------
+// Channels
+// ---------------------------------------------------------------------------
+
+export interface AlertChannelRequest {
+  name: string;
+  environment_id: number;
+  type: string;
+  enabled: boolean;
+  config: unknown;
+  info?: string;
+}
+
+/** GET /api/v1/alerts/channels?env={id}&reveal={0|1}. */
+export function listAlertChannels(opts?: {
+  env?: number;
+  reveal?: boolean;
+}): Promise<AlertChannel[]> {
+  const params = new URLSearchParams();
+  if (opts?.env !== undefined) params.set('env', String(opts.env));
+  if (opts?.reveal) params.set('reveal', '1');
+  const qs = params.toString();
+  return apiFetch<AlertChannel[]>(`/api/v1/alerts/channels${qs ? `?${qs}` : ''}`);
+}
+
+/** GET /api/v1/alerts/channels/types. */
+export function listAlertChannelTypes(): Promise<AlertChannelTypeSpec[]> {
+  return apiFetch<AlertChannelTypeSpec[]>('/api/v1/alerts/channels/types');
+}
+
+/** POST /api/v1/alerts/channels. */
+export function createAlertChannel(body: AlertChannelRequest): Promise<AlertChannel> {
+  return apiFetch<AlertChannel>('/api/v1/alerts/channels', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** PUT /api/v1/alerts/channels/{id}. */
+export function updateAlertChannel(id: number, body: AlertChannelRequest): Promise<AlertChannel> {
+  return apiFetch<AlertChannel>(`/api/v1/alerts/channels/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** DELETE /api/v1/alerts/channels/{id}. Returns 204 No Content. */
+export function deleteAlertChannel(id: number): Promise<void> {
+  return apiFetch<void>(`/api/v1/alerts/channels/${id}`, { method: 'DELETE' });
+}
+
+// ---------------------------------------------------------------------------
+// History + apply
+// ---------------------------------------------------------------------------
+
+/** GET /api/v1/alerts/history?limit={n}. */
+export function listAlertHistory(limit?: number): Promise<AlertHistoryEntry[]> {
+  const qs = limit !== undefined ? `?limit=${limit}` : '';
+  return apiFetch<AlertHistoryEntry[]>(`/api/v1/alerts/history${qs}`);
+}
+
+/** POST /api/v1/alerts/apply — queue a hot-reload of osctrl-tls rules and channels. */
+export function applyAlerts(): Promise<{
+  message: string;
+  service?: string;
+  command?: ServiceCommand;
+}> {
+  return apiFetch('/api/v1/alerts/apply', { method: 'POST' });
+}

--- a/frontend/src/api/features.ts
+++ b/frontend/src/api/features.ts
@@ -5,6 +5,9 @@ export interface Features {
   service_config: boolean;
   log_sinks?: boolean;
   auth_providers?: boolean;
+  /** Alerting subsystem (--alerts-enabled). When false the alerts
+   * routes are absent and the SPA hides the Alerts section. */
+  alerts?: boolean;
   accelerated: boolean;
   console?: boolean;
   file_explorer: boolean;

--- a/frontend/src/components/chrome/SideNav.tsx
+++ b/frontend/src/components/chrome/SideNav.tsx
@@ -3,6 +3,7 @@ import { Link, useRouterState, useParams } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import {
   Archive,
+  Bell,
   Bookmark,
   Boxes,
   DatabaseBackup,
@@ -250,6 +251,8 @@ export function SideNav({ className, collapsed, previewsEnabled = true }: SideNa
     pathname.startsWith('/_app/config') || pathname.startsWith('/config');
   const isLogSinksActive =
     pathname.startsWith('/_app/log-sinks') || pathname.startsWith('/log-sinks');
+  const isAlertsActive =
+    pathname.startsWith('/_app/alerts') || pathname.startsWith('/alerts');
   const isAuthProvidersActive =
     pathname.startsWith('/_app/auth-providers') || pathname.startsWith('/auth-providers');
   const isAuditActive = pathname.startsWith('/_app/audit') || pathname === '/audit';
@@ -563,6 +566,15 @@ export function SideNav({ className, collapsed, previewsEnabled = true }: SideNa
               icon={<FileStack size={14} strokeWidth={1.8} />}
             >
               Log Sinks
+            </NavItem>}
+            {features?.alerts && <NavItem
+              collapsed={collapsed}
+              active={isAlertsActive}
+              to="/_app/alerts"
+              tone="amber"
+              icon={<Bell size={14} strokeWidth={1.8} />}
+            >
+              Alerts
             </NavItem>}
             {features?.auth_providers && <NavItem
               collapsed={collapsed}

--- a/frontend/src/features/alerts/AlertsPage.test.tsx
+++ b/frontend/src/features/alerts/AlertsPage.test.tsx
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRouter,
+  createRoute,
+  createRootRoute,
+  RouterProvider,
+  Outlet,
+} from '@tanstack/react-router';
+import { AlertsPage } from './AlertsPage';
+import type { AlertRule, AlertChannel, AlertChannelTypeSpec } from '$/api/alerts';
+import type { ServiceCommand } from '$/api/service-config';
+
+const mockListRules = vi.fn<(opts?: { env?: number }) => Promise<AlertRule[]>>();
+const mockCreateRule = vi.fn();
+const mockUpdateRule = vi.fn();
+const mockDeleteRule = vi.fn<(id: number) => Promise<void>>();
+const mockListChannels = vi.fn<
+  (opts?: { env?: number; reveal?: boolean }) => Promise<AlertChannel[]>
+>();
+const mockChannelTypes = vi.fn<() => Promise<AlertChannelTypeSpec[]>>();
+const mockCreateChannel = vi.fn();
+const mockUpdateChannel = vi.fn();
+const mockDeleteChannel = vi.fn<(id: number) => Promise<void>>();
+const mockHistory = vi.fn<(limit?: number) => Promise<unknown[]>>();
+const mockApply = vi.fn();
+const mockGetCommand = vi.fn<(commandID: string) => Promise<ServiceCommand>>();
+
+vi.mock('$/api/alerts', () => ({
+  listAlertRules: (opts?: { env?: number }) => mockListRules(opts),
+  createAlertRule: (...args: unknown[]) => mockCreateRule(...args),
+  updateAlertRule: (...args: unknown[]) => mockUpdateRule(...args),
+  deleteAlertRule: (id: number) => mockDeleteRule(id),
+  listAlertChannels: (opts?: { env?: number; reveal?: boolean }) => mockListChannels(opts),
+  listAlertChannelTypes: () => mockChannelTypes(),
+  createAlertChannel: (...args: unknown[]) => mockCreateChannel(...args),
+  updateAlertChannel: (...args: unknown[]) => mockUpdateChannel(...args),
+  deleteAlertChannel: (id: number) => mockDeleteChannel(id),
+  listAlertHistory: (limit?: number) => mockHistory(limit),
+  applyAlerts: () => mockApply(),
+}));
+
+const mockGetFeatures = vi.fn();
+vi.mock('$/api/features', () => ({
+  getFeatures: () => mockGetFeatures(),
+}));
+
+const mockListEnvs = vi.fn();
+vi.mock('$/api/environments', () => ({
+  listEnvironments: () => mockListEnvs(),
+}));
+
+vi.mock('$/api/service-config', () => ({
+  getServiceCommand: (commandID: string) => mockGetCommand(commandID),
+}));
+
+vi.mock('$/api/client', () => ({
+  isAuthenticated: () => true,
+  AuthError: class AuthError extends Error {
+    readonly status = 401;
+    constructor() {
+      super('Unauthorized');
+    }
+  },
+  ApiError: class ApiError extends Error {
+    constructor(msg: string, public status: number, public code?: string) {
+      super(msg);
+    }
+  },
+}));
+
+function makeRule(overrides: Partial<AlertRule> = {}): AlertRule {
+  return {
+    id: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    name: 'sudoers-write',
+    environment_id: 0,
+    source: 'result_log',
+    match_type: 'substring',
+    match_field: 'path',
+    match_value: '/etc/sudoers',
+    status_severity: 'any',
+    cooldown_minutes: 30,
+    channel_ids: [1],
+    enabled: true,
+    info: '',
+    ...overrides,
+  };
+}
+
+function makeChannel(overrides: Partial<AlertChannel> = {}): AlertChannel {
+  return {
+    id: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    name: 'soc-webhook',
+    environment_id: 0,
+    type: 'webhook',
+    enabled: true,
+    config: { url: 'https://hooks.example.com/x', secret: '***' },
+    info: '',
+    ...overrides,
+  };
+}
+
+const webhookType: AlertChannelTypeSpec = {
+  type: 'webhook',
+  description: 'HTTP POST to a URL with the alert as JSON',
+  has_secret: true,
+  secret_fields: ['secret'],
+  fields: [
+    { name: 'url', label: 'URL', type: 'string', required: true, placeholder: 'https://example.com/hook' },
+    { name: 'secret', label: 'HMAC secret', type: 'secret', required: false },
+    { name: 'timeoutSeconds', label: 'Timeout (seconds)', type: 'integer', required: false, default: 10 },
+    { name: 'insecureSkipVerify', label: 'Skip TLS verify', type: 'boolean', required: false, default: false },
+  ],
+};
+
+function renderPage() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const pageRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: AlertsPage,
+  });
+  const history = createMemoryHistory({ initialEntries: ['/'] });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([pageRoute]),
+    history,
+  });
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetFeatures.mockResolvedValue({
+    posture: false,
+    service_config: true,
+    log_sinks: true,
+    alerts: true,
+    accelerated: false,
+    file_explorer: false,
+  });
+  mockListEnvs.mockResolvedValue([{ id: 5, name: 'prod', uuid: 'p', environment_id: 5 }]);
+  mockChannelTypes.mockResolvedValue([webhookType]);
+  mockListRules.mockResolvedValue([]);
+  mockListChannels.mockResolvedValue([]);
+  mockHistory.mockResolvedValue([]);
+});
+
+describe('AlertsPage', () => {
+  it('renders the empty rules state when there are no rules', async () => {
+    renderPage();
+    expect(await screen.findByText('No alert rules')).toBeInTheDocument();
+    // The empty state can render before features resolve (query still
+    // disabled); wait for the actual fetch to confirm the wiring.
+    await waitFor(() => expect(mockListRules).toHaveBeenCalledWith({ env: 0 }));
+  });
+
+  it('shows the disabled shell when the alerts feature is off', async () => {
+    mockGetFeatures.mockResolvedValue({
+      posture: false,
+      service_config: true,
+      log_sinks: true,
+      alerts: false,
+      accelerated: false,
+      file_explorer: false,
+    });
+    renderPage();
+    expect(await screen.findByText('Alerting is disabled')).toBeInTheDocument();
+    // Disabled deployments must not hit the alerts endpoints at all.
+    expect(mockListRules).not.toHaveBeenCalled();
+  });
+
+  it('lists rules with source, pattern and channels', async () => {
+    mockListRules.mockResolvedValue([
+      makeRule(),
+      makeRule({ id: 2, name: 'node-offline', source: 'node_inactive', match_value: '', channel_ids: [] }),
+    ]);
+    mockListChannels.mockResolvedValue([makeChannel()]);
+    renderPage();
+    expect(await screen.findByText('sudoers-write')).toBeInTheDocument();
+    expect(screen.getByText('Result logs')).toBeInTheDocument();
+    expect(screen.getByText('Node inactive')).toBeInTheDocument();
+    expect(screen.getByText('soc-webhook')).toBeInTheDocument();
+    // node-state rule shows an em dash instead of a pattern
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('switches to the channels tab and lists channels', async () => {
+    const user = userEvent.setup();
+    mockListChannels.mockResolvedValue([makeChannel()]);
+    renderPage();
+    await user.click(await screen.findByRole('tab', { name: 'channels' }));
+    expect(await screen.findByText('soc-webhook')).toBeInTheDocument();
+    expect(screen.getByText('HTTP POST to a URL with the alert as JSON')).toBeInTheDocument();
+  });
+
+  it('switches to the history tab and lists dispatched alerts', async () => {
+    const user = userEvent.setup();
+    mockHistory.mockResolvedValue([
+      {
+        id: 1,
+        created_at: new Date().toISOString(),
+        rule_id: 1,
+        rule_name: 'sudoers-write',
+        channel_id: 1,
+        channel_name: 'soc-webhook',
+        environment: 'prod',
+        node_uuid: 'U-1',
+        entity: 'U-1:file_events',
+        detail: '/etc/sudoers',
+      },
+    ]);
+    renderPage();
+    await user.click(await screen.findByRole('tab', { name: 'history' }));
+    expect(await screen.findByText('sudoers-write')).toBeInTheDocument();
+    expect(screen.getByText('soc-webhook')).toBeInTheDocument();
+    expect(mockHistory).toHaveBeenCalled();
+  });
+
+  it('creates a rule through the editor modal', async () => {
+    const user = userEvent.setup();
+    mockListChannels.mockResolvedValue([makeChannel()]);
+    mockCreateRule.mockResolvedValue(makeRule());
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: 'New rule' }));
+
+    await user.type(screen.getByLabelText('Name'), 'sudoers-write');
+    await user.type(screen.getByLabelText('Pattern'), '/etc/sudoers');
+    await user.click(screen.getByRole('button', { name: 'Create rule' }));
+
+    await waitFor(() => {
+      expect(mockCreateRule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'sudoers-write',
+          source: 'result_log',
+          match_value: '/etc/sudoers',
+          enabled: true,
+        }),
+      );
+    });
+  });
+
+  it('requires a pattern for pattern sources and validates', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: 'New rule' }));
+    await user.type(screen.getByLabelText('Name'), 'no-pattern');
+    await user.click(screen.getByRole('button', { name: 'Create rule' }));
+    expect(
+      await screen.findByText('Match value is required for pattern sources'),
+    ).toBeInTheDocument();
+    expect(mockCreateRule).not.toHaveBeenCalled();
+  });
+
+  it('hides pattern inputs for node-state sources', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: 'New rule' }));
+    await user.selectOptions(screen.getByLabelText('Source'), 'node_inactive');
+    expect(screen.queryByLabelText('Pattern')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Match type')).not.toBeInTheDocument();
+  });
+
+  it('creates a channel with registry-driven defaults', async () => {
+    const user = userEvent.setup();
+    mockCreateChannel.mockResolvedValue(makeChannel());
+    renderPage();
+    await user.click(await screen.findByRole('tab', { name: 'channels' }));
+    await user.click(await screen.findByRole('button', { name: 'New channel' }));
+
+    await user.type(screen.getByLabelText('Name'), 'soc-webhook');
+    // Registry defaults (timeoutSeconds=10) prefill the form.
+    expect(screen.getByLabelText('Timeout (seconds)')).toHaveValue(10);
+    await user.type(screen.getByLabelText('URL'), 'https://hooks.example.com/x');
+    await user.click(screen.getByRole('button', { name: 'Create channel' }));
+
+    await waitFor(() => {
+      expect(mockCreateChannel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'soc-webhook',
+          type: 'webhook',
+          config: expect.objectContaining({
+            url: 'https://hooks.example.com/x',
+            timeoutSeconds: 10,
+          }),
+        }),
+      );
+    });
+  });
+
+  it('deletes a rule from the table', async () => {
+    const user = userEvent.setup();
+    mockListRules.mockResolvedValue([makeRule()]);
+    mockDeleteRule.mockResolvedValue(undefined);
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(mockDeleteRule).toHaveBeenCalledWith(1));
+  });
+
+  it('apply triggers the reload command', async () => {
+    const user = userEvent.setup();
+    mockApply.mockResolvedValue({
+      message: 'Reload requested',
+      command: {
+        command_id: 'cmd-1',
+        status: 'consumed',
+        service: 'osctrl-tls',
+        action: 'reload-alerts',
+      },
+    });
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: 'Apply changes' }));
+    await waitFor(() => expect(mockApply).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/features/alerts/AlertsPage.tsx
+++ b/frontend/src/features/alerts/AlertsPage.tsx
@@ -1,0 +1,1205 @@
+import { useState, useMemo, useEffect, type ReactNode } from 'react';
+import { usePageTitle } from '$/lib/usePageTitle';
+import { useNavigate } from '@tanstack/react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  listAlertRules,
+  createAlertRule,
+  updateAlertRule,
+  deleteAlertRule,
+  listAlertChannels,
+  listAlertChannelTypes,
+  createAlertChannel,
+  updateAlertChannel,
+  deleteAlertChannel,
+  listAlertHistory,
+  applyAlerts,
+  type AlertRule,
+  type AlertChannel,
+  type AlertChannelTypeSpec,
+  type AlertFieldSpec,
+  type AlertHistoryEntry,
+  type AlertRuleRequest,
+  type AlertChannelRequest,
+} from '$/api/alerts';
+import { listEnvironments } from '$/api/environments';
+import { getFeatures } from '$/api/features';
+import { getServiceCommand } from '$/api/service-config';
+import { AuthError } from '$/api/client';
+import { formatRelative } from '$/lib/time';
+import { SkeletonRow } from '$/components/data/Skeleton';
+import { EmptyState } from '$/components/data/EmptyState';
+import { ModalShell } from '$/components/feedback/ModalShell';
+import { Button } from '$/components/atoms/Button';
+import { cn } from '$/lib/cn';
+import { StatusBadge } from '$/components/data/StatusBadge';
+
+const GLOBAL_ENV_ID = 0;
+
+/** Rule sources the form offers, with human descriptions. */
+const RULE_SOURCES = [
+  { value: 'result_log', label: 'Result logs', help: 'Scheduled-query result rows (columns and snapshot rows).' },
+  { value: 'status_log', label: 'Status logs', help: 'osquery daemon status messages, filtered by severity.' },
+  { value: 'query_log', label: 'Distributed query results', help: 'On-demand query answers submitted by nodes.' },
+  { value: 'node_inactive', label: 'Node inactive', help: 'Node last_seen crosses the inactive threshold. No pattern needed.' },
+  { value: 'node_recovered', label: 'Node recovered', help: 'A previously inactive node is seen again. No pattern needed.' },
+] as const;
+
+/** Sources that match patterns (vs. node-state sources). */
+const PATTERN_SOURCES = new Set(['result_log', 'status_log', 'query_log']);
+
+type Tab = 'rules' | 'channels' | 'history';
+
+type RuleModalMode =
+  | { kind: 'closed' }
+  | { kind: 'create' }
+  | { kind: 'edit'; rule: AlertRule };
+
+type ChannelModalMode =
+  | { kind: 'closed' }
+  | { kind: 'create' }
+  | { kind: 'edit'; channel: AlertChannel };
+
+function sourceLabel(source: string): string {
+  return RULE_SOURCES.find((s) => s.value === source)?.label ?? source;
+}
+
+/**
+ * Alerts admin page.
+ *
+ * Three tabs: Rules (what to watch), Channels (where notifications go),
+ * History (what was dispatched). Rules and channels are env-scoped with a
+ * global fallback (env 0), matching log sinks. Edits queue locally in the
+ * database; "Apply changes" hot-reloads osctrl-tls without a restart.
+ *
+ * Visual/structural conventions mirror LogSinksPage: sticky header,
+ * SkeletonRow loading, EmptyState for empty/error, ModalShell dialogs,
+ * CSS-var tokens only.
+ */
+export function AlertsPage() {
+  usePageTitle('Alerts');
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const [tab, setTab] = useState<Tab>('rules');
+  const [selectedEnv, setSelectedEnv] = useState<number>(GLOBAL_ENV_ID);
+  const [ruleModal, setRuleModal] = useState<RuleModalMode>({ kind: 'closed' });
+  const [channelModal, setChannelModal] = useState<ChannelModalMode>({ kind: 'closed' });
+  const [applyErr, setApplyErr] = useState<string | null>(null);
+  const [applyFlash, setApplyFlash] = useState(false);
+  const [reloading, setReloading] = useState(false);
+
+  const { data: features } = useQuery({
+    queryKey: ['features'],
+    queryFn: () => getFeatures(),
+    staleTime: 5 * 60_000,
+  });
+  const alertsDisabled = features?.alerts === false;
+
+  const { data: envs } = useQuery({
+    queryKey: ['environments'],
+    queryFn: () => listEnvironments(),
+    staleTime: 60_000,
+  });
+
+  const rulesQuery = useQuery({
+    queryKey: ['alert-rules', selectedEnv],
+    queryFn: () => listAlertRules({ env: selectedEnv }),
+    enabled: !!features?.alerts,
+    staleTime: 30_000,
+  });
+
+  const channelsQuery = useQuery({
+    queryKey: ['alert-channels', selectedEnv],
+    queryFn: () => listAlertChannels({ env: selectedEnv }),
+    enabled: !!features?.alerts,
+    staleTime: 30_000,
+  });
+
+  const { data: channelTypes } = useQuery({
+    queryKey: ['alert-channel-types'],
+    queryFn: () => listAlertChannelTypes(),
+    staleTime: 60_000,
+    enabled: !!features?.alerts,
+  });
+
+  const historyQuery = useQuery({
+    queryKey: ['alert-history'],
+    queryFn: () => listAlertHistory(100),
+    enabled: !!features?.alerts && tab === 'history',
+    staleTime: 15_000,
+  });
+
+  const invalidate = (keys: string[]) => {
+    for (const key of keys) void qc.invalidateQueries({ queryKey: [key] });
+  };
+
+  const deleteRuleMutation = useMutation({
+    mutationFn: (id: number) => deleteAlertRule(id),
+    onSuccess: () => invalidate(['alert-rules']),
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        void navigate({ to: '/login' });
+        return;
+      }
+      setApplyErr(e instanceof Error ? e.message : 'Delete failed');
+    },
+  });
+
+  const deleteChannelMutation = useMutation({
+    mutationFn: (id: number) => deleteAlertChannel(id),
+    onSuccess: () => invalidate(['alert-channels']),
+    onError: (e) => {
+      if (e instanceof AuthError) {
+        void navigate({ to: '/login' });
+        return;
+      }
+      setApplyErr(e instanceof Error ? e.message : 'Delete failed');
+    },
+  });
+
+  const applyMutation = useMutation({
+    mutationFn: () => applyAlerts(),
+    onSuccess: (resp) => {
+      setApplyErr(null);
+      if (!resp.command) {
+        setReloading(false);
+        setApplyFlash(true);
+        setTimeout(() => setApplyFlash(false), 3000);
+        return;
+      }
+      setReloading(true);
+      const poll = setInterval(() => {
+        getServiceCommand(resp.command!.command_id)
+          .then((cmd) => {
+            if (cmd.status !== 'pending') {
+              clearInterval(poll);
+              setReloading(false);
+              setApplyFlash(true);
+              setTimeout(() => setApplyFlash(false), 3000);
+            }
+          })
+          .catch(() => {
+            clearInterval(poll);
+            setReloading(false);
+          });
+      }, 1500);
+    },
+    onError: (e: unknown) => {
+      setApplyErr(e instanceof Error ? e.message : String(e));
+    },
+  });
+
+  // Memoized data BEFORE any early return (React rules of hooks —
+  // early returns must not skip hook calls).
+  const rules = useMemo(
+    () => [...(rulesQuery.data ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+    [rulesQuery.data],
+  );
+  const channels = useMemo(
+    () => [...(channelsQuery.data ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+    [channelsQuery.data],
+  );
+  const history = historyQuery.data ?? [];
+  const envName = (id: number) =>
+    id === GLOBAL_ENV_ID ? 'Global' : (envs?.find((e) => e.id === id)?.name ?? `env ${id}`);
+
+  // Early returns AFTER all hooks (React rules of hooks).
+  if (
+    (rulesQuery.isError && rulesQuery.error instanceof AuthError) ||
+    (channelsQuery.isError && channelsQuery.error instanceof AuthError)
+  ) {
+    void navigate({ to: '/login' });
+    return null;
+  }
+
+  if (alertsDisabled) {
+    return <FeatureDisabledShell />;
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Sticky header */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border)] flex-wrap">
+        <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">
+          Alerts
+        </h1>
+        <p className="text-xs text-[color:var(--text-3)]">
+          Rules match ingested logs and node state; channels deliver the
+          notifications. Global rules apply to every environment.
+        </p>
+        <div className="ml-auto flex items-center gap-2">
+          <Button
+            type="button"
+            onClick={() =>
+              tab === 'channels'
+                ? setChannelModal({ kind: 'create' })
+                : setRuleModal({ kind: 'create' })
+            }
+          >
+            {tab === 'channels' ? 'New channel' : 'New rule'}
+          </Button>
+          <button
+            type="button"
+            disabled={reloading}
+            title="Hot-reload osctrl-tls with the current rule and channel rows"
+            onClick={() => {
+              setApplyErr(null);
+              applyMutation.mutate();
+            }}
+            className={cn(
+              'px-3 py-1 text-xs font-medium rounded transition-colors',
+              reloading
+                ? 'bg-[color:var(--bg-3)] text-[color:var(--text-3)]'
+                : 'bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.12)] text-[color:var(--warning)] hover:bg-[rgba(var(--warning-r),var(--warning-g),var(--warning-b),0.2)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            {reloading
+              ? 'Reloading…'
+              : applyFlash
+                ? 'Reload triggered ✓'
+                : 'Apply changes'}
+          </button>
+        </div>
+      </div>
+
+      {applyErr && (
+        <div
+          role="alert"
+          className="px-4 py-2 text-xs text-[color:var(--danger)] bg-[rgba(var(--danger-r),var(--danger-g),var(--danger-b),0.08)] border-b border-[color:var(--danger)]/30"
+        >
+          {applyErr}
+        </div>
+      )}
+
+      {/* Tabs + env selector */}
+      <div className="flex items-center gap-4 px-4 py-2 border-b border-[color:var(--border)] text-xs">
+        <div role="tablist" aria-label="Alert sections" className="flex items-center gap-1">
+          {(['rules', 'channels', 'history'] as const).map((t) => (
+            <button
+              key={t}
+              role="tab"
+              aria-selected={tab === t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={cn(
+                'px-3 py-1.5 rounded-md font-medium capitalize transition-colors',
+                tab === t
+                  ? 'bg-[color:var(--bg-3)] text-[color:var(--text-1)]'
+                  : 'text-[color:var(--text-3)] hover:text-[color:var(--text-2)] hover:bg-[color:var(--bg-2)]',
+              )}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        {tab !== 'history' && (
+          <div className="ml-auto flex items-center gap-2">
+            <label htmlFor="alerts-env" className="text-[color:var(--text-2)] font-semibold">
+              Environment
+            </label>
+            <select
+              id="alerts-env"
+              value={selectedEnv}
+              onChange={(e) => setSelectedEnv(Number(e.target.value))}
+              aria-label="Select environment whose alerts to show"
+              className={cn(
+                'px-2 py-1 rounded tabular-nums',
+                'bg-[color:var(--bg-3)] border border-[color:var(--border)] text-[color:var(--text-1)]',
+                'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+              )}
+            >
+              <option value={GLOBAL_ENV_ID}>Global (all environments)</option>
+              {envs?.map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto min-h-0">
+        {tab === 'rules' && (
+          <RulesTable
+            rules={rules}
+            loading={rulesQuery.isLoading}
+            envName={envName}
+            channels={channels}
+            onEdit={(rule) => setRuleModal({ kind: 'edit', rule })}
+            onDelete={(id) => deleteRuleMutation.mutate(id)}
+          />
+        )}
+        {tab === 'channels' && (
+          <ChannelsTable
+            channels={channels}
+            types={channelTypes ?? []}
+            loading={channelsQuery.isLoading}
+            envName={envName}
+            onEdit={(channel) => setChannelModal({ kind: 'edit', channel })}
+            onDelete={(id) => deleteChannelMutation.mutate(id)}
+          />
+        )}
+        {tab === 'history' && (
+          <HistoryTable
+            entries={history}
+            loading={historyQuery.isLoading}
+          />
+        )}
+      </div>
+
+      {/* Modals */}
+      {ruleModal.kind !== 'closed' && (
+        <RuleEditorModal
+          mode={ruleModal}
+          envs={envs ?? []}
+          channels={channels}
+          onClose={() => setRuleModal({ kind: 'closed' })}
+          onSaved={() => {
+            setRuleModal({ kind: 'closed' });
+            invalidate(['alert-rules']);
+          }}
+        />
+      )}
+      {channelModal.kind !== 'closed' && (
+        <ChannelEditorModal
+          mode={channelModal}
+          types={channelTypes ?? []}
+          onClose={() => setChannelModal({ kind: 'closed' })}
+          onSaved={() => {
+            setChannelModal({ kind: 'closed' });
+            invalidate(['alert-channels']);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Disabled shell
+// ---------------------------------------------------------------------------
+
+function FeatureDisabledShell() {
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border)] flex-wrap">
+        <h1 className="font-display text-lg font-semibold text-[color:var(--text-1)] mr-2">
+          Alerts
+        </h1>
+        <p className="text-xs text-[color:var(--text-3)]">
+          Super-admin view. Alert rules, channels, and dispatch history.
+        </p>
+      </div>
+      <div className="flex-1 overflow-auto min-h-0">
+        <EmptyState
+          icon={
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M18 8a6 6 0 00-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+              <path d="M13.7 21a2 2 0 01-3.4 0" />
+            </svg>
+          }
+          title="Alerting is disabled"
+          description={
+            'osctrl-api runs with service.alertsEnabled = false, so the alerting subsystem is fully inert: no alert tables, no rule evaluation in osctrl-tls, and no /api/v1/alerts endpoints. Set alertsEnabled: true and restart osctrl-api and osctrl-tls to manage alerts here.'
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tables
+// ---------------------------------------------------------------------------
+
+function RulesTable({
+  rules,
+  loading,
+  envName,
+  channels,
+  onEdit,
+  onDelete,
+}: {
+  rules: AlertRule[];
+  loading: boolean;
+  envName: (id: number) => string;
+  channels: AlertChannel[];
+  onEdit: (rule: AlertRule) => void;
+  onDelete: (id: number) => void;
+}) {
+  if (loading) {
+    return (
+      <div className="divide-y divide-[color:var(--border)]">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <SkeletonRow key={i} cells={7} />
+        ))}
+      </div>
+    );
+  }
+  if (rules.length === 0) {
+    return (
+      <EmptyState
+        icon={<RuleIcon />}
+        title="No alert rules"
+        description="Rules match ingested logs and node state. Create one to start alerting — global rules apply to every environment."
+      />
+    );
+  }
+  const channelName = (id: number) =>
+    channels.find((c) => c.id === id)?.name ?? `#${id}`;
+  return (
+    <div className="divide-y divide-[color:var(--border)]">
+      {rules.map((rule) => (
+        <div
+          key={rule.id}
+          className="grid grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.2fr)_80px_minmax(0,1fr)_120px] items-center gap-3 px-4 py-2.5 text-sm hover:bg-[color:var(--bg-2)] transition-colors"
+        >
+          <div className="min-w-0">
+            <div className="font-medium text-[color:var(--text-1)] truncate">{rule.name}</div>
+            <div className="text-xs text-[color:var(--text-3)] truncate">
+              {envName(rule.environment_id)}
+            </div>
+          </div>
+          <div className="text-xs text-[color:var(--text-2)] truncate">
+            {sourceLabel(rule.source)}
+          </div>
+          <div className="text-xs text-[color:var(--text-2)] truncate">
+            {PATTERN_SOURCES.has(rule.source)
+              ? `${rule.match_type}${rule.match_field ? ` · ${rule.match_field}` : ' · any field'}`
+              : '—'}
+          </div>
+          <div className="text-xs text-[color:var(--text-2)] truncate font-mono">
+            {PATTERN_SOURCES.has(rule.source) ? rule.match_value : '—'}
+          </div>
+          <div className="text-xs text-[color:var(--text-3)] tabular-nums">
+            {rule.cooldown_minutes > 0 ? `${rule.cooldown_minutes}m` : 'default'}
+          </div>
+          <div className="text-xs text-[color:var(--text-2)] truncate">
+            {rule.channel_ids.length > 0
+              ? rule.channel_ids.map(channelName).join(', ')
+              : <span className="text-[color:var(--text-3)]">none</span>}
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <StatusBadge variant={rule.enabled ? 'success' : 'dim'} label={rule.enabled ? 'Enabled' : 'Disabled'} />
+            <button
+              type="button"
+              onClick={() => onEdit(rule)}
+              className="text-xs text-[color:var(--text-3)] hover:text-[color:var(--text-1)] px-1.5 py-0.5 rounded hover:bg-[color:var(--bg-3)]"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(rule.id)}
+              className="text-xs text-[color:var(--text-3)] hover:text-[color:var(--danger)] px-1.5 py-0.5 rounded hover:bg-[color:var(--bg-3)]"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ChannelsTable({
+  channels,
+  types,
+  loading,
+  envName,
+  onEdit,
+  onDelete,
+}: {
+  channels: AlertChannel[];
+  types: AlertChannelTypeSpec[];
+  loading: boolean;
+  envName: (id: number) => string;
+  onEdit: (channel: AlertChannel) => void;
+  onDelete: (id: number) => void;
+}) {
+  if (loading) {
+    return (
+      <div className="divide-y divide-[color:var(--border)]">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <SkeletonRow key={i} cells={4} />
+        ))}
+      </div>
+    );
+  }
+  if (channels.length === 0) {
+    return (
+      <EmptyState
+        icon={<BellIcon />}
+        title="No alert channels"
+        description="Channels deliver notifications — a webhook, an email relay. Rules reference channels by name."
+      />
+    );
+  }
+  const description = (type: string) =>
+    types.find((t) => t.type === type)?.description ?? '';
+  return (
+    <div className="divide-y divide-[color:var(--border)]">
+      {channels.map((channel) => (
+        <div
+          key={channel.id}
+          className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)_minmax(0,2fr)_120px] items-center gap-3 px-4 py-2.5 text-sm hover:bg-[color:var(--bg-2)] transition-colors"
+        >
+          <div className="min-w-0">
+            <div className="font-medium text-[color:var(--text-1)] truncate">{channel.name}</div>
+            <div className="text-xs text-[color:var(--text-3)] truncate">
+              {envName(channel.environment_id)}
+            </div>
+          </div>
+          <div className="text-xs text-[color:var(--text-2)] truncate">{channel.type}</div>
+          <div className="text-xs text-[color:var(--text-3)] truncate">
+            {description(channel.type)}
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <StatusBadge variant={channel.enabled ? 'success' : 'dim'} label={channel.enabled ? 'Enabled' : 'Disabled'} />
+            <button
+              type="button"
+              onClick={() => onEdit(channel)}
+              className="text-xs text-[color:var(--text-3)] hover:text-[color:var(--text-1)] px-1.5 py-0.5 rounded hover:bg-[color:var(--bg-3)]"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(channel.id)}
+              className="text-xs text-[color:var(--text-3)] hover:text-[color:var(--danger)] px-1.5 py-0.5 rounded hover:bg-[color:var(--bg-3)]"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function HistoryTable({
+  entries,
+  loading,
+}: {
+  entries: AlertHistoryEntry[];
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="divide-y divide-[color:var(--border)]">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonRow key={i} cells={5} />
+        ))}
+      </div>
+    );
+  }
+  if (entries.length === 0) {
+    return (
+      <EmptyState
+        icon={<BellIcon />}
+        title="No alerts dispatched yet"
+        description="History records every notification the system sent, per channel. It fills in as rules match."
+      />
+    );
+  }
+  return (
+    <div className="divide-y divide-[color:var(--border)]">
+      {entries.map((entry) => (
+        <div
+          key={entry.id}
+          className="grid grid-cols-[110px_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,2fr)] items-center gap-3 px-4 py-2.5 text-sm"
+        >
+          <div className="text-xs text-[color:var(--text-3)] tabular-nums">
+            {formatRelative(entry.created_at)}
+          </div>
+          <div className="text-xs text-[color:var(--text-2)] truncate">
+            {entry.rule_name}
+          </div>
+          <div className="text-xs text-[color:var(--text-2)] truncate">
+            {entry.channel_name || '—'}
+          </div>
+          <div className="text-xs text-[color:var(--text-3)] truncate font-mono">
+            {entry.node_uuid || entry.entity}
+          </div>
+          <div className="text-xs text-[color:var(--text-3)] truncate" title={entry.detail}>
+            {entry.detail}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rule editor modal
+// ---------------------------------------------------------------------------
+
+function RuleEditorModal({
+  mode,
+  envs,
+  channels,
+  onClose,
+  onSaved,
+}: {
+  mode: RuleModalMode;
+  envs: { id: number; name: string }[];
+  channels: AlertChannel[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const existing = mode.kind === 'edit' ? mode.rule : null;
+  const [name, setName] = useState(existing?.name ?? '');
+  const [envID, setEnvID] = useState<number>(existing?.environment_id ?? GLOBAL_ENV_ID);
+  const [source, setSource] = useState(existing?.source ?? 'result_log');
+  const [matchType, setMatchType] = useState(existing?.match_type ?? 'substring');
+  const [matchField, setMatchField] = useState(existing?.match_field ?? '');
+  const [matchValue, setMatchValue] = useState(existing?.match_value ?? '');
+  const [statusSeverity, setStatusSeverity] = useState(existing?.status_severity || 'any');
+  const [cooldown, setCooldown] = useState(existing?.cooldown_minutes ?? 0);
+  const [channelIDs, setChannelIDs] = useState<number[]>(existing?.channel_ids ?? []);
+  const [enabled, setEnabled] = useState(existing?.enabled ?? true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (body: AlertRuleRequest) =>
+      existing ? updateAlertRule(existing.id, body) : createAlertRule(body),
+    onSuccess: onSaved,
+    onError: (e) => {
+      if (e instanceof AuthError) return;
+      setErr(e instanceof Error ? e.message : 'Save failed');
+    },
+  });
+
+  const inputClass = cn(
+    'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+    'bg-[color:var(--bg-3)] text-[color:var(--text-1)] tabular-nums',
+    'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+  );
+  const needsPattern = PATTERN_SOURCES.has(source);
+  const sourceHelp = RULE_SOURCES.find((s) => s.value === source)?.help;
+
+  const submit = () => {
+    if (!name.trim()) {
+      setErr('Name is required');
+      return;
+    }
+    if (needsPattern && !matchValue.trim()) {
+      setErr('Match value is required for pattern sources');
+      return;
+    }
+    mutation.mutate({
+      name: name.trim(),
+      environment_id: envID,
+      source,
+      match_type: needsPattern ? matchType : 'substring',
+      match_field: needsPattern ? matchField : '',
+      match_value: needsPattern ? matchValue : '',
+      status_severity: source === 'status_log' ? statusSeverity : 'any',
+      cooldown_minutes: cooldown,
+      channel_ids: channelIDs,
+      enabled,
+    });
+  };
+
+  return (
+    <ModalShell
+      title={existing ? `Edit ${existing.name}` : 'New alert rule'}
+      titleId="alert-rule-editor-title"
+      onClose={onClose}
+      bodyClassName="max-h-[70vh] overflow-y-auto"
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+        className="space-y-4"
+      >
+        <div>
+          <label htmlFor="rule-name" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            Name
+          </label>
+          <input
+            id="rule-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. sudoers-modified"
+            className={inputClass}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="rule-env" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+              Environment
+            </label>
+            <select
+              id="rule-env"
+              value={envID}
+              onChange={(e) => setEnvID(Number(e.target.value))}
+              className={inputClass}
+            >
+              <option value={GLOBAL_ENV_ID}>Global (all environments)</option>
+              {envs.map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="rule-source" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+              Source
+            </label>
+            <select
+              id="rule-source"
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              className={inputClass}
+            >
+              {RULE_SOURCES.map((s) => (
+                <option key={s.value} value={s.value}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+            {sourceHelp && (
+              <p className="mt-1 text-xs text-[color:var(--text-3)]">{sourceHelp}</p>
+            )}
+          </div>
+        </div>
+
+        {needsPattern && (
+          <>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="rule-match-type" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+                  Match type
+                </label>
+                <select
+                  id="rule-match-type"
+                  value={matchType}
+                  onChange={(e) => setMatchType(e.target.value)}
+                  className={inputClass}
+                >
+                  <option value="substring">Substring (case-insensitive)</option>
+                  <option value="regex">Regex</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="rule-match-field" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+                  Field <span className="font-normal text-[color:var(--text-3)]">(empty = any)</span>
+                </label>
+                <input
+                  id="rule-match-field"
+                  type="text"
+                  value={matchField}
+                  onChange={(e) => setMatchField(e.target.value)}
+                  placeholder="e.g. path, username, message"
+                  className={inputClass}
+                />
+              </div>
+            </div>
+            <div>
+              <label htmlFor="rule-match-value" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+                Pattern
+              </label>
+              <input
+                id="rule-match-value"
+                type="text"
+                value={matchValue}
+                onChange={(e) => setMatchValue(e.target.value)}
+                placeholder={matchType === 'regex' ? '^/etc/(shadow|sudoers)$' : '/etc/sudoers'}
+                className={cn(inputClass, 'font-mono')}
+              />
+            </div>
+          </>
+        )}
+
+        {source === 'status_log' && (
+          <div>
+            <label htmlFor="rule-severity" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+              Minimum severity
+            </label>
+            <select
+              id="rule-severity"
+              value={statusSeverity}
+              onChange={(e) => setStatusSeverity(e.target.value)}
+              className={inputClass}
+            >
+              <option value="any">Any</option>
+              <option value="warning">Warning and above</option>
+              <option value="error">Error only</option>
+            </select>
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="rule-cooldown" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+              Cooldown (minutes)
+            </label>
+            <input
+              id="rule-cooldown"
+              type="number"
+              min={0}
+              value={cooldown}
+              onChange={(e) => setCooldown(Number(e.target.value))}
+              className={inputClass}
+            />
+            <p className="mt-1 text-xs text-[color:var(--text-3)]">
+              Suppresses repeat alerts for the same match within the window. 0 uses the default (15m).
+            </p>
+          </div>
+          <fieldset className="flex items-end gap-2 pb-2">
+            <label className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => setEnabled(e.target.checked)}
+                className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+              />
+              <span className="tabular-nums">enabled</span>
+            </label>
+          </fieldset>
+        </div>
+
+        <div>
+          <span className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            Channels
+          </span>
+          {channels.length === 0 ? (
+            <p className="text-xs text-[color:var(--text-3)]">
+              No channels yet — the rule will match but nothing is sent. Create a channel in the Channels tab.
+            </p>
+          ) : (
+            <div className="space-y-1">
+              {channels.map((c) => (
+                <label key={c.id} className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+                  <input
+                    type="checkbox"
+                    checked={channelIDs.includes(c.id)}
+                    onChange={(e) => {
+                      setChannelIDs((prev) =>
+                        e.target.checked ? [...prev, c.id] : prev.filter((id) => id !== c.id),
+                      );
+                    }}
+                    className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+                  />
+                  <span className="tabular-nums">{c.name}</span>
+                  <span className="text-[color:var(--text-3)]">({c.type})</span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {err && (
+          <p role="alert" className="text-xs text-[color:var(--danger)]">
+            {err}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? 'Saving…' : existing ? 'Save changes' : 'Create rule'}
+          </Button>
+        </div>
+      </form>
+    </ModalShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Channel editor modal — registry-driven dynamic form
+// ---------------------------------------------------------------------------
+
+function ChannelEditorModal({
+  mode,
+  types,
+  onClose,
+  onSaved,
+}: {
+  mode: ChannelModalMode;
+  types: AlertChannelTypeSpec[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const existing = mode.kind === 'edit' ? mode.channel : null;
+  const [name, setName] = useState(existing?.name ?? '');
+  const [type, setType] = useState(existing?.type ?? 'webhook');
+  const [enabled, setEnabled] = useState(existing?.enabled ?? true);
+  const [config, setConfig] = useState<Record<string, unknown>>(
+    (existing?.config as Record<string, unknown>) ?? {},
+  );
+  const [err, setErr] = useState<string | null>(null);
+
+  // Reset the config object when the type changes during creation.
+  useEffect(() => {
+    if (mode.kind === 'create' && !existing) {
+      setConfig(applyDefaults(types.find((t) => t.type === type)));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type]);
+
+  const spec = types.find((t) => t.type === type);
+
+  const mutation = useMutation({
+    mutationFn: (body: AlertChannelRequest) =>
+      existing ? updateAlertChannel(existing.id, body) : createAlertChannel(body),
+    onSuccess: onSaved,
+    onError: (e) => {
+      if (e instanceof AuthError) return;
+      setErr(e instanceof Error ? e.message : 'Save failed');
+    },
+  });
+
+  const inputClass = cn(
+    'w-full px-3 py-2 text-sm rounded-md border border-[color:var(--border)]',
+    'bg-[color:var(--bg-3)] text-[color:var(--text-1)] tabular-nums',
+    'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
+  );
+
+  const submit = () => {
+    if (!name.trim()) {
+      setErr('Name is required');
+      return;
+    }
+    mutation.mutate({
+      name: name.trim(),
+      environment_id: GLOBAL_ENV_ID,
+      type,
+      enabled,
+      config,
+    });
+  };
+
+  return (
+    <ModalShell
+      title={existing ? `Edit ${existing.name}` : 'New alert channel'}
+      titleId="alert-channel-editor-title"
+      onClose={onClose}
+      bodyClassName="max-h-[70vh] overflow-y-auto"
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+        className="space-y-4"
+      >
+        <div>
+          <label htmlFor="channel-name" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            Name
+          </label>
+          <input
+            id="channel-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. soc-webhook"
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="channel-type" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+            Type
+          </label>
+          <select
+            id="channel-type"
+            value={type}
+            disabled={!!existing}
+            onChange={(e) => setType(e.target.value)}
+            className={inputClass}
+          >
+            {types.map((t) => (
+              <option key={t.type} value={t.type}>
+                {t.type} — {t.description}
+              </option>
+            ))}
+          </select>
+          {spec?.has_secret && (
+            <p className="mt-1 text-xs text-[color:var(--text-3)]">
+              This channel stores credentials ({spec.secret_fields?.join(', ')}).
+              {existing && ' Submit the masked value to keep the stored secret.'}
+            </p>
+          )}
+        </div>
+
+        {/* Registry-driven typed config form. Secret fields render as
+            password inputs; "***" on edit means "keep stored value". */}
+        {spec?.fields?.map((field) => (
+          <ChannelConfigField
+            key={field.name}
+            field={field}
+            value={config[field.name]}
+            onChange={(v) => setConfig((prev) => ({ ...prev, [field.name]: v }))}
+            inputClass={inputClass}
+          />
+        ))}
+
+        <fieldset className="flex items-center gap-2">
+          <label className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+            />
+            <span className="tabular-nums">enabled</span>
+          </label>
+        </fieldset>
+
+        {err && (
+          <p role="alert" className="text-xs text-[color:var(--danger)]">
+            {err}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? 'Saving…' : existing ? 'Save changes' : 'Create channel'}
+          </Button>
+        </div>
+      </form>
+    </ModalShell>
+  );
+}
+
+function applyDefaults(
+  spec: AlertChannelTypeSpec | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const field of spec?.fields ?? []) {
+    if (field.default !== undefined) out[field.name] = field.default;
+  }
+  return out;
+}
+
+function ChannelConfigField({
+  field,
+  value,
+  onChange,
+  inputClass,
+}: {
+  field: AlertFieldSpec;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  inputClass: string;
+}) {
+  const id = `channel-cfg-${field.name.replace(/\./g, '-')}`;
+  const labelEl = (
+    <label htmlFor={id} className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+      {field.label}
+      {field.required && <span className="text-[color:var(--danger)]" aria-hidden="true"> *</span>}
+    </label>
+  );
+  const helpEl = field.help && (
+    <p className="mt-1 text-xs text-[color:var(--text-3)]">{field.help}</p>
+  );
+
+  switch (field.type) {
+    case 'boolean':
+      return (
+        <div>
+          <label className="flex items-center gap-2 text-xs text-[color:var(--text-1)]">
+            <input
+              id={id}
+              type="checkbox"
+              aria-label={field.label}
+              checked={Boolean(value)}
+              onChange={(e) => onChange(e.target.checked)}
+              className="rounded border-[color:var(--border)] accent-[color:var(--signal)]"
+            />
+            <span className="tabular-nums">{field.label}</span>
+          </label>
+          {helpEl}
+        </div>
+      );
+    case 'integer':
+      return (
+        <div>
+          {labelEl}
+          <input
+            id={id}
+            type="number"
+            aria-label={field.label}
+            value={value === undefined || value === null ? '' : String(value)}
+            onChange={(e) => {
+              const raw = e.target.value;
+              onChange(raw === '' ? undefined : Number(raw));
+            }}
+            placeholder={field.placeholder}
+            className={inputClass}
+          />
+          {helpEl}
+        </div>
+      );
+    case 'secret':
+      return (
+        <div>
+          {labelEl}
+          <input
+            id={id}
+            type="password"
+            aria-label={field.label}
+            value={String(value ?? '')}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder}
+            className={inputClass}
+          />
+          {helpEl}
+        </div>
+      );
+    default:
+      return (
+        <div>
+          {labelEl}
+          <input
+            id={id}
+            type="text"
+            aria-label={field.label}
+            value={String(value ?? '')}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder}
+            className={inputClass}
+          />
+          {helpEl}
+        </div>
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Icons — same 24×24 / stroke=1.5 convention as the rest of the app
+// ---------------------------------------------------------------------------
+
+function RuleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M4 6h16M4 12h10M4 18h13" />
+      <circle cx="19" cy="17" r="2" />
+    </svg>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M18 8a6 6 0 00-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M13.7 21a2 2 0 01-3.4 0" />
+    </svg>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -26,6 +26,7 @@ import { settingsServiceRoute } from './routes/_app/settings.$service'
 import { serviceConfigRoute } from './routes/_app/config.$service'
 import { logSinksRoute } from './routes/_app/log-sinks'
 import { authProvidersRoute } from './routes/_app/auth-providers'
+import { alertsRoute } from './routes/_app/alerts'
 import { auditRoute } from './routes/_app/audit'
 import { devComponentsRoute } from './routes/dev.components'
 
@@ -42,6 +43,7 @@ const routeTree = rootRoute.addChildren([
     serviceConfigRoute,
     logSinksRoute,
     authProvidersRoute,
+    alertsRoute,
     auditRoute,
     envRoute.addChildren([
       envIndexRoute,

--- a/frontend/src/routes/_app/alerts.tsx
+++ b/frontend/src/routes/_app/alerts.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { appRoute } from './route';
+import { AlertsPage } from '$/features/alerts/AlertsPage';
+
+export const alertsRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: 'alerts',
+  component: AlertsPage,
+});


### PR DESCRIPTION
## Alerting system Stage 6: SPA "Alerts" section

### Problem

Stages 1–5 delivered the complete alerting backend — rule matching on ingested
logs, node liveness transitions, webhook/email delivery, a management API, and
instant hot-reload — but managing it required the CLI or direct database edits.
This PR adds the operator UI: a full "Alerts" section in the SPA, feature-gated
the same way as Log Sinks and Auth Providers.

### Change

**Feature gating**
- `cmd/api/handlers/features.go` — new `alerts` flag in
  `GET /api/v1/features`, driven by the alerts manager's presence
  (off when `--alerts-enabled` is unset); regression test added for the
  off-by-default case
- `frontend/src/api/features.ts` — `alerts?: boolean` in the `Features` type

**API client — new `frontend/src/api/alerts.ts`**
- Typed wrappers for every Stage-4 endpoint: rules CRUD, channels CRUD plus
  the channel-type registry, history, and apply — mirroring the log-sinks
  client conventions (wire shapes matching the API DTOs)

**Alerts page — new `frontend/src/features/alerts/AlertsPage.tsx`**
(~1,100 lines, LogSinksPage visual/structural conventions: sticky header,
SkeletonRow loading, EmptyState, ModalShell, CSS-var tokens only):
- Three tabs — **Rules**, **Channels**, **History** — with an environment
  selector (Global fallback + per-environment), matching log sinks semantics
- **Rule editor modal**: source picker covering all five sources with help
  text; pattern inputs (type/field/value) render only for pattern sources and
  disappear for node-state sources; severity floor for status logs; cooldown
  with default hint; channel checkboxes; client-side validation
- **Channel editor modal**: registry-driven dynamic form from
  `/channels/types` — typed inputs (string / integer / boolean / secret) with
  defaults prefilled on create, password-masked secret fields on edit, `***`
  placeholder semantics preserved server-side; type locked while editing
- **Apply changes**: queues the reload-alerts service command and polls it to
  consumption — the same UX as the log-sinks apply flow
- Disabled-feature shell explaining `alertsEnabled: false` and how to enable,
  with zero endpoint calls when the feature is off

**Wiring**
- `routes/_app/alerts.tsx` route + router registration
- SideNav "Alerts" item (bell icon, amber tone) in the Admin section, gated
  on `features?.alerts` — hidden entirely on deployments with alerting off

### Validation

- Frontend: full suite **303/303 tests passing** (292 pre-existing + 11 new),
  `npm run check` (tsc) clean
- New AlertsPage tests: empty state + fetch wiring, disabled shell (asserts
  the alerts endpoints are never called), rules table rendering (source,
  pattern, channel attribution, node-state em-dash), channels tab with
  registry description, history tab, rule create round-trip (payload
  asserted), pattern-required validation, pattern inputs hidden for
  node-state sources, channel create with registry defaults asserted in the
  payload, rule delete, apply triggering the reload command
- Backend: `go build ./...` clean; `go test ./cmd/api/... ./pkg/alerts/`
  green, including the updated features regression test
- A rules-of-hooks violation (memoized data after early returns) was caught
  by the new tests and fixed before merge — the page now orders hooks
  correctly for the disabled-feature early return path

### Roadmap position

Stage 6 of 7 (`alerts-frontend`). The alerting system is now fully operable
from the UI: create rules and channels through typed forms, watch dispatched
alerts land in history, and hot-reload osctrl-tls with one click. Remaining:
Stage 7 — load hardening (ingest regression benchmark under rule load) and
the alert-history retention sweep.