### PR TITLE
Serve MCP from `osctrl-api` at `/api/v1/mcp`

### DIFF
--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -272,3 +272,48 @@ service:
 		t.Fatalf("cfg.Version = %d, want 999", cfg.Version)
 	}
 }
+
+func TestLoadedYAMLCarriesMCPSection(t *testing.T) {
+	// Same failure mode the SAML/OIDC sections hit: a section that
+	// loadedYAMLToServiceParams forgets to copy is silently dropped, and the
+	// endpoint stays off with no error anywhere.
+	const body = `
+service:
+  auth: jwt
+db:
+  type: postgres
+mcp:
+  enabled: true
+`
+	cfg, err := loadYAMLConfiguration(writeTempConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration: %v", err)
+	}
+	params := loadedYAMLToServiceParams(cfg, "api.yml")
+
+	if params.MCP == nil {
+		t.Fatal("MCP params are nil — the mcp section was dropped")
+	}
+	if !params.MCP.Enabled {
+		t.Error("MCP.Enabled = false, want true")
+	}
+}
+
+func TestMCPDefaultsOffWhenSectionAbsent(t *testing.T) {
+	// Omitting the section must leave the endpoint unmounted, so an upgrade
+	// never turns on an agent-facing read surface by itself.
+	const body = `
+service:
+  auth: jwt
+db:
+  type: postgres
+`
+	cfg, err := loadYAMLConfiguration(writeTempConfig(t, body))
+	if err != nil {
+		t.Fatalf("loadYAMLConfiguration: %v", err)
+	}
+	params := loadedYAMLToServiceParams(cfg, "api.yml")
+	if params.MCP != nil && params.MCP.Enabled {
+		t.Error("MCP enabled without an mcp section")
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -121,6 +121,7 @@ const (
 	apiFileExplorerPath = "/file-explorer"
 	// API audit logs path
 	apiAuditLogsPath = "/audit-logs"
+	apiMCPPath       = "/mcp"
 	// API logs path
 	apiLogsPath = "/logs"
 	// API stats path
@@ -214,6 +215,7 @@ func init() {
 		JWT:     &config.YAMLConfigurationJWT{},
 		OIDC:    &config.YAMLConfigurationOIDC{},
 		SAML:    &config.YAMLConfigurationSAML{},
+		MCP:     &config.YAMLConfigurationMCP{},
 		TLS:     &config.YAMLConfigurationTLS{},
 		Osquery: &config.YAMLConfigurationOsquery{},
 		Logger: &config.YAMLConfigurationLogger{
@@ -1242,6 +1244,21 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"GET "+_apiPath(apiAuditLogsPath),
 			handlerAuthCheck(http.HandlerFunc(handlersApi.AuditLogsHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	}
+	// MCP endpoint. Registered only when enabled, matching the OIDC/SAML
+	// posture: an operator opts in, and a deployment never inherits the
+	// surface on upgrade.
+	//
+	// handlerAuthCheck rejects unauthenticated callers at the MCP boundary,
+	// so a bad token fails once here rather than once per tool call. Tool
+	// calls are then dispatched back into muxAPI by loopbackTransport, which
+	// re-runs the full chain — including the per-endpoint permission checks
+	// — as the calling user.
+	if flagParams.MCP != nil && flagParams.MCP.Enabled {
+		log.Info().Msgf("MCP enabled — serving %s", _apiPath(apiMCPPath))
+		muxAPI.Handle(
+			_apiPath(apiMCPPath),
+			handlerAuthCheck(mcpHandler(muxAPI, buildVersion), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	}
 	// Launch listeners for API server. The server runs in a goroutine so
 	// the main goroutine can wait on the restart channel and trigger a

--- a/cmd/api/mcp.go
+++ b/cmd/api/mcp.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmpsec/osctrl/pkg/apiclient"
+	osctrlmcp "github.com/jmpsec/osctrl/pkg/mcp"
+)
+
+// mcpInternalHost is the host the in-process client addresses. Nothing
+// resolves it: loopbackTransport routes on method and path only, and none of
+// osctrl-api's mux patterns are host-scoped. It exists because http.Request
+// requires an absolute URL.
+const mcpInternalHost = "http://osctrl-api.internal"
+
+// loopbackTransport dispatches an outbound request into an http.Handler
+// instead of onto the network.
+//
+// This is what lets the hosted MCP server reuse osctrl-api's own handlers.
+// Each MCP tool call becomes a synthetic request through the same mux a real
+// client would hit, so authentication, the per-endpoint permission checks,
+// and audit logging all run exactly as they do for any other caller. The MCP
+// layer therefore contains no authorization logic of its own — which matters
+// because osctrl's read permissions are not uniform (reading a node needs
+// AdminLevel, its posture only UserLevel, queries QueryLevel), and restating
+// that policy anywhere else would over-grant the moment the two drift.
+type loopbackTransport struct {
+	handler http.Handler
+	// creds carries the inbound MCP caller's credentials onto every
+	// synthetic request, so the handler chain authenticates as that user
+	// rather than as the service.
+	authorization string
+	cookies       []*http.Cookie
+	// remoteAddr and userAgent are propagated so audit-log entries and
+	// rate-limit buckets attribute to the real client, not to the server
+	// talking to itself.
+	remoteAddr string
+	userAgent  string
+}
+
+func (t *loopbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone so we never mutate the caller's request.
+	out := req.Clone(req.Context())
+	if t.authorization != "" {
+		out.Header.Set("Authorization", t.authorization)
+	}
+	// Drop anything the client set and replay only the inbound cookies, so a
+	// stale value cannot shadow the real session.
+	out.Header.Del("Cookie")
+	for _, c := range t.cookies {
+		out.AddCookie(c)
+	}
+	if t.userAgent != "" {
+		out.Header.Set("User-Agent", t.userAgent)
+	}
+	out.RemoteAddr = t.remoteAddr
+	// The mux matches on Method + URL.Path; RequestURI must be unset on a
+	// server-side request or net/http panics.
+	out.RequestURI = ""
+
+	rec := newResponseRecorder()
+	t.handler.ServeHTTP(rec, out)
+	return rec.result(req), nil
+}
+
+// responseRecorder is a minimal http.ResponseWriter. net/http/httptest would
+// do the same job, but it is a testing package and this runs in the server.
+type responseRecorder struct {
+	code   int
+	header http.Header
+	body   bytes.Buffer
+}
+
+func newResponseRecorder() *responseRecorder {
+	return &responseRecorder{code: http.StatusOK, header: make(http.Header)}
+}
+
+func (r *responseRecorder) Header() http.Header { return r.header }
+
+func (r *responseRecorder) Write(b []byte) (int, error) { return r.body.Write(b) }
+
+func (r *responseRecorder) WriteHeader(code int) { r.code = code }
+
+func (r *responseRecorder) result(req *http.Request) *http.Response {
+	return &http.Response{
+		Status:        fmt.Sprintf("%d %s", r.code, http.StatusText(r.code)),
+		StatusCode:    r.code,
+		Header:        r.header.Clone(),
+		Body:          io.NopCloser(bytes.NewReader(r.body.Bytes())),
+		ContentLength: int64(r.body.Len()),
+		Request:       req,
+	}
+}
+
+// mcpHandler builds the HTTP handler serving MCP at /api/v1/mcp.
+//
+// apiHandler is the fully-wired API mux; tool calls are dispatched back into
+// it. It is passed as an http.Handler rather than captured at construction so
+// main.go can build the mux first and hand it over once.
+//
+// The returned handler must still be mounted behind handlerAuthCheck: that
+// rejects unauthenticated callers up front, so a bad token fails once at the
+// MCP boundary instead of once per tool call.
+func mcpHandler(apiHandler http.Handler, version string) http.Handler {
+	getServer := func(r *http.Request) *sdk.Server {
+		// One client per request, bound to that request's credentials. The
+		// MCP server is cheap to build and holds no state, so per-request
+		// construction keeps sessions from ever sharing an identity.
+		cfg := apiclient.JSONConfigurationAPI{URL: mcpInternalHost}
+		client, err := apiclient.CreateAPIWithTransport(cfg, &loopbackTransport{
+			handler:       apiHandler,
+			authorization: r.Header.Get("Authorization"),
+			cookies:       r.Cookies(),
+			remoteAddr:    r.RemoteAddr,
+			userAgent:     r.Header.Get("User-Agent"),
+		})
+		if err != nil {
+			// CreateAPIWithTransport only fails on a malformed constant URL
+			// or a nil transport, neither of which is reachable here.
+			return nil
+		}
+		return osctrlmcp.NewServer(client, version)
+	}
+	return sdk.NewStreamableHTTPHandler(getServer, nil)
+}

--- a/cmd/api/mcp_test.go
+++ b/cmd/api/mcp_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// The hosted MCP server deliberately owns no authorization logic: every tool
+// call is dispatched back through osctrl-api's own mux so the real handler
+// chain decides. These tests pin the two properties that makes it safe —
+// the caller's credentials reach the handler, and the handler's verdict
+// reaches the MCP client.
+
+// recordingAPI stands in for the API mux. It records the last request it saw
+// and serves whatever the test configures.
+type recordingAPI struct {
+	gotAuth       string
+	gotCookies    []*http.Cookie
+	gotRemoteAddr string
+	gotUserAgent  string
+	gotPath       string
+	status        int
+	body          string
+}
+
+func (a *recordingAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.gotAuth = r.Header.Get("Authorization")
+	a.gotCookies = r.Cookies()
+	a.gotRemoteAddr = r.RemoteAddr
+	a.gotUserAgent = r.Header.Get("User-Agent")
+	a.gotPath = r.URL.Path
+	if a.status == 0 {
+		a.status = http.StatusOK
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(a.status)
+	_, _ = w.Write([]byte(a.body))
+}
+
+// newMCPClient mounts mcpHandler over api and returns a connected MCP session.
+// creds are applied to the inbound HTTP request the way a real client would.
+func newMCPClient(t *testing.T, api http.Handler, apply func(*http.Request)) *sdk.ClientSession {
+	t.Helper()
+	srv := httptest.NewServer(mcpHandler(api, "test"))
+	t.Cleanup(srv.Close)
+
+	client := sdk.NewClient(&sdk.Implementation{Name: "test", Version: "test"}, nil)
+	session, err := client.Connect(context.Background(), &sdk.StreamableClientTransport{
+		Endpoint:   srv.URL,
+		HTTPClient: &http.Client{Transport: headerInjector{apply: apply}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+// headerInjector applies the test's credentials to every outbound request.
+type headerInjector struct{ apply func(*http.Request) }
+
+func (h headerInjector) RoundTrip(r *http.Request) (*http.Response, error) {
+	if h.apply != nil {
+		h.apply(r)
+	}
+	return http.DefaultTransport.RoundTrip(r)
+}
+
+func TestLoopbackTransportPropagatesCaller(t *testing.T) {
+	api := &recordingAPI{body: `[]`}
+	session := newMCPClient(t, api, func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer caller-token")
+		r.Header.Set("User-Agent", "mcp-client/1.0")
+		r.AddCookie(&http.Cookie{Name: "osctrl_token", Value: "cookie-value"})
+	})
+
+	if _, err := session.CallTool(context.Background(), &sdk.CallToolParams{
+		Name: "list_environments", Arguments: map[string]any{},
+	}); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	// The handler must authenticate as the caller, not as the service.
+	if api.gotAuth != "Bearer caller-token" {
+		t.Errorf("Authorization = %q, want the caller's bearer token", api.gotAuth)
+	}
+	if len(api.gotCookies) != 1 || api.gotCookies[0].Value != "cookie-value" {
+		t.Errorf("cookies = %+v, want the caller's session cookie", api.gotCookies)
+	}
+	// Audit entries and rate-limit buckets must attribute to the real client.
+	if api.gotRemoteAddr == "" {
+		t.Error("RemoteAddr not propagated — audit logs would attribute to the server")
+	}
+	if api.gotUserAgent != "mcp-client/1.0" {
+		t.Errorf("User-Agent = %q, want the caller's", api.gotUserAgent)
+	}
+	if api.gotPath != "/api/v1/environments" {
+		t.Errorf("dispatched to %q, want /api/v1/environments", api.gotPath)
+	}
+}
+
+// The point of dispatching through the mux: whatever the handler decides
+// about permissions is what the MCP client gets. A 403 must surface as a
+// tool error, never as empty-but-successful data.
+func TestHandlerDenialSurfacesAsToolError(t *testing.T) {
+	api := &recordingAPI{status: http.StatusForbidden, body: `{"error":"no access"}`}
+	session := newMCPClient(t, api, func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer low-privilege")
+	})
+
+	res, err := session.CallTool(context.Background(), &sdk.CallToolParams{
+		Name:      "get_node",
+		Arguments: map[string]any{"environment": "prod", "identifier": "UUID1"},
+	})
+	if err == nil && !res.IsError {
+		t.Fatal("a 403 from the handler chain must surface as a tool error, not as success")
+	}
+}
+
+func TestToolDataRoundTripsThroughLoopback(t *testing.T) {
+	api := &recordingAPI{body: `[{"uuid":"e1","name":"prod","hostname":"osctrl.example.com","type":"osquery","secret":"LEAKME"}]`}
+	session := newMCPClient(t, api, func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer token")
+	})
+
+	res, err := session.CallTool(context.Background(), &sdk.CallToolParams{
+		Name: "list_environments", Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %+v", res.Content)
+	}
+	raw, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out struct {
+		Environments []struct {
+			Name string `json:"name"`
+		} `json:"environments"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Environments) != 1 || out.Environments[0].Name != "prod" {
+		t.Fatalf("unexpected environments: %s", raw)
+	}
+	// The projection still applies over the hosted transport.
+	if string(raw) != "" && containsSecret(string(raw)) {
+		t.Errorf("enrollment secret leaked through the hosted transport: %s", raw)
+	}
+}
+
+func containsSecret(s string) bool {
+	for i := 0; i+6 <= len(s); i++ {
+		if s[i:i+6] == "LEAKME" {
+			return true
+		}
+	}
+	return false
+}
+
+// Each request builds its own server bound to that request's credentials, so
+// two callers can never share an identity.
+func TestPerRequestCredentialIsolation(t *testing.T) {
+	api := &recordingAPI{body: `[]`}
+
+	first := newMCPClient(t, api, func(r *http.Request) { r.Header.Set("Authorization", "Bearer alice") })
+	if _, err := first.CallTool(context.Background(), &sdk.CallToolParams{
+		Name: "list_environments", Arguments: map[string]any{},
+	}); err != nil {
+		t.Fatalf("alice: %v", err)
+	}
+	if api.gotAuth != "Bearer alice" {
+		t.Fatalf("Authorization = %q, want alice", api.gotAuth)
+	}
+
+	second := newMCPClient(t, api, func(r *http.Request) { r.Header.Set("Authorization", "Bearer bob") })
+	if _, err := second.CallTool(context.Background(), &sdk.CallToolParams{
+		Name: "list_environments", Arguments: map[string]any{},
+	}); err != nil {
+		t.Fatalf("bob: %v", err)
+	}
+	if api.gotAuth != "Bearer bob" {
+		t.Fatalf("Authorization = %q, want bob — a cached client leaked alice's identity", api.gotAuth)
+	}
+}

--- a/cmd/api/utils.go
+++ b/cmd/api/utils.go
@@ -48,6 +48,9 @@ func loadedYAMLToServiceParams(yml config.APIConfiguration, loadedFile string) *
 	if yml.Debug != nil {
 		params.Debug = yml.Debug
 	}
+	if yml.MCP != nil {
+		params.MCP = yml.MCP
+	}
 	if yml.RateLimits != nil {
 		params.RateLimits = yml.RateLimits
 	}

--- a/deploy/config/api.yml
+++ b/deploy/config/api.yml
@@ -6,7 +6,7 @@
 # startup when this differs from the version the binary supports: a lower
 # number means fields were added since this file was written, a higher
 # number means the binary is older than this file. See pkg/config/version.go.
-version: 1
+version: 2
 
 # Main HTTP service behavior and shared service-level features.
 service:
@@ -299,6 +299,25 @@ oidc:
   linkLocalAccounts: false
   # PKCE (S256) for the authorization code flow
   usePKCE: false
+
+# Model Context Protocol endpoint, served at /api/v1/mcp. Lets MCP clients
+# (Claude Code, Claude Desktop, and others) read the fleet — environments,
+# nodes, the osquery schema, and query results.
+#
+# Disabled by default: it is a read surface designed for LLM agents, and that
+# should be an explicit choice rather than something a deployment inherits on
+# upgrade.
+#
+# Enabling it grants no new access. Requests authenticate with the same bearer
+# token or session cookie as any other API call, and each tool call is
+# dispatched back through osctrl-api's own handlers — so the per-endpoint
+# permission checks apply exactly as they do for the SPA or osctrl-cli. A
+# caller sees only what their own token already allows.
+#
+# The tools are read-only; nothing here schedules a query or mutates state.
+# See docs/mcp.md.
+mcp:
+  enabled: false
 
 # JWT authentication configuration. Used for API bearer tokens and SPA cookies.
 jwt:

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -6,7 +6,7 @@
 # startup when this differs from the version the binary supports: a lower
 # number means fields were added since this file was written, a higher
 # number means the binary is older than this file. See pkg/config/version.go.
-version: 1
+version: 2
 
 # Main HTTP service behavior and shared service-level features.
 service:

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -149,6 +149,37 @@ func CreateAPI(config JSONConfigurationAPI, insecure bool) (*OsctrlAPI, error) {
 	return a, nil
 }
 
+// CreateAPIWithTransport builds a client that issues its requests through rt
+// instead of the network.
+//
+// This exists so osctrl-api can host an MCP server against its own handlers:
+// the transport dispatches straight into the service's mux, so tool calls run
+// the real handler chain — same authentication, same per-endpoint permission
+// checks, same audit logging — without a socket. The alternative, reaching
+// into the managers directly, would mean restating authorization policy that
+// is deliberately non-uniform across endpoints, and any drift there
+// over-grants silently.
+//
+// config.URL still has to parse; the transport is free to ignore its host and
+// route on the path alone.
+func CreateAPIWithTransport(config JSONConfigurationAPI, rt http.RoundTripper) (*OsctrlAPI, error) {
+	if rt == nil {
+		return nil, fmt.Errorf("nil round tripper")
+	}
+	if _, err := url.Parse(config.URL); err != nil {
+		return nil, fmt.Errorf("invalid url - %w", err)
+	}
+	headers := map[string]string{
+		Authorization: fmt.Sprintf("Bearer %s", config.Token),
+		ContentType:   JSONApplicationUTF8,
+	}
+	return &OsctrlAPI{
+		Configuration: config,
+		Client:        &http.Client{Transport: rt},
+		Headers:       headers,
+	}, nil
+}
+
 // GetGeneric - Helper function to implement generic retrieval from API with a GET request
 func (api *OsctrlAPI) GetGeneric(url string, body io.Reader) ([]byte, error) {
 	return api.ReqGeneric(http.MethodGet, url, body)

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -61,6 +61,8 @@ type ServiceParameters struct {
 	SAML *YAMLConfigurationSAML
 	// OIDC configuration values
 	OIDC *YAMLConfigurationOIDC
+	// MCP configuration values
+	MCP *YAMLConfigurationMCP
 	// JWT configuration values
 	JWT *YAMLConfigurationJWT
 	// TLS configuration values
@@ -156,6 +158,7 @@ func InitAPIFlags(params *ServiceParameters) []cli.Flag {
 	allFlags = append(allFlags, initJWTFlags(params)...)
 	allFlags = append(allFlags, initOIDCFlags(params)...)
 	allFlags = append(allFlags, initSAMLFlags(params)...)
+	allFlags = append(allFlags, initMCPFlags(params)...)
 	allFlags = append(allFlags, initOsqueryFlags(params)...)
 	allFlags = append(allFlags, initCarverFlags(params)...)
 	allFlags = append(allFlags, initRateLimitFlags(params, ServiceAPI)...)
@@ -1131,6 +1134,19 @@ func initOsctrldFlags(params *ServiceParameters) []cli.Flag {
 			Usage:       "Enable osctrld endpoints and functionality.",
 			Sources:     cli.EnvVars("OSCTRLD"),
 			Destination: &params.Osctrld.Enabled,
+		},
+	}
+}
+
+// initMCPFlags initializes the flags for the hosted MCP endpoint on
+// osctrl-api. Off by default — see YAMLConfigurationMCP for why.
+func initMCPFlags(params *ServiceParameters) []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "mcp-enabled",
+			Usage:       "Serve the Model Context Protocol endpoint at /api/v1/mcp, exposing osctrl's read surface to MCP clients under the caller's own permissions",
+			Sources:     cli.EnvVars("MCP_ENABLED"),
+			Destination: &params.MCP.Enabled,
 		},
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -107,6 +107,7 @@ type APIConfiguration struct {
 	Logger     *YAMLConfigurationLogger     `mapstructure:"logger"`
 	Carver     *YAMLConfigurationCarver     `mapstructure:"carver"`
 	Debug      *YAMLConfigurationDebug      `mapstructure:"debug"`
+	MCP        *YAMLConfigurationMCP        `mapstructure:"mcp"`
 	RateLimits *YAMLConfigurationRateLimits `mapstructure:"rateLimits"`
 }
 
@@ -400,4 +401,16 @@ type YAMLConfigurationOIDC struct {
 	// on, whoever controls the IdP's username namespace can take over any
 	// same-named local account, including admins.
 	LinkLocalAccounts bool `yaml:"linkLocalAccounts" mapstructure:"linkLocalAccounts"`
+}
+
+// YAMLConfigurationMCP gates the hosted Model Context Protocol endpoint on
+// osctrl-api (/api/v1/mcp).
+//
+// Disabled by default: mounting it opens a read surface designed for LLM
+// agents, and that should be a deliberate choice rather than something a
+// deployment inherits on upgrade. The endpoint sits behind the same auth
+// middleware as the rest of the API, so an enabled endpoint still grants a
+// caller nothing beyond what their own token already allows.
+type YAMLConfigurationMCP struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
 }

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -56,6 +56,7 @@ func GenerateAPIConfigFile(path string, cfg *ServiceParameters, overwrite bool) 
 		Logger:     cfg.Logger,
 		Carver:     cfg.Carver,
 		Debug:      cfg.Debug,
+		MCP:        cfg.MCP,
 		RateLimits: cfg.RateLimits,
 	}
 	return GenerateGenericConfigFile(path, cfgAPI, overwrite)

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -8,7 +8,7 @@ import "fmt"
 // operators whose files predate the change. The sample files in
 // deploy/config and the files written by the config-generate
 // subcommands carry the same number in their top-level "version" field.
-const ConfigVersion = 1
+const ConfigVersion = 2
 
 // ConfigVersionWarning returns a warning when the "version" field of a
 // YAML configuration file does not match ConfigVersion, or an empty


### PR DESCRIPTION
## Serve MCP from osctrl-api at `/api/v1/mcp`

Adds a hosted transport for the MCP server built in the previous PR, so a team
shares one endpoint instead of each operator installing `osctrl-mcp`. Same nine
read-only tools; each caller acts as themselves.

Off by default. Enable with the `mcp:` section in `api.yml`, or
`--mcp-enabled` / `MCP_ENABLED=true`. When disabled the route is not registered
at all, so a deployment never inherits the surface on upgrade.

```yaml
mcp:
  enabled: false
```

### Enabling it grants no new access

Requests authenticate with the same bearer token or session cookie as any other
API call. Each tool call is then dispatched **back through osctrl-api's own
handlers** as the calling user, so the per-endpoint permission checks run
exactly as they do for the SPA or osctrl-cli.

That indirection is the point, and it came out of a finding while building this:
**osctrl's read permissions are not uniform.** `get_node` requires
`AdminLevel`, node posture only `UserLevel`, queries `QueryLevel`, the osquery
schema none at all. An in-process backend reading the managers directly would
have meant restating that policy across nine call sites — and picking
`UserLevel` for reading a node, which is the obvious guess, would have silently
over-granted.

So the MCP layer contains **no authorization logic**. `loopbackTransport`
(`cmd/api/mcp.go`) is an `http.RoundTripper` that dispatches into the API mux
instead of onto the network: real handler chain, real permission checks, real
audit logging, no socket and no loopback network hop. `getServer` builds a
client per request bound to that request's credentials, so sessions can never
share an identity.

This needed no change to `pkg/mcp` — `*apiclient.OsctrlAPI` satisfies `Backend`
verbatim, just with a different transport. The only client addition is
`CreateAPIWithTransport`.

### Configuration

New `mcp:` section plumbed through `APIConfiguration`, `ServiceParameters`,
`loadedYAMLToServiceParams`, and `GenerateAPIConfigFile` — all four, since a
section missed in any one of them is silently dropped.

`ConfigVersion` bumped to 2 with both sample files updated, per the policy in
`pkg/config/version.go` that any added field bumps the schema.

Behind the bundled nginx config this works as-is: `/api/` already proxies with
`proxy_buffering off`, which the streaming transport needs.

### Tests

Four in `cmd/api/mcp_test.go`, driving a real MCP client over HTTP against a
recording handler:

- credentials, `RemoteAddr`, and User-Agent reach the handler — audit entries
  attribute to the real caller, not to the server talking to itself
- **a 403 from the handler chain surfaces as a tool error**, never as
  empty-but-successful data — the property the whole design rests on
- the secret-stripping environment projection still holds over this transport
- two callers in sequence don't share an identity

Plus two config round-trip tests, mirroring the ones that caught the dropped
SAML/OIDC sections earlier.

`go build ./...` and `go vet ./...` clean; all 49 packages pass. Verified
`config-generate` emits the section at version 2 and that the sample config
still validates.

### Follow-up (not in this PR)

Reading a node requires `AdminLevel` while that node's posture requires only
`UserLevel`, so a UserLevel user can read posture but not the node. That
predates this work and looks unintended. Agreed plan is to raise posture to
`AdminLevel` once the remaining MCP phases land, rather than lower `get_node`.

Still to come: write tools behind an explicit opt-in, and routing MCP tool calls
through `pkg/auditlog` so agent activity is distinguishable from SPA/CLI access.