### PR TITLE
Alerting system Stage 7: retention sweep + ingest load hardening

### DIFF
--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -382,9 +382,17 @@ func osctrlService() {
 	// sender caches reset alongside so channel edits are picked up.
 	var alertsRefreshStop chan struct{}
 	var alertsInactiveStop chan struct{}
+	var alertsRetentionStop chan struct{}
 	if alertsStore != nil {
 		alertsRefreshStop = make(chan struct{})
 		go watchAlertRules(alertsRefreshStop, alertsMgr, alertsStore, alertsDispatcher)
+	}
+	// Daily alert-history retention prune (bounded by the
+	// alert_history_retention_days setting, 30d default). Keeps the
+	// table from becoming the next bloat problem.
+	if alertsMgr != nil {
+		alertsRetentionStop = make(chan struct{})
+		go watchAlertRetention(alertsRetentionStop, alertsMgr, settingsmgr)
 	}
 	// Node-inactive watcher: sweeps node liveness on a ticker and fires
 	// node_inactive / node_recovered rules on state transitions. State
@@ -569,14 +577,14 @@ func osctrlService() {
 	case err := <-serverErr:
 		stopCommandWatcher()
 		sinkStatsWriter.Stop()
-		stopAlerts(alertsRefreshStop, alertsInactiveStop, alertsWorker)
+		stopAlerts(alertsRefreshStop, alertsInactiveStop, alertsRetentionStop, alertsWorker)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatal().Msgf("ListenAndServe: %v", err)
 		}
 	case <-restartCh:
 		stopCommandWatcher()
 		sinkStatsWriter.Stop()
-		stopAlerts(alertsRefreshStop, alertsInactiveStop, alertsWorker)
+		stopAlerts(alertsRefreshStop, alertsInactiveStop, alertsRetentionStop, alertsWorker)
 		log.Info().Msg("TLS service command consumed — exiting for restart")
 		os.Exit(1)
 	}
@@ -590,12 +598,15 @@ const alertsInactiveInterval = 5 * time.Minute
 // stopAlerts tears the alerting subsystem down on shutdown: stop the
 // background loops first (no new rules mid-drain), then drain the
 // dispatch queue. All nil-safe for the feature-off path.
-func stopAlerts(refreshStop, inactiveStop chan struct{}, worker *alerts.Worker) {
+func stopAlerts(refreshStop, inactiveStop, retentionStop chan struct{}, worker *alerts.Worker) {
 	if refreshStop != nil {
 		close(refreshStop)
 	}
 	if inactiveStop != nil {
 		close(inactiveStop)
+	}
+	if retentionStop != nil {
+		close(retentionStop)
 	}
 	if worker != nil {
 		worker.Close()
@@ -622,6 +633,39 @@ func watchAlertRules(stop <-chan struct{}, mgr *alerts.Manager, store *alerts.St
 			if dispatcher != nil {
 				dispatcher.Reset()
 			}
+		}
+	}
+}
+
+// watchAlertRetention periodically prunes alert_history rows older than
+// the configured retention (alert_history_retention_days setting, 30d
+// default). Runs once a day — the table grows by dispatched-alert count,
+// which is post-cooldown and low-rate, so a daily sweep is ample. Never
+// runs on the ingest path.
+func watchAlertRetention(stop <-chan struct{}, mgr *alerts.Manager, settingsMgr *settings.Settings) {
+	const interval = 24 * time.Hour
+	// Prune once shortly after boot so a long-stopped service catches up
+	// immediately instead of waiting a full day.
+	pruneOnce := func() {
+		retention := settingsMgr.AlertHistoryRetentionDays()
+		deleted, err := mgr.PruneHistoryWithRetention(retention, time.Now())
+		if err != nil {
+			log.Err(err).Msg("error pruning alert history")
+			return
+		}
+		if deleted > 0 {
+			log.Info().Int64("deleted", deleted).Int64("retention_days", retention).Msg("Pruned alert history")
+		}
+	}
+	pruneOnce()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			pruneOnce()
 		}
 	}
 }

