### PR TITLE
Build RPM packages on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ before:
   hooks:
     - go mod tidy
     - go mod download
+    - sh deploy/cicd/package/generate-systemd-services.sh
 
 builds:
   - id: osctrl-tls
@@ -208,15 +209,33 @@ nfpms:
     license: MIT
     formats:
       - deb
+      - rpm
     bindir: /opt/osctrl/bin
     contents:
       - src: ./dist/osctrl-tls-{{ .Os }}-{{ .Arch }}
         dst: /opt/osctrl/bin/osctrl-tls
-    overrides:
-      deb:
-        scripts:
-          postinstall: deploy/cicd/deb/post-install.sh
-          preremove: deploy/cicd/deb/pre-remove.sh
+      - src: deploy/config/tls.yml
+        dst: /opt/osctrl/config/tls.yml.example
+        file_info:
+          mode: 0640
+          owner: root
+          group: osctrl
+      - src: deploy/config/tls.yml
+        dst: /opt/osctrl/config/tls.yml
+        type: "config|noreplace"
+        file_info:
+          mode: 0640
+          owner: root
+          group: osctrl
+      - src: ./dist/package/osctrl-tls.service
+        dst: /usr/lib/systemd/system/osctrl-tls.service
+        file_info:
+          mode: 0644
+    scripts:
+      preinstall: deploy/cicd/package/pre-install.sh
+      postinstall: deploy/cicd/package/post-install.sh
+      preremove: deploy/cicd/package/pre-remove-tls.sh
+      postremove: deploy/cicd/package/post-remove.sh
 
   - id: osctrl-api
     ids:
@@ -228,15 +247,33 @@ nfpms:
     license: MIT
     formats:
       - deb
+      - rpm
     bindir: /opt/osctrl/bin
     contents:
       - src: ./dist/osctrl-api-{{ .Os }}-{{ .Arch }}
         dst: /opt/osctrl/bin/osctrl-api
-    overrides:
-      deb:
-        scripts:
-          postinstall: deploy/cicd/deb/post-install.sh
-          preremove: deploy/cicd/deb/pre-remove.sh
+      - src: deploy/config/api.yml
+        dst: /opt/osctrl/config/api.yml.example
+        file_info:
+          mode: 0640
+          owner: root
+          group: osctrl
+      - src: deploy/config/api.yml
+        dst: /opt/osctrl/config/api.yml
+        type: "config|noreplace"
+        file_info:
+          mode: 0640
+          owner: root
+          group: osctrl
+      - src: ./dist/package/osctrl-api.service
+        dst: /usr/lib/systemd/system/osctrl-api.service
+        file_info:
+          mode: 0644
+    scripts:
+      preinstall: deploy/cicd/package/pre-install.sh
+      postinstall: deploy/cicd/package/post-install.sh
+      preremove: deploy/cicd/package/pre-remove-api.sh
+      postremove: deploy/cicd/package/post-remove.sh
 
   - id: osctrl-cli
     ids:
@@ -248,15 +285,11 @@ nfpms:
     license: MIT
     formats:
       - deb
+      - rpm
     bindir: /opt/osctrl/bin
     contents:
       - src: ./dist/osctrl-cli-{{ .Os }}-{{ .Arch }}
         dst: /opt/osctrl/bin/osctrl-cli
-    overrides:
-      deb:
-        scripts:
-          postinstall: deploy/cicd/deb/post-install.sh
-          preremove: deploy/cicd/deb/pre-remove.sh
 
 release:
   draft: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -227,7 +227,7 @@ nfpms:
           mode: 0640
           owner: root
           group: osctrl
-      - src: ./dist/package/osctrl-tls.service
+      - src: ./tmp/goreleaser-package/osctrl-tls.service
         dst: /usr/lib/systemd/system/osctrl-tls.service
         file_info:
           mode: 0644
@@ -265,7 +265,7 @@ nfpms:
           mode: 0640
           owner: root
           group: osctrl
-      - src: ./dist/package/osctrl-api.service
+      - src: ./tmp/goreleaser-package/osctrl-api.service
         dst: /usr/lib/systemd/system/osctrl-api.service
         file_info:
           mode: 0644

