### PR TITLE
Fix node-scoped alert creation, and make the resulting rule visible

### DIFF
--- a/cmd/api/handlers/alerts.go
+++ b/cmd/api/handlers/alerts.go
@@ -746,11 +746,19 @@ func respondAlertsErr(w http.ResponseWriter, err error) {
 		apiErrorResponse(w, "already exists", http.StatusConflict, err)
 	case errors.Is(err, alerts.ErrInvalidSource), errors.Is(err, alerts.ErrInvalidChannelType), errors.Is(err, alerts.ErrInvalidChannelConfig):
 		apiErrorResponse(w, "invalid value", http.StatusBadRequest, err)
+	// Rule validation failures are operator input, not server faults —
+	// they used to fall through to the 500 below, which told the SPA
+	// nothing and read as an outage.
+	case errors.Is(err, alerts.ErrInvalidRule):
+		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
 	case errors.Is(err, alerts.ErrTooManyRules):
 		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
 	case errors.Is(err, gorm.ErrRecordNotFound):
 		apiErrorResponse(w, "not found", http.StatusNotFound, err)
 	default:
+		// apiErrorResponse only logs at debug level, so a genuine 500
+		// here was invisible in a normally-configured deployment.
+		log.Error().Err(err).Msg("alerts request failed")
 		apiErrorResponse(w, "error", http.StatusInternalServerError, err)
 	}
 }

--- a/cmd/api/handlers/alerts_test.go
+++ b/cmd/api/handlers/alerts_test.go
@@ -162,6 +162,35 @@ func TestAlertRuleCreateRejectsInvalidSource(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+// TestAlertRuleCreateNodeScoped covers the node detail page's "alert on
+// this node" flow: the scope is osquery's host_identifier, which is not
+// necessarily a UUID. It used to fail validation and surface as a 500.
+func TestAlertRuleCreateNodeScoped(t *testing.T) {
+	h := setupAlertsHandler(t)
+	body := map[string]any{
+		"name": "web-server-01-inactive", "environment_id": 1, "source": "node_inactive",
+		"node_uuid": "WEB-SERVER-01.CORP", "match_type": "substring",
+		"match_field": "", "match_value": "", "cooldown_minutes": 0,
+		"channel_ids": []uint{}, "enabled": true,
+	}
+	rr := call(t, h.AlertRulesCreateHandler, http.MethodPost, "/api/v1/alerts/rules", body)
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	var created alertRuleDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+	require.Equal(t, "WEB-SERVER-01.CORP", created.NodeUUID)
+}
+
+// TestAlertRuleCreateInvalidIs400 pins bad input to 400 with the reason —
+// validation errors used to fall through to a 500 saying only "error".
+func TestAlertRuleCreateInvalidIs400(t *testing.T) {
+	h := setupAlertsHandler(t)
+	body := ruleBody()
+	body["name"] = "   "
+	rr := call(t, h.AlertRulesCreateHandler, http.MethodPost, "/api/v1/alerts/rules", body)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "rule name is required")
+}
+
 func TestAlertChannelCRUDRoundTrip(t *testing.T) {
 	h := setupAlertsHandler(t)
 

--- a/frontend/src/features/alerts/AlertsPage.test.tsx
+++ b/frontend/src/features/alerts/AlertsPage.test.tsx
@@ -165,7 +165,22 @@ describe('AlertsPage', () => {
     renderPage();
     expect(await screen.findByText('No alert rules')).toBeInTheDocument();
     // The empty state can render before features resolve (query still
-    // disabled); wait for the actual fetch to confirm the wiring.
+    // disabled); wait for the actual fetch to confirm the wiring. The
+    // default filter is no filter — every environment's rules, so one
+    // created from a node page is visible without changing the selector.
+    await waitFor(() => expect(mockListRules).toHaveBeenCalledWith(undefined));
+  });
+
+  it('filters by environment only when the operator picks one', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(mockListRules).toHaveBeenCalledWith(undefined));
+
+    const select = screen.getByLabelText('Select environment whose alerts to show');
+    await user.selectOptions(select, '5');
+    await waitFor(() => expect(mockListRules).toHaveBeenCalledWith({ env: 5 }));
+
+    await user.selectOptions(select, '0');
     await waitFor(() => expect(mockListRules).toHaveBeenCalledWith({ env: 0 }));
   });
 
