### PR TITLE
Reject unknown actions with 400 bad request

### DIFF
--- a/cmd/api/handlers/mfa_login.go
+++ b/cmd/api/handlers/mfa_login.go
@@ -131,10 +131,13 @@ func (h *HandlersApi) LoginMFAHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	switch req.Method {
+	case "totp":
+		err = h.MFA.VerifyTOTP(challenge.Username, req.Code)
 	case "recovery":
 		err = h.MFA.VerifyRecoveryCode(challenge.Username, req.Code)
 	default:
-		err = h.MFA.VerifyTOTP(challenge.Username, req.Code)
+		apiErrorResponse(w, "invalid mfa method", http.StatusBadRequest, nil)
+		return
 	}
 	if err != nil {
 		h.mfaFailed(w, r, challenge.Username, "invalid second factor")

--- a/cmd/api/handlers/mfa_login_test.go
+++ b/cmd/api/handlers/mfa_login_test.go
@@ -176,6 +176,37 @@ func TestLoginMFACompletesWithTOTPAndRejectsReuse(t *testing.T) {
 	}
 }
 
+func TestLoginMFARejectsUnknownMethodWithoutConsumingChallenge(t *testing.T) {
+	h, m, _ := mfaTestHandlers(t, false)
+	secret := enrollTOTP(t, m, "admin")
+
+	first := postJSON(t, h.LoginHandler, "/api/v1/login", map[string]any{
+		"username": "admin", "password": "s3cr3t-password",
+	})
+	var challenge MFAChallengeResponse
+	if err := json.Unmarshal(first.Body.Bytes(), &challenge); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	code, err := mfa.Code(secret, mfa.Step(time.Now())+1)
+	if err != nil {
+		t.Fatalf("code: %v", err)
+	}
+
+	bad := postJSON(t, h.LoginMFAHandler, "/api/v1/login/mfa", map[string]any{
+		"challenge": challenge.Challenge, "method": "unknown", "code": code,
+	})
+	if bad.Code != http.StatusBadRequest {
+		t.Fatalf("unknown method status: got %d want 400 (%s)", bad.Code, bad.Body.String())
+	}
+
+	good := postJSON(t, h.LoginMFAHandler, "/api/v1/login/mfa", map[string]any{
+		"challenge": challenge.Challenge, "method": "totp", "code": code,
+	})
+	if good.Code != http.StatusOK {
+		t.Fatalf("challenge after unknown method: got %d want 200 (%s)", good.Code, good.Body.String())
+	}
+}
+
 func TestLoginMFAAcceptsRecoveryCodeOnce(t *testing.T) {
 	h, m, _ := mfaTestHandlers(t, false)
 	enrollTOTP(t, m, "admin")

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -341,6 +341,9 @@ func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		msgReturn = fmt.Sprintf("query %s completed successfully", nameVar)
+	default:
+		apiErrorResponse(w, "invalid action", http.StatusBadRequest, fmt.Errorf("unknown query action %q", actionVar))
+		return
 	}
 	// Return message as serialized response
 	log.Debug().Msgf("Returned message %s", msgReturn)

--- a/cmd/api/handlers/queries_test.go
+++ b/cmd/api/handlers/queries_test.go
@@ -47,3 +47,42 @@ func TestQueriesRunHandlerCreatesPendingNodeQueryForUUIDTarget(t *testing.T) {
 	require.NoError(t, db.Where("node_id = ? AND query_id = ?", node.ID, distributed.ID).First(&nodeQuery).Error)
 	require.Equal(t, queries.DistributedQueryStatusPending, nodeQuery.Status)
 }
+
+func TestQueriesActionHandlerRejectsUnknownAction(t *testing.T) {
+	db, h, env, _ := setupConsoleHandlers(t)
+	h.DebugHTTPConfig = &config.YAMLConfigurationDebug{}
+	auditLog, err := auditlog.CreateAuditLogManager(db, "api", true)
+	require.NoError(t, err)
+	h.AuditLog = auditLog
+
+	query := queries.DistributedQuery{
+		Name:          "query-action-test",
+		Active:        true,
+		EnvironmentID: env.ID,
+	}
+	require.NoError(t, h.Queries.Create(&query))
+
+	req := consoleRequest(http.MethodPost, "/queries", nil, "alice")
+	req.SetPathValue("env", env.Name)
+	req.SetPathValue("action", "unknown")
+	req.SetPathValue("name", query.Name)
+	rr := httptest.NewRecorder()
+
+	h.QueriesActionHandler(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+	var resp types.ApiErrorResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, "invalid action", resp.Error)
+
+	var persisted queries.DistributedQuery
+	require.NoError(t, db.First(&persisted, query.ID).Error)
+	require.True(t, persisted.Active)
+	require.False(t, persisted.Completed)
+	require.False(t, persisted.Deleted)
+	require.False(t, persisted.Expired)
+
+	var auditEntries int64
+	require.NoError(t, db.Model(&auditlog.AuditLog{}).Count(&auditEntries).Error)
+	require.Zero(t, auditEntries)
+}


### PR DESCRIPTION
## Summary

- Reject unknown query actions with `400 Bad Request`.
- Reject unsupported MFA methods instead of treating them as TOTP.
- Preserve MFA challenges after invalid method requests.
- Add regression tests for query state, audit logging, and MFA validation.

## Validation

- `go test ./...`