--- a/deploy/cicd/package/generate-systemd-services.sh
+++ b/deploy/cicd/package/generate-systemd-services.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+template=deploy/config/systemd.service
+output_dir=dist/package
+
+mkdir -p "${output_dir}"
+
+render_service() {
+    component=$1
+    service_name="osctrl-${component}"
+    config_file="/opt/osctrl/config/${component}.yml"
+
+    sed \
+        -e "s|_UU|osctrl|g" \
+        -e "s|_GG|osctrl|g" \
+        -e "s|_DEST|/opt/osctrl|g" \
+        -e "s|_NAME|${service_name}|g" \
+        -e "s|_ARGS|--config --config-file ${config_file}|g" \
+        "${template}" > "${output_dir}/${service_name}.service"
+}
+
+render_service tls
+render_service api

--- a/deploy/cicd/package/generate-systemd-services.sh
+++ b/deploy/cicd/package/generate-systemd-services.sh
@@ -3,7 +3,7 @@
 set -eu
 
 template=deploy/config/systemd.service
-output_dir=dist/package
+output_dir=tmp/goreleaser-package
 
 mkdir -p "${output_dir}"
 

--- a/deploy/cicd/package/post-install.sh
+++ b/deploy/cicd/package/post-install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+fi

--- a/deploy/cicd/package/post-remove.sh
+++ b/deploy/cicd/package/post-remove.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -u
+
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+    systemctl daemon-reload || true
+fi

--- a/deploy/cicd/package/pre-install.sh
+++ b/deploy/cicd/package/pre-install.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -eu
+
+if ! getent group osctrl >/dev/null 2>&1; then
+    if command -v groupadd >/dev/null 2>&1; then
+        groupadd --system osctrl
+    elif command -v addgroup >/dev/null 2>&1; then
+        addgroup --system osctrl
+    else
+        echo "Unable to create the osctrl group" >&2
+        exit 1
+    fi
+fi
+
+if ! id -u osctrl >/dev/null 2>&1; then
+    nologin_shell="$(command -v nologin || true)"
+    if [ -z "${nologin_shell}" ]; then
+        nologin_shell=/sbin/nologin
+    fi
+
+    if command -v useradd >/dev/null 2>&1; then
+        useradd --system --gid osctrl --home-dir /opt/osctrl \
+            --no-create-home --shell "${nologin_shell}" osctrl
+    elif command -v adduser >/dev/null 2>&1; then
+        adduser --system --ingroup osctrl --home /opt/osctrl \
+            --no-create-home --shell "${nologin_shell}" osctrl
+    else
+        echo "Unable to create the osctrl user" >&2
+        exit 1
+    fi
+fi
+
+install -d -o root -g osctrl -m 0750 /opt/osctrl/config

--- a/deploy/cicd/package/pre-remove-api.sh
+++ b/deploy/cicd/package/pre-remove-api.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -u
+
+case "${1:-}" in
+    0|remove)
+        if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+            systemctl disable --now osctrl-api.service || true
+        fi
+        ;;
+esac

--- a/deploy/cicd/package/pre-remove-tls.sh
+++ b/deploy/cicd/package/pre-remove-tls.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -u
+
+case "${1:-}" in
+    0|remove)
+        if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+            systemctl disable --now osctrl-tls.service || true
+        fi
+        ;;
+esac


### PR DESCRIPTION
Implementation of #1028 

## Summary

- Added RPM package generation alongside existing DEB packages.
- Included API and TLS sample configurations in both package formats.
- Added systemd units for `osctrl-api` and `osctrl-tls`, generated from `deploy/config/systemd.service`.
- Added package lifecycle scripts to create the `osctrl` account, reload systemd, and safely disable services during removal.
- Preserved existing configurations during upgrades with `config|noreplace`.
- Removed obsolete CLI service hooks that could delete the shared `osctrl` account.

## Validation

- GoReleaser configuration validation passed.
- Package script syntax checks passed.
- Generated systemd units contain no unresolved placeholders.
- `git diff --check` passed.
- Full package builds were not run because the Go toolchain is blocked in the sandbox.