### PR TITLE
Building binary for `osctrl-mcp` on release

### DIFF
--- a/.github/workflows/build_and_test_develop_merge.yml
+++ b/.github/workflows/build_and_test_develop_merge.yml
@@ -116,3 +116,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_HUB_ORG: ghcr.io/${{ github.repository_owner }}
+
+      - name: Upload osctrl-mcp snapshot binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: osctrl-mcp-${{ github.sha }}
+          path: dist/osctrl-mcp-*
+          if-no-files-found: error
+          retention-days: 10

--- a/.github/workflows/build_and_test_main_merge.yml
+++ b/.github/workflows/build_and_test_main_merge.yml
@@ -116,3 +116,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_HUB_ORG: ghcr.io/${{ github.repository_owner }}
+
+      - name: Upload osctrl-mcp snapshot binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: osctrl-mcp-${{ github.sha }}
+          path: dist/osctrl-mcp-*
+          if-no-files-found: error
+          retention-days: 10

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,6 +67,25 @@ builds:
       - -X main.buildCommit={{.Commit}}
       - -X main.buildDate={{.Date}}
 
+  - id: osctrl-mcp
+    main: ./cmd/mcp
+    binary: "osctrl-mcp-{{ .Os }}-{{ .Arch }}"
+    no_unique_dist_dir: true
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.buildVersion={{.Version}}
+      - -X main.buildCommit={{.Commit}}
+      - -X main.buildDate={{.Date}}
+
 archives:
   - id: osctrl
     allow_different_binary_count: true
@@ -86,6 +105,18 @@ archives:
     files:
       - README.md
       - LICENSE
+
+  - id: osctrl-mcp
+    ids:
+      - osctrl-mcp
+    formats:
+      - binary
+    name_template: >-
+      osctrl-mcp-
+      {{- .Version }}-
+      {{- title .Os }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Summary

- Added cross-platform `osctrl-mcp` binaries for Linux, macOS, and Windows on amd64 and arm64.
- Configured tagged releases to publish the MCP executables directly through GoReleaser.
- Added downloadable MCP snapshot artifacts to the `main` and `develop` continuous integration pipelines.
- Kept `osctrl-mcp` separate from Docker images and DEB/RPM packages.

## Validation

- `git diff --check` passed.
- Full cross-platform compilation was not run locally because the Go toolchain is blocked in the sandbox.
- The existing PR GoReleaser check and snapshot-build jobs provide end-to-end validation.