### PR TITLE
Mark a node when an alert covers it

### DIFF
--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -81,12 +81,14 @@ vi.mock('$/api/carves', () => ({
 const mockCreateAlertRule = vi.fn();
 const mockApplyAlerts = vi.fn();
 const mockListAlertChannels = vi.fn();
+const mockListAlertRules = vi.fn();
 vi.mock('$/api/alerts', () => ({
   // Only forward the first argument: react-query calls mutationFn with
   // (variables, context) and the assertions compare just the payload.
   createAlertRule: (first: unknown) => mockCreateAlertRule(first),
   applyAlerts: (first: unknown) => mockApplyAlerts(first),
   listAlertChannels: (first: unknown) => mockListAlertChannels(first),
+  listAlertRules: (first: unknown) => mockListAlertRules(first),
 }));
 
 vi.mock('$/api/tags', () => ({
@@ -294,6 +296,7 @@ describe('NodeDetailPage', () => {
     mockDeleteNode.mockResolvedValue({ message: 'ok' });
     mockGetNodePosture.mockResolvedValue([]);
     mockGetMe.mockResolvedValue({ admin: true, permissions: {} });
+    mockListAlertRules.mockResolvedValue([]);
     mockListEnvironments.mockResolvedValue([{ id: 5, name: 'test-env', uuid: 'env-uuid-1' }]);
     mockGetNodeActivity.mockResolvedValue(makeActivityBuckets());
     mockGetNodeActivityTiles.mockResolvedValue({
@@ -1020,6 +1023,37 @@ describe('NodeDetailPage', () => {
     // Created confirmation offers the hot-reload apply.
     await user.click(await screen.findByRole('button', { name: 'Apply changes' }));
     await waitFor(() => expect(mockApplyAlerts).toHaveBeenCalled());
+  });
+
+  it('marks the node when a rule covers it, whichever scope it comes from', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, service_config: false, accelerated: false, file_explorer: false, alerts: true });
+    mockListAlertRules.mockResolvedValue([
+      // env 5 is this page's environment (test-env); env 0 is global.
+      { id: 1, name: 'node-errors', environment_id: 5, node_uuid: 'abc12345-0000-0000-0000-000000000001', enabled: true, source: 'status_log', match_type: 'substring', match_field: '', match_value: '', status_severity: 'error', cooldown_minutes: 0, channel_ids: [], created_at: '', updated_at: '', info: '' },
+      { id: 2, name: 'env-wide', environment_id: 5, node_uuid: '', enabled: true, source: 'result_log', match_type: 'substring', match_field: '', match_value: 'x', status_severity: 'any', cooldown_minutes: 0, channel_ids: [], created_at: '', updated_at: '', info: '' },
+      { id: 3, name: 'everywhere', environment_id: 0, node_uuid: '', enabled: true, source: 'result_log', match_type: 'substring', match_field: '', match_value: 'y', status_severity: 'any', cooldown_minutes: 0, channel_ids: [], created_at: '', updated_at: '', info: '' },
+      // Neither of these reaches this node.
+      { id: 4, name: 'other-node', environment_id: 5, node_uuid: 'SOMEONE-ELSE', enabled: true, source: 'result_log', match_type: 'substring', match_field: '', match_value: 'z', status_severity: 'any', cooldown_minutes: 0, channel_ids: [], created_at: '', updated_at: '', info: '' },
+      { id: 5, name: 'switched-off', environment_id: 5, node_uuid: '', enabled: false, source: 'result_log', match_type: 'substring', match_field: '', match_value: 'w', status_severity: 'any', cooldown_minutes: 0, channel_ids: [], created_at: '', updated_at: '', info: '' },
+    ]);
+
+    renderWithProviders(makeTestRouter());
+
+    const marker = await screen.findByLabelText('3 alert rules cover this node');
+    expect(marker).toHaveTextContent('1 this node · 1 env · 1 global');
+    // The tooltip names each rule and why it applies.
+    expect(marker).toHaveAttribute('title', expect.stringContaining('node-errors — this node'));
+    expect(marker).toHaveAttribute('title', expect.stringContaining('everywhere — global'));
+    expect(marker).not.toHaveAttribute('title', expect.stringContaining('other-node'));
+  });
+
+  it('shows no alert marker when nothing covers the node', async () => {
+    mockGetFeatures.mockResolvedValue({ posture: false, service_config: false, accelerated: false, file_explorer: false, alerts: true });
+    renderWithProviders(makeTestRouter());
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'web-server-01' })).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/alert rules? cover this node/)).not.toBeInTheDocument();
   });
 
   it('creates an error-severity rule on this node from the modal', async () => {

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { usePageTitle } from '$/lib/usePageTitle';
 import { NodeAlertModal } from './NodeAlertModal';
+import { nodeAlertCoverage, coverageSummary } from './alertCoverage';
 import { useParams, Link, useNavigate } from '@tanstack/react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Archive, Bell, Copy, FileArchive, PlayCircle, RefreshCw, Tag, Terminal } from 'lucide-react';
@@ -10,6 +11,7 @@ import { runCarve } from '$/api/carves';
 import { runQuery } from '$/api/queries';
 import { listSavedQueries } from '$/api/saved-queries';
 import { listEnvTags, tagNode } from '$/api/tags';
+import { listAlertRules } from '$/api/alerts';
 import type { NodePosture, NodeUptime, PostureScore } from '$/api/types';
 import { getMe } from '$/api/users';
 import { listEnvironments } from '$/api/environments';
@@ -742,13 +744,31 @@ export function NodeDetailPage() {
     queryFn: () => listEnvironments(),
     staleTime: 60_000,
   });
-  const envUuid = envs?.find((e) => e.name === env)?.uuid;
+  const envRow = envs?.find((e) => e.name === env);
+  const envUuid = envRow?.uuid;
+  const envID = envRow?.id;
   const canAdminNode =
     me?.admin === true ||
     (envUuid !== undefined && me?.permissions?.[envUuid]?.admin === true);
   const envAccess = envUuid !== undefined ? me?.permissions?.[envUuid] : undefined;
   const canQueryNode = canAdminNode || envAccess?.query === true;
   const canCarveNode = canAdminNode || envAccess?.carve === true;
+
+  // Which alert rules would fire for this node. One unfiltered list is
+  // enough for all three scopes (node / env / global) and is shared with
+  // the Alerts page by the same query key prefix, so creating a rule from
+  // the modal refreshes the marker. Listing rules is global-admin only —
+  // gate on that, not canAdminNode, or an env-admin fires a doomed 403.
+  const { data: alertRules } = useQuery({
+    queryKey: ['alert-rules', 'all'],
+    queryFn: () => listAlertRules(),
+    enabled: alertsEnabled && me?.admin === true,
+    staleTime: 60_000,
+  });
+  const coveringRules = useMemo(
+    () => (node ? nodeAlertCoverage(alertRules ?? [], envID, node.uuid) : []),
+    [alertRules, envID, node],
+  );
 
   // Archive the current node. The backend's POST /nodes/{env}/delete
   // handler maps to ArchiveDeleteByUUID — it always snapshots into the
@@ -905,6 +925,39 @@ export function NodeDetailPage() {
               <p className="font-mono-tabular text-xs text-[color:var(--text-3)] mt-0.5 break-all">
                 {node.uuid}
               </p>
+              {/* Alert coverage marker — present whenever a rule would fire
+                  for this node, whether it names the node, covers its
+                  environment, or is global. Links to Alerts, where the rule
+                  itself can be edited. */}
+              {coveringRules.length > 0 && (
+                <Link
+                  to="/_app/alerts"
+                  className="mt-1.5 inline-block"
+                  aria-label={`${coveringRules.length} alert ${
+                    coveringRules.length === 1 ? 'rule' : 'rules'
+                  } cover this node`}
+                  title={coveringRules
+                    .map(
+                      ({ rule, scope }) =>
+                        `${rule.name} — ${
+                          scope === 'node'
+                            ? 'this node'
+                            : scope === 'environment'
+                              ? `environment ${env}`
+                              : 'global'
+                        }`,
+                    )
+                    .join('\n')}
+                >
+                  <MetadataBadge className="gap-1.5 hover:border-[color:var(--border-strong)] hover:text-[color:var(--text-1)] transition-colors">
+                    <Bell className="h-3 w-3 text-[color:var(--warning)]" aria-hidden="true" />
+                    {coveringRules.length} alert {coveringRules.length === 1 ? 'rule' : 'rules'}
+                    <span className="font-normal text-[color:var(--text-3)]">
+                      {coverageSummary(coveringRules)}
+                    </span>
+                  </MetadataBadge>
+                </Link>
+              )}
             </div>
             {/* Single-node action toolbar — copy node_key, refresh, archive.
                 Archive routes through the same DELETE endpoint with
@@ -1392,7 +1445,7 @@ export function NodeDetailPage() {
 
       {node && actionModal === 'alert' && (
         <NodeAlertModal
-          envID={envs?.find((e) => e.name === env)?.id}
+          envID={envID}
           envName={env}
           uuid={node.uuid}
           hostname={node.hostname}

--- a/frontend/src/features/nodes/alertCoverage.test.ts
+++ b/frontend/src/features/nodes/alertCoverage.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import type { AlertRule } from '$/api/alerts';
+import { nodeAlertCoverage, coverageSummary } from './alertCoverage';
+
+function rule(over: Partial<AlertRule>): AlertRule {
+  return {
+    id: 1,
+    created_at: '',
+    updated_at: '',
+    name: 'r',
+    environment_id: 1,
+    source: 'result_log',
+    node_uuid: '',
+    match_type: 'substring',
+    match_field: '',
+    match_value: 'x',
+    status_severity: 'any',
+    cooldown_minutes: 0,
+    channel_ids: [],
+    enabled: true,
+    info: '',
+    ...over,
+  };
+}
+
+const UUID = 'ABC12345-0000-0000-0000-000000000001';
+
+describe('nodeAlertCoverage', () => {
+  it('attributes each covering rule to its scope, most specific first', () => {
+    const covering = nodeAlertCoverage(
+      [
+        rule({ id: 1, name: 'global-rule', environment_id: 0 }),
+        rule({ id: 2, name: 'env-rule', environment_id: 1 }),
+        rule({ id: 3, name: 'node-rule', environment_id: 1, node_uuid: UUID }),
+      ],
+      1,
+      UUID,
+    );
+    expect(covering.map((c) => [c.rule.name, c.scope])).toEqual([
+      ['node-rule', 'node'],
+      ['env-rule', 'environment'],
+      ['global-rule', 'global'],
+    ]);
+  });
+
+  it('excludes other environments, other nodes, and disabled rules', () => {
+    const covering = nodeAlertCoverage(
+      [
+        rule({ id: 1, name: 'other-env', environment_id: 2 }),
+        rule({ id: 2, name: 'other-node', environment_id: 1, node_uuid: 'SOME-OTHER-NODE' }),
+        rule({ id: 3, name: 'switched-off', environment_id: 1, enabled: false }),
+        rule({ id: 4, name: 'off-and-global', environment_id: 0, enabled: false }),
+      ],
+      1,
+      UUID,
+    );
+    expect(covering).toEqual([]);
+  });
+
+  it('matches a node scope the backend would match, and not one it would not', () => {
+    // pkg/alerts compares the scope byte-for-byte, so a lowercased UUID does
+    // not cover an uppercase node — do not claim it does.
+    const rules = [rule({ node_uuid: UUID.toLowerCase(), environment_id: 1 })];
+    expect(nodeAlertCoverage(rules, 1, UUID)).toEqual([]);
+    // Whitespace is trimmed on the way in, matching TrimSpace on the server.
+    expect(nodeAlertCoverage([rule({ node_uuid: ` ${UUID} `, environment_id: 1 })], 1, UUID)).toHaveLength(1);
+  });
+
+  it('attributes only global rules before the environment is resolved', () => {
+    const covering = nodeAlertCoverage(
+      [
+        rule({ id: 1, name: 'global-rule', environment_id: 0 }),
+        rule({ id: 2, name: 'env-rule', environment_id: 1 }),
+      ],
+      undefined,
+      UUID,
+    );
+    expect(covering.map((c) => c.rule.name)).toEqual(['global-rule']);
+  });
+});
+
+describe('coverageSummary', () => {
+  it('lists only the scopes present', () => {
+    const covering = nodeAlertCoverage(
+      [
+        rule({ id: 1, environment_id: 0, name: 'g' }),
+        rule({ id: 2, environment_id: 1, node_uuid: UUID, name: 'n1' }),
+        rule({ id: 3, environment_id: 1, node_uuid: UUID, name: 'n2' }),
+      ],
+      1,
+      UUID,
+    );
+    expect(coverageSummary(covering)).toBe('2 this node · 1 global');
+  });
+
+  it('is empty with no coverage', () => {
+    expect(coverageSummary([])).toBe('');
+  });
+});

--- a/frontend/src/features/nodes/alertCoverage.ts
+++ b/frontend/src/features/nodes/alertCoverage.ts
@@ -1,0 +1,71 @@
+import type { AlertRule } from '$/api/alerts';
+
+/**
+ * Why a rule reaches this node:
+ *   node        — the rule names this UUID (created from "Alert on this node")
+ *   environment — an env-scoped rule covering every node in the env
+ *   global      — environment_id 0, covering every node in every env
+ */
+export type AlertScope = 'node' | 'environment' | 'global';
+
+export interface CoveringRule {
+  rule: AlertRule;
+  scope: AlertScope;
+}
+
+/** Sentinel for a global (non-env-scoped) rule row. Mirrors alerts.NoEnvironmentID. */
+const GLOBAL_ENV_ID = 0;
+
+/**
+ * The enabled rules that would fire for one node, and why.
+ *
+ * Mirrors pkg/alerts exactly — `ruleApplies` (env 0 is global, otherwise the
+ * env must match) plus the node scope check shared by the ingest matcher and
+ * the inactive sweep. The UUID comparison is case-sensitive there, so it is
+ * case-sensitive here: claiming coverage the backend would not honor is worse
+ * than showing none. Disabled rules are excluded because the rule snapshot
+ * only loads enabled rows.
+ *
+ * `envID` undefined means the page has not resolved the node's environment
+ * yet, so only global rules can be attributed.
+ */
+export function nodeAlertCoverage(
+  rules: AlertRule[],
+  envID: number | undefined,
+  uuid: string,
+): CoveringRule[] {
+  const covering: CoveringRule[] = [];
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    const global = rule.environment_id === GLOBAL_ENV_ID;
+    if (!global && rule.environment_id !== envID) continue;
+    const nodeScope = rule.node_uuid?.trim() ?? '';
+    if (nodeScope !== '' && nodeScope !== uuid) continue;
+    covering.push({
+      rule,
+      scope: nodeScope !== '' ? 'node' : global ? 'global' : 'environment',
+    });
+  }
+  // Most specific first: a rule written for this node is the one an operator
+  // cares about before the blanket ones.
+  const order: Record<AlertScope, number> = { node: 0, environment: 1, global: 2 };
+  return covering.sort(
+    (a, b) => order[a.scope] - order[b.scope] || a.rule.name.localeCompare(b.rule.name),
+  );
+}
+
+/** "2 this node · 1 env · 3 global", skipping the scopes with nothing in them. */
+export function coverageSummary(covering: CoveringRule[]): string {
+  const labels: [AlertScope, string][] = [
+    ['node', 'this node'],
+    ['environment', 'env'],
+    ['global', 'global'],
+  ];
+  return labels
+    .map(([scope, label]) => {
+      const n = covering.filter((c) => c.scope === scope).length;
+      return n > 0 ? `${n} ${label}` : '';
+    })
+    .filter(Boolean)
+    .join(' · ');
+}


### PR DESCRIPTION
## Mark a node when an alert rule covers it

### What

The node detail page gave no indication that a node was under alerting. You had
to open Alerts and reason about scopes by hand to answer "would anything fire for
this host?".

The header now carries a marker under the UUID whenever at least one enabled rule
would fire for the node:

> 🔔 **3 alert rules** · 1 this node · 1 env · 1 global

It links to the Alerts page, and its tooltip names every covering rule and why it
applies — `node-errors — this node`, `env-wide — environment prod`,
`everywhere — global` — so all three scopes are accounted for, not just the
node-specific ones created from "Alert on this node".

### How coverage is decided

`frontend/src/features/nodes/alertCoverage.ts` (new) mirrors `pkg/alerts` rather
than reinventing the predicate. It is the same test the ingest matcher
(`matcher.go`, `ruleApplies` + `nodeScope`) and the inactive sweep (`inactive.go`)
already apply, which is what makes the marker trustworthy:

- **enabled rules only** — the rule snapshot loads only enabled rows, so a
  switched-off rule marks nothing.
- **env 0 is global**, any other value must equal the node's environment.
- **empty node scope covers every node**; a set scope must equal this UUID,
  compared **case-sensitively and trimmed**, exactly as the server does. A
  lowercased scope on an uppercase node truly never fires, and claiming coverage
  that will not happen is worse than showing none.
- **most specific first** — a rule written for this node ranks above the blanket
  ones.

### Wiring notes

- One unfiltered `listAlertRules()` serves all three scopes. It is keyed under the
  existing `['alert-rules']` prefix, so creating a rule from the node modal
  refreshes the marker with no extra plumbing.
- The query is gated on **global** admin, not `canAdminNode`: listing rules is
  global-admin-only, so gating on the looser check would fire a request the
  server refuses. Consequence to be aware of — the marker is invisible to
  env-admins until the `requireAlertsAdmin` gate is revisited.
- Also hoisted the page's environment lookup into one `envRow` (it was resolved
  twice, once inline for the alert modal).

### Tests

- `alertCoverage.test.ts` (new) — scope attribution and ordering; exclusion of
  other environments, other nodes and disabled rules; the case-sensitivity and
  trim contract; global-only attribution before the environment resolves.
- `NodeDetailPage.test.tsx` — a mixed five-rule set (node / env / global /
  other-node / disabled) renders the right count, summary and tooltip; and no
  marker at all when nothing covers the node.

74 node-feature tests pass (322 frontend total), `tsc --noEmit` clean. Frontend
only — no API or schema changes.