### PR TITLE
Promote `osctrl-api` HTTP client from `cmd/cli` to `pkg/apiclient`

### DIFF
--- a/cmd/cli/alert.go
+++ b/cmd/cli/alert.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"github.com/jmpsec/osctrl/pkg/apiclient"
 	"os"
 	"strconv"
 	"strings"
@@ -68,7 +69,7 @@ func alertRulesList(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func ruleToRow(r alertRuleJSON, _ bool) []string {
+func ruleToRow(r apiclient.AlertRuleJSON, _ bool) []string {
 	return []string{
 		strconv.FormatUint(uint64(r.ID), 10),
 		r.Name,
@@ -190,7 +191,7 @@ func alertChannelsList(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func channelToRow(c alertChannelJSON) []string {
+func channelToRow(c apiclient.AlertChannelJSON) []string {
 	return []string{
 		strconv.FormatUint(uint64(c.ID), 10),
 		c.Name,

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/jmpsec/osctrl/pkg/apiclient"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -62,7 +63,7 @@ var (
 	err          error
 	app          *cli.Command
 	dbConfig     *config.YAMLConfigurationDB
-	apiConfig    JSONConfigurationAPI
+	apiConfig    apiclient.JSONConfigurationAPI
 	flags        []cli.Flag
 	commands     []*cli.Command
 	settingsmgr  *settings.Settings
@@ -74,7 +75,7 @@ var (
 	envs         *environments.EnvManager
 	db           *backend.DBManager
 	auditlogsmgr *auditlog.AuditLogManager
-	osctrlAPI    *OsctrlAPI
+	osctrlAPI    *apiclient.OsctrlAPI
 	formats      map[string]bool
 )
 
@@ -2055,13 +2056,16 @@ func checkAPI(ctx context.Context, cmd *cli.Command) error {
 	}
 	if apiFlag {
 		if apiConfigFile != "" {
-			apiConfig, err = loadAPIConfiguration(apiConfigFile)
+			apiConfig, err = apiclient.LoadConfiguration(apiConfigFile)
 			if err != nil {
-				return fmt.Errorf("loadAPIConfiguration - %w", err)
+				return fmt.Errorf("apiclient.LoadConfiguration - %w", err)
 			}
 		}
 		// Initialize API
-		osctrlAPI = CreateAPI(apiConfig, insecureFlag)
+		osctrlAPI, err = apiclient.CreateAPI(apiConfig, insecureFlag)
+		if err != nil {
+			return fmt.Errorf("error creating API client - %w", err)
+		}
 		if err := osctrlAPI.CheckAPI(); err != nil {
 			return fmt.Errorf("error checking API - %w", err)
 		}
@@ -2108,7 +2112,10 @@ func loginAPI(ctx context.Context, cmd *cli.Command) error {
 	}
 	fmt.Println()
 	// Initialize API
-	osctrlAPI = CreateAPI(apiConfig, insecureFlag)
+	osctrlAPI, err = apiclient.CreateAPI(apiConfig, insecureFlag)
+	if err != nil {
+		return fmt.Errorf("error creating API client - %w", err)
+	}
 	apiResponse, err := osctrlAPI.PostLogin(env, username, string(passwordByte), expHours)
 	if err != nil {
 		return fmt.Errorf("error in login %w", err)
@@ -2118,7 +2125,7 @@ func loginAPI(ctx context.Context, cmd *cli.Command) error {
 		fmt.Printf("\n✅ API Login successful: %s\n", apiResponse.Token)
 	}
 	if writeApiFileFlag {
-		if err := writeAPIConfiguration(apiConfigFile, apiConfig); err != nil {
+		if err := apiclient.WriteConfiguration(apiConfigFile, apiConfig); err != nil {
 			return fmt.Errorf("error writing to file %s, %w", apiConfigFile, err)
 		}
 		if !silentFlag {
@@ -2231,14 +2238,17 @@ func cliWrapper(action func(context.Context, *cli.Command) error) func(context.C
 		if apiFlag {
 			if apiConfigFile != "" {
 				log.Debug().Msg("Loading API configuration from file")
-				apiConfig, err = loadAPIConfiguration(apiConfigFile)
+				apiConfig, err = apiclient.LoadConfiguration(apiConfigFile)
 				if err != nil {
-					return fmt.Errorf("loadAPIConfiguration - %w", err)
+					return fmt.Errorf("apiclient.LoadConfiguration - %w", err)
 				}
 			}
 			// Initialize API
 			log.Debug().Msg("Creating API client")
-			osctrlAPI = CreateAPI(apiConfig, insecureFlag)
+			osctrlAPI, err = apiclient.CreateAPI(apiConfig, insecureFlag)
+			if err != nil {
+				return fmt.Errorf("error creating API client - %w", err)
+			}
 			// Execute action
 			return action(ctx, cmd)
 		}

--- a/cmd/cli/shell_module_extras.go
+++ b/cmd/cli/shell_module_extras.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/jmpsec/osctrl/pkg/apiclient"
 	"sort"
 	"strconv"
 	"strings"
@@ -49,7 +50,7 @@ func shConsoleOpen(s *shellState, args []string) {
 		errf("%v", err)
 		return
 	}
-	res, err := spinGet("⌨️  Opening console session", func() (ConsoleSessionResponse, error) { return cs.CreateConsoleSession(s.env, n.UUID) })
+	res, err := spinGet("⌨️  Opening console session", func() (apiclient.ConsoleSessionResponse, error) { return cs.CreateConsoleSession(s.env, n.UUID) })
 	if err != nil {
 		errf("%v", err)
 		return
@@ -169,7 +170,9 @@ func shFexploreOpen(s *shellState, args []string) {
 		errf("%v", err)
 		return
 	}
-	res, err := spinGet("🗂️  Opening file explorer session", func() (fileExplorerSessionResponse, error) { return cs.CreateFileExplorerSession(s.env, n.UUID) })
+	res, err := spinGet("🗂️  Opening file explorer session", func() (apiclient.FileExplorerSessionResponse, error) {
+		return cs.CreateFileExplorerSession(s.env, n.UUID)
+	})
 	if err != nil {
 		errf("%v", err)
 		return

--- a/cmd/cli/shell_store.go
+++ b/cmd/cli/shell_store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/jmpsec/osctrl/pkg/apiclient"
 	"path"
 	"strconv"
 	"strings"
@@ -28,7 +29,7 @@ const APIStatsPath = "/stats"
 // tui_store.go — single data-access façade for the interactive TUI.
 //
 // The TUI never branches on dbFlag/apiFlag itself; it talks to a DataStore
-// implementation. apiStore wraps the existing OsctrlAPI client; dbStore wraps
+// implementation. apiStore wraps the existing apiclient.OsctrlAPI client; dbStore wraps
 // the pkg/* managers. DTOs (xxxRow) decouple the views from the underlying
 // model JSON shapes so a view does not care whether data came from REST or GORM.
 
@@ -449,16 +450,16 @@ func auditToRow(a auditlog.AuditLog) auditRow {
 // ─────────────────────────────── apiStore ───────────────────────────────
 
 type apiStore struct {
-	api *OsctrlAPI
+	api *apiclient.OsctrlAPI
 }
 
-func newAPIStore(api *OsctrlAPI) DataStore { return &apiStore{api: api} }
+func newAPIStore(api *apiclient.OsctrlAPI) DataStore { return &apiStore{api: api} }
 
 func (s *apiStore) Mode() string { return "api" }
 
 func (s *apiStore) Stats() (tuiStats, error) {
 	var st tuiStats
-	reqURL := fmt.Sprintf("%s%s", s.api.Configuration.URL, path.Join(APIPath, APIStatsPath))
+	reqURL := fmt.Sprintf("%s%s", s.api.Configuration.URL, path.Join(apiclient.APIPath, APIStatsPath))
 	raw, err := s.api.GetGeneric(reqURL, nil)
 	if err != nil {
 		return st, fmt.Errorf("stats: %w - %s", err, string(raw))
@@ -526,7 +527,7 @@ func (s *apiStore) Queries(env, target string) ([]queryRow, error) {
 }
 
 func (s *apiStore) QueryResults(env, name string) (string, error) {
-	reqURL := fmt.Sprintf("%s%s", s.api.Configuration.URL, path.Join(APIPath, APIQueries, env, "results", name))
+	reqURL := fmt.Sprintf("%s%s", s.api.Configuration.URL, path.Join(apiclient.APIPath, apiclient.APIQueries, env, "results", name))
 	raw, err := s.api.GetGeneric(reqURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("results: %w - %s", err, string(raw))

--- a/cmd/cli/shell_store_extras.go
+++ b/cmd/cli/shell_store_extras.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/jmpsec/osctrl/pkg/apiclient"
 
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/fileexplorer"
@@ -18,14 +19,14 @@ import (
 
 // consoleStore is the API-backed surface for interactive per-node access.
 type consoleStore interface {
-	CreateConsoleSession(env, uuid string) (ConsoleSessionResponse, error)
+	CreateConsoleSession(env, uuid string) (apiclient.ConsoleSessionResponse, error)
 	GetConsoleSession(env string, sessionID uint) (console.Session, error)
 	CloseConsoleSession(env string, sessionID uint) error
-	SubmitConsoleCommand(env string, sessionID uint, input string, osqueryMode bool) (ConsoleCommandResponse, error)
+	SubmitConsoleCommand(env string, sessionID uint, input string, osqueryMode bool) (apiclient.ConsoleCommandResponse, error)
 	GetConsoleCommand(env string, sessionID, commandID uint) (console.Command, error)
 	GetConsoleCommandResults(env string, sessionID, commandID uint) ([]map[string]any, error)
 
-	CreateFileExplorerSession(env, uuid string) (fileExplorerSessionResponse, error)
+	CreateFileExplorerSession(env, uuid string) (apiclient.FileExplorerSessionResponse, error)
 	CloseFileExplorerSession(env string, sessionID uint) error
 	SubmitFileExplorerList(env string, sessionID uint, path string) (fileexplorer.Request, error)
 	SubmitFileExplorerStat(env string, sessionID uint, path string) (fileexplorer.Request, error)
@@ -76,7 +77,7 @@ func storeSaved(s DataStore) (savedStore, error) {
 
 // ─────────────────────────────── apiStore implementations ───────────────────────────────
 
-func (s *apiStore) CreateConsoleSession(env, uuid string) (ConsoleSessionResponse, error) {
+func (s *apiStore) CreateConsoleSession(env, uuid string) (apiclient.ConsoleSessionResponse, error) {
 	return s.api.CreateConsoleSession(env, uuid)
 }
 
@@ -88,7 +89,7 @@ func (s *apiStore) CloseConsoleSession(env string, sessionID uint) error {
 	return s.api.CloseConsoleSession(env, sessionID)
 }
 
-func (s *apiStore) SubmitConsoleCommand(env string, sessionID uint, input string, osqueryMode bool) (ConsoleCommandResponse, error) {
+func (s *apiStore) SubmitConsoleCommand(env string, sessionID uint, input string, osqueryMode bool) (apiclient.ConsoleCommandResponse, error) {
 	return s.api.SubmitConsoleCommand(env, sessionID, input, osqueryMode)
 }
 
@@ -100,7 +101,7 @@ func (s *apiStore) GetConsoleCommandResults(env string, sessionID, commandID uin
 	return s.api.GetConsoleCommandResults(env, sessionID, commandID)
 }
 
-func (s *apiStore) CreateFileExplorerSession(env, uuid string) (fileExplorerSessionResponse, error) {
+func (s *apiStore) CreateFileExplorerSession(env, uuid string) (apiclient.FileExplorerSessionResponse, error) {
 	return s.api.CreateFileExplorerSession(env, uuid)
 }
 

--- a/cmd/cli/shell_store_extras_test.go
+++ b/cmd/cli/shell_store_extras_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/apiclient"
+)
+
+// These tests moved here from the old cmd/cli/api_extras_test.go when the HTTP
+// client was promoted to pkg/apiclient. They exercise cmd/cli's own store and
+// formatting helpers, not the client — the client round-trip tests stayed with
+// the client in pkg/apiclient/extras_test.go.
+
+func TestStoreCastErrors(t *testing.T) {
+	// dbStore does not implement the console/posture/saved surfaces.
+	store := newDBStore()
+	if _, err := storeConsole(store); err == nil {
+		t.Fatal("expected storeConsole to reject dbStore")
+	}
+	if _, err := storePosture(store); err == nil {
+		t.Fatal("expected storePosture to reject dbStore")
+	}
+	if _, err := storeSaved(store); err == nil {
+		t.Fatal("expected storeSaved to reject dbStore")
+	}
+}
+
+func TestAPIStoreImplementsExtraSurfaces(t *testing.T) {
+	// Pure type-assertion check — no request is ever issued, so a client
+	// pointed at an unreachable URL is sufficient.
+	api, err := apiclient.CreateAPI(apiclient.JSONConfigurationAPI{
+		URL:   "http://127.0.0.1:1",
+		Token: "testtoken",
+	}, false)
+	if err != nil {
+		t.Fatalf("CreateAPI: %v", err)
+	}
+	store := newAPIStore(api)
+	if _, err := storeConsole(store); err != nil {
+		t.Fatalf("apiStore should implement consoleStore: %v", err)
+	}
+	if _, err := storePosture(store); err != nil {
+		t.Fatalf("apiStore should implement postureStore: %v", err)
+	}
+	if _, err := storeSaved(store); err != nil {
+		t.Fatalf("apiStore should implement savedStore: %v", err)
+	}
+}
+
+func TestColumnKeysAndIndent(t *testing.T) {
+	keys := columnKeys(map[string]any{"b": 1, "a": 2, "c": 3})
+	if len(keys) != 3 || keys[0] != "a" || keys[2] != "c" {
+		t.Fatalf("columnKeys not sorted: %v", keys)
+	}
+	if got := indentLines("x\ny", "  "); got != "  x\n  y" {
+		t.Fatalf("indentLines: %q", got)
+	}
+}

--- a/pkg/apiclient/alerts.go
+++ b/pkg/apiclient/alerts.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"
@@ -27,8 +27,8 @@ import (
 //   GET    /api/v1/alerts/history[?limit={n}]
 //   POST   /api/v1/alerts/apply
 
-// alertRuleJSON mirrors the API DTO.
-type alertRuleJSON struct {
+// AlertRuleJSON mirrors the API DTO.
+type AlertRuleJSON struct {
 	ID              uint   `json:"id"`
 	Name            string `json:"name"`
 	EnvironmentID   uint   `json:"environment_id"`
@@ -43,8 +43,8 @@ type alertRuleJSON struct {
 	Info            string `json:"info"`
 }
 
-// alertChannelJSON mirrors the API DTO (config decoded).
-type alertChannelJSON struct {
+// AlertChannelJSON mirrors the API DTO (config decoded).
+type AlertChannelJSON struct {
 	ID            uint            `json:"id"`
 	Name          string          `json:"name"`
 	EnvironmentID uint            `json:"environment_id"`
@@ -55,8 +55,8 @@ type alertChannelJSON struct {
 }
 
 // GetAlertRules lists alert rules.
-func (api *OsctrlAPI) GetAlertRules() ([]alertRuleJSON, error) {
-	var rules []alertRuleJSON
+func (api *OsctrlAPI) GetAlertRules() ([]AlertRuleJSON, error) {
+	var rules []AlertRuleJSON
 	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "rules"))
 	raw, err := api.GetGeneric(reqURL, nil)
 	if err != nil {
@@ -111,8 +111,8 @@ func (api *OsctrlAPI) DeleteAlertRule(id uint) error {
 }
 
 // GetAlertChannels lists alert channels.
-func (api *OsctrlAPI) GetAlertChannels() ([]alertChannelJSON, error) {
-	var channels []alertChannelJSON
+func (api *OsctrlAPI) GetAlertChannels() ([]AlertChannelJSON, error) {
+	var channels []AlertChannelJSON
 	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/alerts", "channels"))
 	raw, err := api.GetGeneric(reqURL, nil)
 	if err != nil {

--- a/pkg/apiclient/audit.go
+++ b/pkg/apiclient/audit.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"encoding/json"

--- a/pkg/apiclient/carve.go
+++ b/pkg/apiclient/carve.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"crypto/tls"
@@ -17,6 +17,10 @@ import (
 )
 
 const (
+	// ConfigKey is the top-level JSON key the API configuration lives under
+	// in the on-disk config file (osctrl-api.json). Previously read from
+	// cmd/cli's projectName const; inlined here so the package stands alone.
+	ConfigKey = "osctrl"
 	// APIPath for the generic API path in osctrl
 	APIPath = "/api/v1"
 	// APINodes for the nodes path
@@ -66,8 +70,8 @@ type OsctrlAPI struct {
 	Headers       map[string]string
 }
 
-// loadAPIConfiguration to load the API configuration file and assign to variables
-func loadAPIConfiguration(file string) (JSONConfigurationAPI, error) {
+// LoadConfiguration to load the API configuration file and assign to variables
+func LoadConfiguration(file string) (JSONConfigurationAPI, error) {
 	var config JSONConfigurationAPI
 	// Load file and read config
 	viper.SetConfigFile(file)
@@ -75,9 +79,9 @@ func loadAPIConfiguration(file string) (JSONConfigurationAPI, error) {
 		return config, err
 	}
 	// API values
-	apiRaw := viper.Sub(projectName)
+	apiRaw := viper.Sub(ConfigKey)
 	if apiRaw == nil {
-		return config, fmt.Errorf("JSON key %s not found in %s", projectName, file)
+		return config, fmt.Errorf("JSON key %s not found in %s", ConfigKey, file)
 	}
 	if err := apiRaw.Unmarshal(&config); err != nil {
 		return config, err
@@ -86,13 +90,13 @@ func loadAPIConfiguration(file string) (JSONConfigurationAPI, error) {
 	return config, nil
 }
 
-// writeAPIConfiguration to write the API configuration file and update values
-func writeAPIConfiguration(file string, apiConf JSONConfigurationAPI) error {
+// WriteConfiguration to write the API configuration file and update values
+func WriteConfiguration(file string, apiConf JSONConfigurationAPI) error {
 	if apiConf.URL == "" || apiConf.Token == "" {
 		return fmt.Errorf("invalid JSON values")
 	}
 	fileData := make(map[string]JSONConfigurationAPI)
-	fileData[projectName] = apiConf
+	fileData[ConfigKey] = apiConf
 	confByte, err := json.MarshalIndent(fileData, "", " ")
 	if err != nil {
 		return fmt.Errorf("error serializing data %w", err)
@@ -103,20 +107,25 @@ func writeAPIConfiguration(file string, apiConf JSONConfigurationAPI) error {
 	return nil
 }
 
-// CreateAPI to initialize the API client and handlers
-func CreateAPI(config JSONConfigurationAPI, insecure bool) *OsctrlAPI {
+// CreateAPI to initialize the API client and handlers.
+//
+// Returns an error rather than calling log.Fatal on bad input: as a library
+// this is called by long-lived processes (and by tests) where killing the
+// process on a malformed URL is not an acceptable failure mode. Callers that
+// genuinely want to abort should log.Fatal on the returned error themselves.
+func CreateAPI(config JSONConfigurationAPI, insecure bool) (*OsctrlAPI, error) {
 	var a *OsctrlAPI
 	// Prepare URL
 	u, err := url.Parse(config.URL)
 	if err != nil {
-		log.Fatal().Msgf("invalid url: %v", err)
+		return nil, fmt.Errorf("invalid url - %w", err)
 	}
 	// Define client with correct TLS settings
 	client := &http.Client{}
 	if u.Scheme == "https" {
 		certPool, err := x509.SystemCertPool()
 		if err != nil {
-			log.Fatal().Msgf("error loading x509 certificate pool: %v", err)
+			return nil, fmt.Errorf("error loading x509 certificate pool - %w", err)
 		}
 		tlsCfg := &tls.Config{RootCAs: certPool}
 		if insecure {
@@ -133,7 +142,7 @@ func CreateAPI(config JSONConfigurationAPI, insecure bool) *OsctrlAPI {
 		Client:        client,
 		Headers:       headers,
 	}
-	return a
+	return a, nil
 }
 
 // GetGeneric - Helper function to implement generic retrieval from API with a GET request

--- a/pkg/apiclient/console.go
+++ b/pkg/apiclient/console.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"
@@ -18,8 +18,8 @@ import (
 //   GET    /api/v1/console/{env}/sessions/{session_id}/commands/{command_id}
 //   GET    /api/v1/console/{env}/sessions/{session_id}/commands/{command_id}/results
 
-// consoleNodeInfo mirrors the API's node_info projection for a console session.
-type consoleNodeInfo struct {
+// ConsoleNodeInfo mirrors the API's node_info projection for a console session.
+type ConsoleNodeInfo struct {
 	IPAddress       string `json:"ip_address"`
 	OsqueryUser     string `json:"osquery_user"`
 	OsqueryVersion  string `json:"osquery_version"`
@@ -31,7 +31,7 @@ type consoleNodeInfo struct {
 type ConsoleSessionResponse struct {
 	Session  console.Session        `json:"session"`
 	History  []console.HistoryEntry `json:"history"`
-	NodeInfo consoleNodeInfo        `json:"node_info"`
+	NodeInfo ConsoleNodeInfo        `json:"node_info"`
 }
 
 // ConsoleCommandResponse mirrors the submit-command response.

--- a/pkg/apiclient/environment.go
+++ b/pkg/apiclient/environment.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"encoding/json"

--- a/pkg/apiclient/extras.go
+++ b/pkg/apiclient/extras.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"
@@ -38,15 +38,15 @@ import (
 // Node logs routes:
 //   GET /api/v1/logs/{type}/{env}/{uuid}
 
-// fileExplorerSessionResponse mirrors the create-session response.
-type fileExplorerSessionResponse struct {
+// FileExplorerSessionResponse mirrors the create-session response.
+type FileExplorerSessionResponse struct {
 	Session  fileexplorer.Session `json:"session"`
-	NodeInfo consoleNodeInfo      `json:"node_info"`
+	NodeInfo ConsoleNodeInfo      `json:"node_info"`
 }
 
 // CreateFileExplorerSession opens a file explorer session against a node.
-func (api *OsctrlAPI) CreateFileExplorerSession(env, uuid string) (fileExplorerSessionResponse, error) {
-	var res fileExplorerSessionResponse
+func (api *OsctrlAPI) CreateFileExplorerSession(env, uuid string) (FileExplorerSessionResponse, error) {
+	var res FileExplorerSessionResponse
 	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/file-explorer", env, "nodes", uuid, "sessions"))
 	raw, err := api.PostGeneric(reqURL, nil)
 	if err != nil {
@@ -267,8 +267,8 @@ func (api *OsctrlAPI) GetQuerySamples() ([]queries.QuerySample, error) {
 }
 
 // GetFeatures retrieves the deployment feature switches.
-func (api *OsctrlAPI) GetFeatures() (featuresResponse, error) {
-	var res featuresResponse
+func (api *OsctrlAPI) GetFeatures() (FeaturesResponse, error) {
+	var res FeaturesResponse
 	reqURL := fmt.Sprintf("%s%s", api.Configuration.URL, path.Join(APIPath, "/features"))
 	raw, err := api.GetGeneric(reqURL, nil)
 	if err != nil {
@@ -280,8 +280,8 @@ func (api *OsctrlAPI) GetFeatures() (featuresResponse, error) {
 	return res, nil
 }
 
-// featuresResponse mirrors the /features deployment switches.
-type featuresResponse struct {
+// FeaturesResponse mirrors the /features deployment switches.
+type FeaturesResponse struct {
 	Posture       bool `json:"posture"`
 	ServiceConfig bool `json:"service_config"`
 	LogSinks      bool `json:"log_sinks"`

--- a/pkg/apiclient/extras_test.go
+++ b/pkg/apiclient/extras_test.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"encoding/json"
@@ -34,7 +34,7 @@ func newTestAPI(t *testing.T) *OsctrlAPI {
 		}
 		_ = json.NewEncoder(w).Encode(ConsoleSessionResponse{
 			Session:  console.Session{ID: 7, NodeUUID: "UUID1", CWD: "/", Platform: "linux"},
-			NodeInfo: consoleNodeInfo{OsqueryVersion: "5.23.1"},
+			NodeInfo: ConsoleNodeInfo{OsqueryVersion: "5.23.1"},
 		})
 	})
 	mux.HandleFunc("DELETE /api/v1/console/{env}/sessions/{session_id}", func(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +70,7 @@ func newTestAPI(t *testing.T) *OsctrlAPI {
 
 	// File explorer routes
 	mux.HandleFunc("POST /api/v1/file-explorer/{env}/nodes/{uuid}/sessions", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(fileExplorerSessionResponse{
+		_ = json.NewEncoder(w).Encode(FileExplorerSessionResponse{
 			Session: fileexplorer.Session{ID: 9, Root: "/"},
 		})
 	})
@@ -153,7 +153,11 @@ func newTestAPI(t *testing.T) *OsctrlAPI {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	return CreateAPI(JSONConfigurationAPI{URL: srv.URL, Token: "testtoken"}, false)
+	api, err := CreateAPI(JSONConfigurationAPI{URL: srv.URL, Token: "testtoken"}, false)
+	if err != nil {
+		t.Fatalf("CreateAPI: %v", err)
+	}
+	return api
 }
 
 func TestConsoleClientRoundTrip(t *testing.T) {
@@ -324,44 +328,6 @@ func TestQuerySamplesAndNodeLogs(t *testing.T) {
 	}
 	if parsed.Type != "result" || parsed.Env != "dev" {
 		t.Fatalf("unexpected logs body: %s", body)
-	}
-}
-
-func TestStoreCastErrors(t *testing.T) {
-	// dbStore does not implement the console/posture/saved surfaces.
-	store := newDBStore()
-	if _, err := storeConsole(store); err == nil {
-		t.Fatal("expected storeConsole to reject dbStore")
-	}
-	if _, err := storePosture(store); err == nil {
-		t.Fatal("expected storePosture to reject dbStore")
-	}
-	if _, err := storeSaved(store); err == nil {
-		t.Fatal("expected storeSaved to reject dbStore")
-	}
-}
-
-func TestAPIStoreImplementsExtraSurfaces(t *testing.T) {
-	api := newTestAPI(t)
-	store := newAPIStore(api)
-	if _, err := storeConsole(store); err != nil {
-		t.Fatalf("apiStore should implement consoleStore: %v", err)
-	}
-	if _, err := storePosture(store); err != nil {
-		t.Fatalf("apiStore should implement postureStore: %v", err)
-	}
-	if _, err := storeSaved(store); err != nil {
-		t.Fatalf("apiStore should implement savedStore: %v", err)
-	}
-}
-
-func TestColumnKeysAndIndent(t *testing.T) {
-	keys := columnKeys(map[string]any{"b": 1, "a": 2, "c": 3})
-	if len(keys) != 3 || keys[0] != "a" || keys[2] != "c" {
-		t.Fatalf("columnKeys not sorted: %v", keys)
-	}
-	if got := indentLines("x\ny", "  "); got != "  x\n  y" {
-		t.Fatalf("indentLines: %q", got)
 	}
 }
 

--- a/pkg/apiclient/login.go
+++ b/pkg/apiclient/login.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"

--- a/pkg/apiclient/node.go
+++ b/pkg/apiclient/node.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"

--- a/pkg/apiclient/query.go
+++ b/pkg/apiclient/query.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"

--- a/pkg/apiclient/tag.go
+++ b/pkg/apiclient/tag.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"

--- a/pkg/apiclient/user.go
+++ b/pkg/apiclient/user.go
@@ -1,4 +1,4 @@
-package main
+package apiclient
 
 import (
 	"bytes"


### PR DESCRIPTION
## Promote the osctrl-api HTTP client to `pkg/apiclient`

Moves the CLI's API client out of `package main` so other binaries can import it.
Groundwork for an MCP server (`cmd/osctrl-mcp`), which needs the same typed client
that `osctrl-cli` already has — and which we'd otherwise have to duplicate.

### What moved

13 files from `cmd/cli/api*.go` → `pkg/apiclient/` (tracked as git renames, history preserved):

- `api.go` → `client.go`, and `api-{alerts,audit,carve,console,environment,extras,login,node,query,tag,user}.go` → `{name}.go`
- `api_extras_test.go` → `extras_test.go`

The client only ever depended on `pkg/*`, stdlib, zerolog, and viper, so it moved cleanly.

### Public surface

Five identifiers leaked through exported method signatures and are now exported —
`cmd/cli` names them in `alert.go`, `shell_module_extras.go`, and `shell_store_extras.go`:

`alertRuleJSON` → `AlertRuleJSON`, `alertChannelJSON` → `AlertChannelJSON`,
`fileExplorerSessionResponse` → `FileExplorerSessionResponse`, `featuresResponse` → `FeaturesResponse`,
`consoleNodeInfo` → `ConsoleNodeInfo` (a field type inside the already-public `ConsoleSessionResponse`).

Capitalized rather than renamed, to keep the diff mechanical.

`loadAPIConfiguration` / `writeAPIConfiguration` → `LoadConfiguration` / `WriteConfiguration`:
future consumers read the same `osctrl-api.json`, so these belong with the client.

### Behavior changes

**`CreateAPI` now returns `(*OsctrlAPI, error)`.** It previously called `log.Fatal()` on a
malformed URL or unreadable cert pool — acceptable in a CLI, fatal in a long-lived server that
should return an error instead of exiting. The three call sites in `cmd/cli/main.go` propagate,
so the CLI's observable behavior is unchanged:
```
FTL ❌ error creating API client - invalid url - parse "ht tp://bad url": ...
```

**`projectName` → `apiclient.ConfigKey`** — the one `package main` const the client referenced,
inlined so the package stands alone.

### Tests

`api_extras_test.go` mixed client round-trip tests with CLI shell/UI tests. The client tests
stayed with the client; `TestStoreCastErrors`, `TestAPIStoreImplementsExtraSurfaces`, and
`TestColumnKeysAndIndent` moved to `cmd/cli/shell_store_extras_test.go`. The last of those is a
pure type assertion, so it now builds a client against an unreachable URL rather than needing
the httptest server.

### Verification

`go build ./...`, `go vet`, and `gofmt -l` all clean; all 38 packages pass. Smoke-tested the
rebuilt `osctrl-cli` binary.

### Follow-up

The User-Agent is still hardcoded `osctrl-cli-http-client/<version>` (`pkg/apiclient/client.go:57`).
Consumers should be able to identify themselves so operators can distinguish traffic in the API
logs — left alone here to keep this a pure move.