@@ -197,6 +212,10 @@ describe('AlertsPage', () => {
     expect(screen.getByText('soc-webhook')).toBeInTheDocument();
     // node-state rule shows an em dash instead of a pattern
     expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+    // column titles above the rows
+    for (const title of ['Rule', 'Source', 'Match', 'Pattern', 'Cooldown', 'Channels', 'Status']) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
   });
 
   it('switches to the channels tab and lists channels', async () => {
@@ -206,6 +225,9 @@ describe('AlertsPage', () => {
     await user.click(await screen.findByRole('tab', { name: 'channels' }));
     expect(await screen.findByText('soc-webhook')).toBeInTheDocument();
     expect(screen.getByText('HTTP POST to a URL with the alert as JSON')).toBeInTheDocument();
+    for (const title of ['Channel', 'Type', 'Description', 'Status']) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
   });
 
   it('switches to the history tab and lists dispatched alerts', async () => {

--- a/frontend/src/features/alerts/AlertsPage.tsx
+++ b/frontend/src/features/alerts/AlertsPage.tsx
@@ -35,6 +35,11 @@ import { cn } from '$/lib/cn';
 import { StatusBadge } from '$/components/data/StatusBadge';
 
 const GLOBAL_ENV_ID = 0;
+// Sentinel for the env selector: no env filter at all, so the list shows
+// every environment's rules. GLOBAL_ENV_ID is a real filter (env 0 rows),
+// not "everything" — a rule created from a node's page lives in that
+// node's environment and was invisible under it.
+const ALL_ENVS = -1;
 
 /** Rule sources the form offers, with human descriptions. */
 const RULE_SOURCES = [
@@ -82,7 +87,7 @@ export function AlertsPage() {
   const qc = useQueryClient();
 
   const [tab, setTab] = useState<Tab>('rules');
-  const [selectedEnv, setSelectedEnv] = useState<number>(GLOBAL_ENV_ID);
+  const [selectedEnv, setSelectedEnv] = useState<number>(ALL_ENVS);
   const [ruleModal, setRuleModal] = useState<RuleModalMode>({ kind: 'closed' });
   const [channelModal, setChannelModal] = useState<ChannelModalMode>({ kind: 'closed' });
   const [applyErr, setApplyErr] = useState<string | null>(null);
@@ -104,14 +109,14 @@ export function AlertsPage() {
 
   const rulesQuery = useQuery({
     queryKey: ['alert-rules', selectedEnv],
-    queryFn: () => listAlertRules({ env: selectedEnv }),
+    queryFn: () => listAlertRules(selectedEnv === ALL_ENVS ? undefined : { env: selectedEnv }),
     enabled: !!features?.alerts,
     staleTime: 30_000,
   });
 
   const channelsQuery = useQuery({
     queryKey: ['alert-channels', selectedEnv],
-    queryFn: () => listAlertChannels({ env: selectedEnv }),
+    queryFn: () => listAlertChannels(selectedEnv === ALL_ENVS ? undefined : { env: selectedEnv }),
     enabled: !!features?.alerts,
     staleTime: 30_000,
   });
@@ -310,7 +315,8 @@ export function AlertsPage() {
                 'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
               )}
             >
-              <option value={GLOBAL_ENV_ID}>Global (all environments)</option>
+              <option value={ALL_ENVS}>All environments</option>
+              <option value={GLOBAL_ENV_ID}>Global rules only</option>
               {envs?.map((e) => (
                 <option key={e.id} value={e.id}>
                   {e.name}
@@ -416,6 +422,34 @@ function FeatureDisabledShell() {
 // Tables
 // ---------------------------------------------------------------------------
 
+// Grid templates are shared between each table's header and its rows so the
+// two can never drift out of alignment.
+const RULES_GRID =
+  'grid grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.2fr)_80px_minmax(0,1fr)_120px] items-center gap-3 px-4';
+const CHANNELS_GRID =
+  'grid grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)_minmax(0,2fr)_120px] items-center gap-3 px-4';
+
+// Column titles, in the same style as the <th> rows on the other admin
+// pages. The last column holds the status badge and row actions, so it is
+// right-aligned to match.
+function TableHeader({ grid, columns }: { grid: string; columns: string[] }) {
+  return (
+    <div
+      className={cn(
+        grid,
+        'sticky top-0 z-10 py-2 bg-[color:var(--bg-2)]',
+        'text-xs font-medium uppercase tracking-wide text-[color:var(--text-2)]',
+      )}
+    >
+      {columns.map((label, i) => (
+        <div key={label || i} className={cn('truncate', i === columns.length - 1 && 'text-right')}>
+          {label}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function RulesTable({
   rules,
   loading,
@@ -453,10 +487,14 @@ function RulesTable({
     channels.find((c) => c.id === id)?.name ?? `#${id}`;
   return (
     <div className="divide-y divide-[color:var(--border)]">
+      <TableHeader
+        grid={RULES_GRID}
+        columns={['Rule', 'Source', 'Match', 'Pattern', 'Cooldown', 'Channels', 'Status']}
+      />
       {rules.map((rule) => (
         <div
           key={rule.id}
-          className="grid grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.2fr)_80px_minmax(0,1fr)_120px] items-center gap-3 px-4 py-2.5 text-sm hover:bg-[color:var(--bg-2)] transition-colors"
+          className={cn(RULES_GRID, 'py-2.5 text-sm hover:bg-[color:var(--bg-2)] transition-colors')}
         >
           <div className="min-w-0">
             <div className="font-medium text-[color:var(--text-1)] truncate">{rule.name}</div>
@@ -551,10 +589,14 @@ function ChannelsTable({
     types.find((t) => t.type === type)?.description ?? '';
   return (
     <div className="divide-y divide-[color:var(--border)]">
+      <TableHeader
+        grid={CHANNELS_GRID}
+        columns={['Channel', 'Type', 'Description', 'Status']}
+      />
       {channels.map((channel) => (
         <div
           key={channel.id}
-          className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)_minmax(0,2fr)_120px] items-center gap-3 px-4 py-2.5 text-sm hover:bg-[color:var(--bg-2)] transition-colors"
+          className={cn(CHANNELS_GRID, 'py-2.5 text-sm hover:bg-[color:var(--bg-2)] transition-colors')}
         >
           <div className="min-w-0">
             <div className="font-medium text-[color:var(--text-1)] truncate">{channel.name}</div>

--- a/frontend/src/features/nodes/NodeAlertModal.tsx
+++ b/frontend/src/features/nodes/NodeAlertModal.tsx
@@ -55,6 +55,9 @@ export function NodeAlertModal({
   const createMutation = useMutation({
     mutationFn: createAlertRule,
     onSuccess: () => {
+      // Drop every cached rule list (all env filters) so the new rule is
+      // there whether or not the operator goes on to apply it.
+      void qc.invalidateQueries({ queryKey: ['alert-rules'] });
       setSaved(true);
     },
     onError: (e) => {

--- a/pkg/alerts/node_scope_test.go
+++ b/pkg/alerts/node_scope_test.go
@@ -2,6 +2,8 @@ package alerts
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jmpsec/osctrl/pkg/types"
@@ -79,20 +81,32 @@ func TestInactiveWatcherNodeScopedRule(t *testing.T) {
 	}
 }
 
-// TestValidateRuleNodeUUID rejects malformed node scopes before rows
-// are stored — a typo would silently create a rule matching nothing.
+// TestValidateRuleNodeUUID accepts any node identifier that fits the
+// column. A node's UUID is osquery's host_identifier uppercased, so it is
+// a hostname / instance id / vendor serial under every --host_identifier
+// but "uuid" — validating it as RFC-4122 rejected real nodes and the API
+// reported that as a 500.
 func TestValidateRuleNodeUUID(t *testing.T) {
-	bad := AlertRule{Name: "r", Source: SourceResultLog, MatchType: MatchTypeSubstring, MatchValue: "x", NodeUUID: "not-a-uuid"}
-	if err := ValidateRule(bad); err == nil {
-		t.Fatal("malformed node_uuid must be rejected")
+	for _, scope := range []string{
+		"123e4567-e89b-42d3-a456-426614174000", // --host_identifier=uuid
+		"WEB-SERVER-01.CORP",                   // =hostname
+		"i-0abcd1234efgh5678",                  // =instance
+		"",                                     // all nodes
+	} {
+		rule := AlertRule{Name: "r", Source: SourceResultLog, MatchType: MatchTypeSubstring, MatchValue: "x", NodeUUID: scope}
+		if err := ValidateRule(rule); err != nil {
+			t.Fatalf("node scope %q rejected: %v", scope, err)
+		}
 	}
-	good := AlertRule{Name: "r", Source: SourceResultLog, MatchType: MatchTypeSubstring, MatchValue: "x", NodeUUID: "123e4567-e89b-42d3-a456-426614174000"}
-	if err := ValidateRule(good); err != nil {
-		t.Fatalf("valid node_uuid rejected: %v", err)
+	tooLong := AlertRule{Name: "r", Source: SourceResultLog, MatchType: MatchTypeSubstring, MatchValue: "x", NodeUUID: strings.Repeat("a", MaxNodeUUIDLen+1)}
+	if err := ValidateRule(tooLong); err == nil {
+		t.Fatal("node scope wider than the column must be rejected")
 	}
-	none := AlertRule{Name: "r", Source: SourceResultLog, MatchType: MatchTypeSubstring, MatchValue: "x"}
-	if err := ValidateRule(none); err != nil {
-		t.Fatalf("empty node_uuid must stay valid: %v", err)
+	// Every validation failure has to be recognizable as bad input so the
+	// API answers 400 with the reason instead of an opaque 500.
+	noName := AlertRule{Source: SourceResultLog, MatchType: MatchTypeSubstring, MatchValue: "x"}
+	if err := ValidateRule(noName); !errors.Is(err, ErrInvalidRule) {
+		t.Fatalf("validation error must wrap ErrInvalidRule, got %v", err)
 	}
 }
 

--- a/pkg/alerts/validate.go
+++ b/pkg/alerts/validate.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/jmpsec/osctrl/pkg/utils"
 )
 
 // errors.go + channel decode helpers.
@@ -22,6 +20,8 @@ var (
 	ErrChannelExists = errors.New("alert channel already exists")
 	// ErrInvalidSource is returned when Source is not a known source.
 	ErrInvalidSource = errors.New("invalid alert source")
+	// ErrInvalidRule wraps every ValidateRule failure.
+	ErrInvalidRule = errors.New("invalid alert rule")
 	// errInvalidMatchType guards MatchType.
 	errInvalidMatchType = errors.New("invalid match type")
 	// errPatternTooLong guards MaxPatternLen.
@@ -29,6 +29,9 @@ var (
 	// ErrTooManyRules guards MaxRulesPerEnv.
 	ErrTooManyRules = fmt.Errorf("too many alert rules for one environment (max %d)", MaxRulesPerEnv)
 )
+
+// MaxNodeUUIDLen bounds NodeUUID to its column width.
+const MaxNodeUUIDLen = 64
 
 // validSources is the closed set of Source values a rule may use.
 var validSources = map[string]bool{
@@ -40,18 +43,30 @@ var validSources = map[string]bool{
 }
 
 // ValidateRule checks the operator-facing fields of a rule before it is
-// stored. Mirrors logsinks.ValidateSink.
+// stored. Mirrors logsinks.ValidateSink. Every failure wraps
+// ErrInvalidRule: these are all operator-input errors, so the API answers
+// 400 with the reason instead of an opaque 500.
 func ValidateRule(rule AlertRule) error {
+	if err := validateRule(rule); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidRule, err)
+	}
+	return nil
+}
+
+func validateRule(rule AlertRule) error {
 	if strings.TrimSpace(rule.Name) == "" {
 		return errors.New("rule name is required")
 	}
 	if !validSources[rule.Source] {
 		return fmt.Errorf("%w: %q", ErrInvalidSource, rule.Source)
 	}
-	// A node scope, when set, must be a syntactically valid UUID so a
-	// typo cannot silently create a rule that never matches anything.
-	if rule.NodeUUID != "" && !utils.CheckUUID(strings.TrimSpace(rule.NodeUUID)) {
-		return errors.New("node_uuid must be a valid UUID")
+	// A node scope, when set, only has to fit the column. It is NOT an
+	// RFC-4122 UUID: a node's UUID is osquery's host_identifier
+	// uppercased, which is a hostname / instance id / vendor serial
+	// under any --host_identifier but "uuid". Parsing it as a UUID
+	// rejected legitimate nodes outright.
+	if len(strings.TrimSpace(rule.NodeUUID)) > MaxNodeUUIDLen {
+		return fmt.Errorf("node_uuid exceeds %d characters", MaxNodeUUIDLen)
 	}
 	if rule.Source == SourceNodeInactive || rule.Source == SourceNodeRecovered {
 		// Node-state rules do no pattern matching.


### PR DESCRIPTION
## Fix node-scoped alert creation, and make the resulting rule visible

### Problem

Creating an alert from a node's detail page failed with
`POST /api/v1/alerts/rules 500 (Internal Server Error)` and no usable message.

Root cause: `ValidateRule` required `node_uuid` to parse as an RFC-4122 UUID. A
node's UUID is osquery's `host_identifier` uppercased (`cmd/tls/handlers/post.go`),
so it is a hostname, instance id, or vendor serial under every `--host_identifier`
except `uuid` — legitimate nodes were rejected outright. The resulting error then
fell through `respondAlertsErr` to the `default:` branch, so operator input came
back as a 500 whose body was just `"error"`, logged only at debug level.
`pkg/alerts/node_scope_test.go` already exercised matching with `WATCH-U9`-style
scopes, so validation contradicted the matcher in the same package.

### Changes

**`pkg/alerts/validate.go`**
- `node_uuid` is now bounded to its column width (`MaxNodeUUIDLen = 64`) instead of
  being parsed as a UUID.
- New `ErrInvalidRule` sentinel wraps every `ValidateRule` failure, so callers can
  tell bad input from a server fault.

**`cmd/api/handlers/alerts.go`**
- `respondAlertsErr` answers **400 with the actual reason** for `ErrInvalidRule`.
- Genuine 500s log at error level (previously debug-only, i.e. invisible in a
  normally-configured deployment).

**`frontend/src/features/alerts/AlertsPage.tsx`**
- The env filter's default option was labeled "Global (all environments)" but sent
  `?env=0`, which the server filters as `environment_id = 0`. A rule created from a
  node lives in that node's environment, so it was invisible in the default view.
  Added an `ALL_ENVS` sentinel that omits the `env` param entirely (server returns
  every environment) and made it the default; the two meanings are now distinct
  options: **All environments** / **Global rules only** / per-env. Applies to
  channels too.
- Column titles on the rules and channels tables via one sticky `TableHeader`,
  matching the `<th>` style used on the other admin pages. Each table's grid
  template is now a shared const, so header and rows cannot drift out of alignment.

**`frontend/src/features/nodes/NodeAlertModal.tsx`**
- Invalidate `['alert-rules']` on create, not only on apply, so the new rule shows
  up even if the operator chooses "Apply later".

### Tests

- `TestAlertRuleCreateNodeScoped` — hostname-style node scope → 201, scope round-trips.
- `TestAlertRuleCreateInvalidIs400` — blank name → 400 containing "rule name is required".
- `TestValidateRuleNodeUUID` — rewritten: accepts uuid/hostname/instance-id/empty
  scopes, rejects over-column-width, asserts failures wrap `ErrInvalidRule`.
- Frontend: env filter sends no filter by default, `{env: 5}` / `{env: 0}` when
  chosen; both tables' column titles asserted.

`go test ./pkg/alerts/ ./cmd/api/handlers/` and 228 frontend tests pass; `tsc --noEmit` clean.

### Deploy note

Requires an `osctrl-api` restart to pick up the validation change.