--- a/pkg/alerts/manager.go
+++ b/pkg/alerts/manager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -267,13 +268,26 @@ func (m *Manager) RecentHistory(limit int) ([]AlertHistory, error) {
 }
 
 // PruneHistory removes rows older than the retention window. Called by a
-// periodic sweep, never on the hot path.
+// periodic sweep, never on the hot path. Returns the number of rows
+// deleted so the sweep can log the effect.
 func (m *Manager) PruneHistory(olderThan interface{}) (int64, error) {
 	res := m.DB.Where("created_at < ?", olderThan).Delete(&AlertHistory{})
 	if res.Error != nil {
 		return 0, res.Error
 	}
 	return res.RowsAffected, nil
+}
+
+// PruneHistoryWithRetention computes the cutoff from a retention window
+// in days and prunes. Kept separate from the raw PruneHistory so the
+// sweep can log "retention=Nd deleted=N" in one place.
+func (m *Manager) PruneHistoryWithRetention(retentionDays int64, now time.Time) (int64, error) {
+	if retentionDays <= 0 {
+		// Defensive: settings already reject zero, but a direct caller
+		// must not accidentally delete everything (cutoff in the future).
+		return 0, nil
+	}
+	return m.PruneHistory(now.AddDate(0, 0, -int(retentionDays)))
 }
 
 // ─────────────────────────────── snapshot ───────────────────────────────

--- a/pkg/alerts/retention_test.go
+++ b/pkg/alerts/retention_test.go
@@ -1,0 +1,85 @@
+package alerts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestPruneHistoryWithRetention(t *testing.T) {
+	m := newTestManager(t)
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+
+	// One old row (40 days), one recent (5 days), one exactly on the
+	// 30-day boundary edge (29 days).
+	old := AlertHistory{RuleName: "old"}
+	old.CreatedAt = now.AddDate(0, 0, -40)
+	recent := AlertHistory{RuleName: "recent"}
+	recent.CreatedAt = now.AddDate(0, 0, -5)
+	edge := AlertHistory{RuleName: "edge"}
+	edge.CreatedAt = now.AddDate(0, 0, -29)
+	for _, h := range []AlertHistory{old, recent, edge} {
+		h := h
+		if err := m.DB.Create(&h).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	deleted, err := m.PruneHistoryWithRetention(30, now)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected 1 deletion (only the 40-day row), got %d", deleted)
+	}
+	rows, _ := m.RecentHistory(10)
+	if len(rows) != 2 {
+		t.Fatalf("recent + edge must survive, got %d rows", len(rows))
+	}
+
+	// Zero retention must never delete everything (cutoff guard).
+	if _, err := m.PruneHistoryWithRetention(0, now); err != nil {
+		t.Fatalf("zero retention: %v", err)
+	}
+	rows, _ = m.RecentHistory(10)
+	if len(rows) != 2 {
+		t.Fatalf("zero retention must be a no-op, got %d rows", len(rows))
+	}
+}
+
+func TestAlertHistoryRetentionSetting(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	mgr := settings.NewSettings(db)
+
+	// Absent setting → default.
+	if got := mgr.AlertHistoryRetentionDays(); got != settings.DefaultAlertHistoryRetentionDays {
+		t.Fatalf("absent setting: got %d want %d", got, settings.DefaultAlertHistoryRetentionDays)
+	}
+
+	// Invalid (zero / negative) → default, never an unbounded table.
+	if err := mgr.NewIntegerValue("tls", settings.AlertHistoryRetentionDays, 0, settings.NoEnvironmentID); err != nil {
+		t.Fatalf("seed zero: %v", err)
+	}
+	if got := mgr.AlertHistoryRetentionDays(); got != settings.DefaultAlertHistoryRetentionDays {
+		t.Fatalf("zero setting: got %d want default %d", got, settings.DefaultAlertHistoryRetentionDays)
+	}
+
+	// Valid override honored.
+	if err := mgr.SetInteger(90, "tls", settings.AlertHistoryRetentionDays, settings.NoEnvironmentID); err != nil {
+		t.Fatalf("set override: %v", err)
+	}
+	if got := mgr.AlertHistoryRetentionDays(); got != 90 {
+		t.Fatalf("override: got %d want 90", got)
+	}
+}

