### PR TITLE
Test alert button in alerts channel creation modal + bugfixes

### DIFF
--- a/cmd/api/handlers/alerts.go
+++ b/cmd/api/handlers/alerts.go
@@ -539,6 +539,80 @@ func (h *HandlersApi) AlertChannelsCreateHandler(w http.ResponseWriter, r *http.
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, toAlertChannelDTO(row, true))
 }
 
+// AlertChannelsTestHandler — POST /api/v1/alerts/channels/test
+//
+// Sends one synthetic notification through the posted config without
+// storing it, so a channel can be verified from the editor before it is
+// saved. No new capability: an admin could already save a channel and
+// wait for it to fire — this just closes the feedback loop.
+//
+// @Summary Test an alert channel
+// @Description Delivers a test notification through the posted channel config. Secrets left as "***" are merged from the stored channel named by id.
+// @Tags alerts
+// @Accept json
+// @Produce json
+// @Param request body types.AlertChannelTestRequest true "Request body"
+// @Success 200 {object} types.ApiGenericResponse
+// @Failure 400 {object} types.ApiErrorResponse "Bad request"
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 502 {object} types.ApiErrorResponse "Delivery failed"
+// @Failure 503 {object} types.ApiErrorResponse "Alerts disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/alerts/channels/test [post]
+func (h *HandlersApi) AlertChannelsTestHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, h.DebugHTTPConfig.ShowBody)
+	}
+	user, ok := h.requireAlertsAdmin(w, r)
+	if !ok {
+		return
+	}
+	mgr, ok := h.alertsMgr(w)
+	if !ok {
+		return
+	}
+	var body types.AlertChannelTestRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apiErrorResponse(w, "error parsing request body", http.StatusBadRequest, err)
+		return
+	}
+	cfg := string(body.Config)
+	// Editing an existing channel reads its secrets back as "***", so a
+	// test of an untouched secret has to merge the stored value or it
+	// would send the placeholder and fail for the wrong reason.
+	if body.ID != 0 {
+		prev, err := mgr.GetChannel(body.ID)
+		if err != nil {
+			respondAlertsErr(w, err)
+			return
+		}
+		if body.Type == "" {
+			body.Type = prev.Type
+		}
+		merged, err := alerts.MergeChannelSecrets(prev.Type, prev.Config, cfg)
+		if err != nil {
+			apiErrorResponse(w, "error merging channel secrets", http.StatusBadRequest, err)
+			return
+		}
+		cfg = merged
+	}
+	h.AuditLog.SettingsAction(user, fmt.Sprintf("tested alert channel (type %s, id %d)", body.Type, body.ID), strings.Split(r.RemoteAddr, ":")[0])
+	if err := alerts.TestSend(body.Type, cfg); err != nil {
+		// A bad config is the operator's input; anything else is the
+		// relay refusing us, which is not a 400 and not our 500.
+		if errors.Is(err, alerts.ErrInvalidChannelType) || errors.Is(err, alerts.ErrInvalidChannelConfig) {
+			respondAlertsErr(w, err)
+			return
+		}
+		apiErrorResponse(w, err.Error(), http.StatusBadGateway, err)
+		return
+	}
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{
+		Message: fmt.Sprintf("Test notification sent through the %s channel", body.Type),
+	})
+}
+
 // AlertChannelsUpdateHandler — PUT /api/v1/alerts/channels/{id}
 //
 // @Summary Update an alert channel
