### PR TITLE
Reject unknown user actions instead of silently returning 200

### DIFF
--- a/cmd/api/handlers/users.go
+++ b/cmd/api/handlers/users.go
@@ -318,6 +318,13 @@ func (h *HandlersApi) UserActionHandler(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 		returnData = "user removed successfully"
+	default:
+		// Reject unknown actions explicitly. Without this case an
+		// unrecognized action (e.g. "update") matches nothing, skips all
+		// branches, and still returns 200 with an empty payload — a silent
+		// no-op that looks like success while creating/editing nothing.
+		apiErrorResponse(w, "invalid action", http.StatusBadRequest, fmt.Errorf("unknown user action %q", actionVar))
+		return
 	}
 	// Serialize and serve JSON
 	log.Debug().Msgf("Returned [%s]", returnData)


### PR DESCRIPTION
UserActionHandler switches on the {action} path segment but had no default case. An unrecognized action (e.g. "update") matched none of add/edit/remove, skipped every branch, and still fell through to the trailing HTTPResponse — returning 200 {"data":""} while creating, editing, or removing nothing. Callers reasonably read the 200 as success, so a typo'd action silently no-ops.

Add a default case that returns 400 "invalid action".