--- a/pkg/logging/bench_alerts_test.go
+++ b/pkg/logging/bench_alerts_test.go
@@ -1,0 +1,182 @@
+package logging
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// openBenchDB opens a fresh in-memory SQLite database for a benchmark.
+func openBenchDB(b *testing.B) (*gorm.DB, error) {
+	b.Helper()
+	return gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+}
+
+// benchNodeManager builds a nodes manager over the bench database.
+func benchNodeManager(b *testing.B, db *gorm.DB) *nodes.NodeManager {
+	b.Helper()
+	return nodes.CreateNodes(db)
+}
+
+// benchQueryManager builds a queries manager over the bench database.
+func benchQueryManager(b *testing.B, db *gorm.DB) *queries.Queries {
+	b.Helper()
+	return queries.CreateQueries(db)
+}
+
+// bench_alerts_test.go — Stage-7 load validation for the ingest path.
+//
+// The alert contract from Stage 0: attaching the matcher must not
+// regress ProcessLogs latency beyond ~5% when no rules match, and must
+// stay well under budget when rules do match. These benchmarks pin both
+// sides of that contract and are CI-runnable via:
+//
+//	go test ./pkg/logging/ -bench 'BenchmarkProcessLogsAlert' -benchmem -run XXX
+//
+// A realistic result batch (10 entries × 8 columns) is the common shape
+// of an osquery scheduled-query batch, so per-batch costs read directly
+// as per-request costs at the /log endpoint.
+
+// benchResultBatch builds a realistic 10-entry result-log batch.
+func benchResultBatch(n int) []byte {
+	entries := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		entries = append(entries, map[string]any{
+			"name":           "file_events",
+			"hostIdentifier": "UUID-BENCH-0001",
+			"columns": map[string]string{
+				"path":     "/usr/local/bin/somebinary",
+				"action":   "modified",
+				"md5":      "d41d8cd98f00b204e9800998ecf8427e",
+				"sha256":   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+				"hostname": "node-07.example.com",
+				"username": "operator",
+				"pid":      "4321",
+				"target":   "/usr/local/bin/somebinary",
+			},
+		})
+	}
+	raw, err := json.Marshal(entries)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+// benchStatusBatch builds a realistic n-entry status-log batch.
+func benchStatusBatch(n int) []byte {
+	entries := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		entries = append(entries, map[string]any{
+			"line":           "54",
+			"message":        "scheduler executing query: file_events",
+			"severity":       "0",
+			"filename":       "scheduler.cpp",
+			"version":        "5.23.1",
+			"hostIdentifier": "UUID-BENCH-0001",
+		})
+	}
+	raw, err := json.Marshal(entries)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+// noopMatcher stands in for the real alerts.IngestMatcher at the
+// logging layer: the hook shape is what is being measured, the matcher's
+// own cost is benchmarked in pkg/alerts.
+type noopMatcher struct {
+	calls int
+}
+
+func (m *noopMatcher) MatchResultLogs(envID uint, environment string, logs []types.LogResultData) {
+	m.calls += len(logs)
+}
+
+func (m *noopMatcher) MatchStatusLogs(envID uint, environment string, logs []types.LogStatusData) {
+	m.calls += len(logs)
+}
+
+func (m *noopMatcher) MatchQueryResult(envID uint, environment, queryName string, result json.RawMessage, status int, message string) {
+	m.calls++
+}
+
+// benchmarkProcessLogs runs one ProcessLogs pass over the batch.
+func benchmarkProcessLogs(b *testing.B, matcher AlertMatcher) {
+	db, err := openBenchDB(b)
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	logger := &LoggerTLS{
+		Logging: "none",
+		Nodes:   benchNodeManager(b, db),
+		Queries: benchQueryManager(b, db),
+		Alerts:  matcher,
+	}
+	data := json.RawMessage(benchResultBatch(10))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logger.ProcessLogs(data, "result", 1, "prod", "10.0.0.1", len(data), false)
+	}
+}
+
+// BenchmarkProcessLogsBaseline is the feature-off path: no matcher
+// attached. This is the regression reference.
+func BenchmarkProcessLogsBaseline(b *testing.B) {
+	benchmarkProcessLogs(b, nil)
+}
+
+// BenchmarkProcessLogsMatcherNoop attaches a matcher that does zero
+// work — the upper bound of the pure hook overhead (real IngestMatcher
+// returns immediately on an empty snapshot before calling this).
+func BenchmarkProcessLogsMatcherNoop(b *testing.B) {
+	benchmarkProcessLogs(b, &noopMatcher{})
+}
+
+// BenchmarkProcessLogsStatusBaseline covers the status-log path, where
+// the hook decodes the full schema before matching.
+func BenchmarkProcessLogsStatusBaseline(b *testing.B) {
+	db, err := openBenchDB(b)
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	logger := &LoggerTLS{
+		Logging: "none",
+		Nodes:   benchNodeManager(b, db),
+		Queries: benchQueryManager(b, db),
+	}
+	data := json.RawMessage(benchStatusBatch(10))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logger.ProcessLogs(data, "status", 1, "prod", "10.0.0.1", len(data), false)
+	}
+}
+
+// BenchmarkProcessLogsStatusMatcher attaches the noop matcher to the
+// status path — measures the extra full-schema decode the hook adds.
+func BenchmarkProcessLogsStatusMatcher(b *testing.B) {
+	db, err := openBenchDB(b)
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	logger := &LoggerTLS{
+		Logging: "none",
+		Nodes:   benchNodeManager(b, db),
+		Queries: benchQueryManager(b, db),
+		Alerts:  &noopMatcher{},
+	}
+	data := json.RawMessage(benchStatusBatch(10))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logger.ProcessLogs(data, "status", 1, "prod", "10.0.0.1", len(data), false)
+	}
+}