@@ -744,8 +818,11 @@ func respondAlertsErr(w http.ResponseWriter, err error) {
 		apiErrorResponse(w, "not found", http.StatusNotFound, err)
 	case errors.Is(err, alerts.ErrRuleExists), errors.Is(err, alerts.ErrChannelExists):
 		apiErrorResponse(w, "already exists", http.StatusConflict, err)
+	// Echo the reason: "invalid value" told the operator nothing about
+	// which field the registry rejected, or why a channel test refused to
+	// build. These endpoints are admin-only.
 	case errors.Is(err, alerts.ErrInvalidSource), errors.Is(err, alerts.ErrInvalidChannelType), errors.Is(err, alerts.ErrInvalidChannelConfig):
-		apiErrorResponse(w, "invalid value", http.StatusBadRequest, err)
+		apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
 	// Rule validation failures are operator input, not server faults —
 	// they used to fall through to the 500 below, which told the SPA
 	// nothing and read as an outage.

--- a/cmd/api/handlers/alerts_test.go
+++ b/cmd/api/handlers/alerts_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -243,6 +245,76 @@ func TestAlertChannelRejectsBadConfig(t *testing.T) {
 	}
 	rr := call(t, h.AlertChannelsCreateHandler, http.MethodPost, "/api/v1/alerts/channels", body)
 	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestAlertChannelTestHandler covers the editor's "Send test" button: a
+// working relay answers 200, a refused one is 502 (the relay's fault, not
+// the operator's input), and an unknown type is 400.
+func TestAlertChannelTestHandler(t *testing.T) {
+	h := setupAlertsHandler(t)
+	var got []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rr := call(t, h.AlertChannelsTestHandler, http.MethodPost, "/api/v1/alerts/channels/test", map[string]any{
+		"type":   "webhook",
+		"config": json.RawMessage(fmt.Sprintf(`{"url":%q,"timeoutSeconds":5,"allowPrivateTargets":true}`, srv.URL)),
+	})
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	require.Contains(t, string(got), "osctrl-channel-test")
+
+	// Nothing listening → the relay refused, 502.
+	rr = call(t, h.AlertChannelsTestHandler, http.MethodPost, "/api/v1/alerts/channels/test", map[string]any{
+		"type":   "webhook",
+		"config": json.RawMessage(`{"url":"http://127.0.0.1:1/x","timeoutSeconds":1,"allowPrivateTargets":true}`),
+	})
+	require.Equal(t, http.StatusBadGateway, rr.Code)
+
+	rr = call(t, h.AlertChannelsTestHandler, http.MethodPost, "/api/v1/alerts/channels/test", map[string]any{
+		"type": "carrier_pigeon", "config": json.RawMessage(`{}`),
+	})
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "carrier_pigeon", "a 400 has to name what was rejected")
+
+	// A config the registry refuses to build reports the reason, not a
+	// bare "invalid value" — here, the private-target guard.
+	rr = call(t, h.AlertChannelsTestHandler, http.MethodPost, "/api/v1/alerts/channels/test", map[string]any{
+		"type":   "webhook",
+		"config": json.RawMessage(`{"url":"http://127.0.0.1:9/x"}`),
+	})
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "allowPrivateTargets")
+}
+
+// TestAlertChannelTestMergesStoredSecret pins the edit case: the form
+// reads secrets back as "***", so testing an untouched secret has to send
+// the stored one instead of the placeholder.
+func TestAlertChannelTestMergesStoredSecret(t *testing.T) {
+	h := setupAlertsHandler(t)
+	var signature string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		signature = r.Header.Get("X-Osctrl-Signature")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rr := call(t, h.AlertChannelsCreateHandler, http.MethodPost, "/api/v1/alerts/channels", map[string]any{
+		"name": "signed-hook", "type": "webhook", "enabled": true,
+		"config": json.RawMessage(fmt.Sprintf(`{"url":%q,"secret":"s3cr3t","timeoutSeconds":5,"allowPrivateTargets":true}`, srv.URL)),
+	})
+	require.Equal(t, http.StatusCreated, rr.Code)
+	var created alertChannelDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &created))
+
+	rr = call(t, h.AlertChannelsTestHandler, http.MethodPost, "/api/v1/alerts/channels/test", map[string]any{
+		"id": created.ID, "type": "webhook",
+		"config": json.RawMessage(fmt.Sprintf(`{"url":%q,"secret":"***","timeoutSeconds":5,"allowPrivateTargets":true}`, srv.URL)),
+	})
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	require.NotEmpty(t, signature, "stored HMAC secret must be merged into the test send")
 }
 
 func TestAlertChannelTypesHandler(t *testing.T) {

--- a/cmd/api/handlers/service_config_apply_test.go
+++ b/cmd/api/handlers/service_config_apply_test.go
@@ -47,6 +47,59 @@ func serviceConfigApplyRequest(t *testing.T, service string) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), ContextKey(contextAPI), ContextValue{ctxUser: "alice"}))
 }
 
+// TestServiceConfigApplyHandlerRestartsAPI covers the branch the SPA's
+// "Apply & Restart" hits for osctrl-api: the 202 goes out AND the restart
+// signal reaches main, which drains before exiting.
+func TestServiceConfigApplyHandlerRestartsAPI(t *testing.T) {
+	h, restartCh := setupServiceConfigApplyHandler(t)
+	req := serviceConfigApplyRequest(t, config.ServiceAPI)
+	rr := httptest.NewRecorder()
+
+	h.ServiceConfigApplyHandler(rr, req)
+
+	require.Equal(t, http.StatusAccepted, rr.Code)
+	select {
+	case <-restartCh:
+	default:
+		t.Fatal("api apply must signal the restart channel")
+	}
+	var resp types.ServiceConfigApplyResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, config.ServiceAPI, resp.Service)
+	// The API restarts itself in-process; there is no queued command to poll.
+	require.Nil(t, resp.Command)
+}
+
+// An empty body means "this service", so a bare POST restarts the API
+// rather than falling through to the invalid-service branch.
+func TestServiceConfigApplyHandlerDefaultsToAPI(t *testing.T) {
+	h, restartCh := setupServiceConfigApplyHandler(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/service-config/apply", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req = req.WithContext(context.WithValue(req.Context(), ContextKey(contextAPI), ContextValue{ctxUser: "alice"}))
+	rr := httptest.NewRecorder()
+
+	h.ServiceConfigApplyHandler(rr, req)
+
+	require.Equal(t, http.StatusAccepted, rr.Code)
+	select {
+	case <-restartCh:
+	default:
+		t.Fatal("bodyless apply must signal the restart channel")
+	}
+}
+
+// Without a wired channel the endpoint has to say so, not accept and drop.
+func TestServiceConfigApplyHandlerWithoutRestartCh(t *testing.T) {
+	h, _ := setupServiceConfigApplyHandler(t)
+	h.RestartCh = nil
+	rr := httptest.NewRecorder()
+
+	h.ServiceConfigApplyHandler(rr, serviceConfigApplyRequest(t, config.ServiceAPI))
+
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
 func TestServiceConfigApplyHandlerQueuesTLSRestart(t *testing.T) {
 	h, restartCh := setupServiceConfigApplyHandler(t)
 	req := serviceConfigApplyRequest(t, config.ServiceTLS)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -59,6 +59,10 @@ const (
 	appDescription = serviceDescription + ", a fast and efficient osquery management"
 	// Default refreshing interval in seconds
 	defaultRefresh int = 300
+	// restartDrainTimeout bounds how long a restart waits for in-flight
+	// requests — including the apply response that triggered it — before
+	// the process exits.
+	restartDrainTimeout = 5 * time.Second
 )
 
 // Build-time metadata (overridden via -ldflags "-X main.buildVersion=... -X main.buildCommit=... -X main.buildDate=...")
@@ -1157,6 +1161,9 @@ func osctrlAPIService() {
 			"POST "+_apiPath(apiAlertsPath)+"/channels",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsCreateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		muxAPI.Handle(
+			"POST "+_apiPath(apiAlertsPath)+"/channels/test",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsTestHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+		muxAPI.Handle(
 			"PUT "+_apiPath(apiAlertsPath)+"/channels/{id}",
 			handlerAuthCheck(http.HandlerFunc(handlersApi.AlertChannelsUpdateHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 		muxAPI.Handle(
@@ -1277,7 +1284,17 @@ func osctrlAPIService() {
 			log.Fatal().Msgf("ListenAndServe: %v", err)
 		}
 	case <-restartCh:
-		log.Info().Msg("Service config apply triggered — exiting for restart")
+		log.Info().Msg("Service config apply triggered — draining requests before restart")
+		// Drain first. Exiting straight off the signal raced the apply
+		// handler's own 202: the handler had written the response but the
+		// server had not flushed it, so the operator's client could see an
+		// aborted request while the process was already gone.
+		drainCtx, cancelDrain := context.WithTimeout(context.Background(), restartDrainTimeout)
+		if err := srv.Shutdown(drainCtx); err != nil {
+			log.Err(err).Msg("error draining HTTP server before restart")
+		}
+		cancelDrain()
+		log.Info().Msg("Drained — exiting for restart")
 		// Exit with code 1 so process managers (systemd, docker, k8s) and
 		// dev tools like air restart the process. A clean exit (0) is not
 		// restarted by air (the dev hot-reload tool), which treats exit 0

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -168,6 +168,23 @@ export function createAlertChannel(body: AlertChannelRequest): Promise<AlertChan
   });
 }
 
+/**
+ * POST /api/v1/alerts/channels/test — deliver one test notification
+ * through this config without storing it. Pass `id` when testing a saved
+ * channel so secrets left as "***" are merged from the stored row.
+ */
+export function testAlertChannel(body: {
+  id?: number;
+  type: string;
+  config: unknown;
+}): Promise<{ message: string }> {
+  return apiFetch('/api/v1/alerts/channels/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
 /** PUT /api/v1/alerts/channels/{id}. */
 export function updateAlertChannel(id: number, body: AlertChannelRequest): Promise<AlertChannel> {
   return apiFetch<AlertChannel>(`/api/v1/alerts/channels/${id}`, {

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { isAuthenticated, setCsrfToken, primeCsrfFromCookie } from './client';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { apiFetch, ApiError, isAuthenticated, setCsrfToken, primeCsrfFromCookie } from './client';
 
 // Tests for the cookie-priming bootstrap. The OIDC flow finishes with
 // a server 302 to "/" and the SPA boots fresh — the in-memory CSRF
@@ -46,5 +46,37 @@ describe('primeCsrfFromCookie', () => {
     document.cookie = 'another=xyz; Path=/';
     primeCsrfFromCookie();
     expect(isAuthenticated()).toBe(true);
+  });
+});
+
+// Every DELETE endpoint answers 204 with no body. apiFetch used to end in
+// res.json(), which threw "Unexpected end of JSON input" and surfaced in
+// the UI as a failed delete that had in fact succeeded.
+describe('apiFetch response bodies', () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('resolves to undefined for a 204 with no body', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(null, { status: 204 }),
+    ) as unknown as typeof fetch;
+    await expect(apiFetch<void>('/api/v1/alerts/rules/1', { method: 'DELETE' })).resolves.toBeUndefined();
+  });
+
+  it('still parses a JSON body', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 7 }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    await expect(apiFetch<{ id: number }>('/api/v1/alerts/rules/7')).resolves.toEqual({ id: 7 });
+  });
+
+  it('still reports the error message on a failure', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'not found' }), { status: 404 }),
+    ) as unknown as typeof fetch;
+    await expect(apiFetch('/api/v1/alerts/rules/9', { method: 'DELETE' })).rejects.toThrow(ApiError);
   });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -153,7 +153,12 @@ export async function apiFetch<T>(
     throw new ApiError(errorMsg, res.status, code);
   }
 
-  return res.json() as Promise<T>;
+  // A 204 (every DELETE endpoint) and any other empty body have nothing
+  // to parse: res.json() threw "Unexpected end of JSON input", which the
+  // caller's onError reported as a failure even though the request had
+  // succeeded. Parse only when there are bytes.
+  const text = await res.text();
+  return (text ? (JSON.parse(text) as T) : (undefined as T));
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/alerts/AlertsPage.test.tsx
+++ b/frontend/src/features/alerts/AlertsPage.test.tsx
@@ -27,6 +27,7 @@ const mockUpdateChannel = vi.fn();
 const mockDeleteChannel = vi.fn<(id: number) => Promise<void>>();
 const mockHistory = vi.fn<(limit?: number) => Promise<unknown[]>>();
 const mockApply = vi.fn();
+const mockTestChannel = vi.fn();
 const mockGetCommand = vi.fn<(commandID: string) => Promise<ServiceCommand>>();
 
 vi.mock('$/api/alerts', () => ({
@@ -40,6 +41,7 @@ vi.mock('$/api/alerts', () => ({
   updateAlertChannel: (...args: unknown[]) => mockUpdateChannel(...args),
   deleteAlertChannel: (id: number) => mockDeleteChannel(id),
   listAlertHistory: (limit?: number) => mockHistory(limit),
+  testAlertChannel: (...args: unknown[]) => mockTestChannel(...args),
   applyAlerts: () => mockApply(),
 }));
 
@@ -276,6 +278,31 @@ describe('AlertsPage', () => {
     });
   });
 
+  it('fills the form from the errors-reported preset and saves it without a pattern', async () => {
+    const user = userEvent.setup();
+    mockCreateRule.mockResolvedValue(makeRule());
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: 'New rule' }));
+    await user.click(screen.getByRole('button', { name: 'Errors reported' }));
+
+    // Preset picks the source and severity, and names the rule.
+    expect(screen.getByLabelText('Name')).toHaveValue('errors-reported');
+    expect(screen.getByLabelText('Source')).toHaveValue('status_log');
+    expect(screen.getByLabelText('Minimum severity')).toHaveValue('error');
+
+    await user.click(screen.getByRole('button', { name: 'Create rule' }));
+    await waitFor(() => {
+      expect(mockCreateRule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'errors-reported',
+          source: 'status_log',
+          status_severity: 'error',
+          match_value: '',
+        }),
+      );
+    });
+  });
+
   it('requires a pattern for pattern sources and validates', async () => {
     const user = userEvent.setup();
     renderPage();
@@ -322,6 +349,43 @@ describe('AlertsPage', () => {
         }),
       );
     });