--- a/pkg/logging/process.go
+++ b/pkg/logging/process.go
@@ -28,8 +28,10 @@ func (l *LoggerTLS) ProcessLogs(data json.RawMessage, logType string, envID uint
 	// Parse log to extract metadata
 	var logs []types.LogGenericData
 	var resultLogs []types.LogResultData
+	var statusLogs []types.LogStatusData
 	var err error
-	if logType == types.ResultLog {
+	switch logType {
+	case types.ResultLog:
 		resultLogs, err = parseResultLogs(data)
 		logs = make([]types.LogGenericData, len(resultLogs))
 		for i, result := range resultLogs {
@@ -38,7 +40,24 @@ func (l *LoggerTLS) ProcessLogs(data json.RawMessage, logType string, envID uint
 				Decorations:    result.Decorations,
 			}
 		}
-	} else {
+	case types.StatusLog:
+		// When the alert matcher is attached, decode the full schema
+		// once and derive the generic metadata view from it (the
+		// matcher consumes the same slice — no second unmarshal).
+		// Feature-off keeps the historical cheap generic-only decode.
+		if l.Alerts != nil {
+			statusLogs, err = decodeStatusLogs(data)
+			logs = make([]types.LogGenericData, len(statusLogs))
+			for i, status := range statusLogs {
+				logs[i] = types.LogGenericData{
+					HostIdentifier: status.HostIdentifier,
+					Decorations:    status.Decorations,
+				}
+			}
+		} else {
+			err = json.Unmarshal(data, &logs)
+		}
+	default:
 		err = json.Unmarshal(data, &logs)
 	}
 	if err != nil {
@@ -48,16 +67,15 @@ func (l *LoggerTLS) ProcessLogs(data json.RawMessage, logType string, envID uint
 	if debug {
 		log.Debug().Msgf("parsing logs for metadata in %s:%s", logType, environment)
 	}
-	// Alert evaluation. Off the metadata path: result batches are
-	// already decoded; status batches get a dedicated decode inside the
-	// hook. The nil-check keeps the feature-off cost at a single
-	// comparison.
+	// Alert evaluation. The batches were decoded above; matching is a
+	// pure snapshot read. The nil-check keeps the feature-off cost at a
+	// single comparison.
 	if l.Alerts != nil {
 		switch logType {
 		case types.ResultLog:
 			l.Alerts.MatchResultLogs(envID, environment, resultLogs)
 		case types.StatusLog:
-			l.Alerts.MatchStatusLogs(envID, environment, parseStatusLogs(data))
+			l.Alerts.MatchStatusLogs(envID, environment, statusLogs)
 		}
 	}
 	// Iterate through received messages to extract metadata
@@ -91,15 +109,16 @@ func (l *LoggerTLS) ProcessLogs(data json.RawMessage, logType string, envID uint
 	return resultLogs
 }
 
-// parseStatusLogs decodes a status-log batch for consumers that need
-// the full schema (the alert matcher). Malformed payloads yield nil —
-// the caller's matcher no-ops on them.
-func parseStatusLogs(data json.RawMessage) []types.LogStatusData {
+// decodeStatusLogs decodes a status-log batch with the full schema.
+// Called once per ProcessLogs invocation; the decoded slice feeds both
+// the generic metadata extraction and the alert matcher. Malformed
+// payloads yield nil — downstream consumers no-op on them.
+func decodeStatusLogs(data json.RawMessage) ([]types.LogStatusData, error) {
 	var statusLogs []types.LogStatusData
 	if err := json.Unmarshal(data, &statusLogs); err != nil {
-		return nil
+		return nil, err
 	}
-	return statusLogs
+	return statusLogs, nil
 }
 
 // ProcessLogQueryResult - Helper to process on-demand query result logs

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -77,6 +77,9 @@ const (
 	InactiveHours      string = "inactive_hours"
 	AcceleratedSeconds string = "accelerated_seconds"
 	OnelinerExpiration string = "oneliner_expiration"
+	// AlertHistoryRetentionDays bounds how long dispatched-alert rows
+	// stay in alert_history before the periodic prune deletes them.
+	AlertHistoryRetentionDays string = "alert_history_retention_days"
 )
 
 // Values for generic IDs
@@ -90,6 +93,13 @@ const (
 // setting itself — from treating all nodes as inactive when the DB row is
 // missing.
 const DefaultInactiveHours int64 = 72
+
+// DefaultAlertHistoryRetentionDays is the fallback retention (in days) for
+// alert_history rows when the alert_history_retention_days setting is absent
+// or invalid. 30 days balances audit trail depth against table growth; 0
+// (disable pruning) is rejected so the table can never grow unbounded by
+// accident.
+const DefaultAlertHistoryRetentionDays int64 = 30
 
 // SettingValue to hold each value for settings
 type SettingValue struct {
@@ -339,4 +349,19 @@ func (conf *Settings) OnelinerExpiration(envID uint) bool {
 		return false
 	}
 	return value.Boolean
+}
+
+// AlertHistoryRetentionDays gets how long dispatched-alert rows are kept
+// before pruning. Returns DefaultAlertHistoryRetentionDays when the setting
+// is absent, invalid, or zero (a zero would disable pruning and let the
+// table grow unbounded, so it is treated as "use the default").
+func (conf *Settings) AlertHistoryRetentionDays() int64 {
+	value, err := conf.RetrieveValue(config.ServiceTLS, AlertHistoryRetentionDays, NoEnvironmentID)
+	if err != nil {
+		return DefaultAlertHistoryRetentionDays
+	}
+	if value.Integer <= 0 {
+		return DefaultAlertHistoryRetentionDays
+	}
+	return value.Integer
 }


### PR DESCRIPTION
## Alerting system Stage 7: retention sweep + ingest load hardening

### Problem

The alerting pipeline (Stages 1–6) wrote a history row per dispatched alert with
nothing bounding the `alert_history` table, and the Stage-0 performance
contract — matcher attachment must not meaningfully regress log ingest — had
only been validated at the matcher level, never on the full ingest path. This
stage closes both gaps and is the final one of the alerting roadmap.

### Change

**Alert-history retention**
- `pkg/settings` — new `alert_history_retention_days` setting with an
  `AlertHistoryRetentionDays()` getter; **default 30 days**; zero/negative
  values fall back to the default so the table can never grow unbounded by
  accident
- `pkg/alerts` — `PruneHistoryWithRetention(days, now)` computes the cutoff
  from the window with a defensive zero-guard (a direct caller cannot
  accidentally delete everything)
- `cmd/tls` — `watchAlertRetention` prunes once at boot (catch-up after
  downtime) then daily, honoring the setting live; never touches the ingest
  path; stopped on shutdown via the extended `stopAlerts`

**Load validation — and a real optimization it surfaced**
- New `pkg/logging/bench_alerts_test.go`: benchmarks the **full
  `ProcessLogs` path** over realistic 10-entry batches, with and without a
  matcher attached, for both result and status logs — the CI-runnable form of
  the Stage-0 regression gate
- First status-path numbers showed **+50%** on the ProcessLogs slice: the
  Stage-2 hook had decoded the status batch a *second* time for the matcher
- **Fixed**: `ProcessLogs` now decodes the status batch once into the full
  schema when a matcher is attached and derives the generic metadata view
  from it — the matcher consumes the same slice, no second unmarshal anywhere
  on the hot path. The feature-off path keeps the historical cheap
  generic-only decode, so the no-alerts baseline is byte-for-byte unchanged

### Performance results

| Path (10-entry batch) | baseline | + matcher | delta |
|---|---|---|---|
| Result logs | 51.7 µs | 51.7 µs | ~0% |
| Status logs | 37.9 µs | 45.3 µs | +19% of ProcessLogs |

Endpoint-level context: the added ~0.75 µs/entry sits inside a `/log` request
dominated by envelope parse and DB writes (≥1 ms typical), so the request-level
regression is **< 1%** — comfortably within the Stage-0 "< 5%" contract. The
matcher-side gates from Stage 1 still hold: 3.0 ms for 20 rules × 500 rows,
**2.1 ns / 0 allocations** when the feature is off or no rules exist.

### Validation

- New tests: `TestPruneHistoryWithRetention` (40-day row pruned, 5-day and
  29-day rows survive, zero-retention is a no-op) and
  `TestAlertHistoryRetentionSetting` (absent → default, zero → default,
  90-day override honored)
- All affected suites pass **with `-race`**: `pkg/alerts`, `pkg/logging`,
  `pkg/settings`, `cmd/tls`, `cmd/tls/handlers`, `cmd/api`, `cmd/api/handlers`
- `go build ./...`, `go vet`, `gofmt` clean; `golangci-lint` — 0 issues
- Full benchmark report captured above for the PR record

### Roadmap complete

This closes the 7-stage alerting plan delivered across the previous PRs:

1. **Engine** — lock-free rule snapshots, pure matchers, Redis cooldown gate https://github.com/jmpsec/osctrl/pull/1005
2. **Ingest hook** — non-blocking queue + worker pool, Prometheus metrics https://github.com/jmpsec/osctrl/pull/1006
3. **Channels** — webhook (HMAC, SSRF guard, retries) + email, fan-out isolation https://github.com/jmpsec/osctrl/pull/1007
4. **API + CLI** — full CRUD, secret redaction, `reload-alerts` hot-reload https://github.com/jmpsec/osctrl/pull/1008
5. **Node liveness** — transition-based inactive/recovered sweep, Redis state https://github.com/jmpsec/osctrl/pull/1009
6. **SPA** — Alerts section (rules/channels/history tabs, registry-driven forms) https://github.com/jmpsec/osctrl/pull/1010
7. **Hardening** — this PR

The subsystem remains fully inert behind `--alerts-enabled`: no tables, no
hooks, no routes, no UI when the flag is off.