+  });
+
+  it('sends a test notification from the channel editor', async () => {
+    const user = userEvent.setup();
+    mockTestChannel.mockResolvedValue({ message: 'Test notification sent through the webhook channel' });
+    renderPage();
+    await user.click(await screen.findByRole('tab', { name: 'channels' }));
+    await user.click(await screen.findByRole('button', { name: 'New channel' }));
+    await user.type(screen.getByLabelText('URL'), 'https://hooks.example.com/x');
+    await user.click(screen.getByRole('button', { name: 'Send test' }));
+
+    await waitFor(() =>
+      expect(mockTestChannel).toHaveBeenCalledWith({
+        id: undefined,
+        type: 'webhook',
+        config: expect.objectContaining({ url: 'https://hooks.example.com/x' }),
+      }),
+    );
+    expect(
+      await screen.findByText('Test notification sent through the webhook channel'),
+    ).toBeInTheDocument();
+    // Testing must not save anything.
+    expect(mockCreateChannel).not.toHaveBeenCalled();
+  });
+
+  it('shows why a channel test failed', async () => {
+    const user = userEvent.setup();
+    mockTestChannel.mockRejectedValue(new Error('webhook delivery failed after 3 attempts'));
+    mockListChannels.mockResolvedValue([makeChannel()]);
+    renderPage();
+    await user.click(await screen.findByRole('tab', { name: 'channels' }));
+    await user.click(await screen.findByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Send test' }));
+
+    expect(await screen.findByText('webhook delivery failed after 3 attempts')).toBeInTheDocument();
+    // Editing a saved channel sends its id so stored secrets are merged.
+    expect(mockTestChannel).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
   });
 
   it('deletes a rule from the table', async () => {

--- a/frontend/src/features/alerts/AlertsPage.tsx
+++ b/frontend/src/features/alerts/AlertsPage.tsx
@@ -10,6 +10,7 @@ import {
   listAlertChannels,
   listAlertChannelTypes,
   createAlertChannel,
+  testAlertChannel,
   updateAlertChannel,
   deleteAlertChannel,
   listAlertHistory,
@@ -48,6 +49,26 @@ const RULE_SOURCES = [
   { value: 'query_log', label: 'Distributed query results', help: 'On-demand query answers submitted by nodes.' },
   { value: 'node_inactive', label: 'Node inactive', help: 'Node last_seen crosses the inactive threshold. No pattern needed.' },
   { value: 'node_recovered', label: 'Node recovered', help: 'A previously inactive node is seen again. No pattern needed.' },
+] as const;
+
+/**
+ * One-click starting points for the rule form. Same premade rules the node
+ * detail page offers, minus the node scope — from here they cover every
+ * node in the selected environment.
+ */
+const RULE_PRESETS = [
+  {
+    label: 'Errors reported',
+    help: 'Any osquery status line at error severity — a failing scheduled query, a bad config, a plugin that will not start. No pattern needed.',
+    name: 'errors-reported',
+    fields: {
+      source: 'status_log',
+      status_severity: 'error',
+      match_type: 'substring',
+      match_field: '',
+      match_value: '',
+    },
+  },
 ] as const;
 
 /** Sources that match patterns (vs. node-state sources). */
@@ -731,14 +752,28 @@ function RuleEditorModal({
     'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
   );
   const needsPattern = PATTERN_SOURCES.has(source);
+  // A status-log rule with a severity floor is complete without a pattern:
+  // "every error line" is the whole rule. Result/query rules still need
+  // one — an empty pattern there matches every row that lands.
+  const patternOptional = source === 'status_log' && statusSeverity !== 'any';
   const sourceHelp = RULE_SOURCES.find((s) => s.value === source)?.help;
+
+  const applyPreset = (preset: (typeof RULE_PRESETS)[number]) => {
+    setErr(null);
+    if (!name.trim()) setName(preset.name);
+    setSource(preset.fields.source);
+    setStatusSeverity(preset.fields.status_severity);
+    setMatchType(preset.fields.match_type);
+    setMatchField(preset.fields.match_field);
+    setMatchValue(preset.fields.match_value);
+  };
 
   const submit = () => {
     if (!name.trim()) {
       setErr('Name is required');
       return;
     }
-    if (needsPattern && !matchValue.trim()) {
+    if (needsPattern && !patternOptional && !matchValue.trim()) {
       setErr('Match value is required for pattern sources');
       return;
     }
@@ -771,6 +806,28 @@ function RuleEditorModal({
         }}
         className="space-y-4"
       >
+        {!existing && (
+          <div>
+            <span className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
+              Start from a premade rule
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {RULE_PRESETS.map((preset) => (
+                <Button
+                  key={preset.label}
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  title={preset.help}
+                  onClick={() => applyPreset(preset)}
+                >
+                  {preset.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+
         <div>
           <label htmlFor="rule-name" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
             Name
@@ -859,7 +916,12 @@ function RuleEditorModal({
             </div>
             <div>
               <label htmlFor="rule-match-value" className="block text-xs font-semibold text-[color:var(--text-2)] mb-1">
-                Pattern
+                Pattern{' '}
+                {patternOptional && (
+                  <span className="font-normal text-[color:var(--text-3)]">
+                    (empty = every line at this severity)
+                  </span>
+                )}
               </label>
               <input
                 id="rule-match-value"
@@ -993,6 +1055,7 @@ function ChannelEditorModal({
     (existing?.config as Record<string, unknown>) ?? {},
   );
   const [err, setErr] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
 
   // Reset the config object when the type changes during creation.
   useEffect(() => {
@@ -1011,6 +1074,22 @@ function ChannelEditorModal({
     onError: (e) => {
       if (e instanceof AuthError) return;
       setErr(e instanceof Error ? e.message : 'Save failed');
+    },
+  });
+
+  // Test delivery uses the form's current values, so a channel can be
+  // proven before it is saved. Editing an existing one sends its id too:
+  // untouched secrets read back as "***" and the server merges them.
+  const testMutation = useMutation({
+    mutationFn: () =>
+      testAlertChannel({ id: existing?.id, type, config }),
+    onSuccess: (res) => {
+      setErr(null);
+      setTestResult({ ok: true, message: res.message });
+    },
+    onError: (e) => {
+      if (e instanceof AuthError) return;
+      setTestResult({ ok: false, message: e instanceof Error ? e.message : 'Test failed' });
     },
   });
 
@@ -1117,13 +1196,40 @@ function ChannelEditorModal({
           </p>
         )}
 
-        <div className="flex justify-end gap-2 pt-2">
-          <Button type="button" variant="ghost" onClick={onClose}>
-            Cancel
+        {testResult && (
+          <p
+            role="status"
+            className={cn(
+              'text-xs',
+              testResult.ok
+                ? 'text-[color:var(--success)]'
+                : 'text-[color:var(--danger)]',
+            )}
+          >
+            {testResult.message}
+          </p>
+        )}
+
+        <div className="flex items-center gap-2 pt-2">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={testMutation.isPending}
+            onClick={() => {
+              setTestResult(null);
+              testMutation.mutate();
+            }}
+          >
+            {testMutation.isPending ? 'Sending…' : 'Send test'}
           </Button>
-          <Button type="submit" disabled={mutation.isPending}>
-            {mutation.isPending ? 'Saving…' : existing ? 'Save changes' : 'Create channel'}
-          </Button>
+          <span className="ml-auto flex gap-2">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Saving…' : existing ? 'Save changes' : 'Create channel'}
+            </Button>
+          </span>
         </div>
       </form>
     </ModalShell>

--- a/frontend/src/features/nodes/NodeAlertModal.tsx
+++ b/frontend/src/features/nodes/NodeAlertModal.tsx
@@ -24,6 +24,47 @@ import { AuthError } from '$/api/client';
  * ends with the apply action so the rule goes live immediately — the
  * same hot-reload path as the Alerts page.
  */
+type NodeAlertKind = 'inactive' | 'error' | 'result';
+
+/**
+ * The predefined node-scoped rules, in the order they are offered.
+ *
+ * `rule` is merged into the create request, so each kind is fully
+ * described here rather than in a chain of ternaries at the submit site.
+ * "error" leans on the matcher's existing behavior: a status_log rule
+ * with an empty substring and a severity floor of "error" matches every
+ * error line this node reports, with no pattern for the operator to get
+ * right.
+ */
+const NODE_ALERT_KINDS: Record<
+  NodeAlertKind,
+  {
+    suffix: string;
+    title: string;
+    help: string;
+    rule: { source: string; status_severity: string };
+  }
+> = {
+  inactive: {
+    suffix: 'inactive',
+    title: 'Node goes inactive',
+    help: "Fires once when this node stops reporting past the environment's inactive threshold, and again on recovery if a recovery rule exists.",
+    rule: { source: 'node_inactive', status_severity: '' },
+  },
+  error: {
+    suffix: 'errors',
+    title: 'Errors reported by this node',
+    help: 'Fires on any osquery status line this node reports at error severity — a failing scheduled query, a bad config, a plugin that cannot start. No pattern needed.',
+    rule: { source: 'status_log', status_severity: 'error' },
+  },
+  result: {
+    suffix: 'log-match',
+    title: 'Log match on this node',
+    help: 'Alerts when this node ingests a result-log row matching your pattern (case-insensitive substring).',
+    rule: { source: 'result_log', status_severity: '' },
+  },
+};
+
 export function NodeAlertModal({
   envID,
   envName,
@@ -38,7 +79,7 @@ export function NodeAlertModal({
   onClose: () => void;
 }) {
   const qc = useQueryClient();
-  const [kind, setKind] = useState<'inactive' | 'result'>('inactive');
+  const [kind, setKind] = useState<NodeAlertKind>('inactive');
   const [pattern, setPattern] = useState('');
   const [matchField, setMatchField] = useState('');
   const [cooldown, setCooldown] = useState(0);
@@ -83,8 +124,8 @@ export function NodeAlertModal({
     'focus:outline focus:outline-2 focus:outline-[color:var(--signal)]',
   );
 
-  const baseName =
-    kind === 'inactive' ? `${hostname}-inactive` : `${hostname}-log-match`;
+  const spec = NODE_ALERT_KINDS[kind];
+  const baseName = `${hostname}-${spec.suffix}`;
 
   const submit = () => {
     setErr(null);
@@ -99,14 +140,16 @@ export function NodeAlertModal({
     createMutation.mutate({
       name: baseName,
       environment_id: envID,
-      source: kind === 'inactive' ? 'node_inactive' : 'result_log',
       node_uuid: uuid,
-      match_type: kind === 'result' ? 'substring' : 'substring',
+      // Substring with an empty value matches anything, which is what the
+      // two pattern-less kinds want.
+      match_type: 'substring',
       match_field: kind === 'result' ? matchField : '',
       match_value: kind === 'result' ? pattern : '',
       cooldown_minutes: cooldown,
       channel_ids: channelIDs,
       enabled: true,
+      ...spec.rule,
     });
   };
 
@@ -168,57 +211,31 @@ export function NodeAlertModal({
 
         {/* Rule kind */}
         <div role="radiogroup" aria-label="Alert type" className="space-y-2">
-          <label
-            className={cn(
-              'flex items-start gap-2 rounded-md border px-3 py-2 cursor-pointer transition-colors',
-              kind === 'inactive'
-                ? 'border-[color:var(--signal)] bg-[color:var(--bg-3)]'
-                : 'border-[color:var(--border)] hover:bg-[color:var(--bg-2)]',
-            )}
-          >
-            <input
-              type="radio"
-              name="alert-kind"
-              className="mt-0.5 accent-[color:var(--signal)]"
-              checked={kind === 'inactive'}
-              onChange={() => setKind('inactive')}
-            />
-            <span className="text-xs">
-              <span className="block font-semibold text-[color:var(--text-1)]">
-                Node goes inactive
+          {(Object.keys(NODE_ALERT_KINDS) as NodeAlertKind[]).map((k) => (
+            <label
+              key={k}
+              className={cn(
+                'flex items-start gap-2 rounded-md border px-3 py-2 cursor-pointer transition-colors',
+                kind === k
+                  ? 'border-[color:var(--signal)] bg-[color:var(--bg-3)]'
+                  : 'border-[color:var(--border)] hover:bg-[color:var(--bg-2)]',
+              )}
+            >
+              <input
+                type="radio"
+                name="alert-kind"
+                className="mt-0.5 accent-[color:var(--signal)]"
+                checked={kind === k}
+                onChange={() => setKind(k)}
+              />
+              <span className="text-xs">
+                <span className="block font-semibold text-[color:var(--text-1)]">
+                  {NODE_ALERT_KINDS[k].title}
+                </span>
+                <span className="text-[color:var(--text-3)]">{NODE_ALERT_KINDS[k].help}</span>
               </span>
-              <span className="text-[color:var(--text-3)]">
-                Fires once when this node stops reporting past the
-                environment&apos;s inactive threshold, and again on recovery
-                if a recovery rule exists.
-              </span>
-            </span>
-          </label>
-          <label
-            className={cn(
-              'flex items-start gap-2 rounded-md border px-3 py-2 cursor-pointer transition-colors',
-              kind === 'result'
-                ? 'border-[color:var(--signal)] bg-[color:var(--bg-3)]'
-                : 'border-[color:var(--border)] hover:bg-[color:var(--bg-2)]',
-            )}
-          >
-            <input
-              type="radio"
-              name="alert-kind"
-              className="mt-0.5 accent-[color:var(--signal)]"
-              checked={kind === 'result'}
-              onChange={() => setKind('result')}
-            />
-            <span className="text-xs">
-              <span className="block font-semibold text-[color:var(--text-1)]">
-                Log match on this node
-              </span>
-              <span className="text-[color:var(--text-3)]">
-                Alerts when this node ingests a result-log row matching your
-                pattern (case-insensitive substring).
-              </span>
-            </span>
-          </label>
+            </label>
+          ))}
         </div>
 
         {kind === 'result' && (

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -1022,6 +1022,31 @@ describe('NodeDetailPage', () => {
     await waitFor(() => expect(mockApplyAlerts).toHaveBeenCalled());
   });
 
+  it('creates an error-severity rule on this node from the modal', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, service_config: false, accelerated: false, file_explorer: false, alerts: true });
+    const user = userEvent.setup();
+    renderWithProviders(makeTestRouter());
+    await user.click(await screen.findByRole('button', { name: 'Create alert for this node' }));
+
+    await user.click(screen.getByRole('radio', { name: /Errors reported by this node/ }));
+    // Predefined: no pattern for the operator to fill in.
+    expect(screen.queryByLabelText(/Pattern/)).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Create alert' }));
+
+    await waitFor(() => {
+      expect(mockCreateAlertRule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'web-server-01-errors',
+          source: 'status_log',
+          status_severity: 'error',
+          node_uuid: 'abc12345-0000-0000-0000-000000000001',
+          match_value: '',
+          enabled: true,
+        }),
+      );
+    });
+  });
+
   it('creates a log-match rule on this node from the modal', async () => {
     mockGetFeatures.mockResolvedValue({ posture: false, service_config: false, accelerated: false, file_explorer: false, alerts: true });
     const user = userEvent.setup();

--- a/pkg/alerts/channels.go
+++ b/pkg/alerts/channels.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 )
 
 // channels.go — pluggable notification channels (logsinks Registry
@@ -55,6 +56,7 @@ var ChannelRegistry = map[string]ChannelSpec{
 			{Name: "secret", Label: "HMAC secret", Type: FieldSecret, Help: "When set, the payload is signed with X-Osctrl-Signature (HMAC-SHA256, hex)."},
 			{Name: "timeoutSeconds", Label: "Timeout (seconds)", Type: FieldInteger, Default: 10, Help: "Per-request timeout, including retries."},
 			{Name: "insecureSkipVerify", Label: "Skip TLS verify", Type: FieldBoolean, Default: false, Help: "Do not verify the server certificate. Avoid in production."},
+			{Name: "allowPrivateTargets", Label: "Allow private/loopback target", Type: FieldBoolean, Default: false, Help: "Required to reach localhost or an RFC1918 address. Off by default so a webhook cannot be pointed at internal services; enable only for a relay you run yourself."},
 		},
 		Decode: decodeTyped[WebhookConfig](),
 		Build: func(cfg any) (ChannelSender, error) {
@@ -80,6 +82,55 @@ var ChannelRegistry = map[string]ChannelSpec{
 			return buildEmail(*cfg.(*EmailConfig))
 		},
 	},
+}
+
+// TestSendTimeout bounds a channel test so an unresponsive relay cannot
+// hold the API request open. Senders carry their own per-request
+// timeouts; this is the backstop for the ones that do not (SMTP).
+const TestSendTimeout = 15 * time.Second
+
+// TestSend delivers one synthetic notification through a channel config
+// without storing it, so an operator can verify a channel from the form
+// before saving. Config errors and delivery errors are both returned as
+// they are — the operator needs to see which relay refused what.
+func TestSend(typ, cfgJSON string) error {
+	spec, ok := ChannelRegistry[normalizeChannelType(typ)]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrInvalidChannelType, typ)
+	}
+	if strings.TrimSpace(cfgJSON) == "" {
+		cfgJSON = "{}"
+	}
+	decoded, err := spec.Decode(json.RawMessage(cfgJSON))
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidChannelConfig, err)
+	}
+	sender, err := spec.Build(decoded)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidChannelConfig, err)
+	}
+	// Buffered by one so an abandoned send finishes into the channel and
+	// the goroutine exits instead of leaking on timeout.
+	done := make(chan error, 1)
+	go func() { done <- sender.Send(TestHit()) }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(TestSendTimeout):
+		return fmt.Errorf("channel test timed out after %s", TestSendTimeout)
+	}
+}
+
+// TestHit is the payload a channel test delivers. It is shaped like a
+// real hit so the operator sees exactly the format their relay will
+// receive, and is labelled so nobody mistakes it for a live alert.
+func TestHit() Hit {
+	return Hit{
+		RuleName:    "osctrl-channel-test",
+		Environment: "osctrl",
+		Entity:      "channel-test",
+		Detail:      "Test notification from osctrl. If you are reading this, the channel works.",
+	}
 }
 
 // FieldSpec reuses the logsinks field schema for SPA form rendering.

--- a/pkg/alerts/matcher.go
+++ b/pkg/alerts/matcher.go
@@ -272,6 +272,17 @@ func matchStatus(r *compiledRule, entry *types.LogStatusData, lowered map[string
 	}, lowered)
 }
 
+// substringDetail is the context a substring match reports. An empty
+// pattern matches everything (the "any error from this node" preset), and
+// echoing the empty pattern back would leave the notification with no
+// context at all — so fall back to the value that matched.
+func substringDetail(pattern, value string) string {
+	if pattern == "" {
+		return value
+	}
+	return pattern
+}
+
 // matchSingle evaluates one value against the rule, lowering through
 // the shared cache.
 func matchSingle(r *compiledRule, value, key string, lowered map[string]string) (bool, string) {
@@ -283,14 +294,14 @@ func matchSingle(r *compiledRule, value, key string, lowered map[string]string) 
 	}
 	if lv, ok := lowered[key]; ok {
 		if strings.Contains(lv, r.matchSubstring) {
-			return true, r.matchSubstring
+			return true, substringDetail(r.matchSubstring, value)
 		}
 		return false, ""
 	}
 	lv := strings.ToLower(value)
 	lowered[key] = lv
 	if strings.Contains(lv, r.matchSubstring) {
-		return true, r.matchSubstring
+		return true, substringDetail(r.matchSubstring, value)
 	}
 	return false, ""
 }
@@ -321,7 +332,7 @@ func matchFields(r *compiledRule, fields map[string]string, lowered map[string]s
 			return false, ""
 		}
 		if strings.Contains(lowerOnce(r.matchFieldLower, v), r.matchSubstring) {
-			return true, r.matchSubstring
+			return true, substringDetail(r.matchSubstring, v)
 		}
 		return false, ""
 	}
@@ -335,7 +346,7 @@ func matchFields(r *compiledRule, fields map[string]string, lowered map[string]s
 	}
 	for k, v := range fields {
 		if strings.Contains(lowerOnce(k, v), r.matchSubstring) {
-			return true, r.matchSubstring
+			return true, substringDetail(r.matchSubstring, v)
 		}
 	}
 	return false, ""

--- a/pkg/alerts/node_scope_test.go
+++ b/pkg/alerts/node_scope_test.go
@@ -81,6 +81,32 @@ func TestInactiveWatcherNodeScopedRule(t *testing.T) {
 	}
 }
 
+// TestMatchNodeScopedErrorRule pins the node page's "errors reported by
+// this node" preset: a status_log rule scoped to the node, severity floor
+// "error", and no pattern at all. It must fire on every error line from
+// that node and nothing else.
+func TestMatchNodeScopedErrorRule(t *testing.T) {
+	rs := compileForTest(t, AlertRule{
+		Model: ruleWithID(1), Name: "node-errors", Source: SourceStatusLog,
+		MatchType: MatchTypeSubstring, MatchValue: "", StatusSeverity: "error",
+		NodeUUID: "WATCH-U9",
+	})
+	logs := []types.LogStatusData{
+		statusEntry("WATCH-U9", 2, "query failed to execute"),
+		statusEntry("WATCH-U9", 1, "a warning nobody asked to be paged for"),
+		statusEntry("WATCH-U9", 0, "an informational line"),
+		statusEntry("OTHER-NODE", 2, "someone else's error"),
+	}
+	hits := rs.MatchStatusLogs(0, "prod", logs)
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly the node's error line to hit, got %+v", hits)
+	}
+	// A pattern-less rule still has to say what happened.
+	if hits[0].NodeUUID != "WATCH-U9" || hits[0].Detail != "query failed to execute" {
+		t.Fatalf("hit must carry the node and the error text: %+v", hits[0])
+	}
+}
+
 // TestValidateRuleNodeUUID accepts any node identifier that fits the
 // column. A node's UUID is osquery's host_identifier uppercased, so it is
 // a hostname / instance id / vendor serial under every --host_identifier

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -724,9 +724,9 @@ type LogSinkCloneRequest struct {
 // AlertRuleCreateRequest is the body for POST /api/v1/alerts/rules and
 // PUT /api/v1/alerts/rules/{id}. All fields are required on update.
 type AlertRuleCreateRequest struct {
-	Name            string `json:"name"`
-	EnvironmentID   uint   `json:"environment_id"`
-	Source          string `json:"source"`
+	Name          string `json:"name"`
+	EnvironmentID uint   `json:"environment_id"`
+	Source        string `json:"source"`
 	// NodeUUID optionally scopes the rule to one node (used by the node
 	// detail page's "Alert on this node" button). Empty = all nodes.
 	NodeUUID        string `json:"node_uuid,omitempty"`
@@ -750,6 +750,16 @@ type AlertChannelCreateRequest struct {
 	Enabled       bool            `json:"enabled"`
 	Config        json.RawMessage `json:"config"`
 	Info          string          `json:"info,omitempty"`
+}
+
+// AlertChannelTestRequest is the body for POST /api/v1/alerts/channels/test:
+// deliver one synthetic notification through this config without storing
+// it. ID, when set, names the stored channel whose secrets fill in any
+// "***" placeholder the form did not touch.
+type AlertChannelTestRequest struct {
+	ID     uint            `json:"id,omitempty"`
+	Type   string          `json:"type"`
+	Config json.RawMessage `json:"config"`
 }
 
 // AlertFieldSpec is one field in an alert channel type's config schema.


### PR DESCRIPTION
## Test alert channels before saving, plus two premade error alerts

### Test a channel from the editor

Channels could only be verified by saving one and waiting for a real alert to
fire. The editor (New and Edit) now has a **Send test** button that delivers one
synthetic notification using the form's current values — nothing is stored — and
reports the outcome inline: the server's confirmation, or the relay's own error.

- `alerts.TestSend(type, config)` builds a sender from the existing
  `ChannelRegistry` and sends `TestHit()` (`rule_name: osctrl-channel-test`),
  bounded by a 15s backstop since the SMTP sender carries no timeout of its own.
  The goroutine is buffered-by-one so an abandoned send exits instead of leaking.
- `POST /api/v1/alerts/channels/test` (`types.AlertChannelTestRequest`) — global
  admin, audit-logged, same gate as the rest of the alerts API. A config the
  registry refuses is **400**; a relay that refuses us is **502**, so an operator
  mistake and a broken endpoint don't look alike. No new capability: an admin
  could already save a channel and wait for it to fire.
- Passing `id` (edit mode) merges stored secrets through the existing
  `MergeChannelSecrets`, so testing an untouched secret sends the real one
  instead of the `***` placeholder.

### "Errors reported" premade alert

The node detail page's alert modal offered "node inactive" and "log match". It
now offers a third, and so does the Alerts page's rule editor:

- **Node modal**: "Errors reported by this node" → a `status_log` rule scoped to
  the node with `status_severity: error` and no pattern, named `<hostname>-errors`.
  The three kinds now live in one `NODE_ALERT_KINDS` table (suffix, title, help,
  rule fields), which replaced two copy-pasted `<label>` blocks and the ternary
  chain at the submit site.
- **Rule editor**: a "Start from a premade rule" row (create mode) whose
  **Errors reported** button fills in name, source and severity — same rule
  without the node scope, so it covers every node in the environment.

No new matcher machinery: a severity floor with an empty substring already means
"every error line".

### Bugs found on the way

- **`invalid value` told the operator nothing.** `respondAlertsErr` collapsed
  every rejected channel config, channel type and rule source into that string,
  so a channel test failed with no reason. It now echoes the actual error
  (admin-only endpoints), e.g. `webhook target "127.0.0.1" is a private/loopback
  address; set allowPrivateTargets to override (dev only)`.
- **That private-target guard had no UI.** `allowPrivateTargets` was reachable
  only via API/YAML, so a local relay could never be configured — let alone
  tested — from the browser. Exposed as an off-by-default checkbox with help
  text saying what it is for.
- **Pattern-less rules alerted with no context.** An empty substring returned
  *itself* as the hit detail, so any rule without a pattern (the new preset
  included) would have paged with an empty `Detail`. `substringDetail` now falls
  back to the value that matched. Affects every pattern-less rule.
- **The rule editor could not express "every error line".** `submit()` demanded a
  match value for any pattern source. A status-log rule with a severity floor is
  now complete without one (`patternOptional`), and the label says so. Result and
  query rules still require a pattern — an empty one there matches every row.
- **`Unexpected end of JSON input` on every DELETE.** `apiFetch` ended in
  `res.json()`, which throws on the 204 that all five delete endpoints return —
  alert rules, alert channels, log sinks, auth providers, env packages. Each
  deleted the row server-side, then reported a failure and skipped its cache
  invalidation, so the row lingered until reload. It now reads the body as text
  and parses only when there are bytes. Audited the rest of the API: those five
  (plus `GET /health` when the DB is degraded, which the SPA never calls) are the
  only empty-body responses; every other route returns JSON.
- **`osctrl-api` exited without draining on restart.** The apply handler wrote its
  202 and signalled `RestartCh`; main called `os.Exit(1)` immediately, racing the
  response flush the handler's own docs promised to wait for. It now calls
  `srv.Shutdown` with a 5s bound first.

### Tests

Go — channel test send (200 / 502 / 400, and that a 400 names what it rejected),
stored-secret merge (asserts `X-Osctrl-Signature` arrives), node-scoped error rule
matching (fires on the node's error line only, and carries the message), and the
API restart branch of the apply handler, which had no coverage (explicit
`service: "api"`, bodyless POST, and 503 without a wired channel).

Frontend — the Send test success and failure paths, the preset button and the body
it saves, the node modal's error kind, and `apiFetch` body handling (204 →
`undefined`, JSON still parsed, error body still raises `ApiError`).

`go build ./... && go test ./pkg/alerts/ ./cmd/api/...` pass; 314 frontend tests
pass; `tsc --noEmit` clean.

### Deploy note

Requires an `osctrl-api` restart for the new endpoint and the registry field.