### PR TITLE
Health system status for `osctrl-api` and `osctrl-tls`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,6 +62,7 @@ Main runtime components:
 - `pkg/auth`, `pkg/authproviders`, `pkg/mfa`: OIDC/SAML providers, federated-login state, TOTP, WebAuthn, and recovery codes.
 - `pkg/console`, `pkg/fileexplorer`: interactive workflows implemented through distributed queries.
 - `pkg/environments`: environment model, enrollment/config path metadata, package/script metadata.
+- `pkg/health`: deployment health — the `service_status` heartbeat table, component status derivation (operational/degraded/down/stale/unknown), Go runtime snapshots, and a 24h-refreshed upgrade-version cache. Gated by `--health-enabled` (default off).
 - `pkg/nodes`: node registry, lookup, archive, metadata updates.
 - `pkg/queries`: distributed query definitions, targets, node-query state, saved queries.
 - `pkg/carves`: file carving metadata and storage backends (`db`, `local`, `s3`).
@@ -94,7 +95,7 @@ Both long-lived backend services follow the same pattern in their `main.go`:
 
 Service-specific additions:
 
-- `osctrl-tls` wires Redis-backed environment/settings/query-dispatch caches, node activity batching, node metadata batching, persisted log sinks, service-command polling, and optional DB-health, posture, alerting, and Prometheus components.
+- `osctrl-tls` wires Redis-backed environment/settings/query-dispatch caches, node activity batching, node metadata batching, persisted log sinks, service-command polling, and optional DB-health, posture, alerting, and Prometheus components. When `--health-enabled` is set, it also writes a `service_status` heartbeat (version, uptime, goroutines, worker counters) every 60s by riding the existing 5s service-command poll loop rather than starting a new ticker.
 - `osctrl-api` wires the shared environment/query caches and activity reader; initializes audit, MFA, console, file-explorer, service-config, log-sink, and auth-provider managers; and conditionally registers posture, alerting, service-management, federated-auth, and hosted-MCP routes.
 
 The standalone `osctrl-mcp` process has a smaller startup flow:
@@ -126,6 +127,7 @@ Representative routes (some are feature-gated):
   - `GET /api/v1/nodes/{env}/all`
   - `POST /api/v1/queries/{env}`
   - `GET /api/v1/settings/{service}/{env}`
+  - `GET /api/v1/health/status` when `health.enabled` is true (admin only, 503 when disabled)
   - `/api/v1/mcp` when `mcp.enabled` is true
 
 Request controls are composed at route registration:
@@ -334,6 +336,8 @@ Feature-owned tables are migrated only when their manager is initialized. In par
   - `pkg/logging.OsqueryQueryData` -> `osquery_query_data`
 - Audit:
   - `pkg/auditlog.AuditLog` -> `audit_logs`
+- Health:
+  - `pkg/health.ServiceStatus` -> `service_status` (one upserted row per reporting service; created only when `--health-enabled` is set)
 
 Redis-only state such as activity rollups, query-dispatch hints, and alert cooldown/inactive markers is not represented in these tables. Important relationships are implemented through indexed ID/UUID fields and application code rather than database foreign-key constraints.
 
@@ -371,3 +375,4 @@ Redis-only state such as activity rollups, query-dispatch hints, and alert coold
 - Relationships mostly use indexed numeric IDs, UUIDs, or names without database foreign-key constraints. External routes also mix environment names/UUIDs, node UUIDs/names, and numeric configuration IDs, which matters when integrating or troubleshooting.
 - SAML assertion replay protection uses a per-process TTL cache. In a multi-replica API deployment, the same assertion can be presented once to each replica within its validity window unless a shared replay layer is added.
 - Graceful shutdown is limited. `osctrl-api` drains HTTP requests for an internally requested config restart, while `osctrl-tls` exits for its restart command; neither service currently installs a general OS-signal shutdown path.
+- Health reporting needs `--health-enabled` on both services to show a complete picture: with only `osctrl-api` enabled, the page shows `osctrl-tls` as "not reporting" (unknown), never "down", since there is no heartbeat row to compare against. Multiple `osctrl-tls` replicas share the single `service_status` row for `"tls"` — the last writer wins, so overall liveness stays correct but per-replica detail (which instance, how many) is lost. The health page is a point-in-time snapshot with no history.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ With **osctrl** you can:
 - Carve files and directories
 - Alert on log matches and node state through webhook or email channels
 - Track node posture, GeoIP country metadata, and node activity
+- Check deployment health: database, Redis, services, workers, and upgrade status
 - Scale from hundreds to hundreds of thousands of nodes
 
 > [!WARNING]
@@ -50,6 +51,7 @@ Whether you’re running a small deployment or managing large fleets, **osctrl**
 - **Model Context Protocol**: A standalone `osctrl-mcp` stdio server and an optional hosted `/api/v1/mcp` endpoint expose permission-checked fleet inspection tools to MCP clients. Mutating tools are separately gated and disabled by default.
 - **Alerting**: Optional rule-based alerting on result/status/query logs and node state (inactive/recovered), scoped globally, per environment, or to a single node. Notifications fan out to webhook and email channels with Redis-backed cooldown/dedupe, dispatched history, and hot reload without a restart. Rules can be created straight from a node's page, and a node shows a marker when any rule covers it.
 - **Posture and enrichment hooks**: Optional posture ingestion from scheduled query prefixes, optional MaxMind GeoIP country enrichment, Redis-backed activity tracking, and API-managed service configuration sections.
+- **Health / system status**: Optional deployment health page behind `--health-enabled` (disabled by default), fusing a live database ping, a Redis PING, per-service runtime stats, an `osctrl-tls` heartbeat, and cached upgrade status.
 
 ## Documentation
 
@@ -81,6 +83,7 @@ osctrl/
 │   ├── fileexplorer/            # Accelerated per-node file explorer
 │   ├── filequery/               # File query helpers
 │   ├── geoip/                   # MaxMind GeoIP enrichment
+│   ├── health/                  # Deployment health: service heartbeats, component status
 │   ├── handlers/                # Shared HTTP handler helpers (query/carve targeting)
 │   ├── logging/                 # Log pipeline, readers, and logger backends
 │   ├── logsinks/                # Per-environment persisted log sink configs

--- a/cmd/api/handlers/features.go
+++ b/cmd/api/handlers/features.go
@@ -24,6 +24,9 @@ type FeaturesResponse struct {
 	Accelerated  bool `json:"accelerated"`
 	Console      bool `json:"console"`
 	FileExplorer bool `json:"file_explorer"`
+	// Health gates the Health section in the SPA. Tied to --health-enabled —
+	// when false the /api/v1/health routes are not registered.
+	Health bool `json:"health"`
 }
 
 // FeaturesHandler — GET /api/v1/features.
@@ -40,5 +43,6 @@ func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 		Accelerated:   h.OsqueryValues.Accelerated,
 		Console:       h.OsqueryValues.Query && h.OsqueryValues.Console,
 		FileExplorer:  h.OsqueryValues.Query && h.OsqueryValues.FileExplorer,
+		Health:        h.Health != nil,
 	})
 }

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -1,16 +1,20 @@
 package handlers
 
 import (
+	"time"
+
 	"github.com/jmpsec/osctrl/pkg/alerts"
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/authproviders"
 	"github.com/jmpsec/osctrl/pkg/backend"
+	"github.com/jmpsec/osctrl/pkg/cache"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/geoip"
+	"github.com/jmpsec/osctrl/pkg/health"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/logsinks"
 	"github.com/jmpsec/osctrl/pkg/mfa"
@@ -59,6 +63,18 @@ type HandlersApi struct {
 	// tables when --alerts-enabled is set. nil otherwise — the alert
 	// routes are not registered in that case.
 	Alerts *alerts.Manager
+	// Health, when wired via WithHealth, serves /api/v1/health/status. nil
+	// means --health-enabled is off: the routes are not registered and the
+	// service_status table was never created.
+	Health *health.Manager
+	// HealthVersions caches the upstream version check so the request path
+	// never makes an external HTTP call.
+	HealthVersions *health.VersionCache
+	// StartedAt is this process's boot time, for uptime reporting.
+	StartedAt time.Time
+	// Redis, when wired via WithRedis, lets the health endpoint PING the
+	// cache. nil is reported as "redis is not configured" rather than down.
+	Redis *cache.RedisManager
 	// AuthProviders holds the live multi-provider registry (OIDC + SAML).
 	AuthProviders        *AuthProviderRegistry
 	AuthProviderMgr      *authproviders.AuthProviderManager
@@ -218,6 +234,37 @@ func WithLogSinks(mgr *logsinks.LogSinksManager) HandlersOption {
 func WithAlerts(mgr *alerts.Manager) HandlersOption {
 	return func(h *HandlersApi) {
 		h.Alerts = mgr
+	}
+}
+
+// WithHealth wires the health manager. Only meaningful when
+// --health-enabled is also set; the routes are gated on that flag in
+// cmd/api/main.go.
+func WithHealth(mgr *health.Manager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.Health = mgr
+	}
+}
+
+// WithHealthVersions wires the cached upstream version check.
+func WithHealthVersions(c *health.VersionCache) HandlersOption {
+	return func(h *HandlersApi) {
+		h.HealthVersions = c
+	}
+}
+
+// WithStartedAt records this process's boot time for uptime reporting.
+func WithStartedAt(t time.Time) HandlersOption {
+	return func(h *HandlersApi) {
+		h.StartedAt = t
+	}
+}
+
+// WithRedis wires the Redis manager so the health endpoint can PING the
+// cache.
+func WithRedis(rm *cache.RedisManager) HandlersOption {
+	return func(h *HandlersApi) {
+		h.Redis = rm
 	}
 }
 

--- a/cmd/api/handlers/health_status.go
+++ b/cmd/api/handlers/health_status.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/health"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+)
+
+// healthStatusResponse is the payload the SPA renders. One response carries
+// every component and its details, so the page's drill-downs are expansions
+// rather than extra round trips.
+type healthStatusResponse struct {
+	GeneratedAt time.Time          `json:"generated_at"`
+	Components  []health.Component `json:"components"`
+	Upgrade     health.UpgradeInfo `json:"upgrade"`
+}
+
+// HealthStatusHandler — GET /api/v1/health/status
+//
+// @Summary Deployment health
+// @Description Component health, per-service runtime detail and upgrade status. Admin only.
+// @Tags health
+// @Produce json
+// @Success 200 {object} healthStatusResponse
+// @Failure 401 {object} types.ApiErrorResponse "Unauthorized"
+// @Failure 403 {object} types.ApiErrorResponse "Forbidden"
+// @Failure 503 {object} types.ApiErrorResponse "Health reporting disabled"
+// @Security ApiKeyAuth
+// @Router /api/v1/health/status [get]
+func (h *HandlersApi) HealthStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
+		utils.DebugHTTPDump(h.DebugHTTP, r, false)
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !h.Users.CheckPermissions(ctx[ctxUser], users.AdminLevel, users.NoEnvironment) {
+		apiErrorResponse(w, "no access", http.StatusForbidden, fmt.Errorf("attempt to use health API by user %s", ctx[ctxUser]))
+		return
+	}
+	if h.Health == nil {
+		apiErrorResponse(w, "health reporting not enabled", http.StatusServiceUnavailable, nil)
+		return
+	}
+
+	now := time.Now()
+	components := []health.Component{
+		h.databaseComponent(r),
+		h.redisComponent(),
+		h.apiComponent(),
+	}
+
+	row, err := h.Health.Get(config.ServiceTLS)
+	components = append(components,
+		health.ServiceComponent(row, err, now, h.ServiceVersion),
+		health.WorkersComponent(row, err, now),
+	)
+
+	upgrade := health.UpgradeInfo{Current: h.ServiceVersion}
+	if h.HealthVersions != nil {
+		upgrade = h.HealthVersions.Info(row.Version)
+	}
+
+	h.AuditLog.Visit(ctx[ctxUser], r.URL.Path, strings.Split(r.RemoteAddr, ":")[0], auditlog.NoEnvironment)
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, healthStatusResponse{
+		GeneratedAt: now,
+		Components:  components,
+		Upgrade:     upgrade,
+	})
+}
+
+// databaseComponent pings the database, on top of the existing background
+// health monitor's verdict.
+func (h *HandlersApi) databaseComponent(r *http.Request) health.Component {
+	var degraded bool
+	if h.DBHealth != nil {
+		degraded = h.DBHealth.IsDegraded()
+	}
+	start := time.Now()
+	var pingErr error
+	sqlDB, err := h.DB.DB()
+	if err != nil {
+		pingErr = err
+	} else {
+		pingErr = sqlDB.PingContext(r.Context())
+	}
+	return health.DatabaseComponent(degraded, pingErr, time.Since(start))
+}
+
+// redisComponent reuses the existing cache manager check.
+func (h *HandlersApi) redisComponent() health.Component {
+	start := time.Now()
+	var err error
+	if h.Redis == nil {
+		err = fmt.Errorf("redis is not configured")
+	} else {
+		err = h.Redis.Check()
+	}
+	return health.RedisComponent(err, time.Since(start))
+}
+
+// apiComponent reports this process. It is operational by definition — it
+// answered the request — so the value here is the runtime detail.
+func (h *HandlersApi) apiComponent() health.Component {
+	stats := health.Snapshot(h.StartedAt)
+	return health.Component{
+		ID:      "api",
+		Name:    "osctrl-api",
+		Status:  health.StatusOperational,
+		Summary: fmt.Sprintf("up %s, %d goroutines", time.Since(h.StartedAt).Round(time.Minute), stats.Goroutines),
+		Details: map[string]any{
+			"version":        h.ServiceVersion,
+			"uptime_seconds": stats.UptimeSeconds,
+			"goroutines":     stats.Goroutines,
+			"runtime":        stats,
+		},
+	}
+}

--- a/cmd/api/handlers/health_status.go
+++ b/cmd/api/handlers/health_status.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -12,6 +13,12 @@ import (
 	"github.com/jmpsec/osctrl/pkg/users"
 	"github.com/jmpsec/osctrl/pkg/utils"
 )
+
+// healthCheckTimeout bounds every DB/Redis check the health endpoint makes.
+// This page's entire job is to answer during an outage, so a saturated pool
+// or a blackholed connection must not hang the request forever — it must
+// render "down" within a fixed budget instead.
+const healthCheckTimeout = 3 * time.Second
 
 // healthStatusResponse is the payload the SPA renders. One response carries
 // every component and its details, so the page's drill-downs are expansions
@@ -48,14 +55,17 @@ func (h *HandlersApi) HealthStatusHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	checkCtx, cancel := context.WithTimeout(r.Context(), healthCheckTimeout)
+	defer cancel()
+
 	now := time.Now()
 	components := []health.Component{
-		h.databaseComponent(r),
-		h.redisComponent(),
+		h.databaseComponent(checkCtx),
+		h.redisComponent(checkCtx),
 		h.apiComponent(),
 	}
 
-	row, err := h.Health.Get(config.ServiceTLS)
+	row, err := h.Health.GetContext(checkCtx, config.ServiceTLS)
 	components = append(components,
 		health.ServiceComponent(row, err, now, h.ServiceVersion),
 		health.WorkersComponent(row, err, now),
@@ -75,8 +85,8 @@ func (h *HandlersApi) HealthStatusHandler(w http.ResponseWriter, r *http.Request
 }
 
 // databaseComponent pings the database, on top of the existing background
-// health monitor's verdict.
-func (h *HandlersApi) databaseComponent(r *http.Request) health.Component {
+// health monitor's verdict. ctx carries the bounded health-check deadline.
+func (h *HandlersApi) databaseComponent(ctx context.Context) health.Component {
 	var degraded bool
 	if h.DBHealth != nil {
 		degraded = h.DBHealth.IsDegraded()
@@ -87,19 +97,20 @@ func (h *HandlersApi) databaseComponent(r *http.Request) health.Component {
 	if err != nil {
 		pingErr = err
 	} else {
-		pingErr = sqlDB.PingContext(r.Context())
+		pingErr = sqlDB.PingContext(ctx)
 	}
 	return health.DatabaseComponent(degraded, pingErr, time.Since(start))
 }
 
-// redisComponent reuses the existing cache manager check.
-func (h *HandlersApi) redisComponent() health.Component {
+// redisComponent reuses the existing cache manager check. ctx carries the
+// bounded health-check deadline.
+func (h *HandlersApi) redisComponent(ctx context.Context) health.Component {
 	start := time.Now()
 	var err error
 	if h.Redis == nil {
 		err = fmt.Errorf("redis is not configured")
 	} else {
-		err = h.Redis.Check()
+		err = h.Redis.CheckContext(ctx)
 	}
 	return health.RedisComponent(err, time.Since(start))
 }

--- a/cmd/api/handlers/health_status_test.go
+++ b/cmd/api/handlers/health_status_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/health"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupHealthHandler(t *testing.T) (*HandlersApi, *health.Manager) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	userManager := users.CreateUserManager(db)
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "alice", Admin: true}))
+	require.NoError(t, userManager.Create(users.AdminUser{Username: "bob"}))
+	auditLog, err := auditlog.CreateAuditLogManager(db, "osctrl-api", false)
+	require.NoError(t, err)
+	mgr := health.NewManager(db)
+	h := CreateHandlersApi(
+		WithDB(db),
+		WithUsers(userManager),
+		WithAuditLog(auditLog),
+		WithDebugHTTP(&config.YAMLConfigurationDebug{}),
+		WithHealth(mgr),
+		WithHealthVersions(health.NewVersionCache("0.5.8")),
+		WithStartedAt(time.Now().Add(-time.Hour)),
+	)
+	return h, mgr
+}
+
+func healthRequest(user string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health/status", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	return req.WithContext(alertsCtx(user))
+}
+
+func TestHealthStatusRejectsNonAdmin(t *testing.T) {
+	h, _ := setupHealthHandler(t)
+	rr := httptest.NewRecorder()
+	h.HealthStatusHandler(rr, healthRequest("bob"))
+	require.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestHealthStatusReturns503WhenDisabled(t *testing.T) {
+	h, _ := setupHealthHandler(t)
+	h.Health = nil
+	rr := httptest.NewRecorder()
+	h.HealthStatusHandler(rr, healthRequest("alice"))
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+func TestHealthStatusReportsComponents(t *testing.T) {
+	h, mgr := setupHealthHandler(t)
+	require.NoError(t, mgr.Report(health.ServiceStatus{
+		Service: "tls", Version: "0.5.8",
+		StartedAt: time.Now().Add(-2 * time.Hour), ReportedAt: time.Now(),
+		Goroutines: 71,
+		Payload:    `{"alerts":{"enabled":true,"queue_depth":0,"queue_capacity":8192,"dispatched":9}}`,
+	}))
+
+	rr := httptest.NewRecorder()
+	h.HealthStatusHandler(rr, healthRequest("alice"))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp healthStatusResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	byID := map[string]health.Component{}
+	for _, c := range resp.Components {
+		byID[c.ID] = c
+	}
+	require.Contains(t, byID, "database")
+	require.Contains(t, byID, "redis")
+	require.Contains(t, byID, "api")
+	require.Equal(t, health.StatusOperational, byID["api"].Status)
+	require.Equal(t, health.StatusOperational, byID["tls"].Status)
+	require.Equal(t, health.StatusOperational, byID["workers"].Status)
+	require.Equal(t, "0.5.8", resp.Upgrade.Current)
+	require.False(t, resp.Upgrade.Skew)
+}
+
+func TestHealthStatusFlagsMissingTLS(t *testing.T) {
+	h, _ := setupHealthHandler(t)
+	rr := httptest.NewRecorder()
+	h.HealthStatusHandler(rr, healthRequest("alice"))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp healthStatusResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	for _, c := range resp.Components {
+		if c.ID == "tls" {
+			require.Equal(t, health.StatusUnknown, c.Status)
+			require.Contains(t, c.Summary, "--health-enabled")
+			return
+		}
+	}
+	t.Fatal("tls component missing from the response")
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/geoip"
+	"github.com/jmpsec/osctrl/pkg/health"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/logsinks"
 	"github.com/jmpsec/osctrl/pkg/mfa"
@@ -112,8 +113,10 @@ const (
 	// API service config path
 	apiServiceConfigPath = "/service-config"
 	// API log sinks path
-	apiLogSinksPath      = "/log-sinks"
-	apiAlertsPath        = "/alerts"
+	apiLogSinksPath = "/log-sinks"
+	apiAlertsPath   = "/alerts"
+	// API health / system status path
+	apiHealthPath        = "/health"
 	apiAuthProvidersPath = "/auth-providers"
 	// API features path
 	apiFeaturesPath = "/features"
@@ -383,6 +386,32 @@ func osctrlAPIService() {
 	} else {
 		log.Info().Msg("Alerting system disabled (enable with --alerts-enabled)")
 	}
+	// Health / system status subsystem (disabled by default). When
+	// disabled the service_status table is not created and the health
+	// API routes are not registered.
+	var healthMgr *health.Manager
+	var healthVersions *health.VersionCache
+	if flagParams.Service.HealthEnabled {
+		healthMgr = health.NewManager(db.Conn)
+		healthVersions = health.NewVersionCache(buildVersion)
+		// Seed from the boot check, then refresh daily. This is an external
+		// HTTP call, so it must never happen on the request path.
+		go func() {
+			if err := healthVersions.Refresh(version.VersionDataURL); err != nil {
+				log.Err(err).Msg("error retrieving version data for health")
+			}
+			ticker := time.NewTicker(24 * time.Hour)
+			defer ticker.Stop()
+			for range ticker.C {
+				if err := healthVersions.Refresh(version.VersionDataURL); err != nil {
+					log.Err(err).Msg("error refreshing version data for health")
+				}
+			}
+		}()
+		log.Info().Msg("Health system enabled")
+	} else {
+		log.Info().Msg("Health system disabled (enable with --health-enabled)")
+	}
 	// Initialize settings
 	// Multi-factor authentication for password logins. The manager owns its
 	// tables and is always available; WebAuthn additionally needs a relying
@@ -586,6 +615,10 @@ func osctrlAPIService() {
 		handlers.WithServiceConfig(serviceConfigMgr),
 		handlers.WithLogSinks(logSinksMgr),
 		handlers.WithAlerts(alertsMgr),
+		handlers.WithHealth(healthMgr),
+		handlers.WithHealthVersions(healthVersions),
+		handlers.WithStartedAt(time.Now()),
+		handlers.WithRedis(redis),
 		handlers.WithAuthProviders(authProviderRegistry, authProvidersMgr),
 		handlers.WithServiceConfigEnabled(flagParams.Service.ServiceConfigEnabled),
 		handlers.WithLogSinksEnabled(logSinksEnabled),
@@ -1177,6 +1210,14 @@ func osctrlAPIService() {
 		muxAPI.Handle(
 			"POST "+_apiPath(apiAlertsPath)+"/apply",
 			restartRateLimit(handlerAuthCheck(http.HandlerFunc(handlersApi.AlertsApplyHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret)))
+	}
+
+	// API: health / system status. Gated by --health-enabled; when the flag
+	// is off the route is absent and the table was never created.
+	if flagParams.Service.HealthEnabled {
+		muxAPI.Handle(
+			"GET "+_apiPath(apiHealthPath)+"/status",
+			handlerAuthCheck(http.HandlerFunc(handlersApi.HealthStatusHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	}
 
 	// API: auth providers. Independently gated by

--- a/cmd/tls/health.go
+++ b/cmd/tls/health.go
@@ -20,11 +20,16 @@ const heartbeatEveryNTicks = int(health.HeartbeatInterval / serviceCommandPollIn
 // out of the loop so the cadence is testable without waiting a minute.
 func shouldHeartbeat(tick int) bool { return tick%heartbeatEveryNTicks == 0 }
 
-// buildHealthPayload renders the worker counters carried by the heartbeat.
+// buildHealthPayload renders the worker counters and runtime state carried
+// by the heartbeat.
 // Every value read here is a plain atomic or a channel length — nothing that
 // stops the world.
-func buildHealthPayload(w *alerts.Worker) string {
-	var payload health.WorkerPayload
+func buildHealthPayload(w *alerts.Worker, processStartedAt time.Time) string {
+	// Sampled through runtime/metrics, never ReadMemStats: this runs on the
+	// 60s heartbeat inside the log-ingest service, where a stop-the-world
+	// pause is exactly what the design refuses to pay.
+	runtimeStats := health.SampleRuntimeMetrics(processStartedAt)
+	payload := health.WorkerPayload{Runtime: &runtimeStats}
 	if w != nil {
 		snap := w.MetricsSnapshot()
 		payload.Alerts = &health.AlertsWorkerStats{
@@ -58,7 +63,7 @@ func reportHealth(mgr *health.Manager, w *alerts.Worker, startedAt time.Time, bu
 		StartedAt:  startedAt,
 		ReportedAt: time.Now(),
 		Goroutines: runtimeNumGoroutine(),
-		Payload:    buildHealthPayload(w),
+		Payload:    buildHealthPayload(w, startedAt),
 	}); err != nil {
 		log.Err(err).Msg("error writing health heartbeat")
 	}

--- a/cmd/tls/health.go
+++ b/cmd/tls/health.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"runtime"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/alerts"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/health"
+	"github.com/rs/zerolog/log"
+)
+
+// heartbeatEveryNTicks is how many service-command polls pass between
+// heartbeats. The heartbeat rides that existing loop rather than starting a
+// ticker of its own: 5s × 12 = the 60s interval, and no new goroutine.
+const heartbeatEveryNTicks = int(health.HeartbeatInterval / serviceCommandPollInterval)
+
+// shouldHeartbeat reports whether this poll tick is a heartbeat tick. Split
+// out of the loop so the cadence is testable without waiting a minute.
+func shouldHeartbeat(tick int) bool { return tick%heartbeatEveryNTicks == 0 }
+
+// buildHealthPayload renders the worker counters carried by the heartbeat.
+// Every value read here is a plain atomic or a channel length — nothing that
+// stops the world.
+func buildHealthPayload(w *alerts.Worker) string {
+	var payload health.WorkerPayload
+	if w != nil {
+		snap := w.MetricsSnapshot()
+		payload.Alerts = &health.AlertsWorkerStats{
+			Enabled:       true,
+			QueueDepth:    snap.QueueDepth,
+			QueueCapacity: snap.QueueCapacity,
+			Matched:       snap.Matched,
+			Dispatched:    snap.Dispatched,
+			Collapsed:     snap.Collapsed,
+			Dropped:       snap.Dropped,
+			Failed:        snap.Failed,
+		}
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+// reportHealth writes one heartbeat. A failure is logged and dropped: health
+// reporting must never take the service down, and a DB outage is exactly when
+// the write fails anyway.
+func reportHealth(mgr *health.Manager, w *alerts.Worker, startedAt time.Time, buildVersion string) {
+	if mgr == nil {
+		return
+	}
+	if err := mgr.Report(health.ServiceStatus{
+		Service:    config.ServiceTLS,
+		Version:    buildVersion,
+		StartedAt:  startedAt,
+		ReportedAt: time.Now(),
+		Goroutines: runtimeNumGoroutine(),
+		Payload:    buildHealthPayload(w),
+	}); err != nil {
+		log.Err(err).Msg("error writing health heartbeat")
+	}
+}
+
+// runtimeNumGoroutine is split out so the heartbeat's only runtime call is
+// obvious and cheap. NumGoroutine is a plain load; ReadMemStats (which stops
+// the world) is deliberately NOT called here.
+func runtimeNumGoroutine() int { return runtime.NumGoroutine() }

--- a/cmd/tls/health_test.go
+++ b/cmd/tls/health_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/jmpsec/osctrl/pkg/alerts"
 	"github.com/jmpsec/osctrl/pkg/health"
@@ -11,8 +12,11 @@ import (
 
 func TestBuildHealthPayloadWithoutAlerts(t *testing.T) {
 	var payload health.WorkerPayload
-	require.NoError(t, json.Unmarshal([]byte(buildHealthPayload(nil)), &payload))
+	require.NoError(t, json.Unmarshal([]byte(buildHealthPayload(nil, time.Now().Add(-time.Hour))), &payload))
 	require.Nil(t, payload.Alerts, "a disabled subsystem must be omitted, not reported as zeroes")
+	require.NotNil(t, payload.Runtime, "runtime state rides every heartbeat, alerts or not")
+	require.Greater(t, payload.Runtime.HeapAlloc, uint64(0))
+	require.InDelta(t, 3600, payload.Runtime.UptimeSeconds, 5)
 }
 
 func TestBuildHealthPayloadWithAlerts(t *testing.T) {
@@ -20,7 +24,7 @@ func TestBuildHealthPayloadWithAlerts(t *testing.T) {
 	defer w.Close()
 
 	var payload health.WorkerPayload
-	require.NoError(t, json.Unmarshal([]byte(buildHealthPayload(w)), &payload))
+	require.NoError(t, json.Unmarshal([]byte(buildHealthPayload(w, time.Now().Add(-time.Hour))), &payload))
 	require.NotNil(t, payload.Alerts)
 	require.True(t, payload.Alerts.Enabled)
 	require.Equal(t, 32, payload.Alerts.QueueCapacity)

--- a/cmd/tls/health_test.go
+++ b/cmd/tls/health_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/alerts"
+	"github.com/jmpsec/osctrl/pkg/health"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildHealthPayloadWithoutAlerts(t *testing.T) {
+	var payload health.WorkerPayload
+	require.NoError(t, json.Unmarshal([]byte(buildHealthPayload(nil)), &payload))
+	require.Nil(t, payload.Alerts, "a disabled subsystem must be omitted, not reported as zeroes")
+}
+
+func TestBuildHealthPayloadWithAlerts(t *testing.T) {
+	w := alerts.NewWorker(alerts.NewStore(), nil, nil, nil, 32, 1)
+	defer w.Close()
+
+	var payload health.WorkerPayload
+	require.NoError(t, json.Unmarshal([]byte(buildHealthPayload(w)), &payload))
+	require.NotNil(t, payload.Alerts)
+	require.True(t, payload.Alerts.Enabled)
+	require.Equal(t, 32, payload.Alerts.QueueCapacity)
+}
+
+func TestHeartbeatTicksEveryTwelfthPoll(t *testing.T) {
+	// 5s poll interval × 12 ticks = the 60s heartbeat interval.
+	require.Equal(t, int(health.HeartbeatInterval/serviceCommandPollInterval), heartbeatEveryNTicks)
+	require.Equal(t, 12, heartbeatEveryNTicks)
+
+	// The loop calls shouldHeartbeat with its tick counter; only every
+	// twelfth tick writes, so one minute of polling costs one row.
+	var writes int
+	for tick := 1; tick <= 24; tick++ {
+		if shouldHeartbeat(tick) {
+			writes++
+		}
+	}
+	require.Equal(t, 2, writes, "two minutes of polling must produce two heartbeats")
+	require.False(t, shouldHeartbeat(1))
+	require.True(t, shouldHeartbeat(12))
+}

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/health"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/logsinks"
 	"github.com/jmpsec/osctrl/pkg/nodes"
@@ -286,6 +287,19 @@ func osctrlService() {
 	} else {
 		log.Info().Msg("Alerting system disabled (enable with --alerts-enabled)")
 	}
+	// Health/system-status heartbeat (disabled by default). When off, no
+	// manager is constructed, so no table is created and nothing is written.
+	var healthMgr *health.Manager
+	serviceStartedAt := time.Now()
+	if flagParams.Service.HealthEnabled {
+		healthMgr = health.NewManager(db.Conn)
+		log.Info().Msg("Health reporting enabled")
+	} else {
+		log.Info().Msg("Health reporting disabled (enable with --health-enabled)")
+	}
+	// Write the first heartbeat now so the page is populated without
+	// waiting a minute for the poll loop's first tick.
+	reportHealth(healthMgr, alertsWorker, serviceStartedAt, buildVersion)
 	log.Info().Msg("Initialize tags")
 	tagsmgr = tags.CreateTagManager(db.Conn)
 	log.Info().Msg("Initialize queries")
@@ -562,7 +576,7 @@ func osctrlService() {
 		srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
 	}
 	watchCtx, stopCommandWatcher := context.WithCancel(context.Background())
-	go watchServiceCommands(watchCtx, serviceCommandMgr, serviceConfigMgr, logSinksMgr, loggerTLS, settingsmgr, auditLog, alertsReloadFn(alertsMgr, alertsStore, alertsDispatcher), restartCh)
+	go watchServiceCommands(watchCtx, serviceCommandMgr, serviceConfigMgr, logSinksMgr, loggerTLS, settingsmgr, auditLog, alertsReloadFn(alertsMgr, alertsStore, alertsDispatcher), restartCh, healthMgr, alertsWorker, serviceStartedAt)
 	serverErr := make(chan error, 1)
 	go func() {
 		log.Info().Msgf("%s v%s - HTTP%s listening %s", serviceName, buildVersion, map[bool]string{true: "S", false: ""}[flagParams.TLS.Termination], serviceListener)
@@ -687,14 +701,20 @@ func alertsReloadFn(mgr *alerts.Manager, store *alerts.Store, dispatcher *alerts
 	}
 }
 
-func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfgMgr *serviceconfig.ServiceConfigManager, sinksMgr *logsinks.LogSinksManager, logTLS *logging.LoggerTLS, settingsMgr *settings.Settings, auditLog *auditlog.AuditLogManager, reloadAlerts func(), restartCh chan<- struct{}) {
+func watchServiceCommands(ctx context.Context, mgr *servicecommands.Manager, cfgMgr *serviceconfig.ServiceConfigManager, sinksMgr *logsinks.LogSinksManager, logTLS *logging.LoggerTLS, settingsMgr *settings.Settings, auditLog *auditlog.AuditLogManager, reloadAlerts func(), restartCh chan<- struct{}, healthMgr *health.Manager, alertsWorker *alerts.Worker, startedAt time.Time) {
 	ticker := time.NewTicker(serviceCommandPollInterval)
 	defer ticker.Stop()
+	ticks := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			// Heartbeat rides this loop: no extra goroutine, no extra ticker.
+			ticks++
+			if shouldHeartbeat(ticks) {
+				reportHealth(healthMgr, alertsWorker, startedAt, buildVersion)
+			}
 			cmd, ok, err := mgr.ConsumeNext(config.ServiceTLS, serviceName, time.Now())
 			if err != nil {
 				log.Err(err).Msg("error checking TLS service commands")

--- a/deploy/config/api.yml
+++ b/deploy/config/api.yml
@@ -85,6 +85,13 @@ service:
   # history from the shared database (evaluated by osctrl-tls).
   # Requires a service restart to change.
   alertsEnabled: false
+  # Enable the health/system-status subsystem. When false (default), the
+  # /api/v1/health routes are not registered and the SPA hides the Health
+  # section. When true, the API serves GET /api/v1/health/status: a live
+  # DB ping, a Redis PING, its own runtime stats, the osctrl-tls
+  # heartbeat, and cached upgrade status. Requires a service restart to
+  # change.
+  healthEnabled: false
   # DB health monitor. When enabled, osctrl-api pings the database
   # every dbHealthInterval seconds. After dbHealthThreshold
   # consecutive failures, EnvCache switches to stale-serve mode:

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -67,6 +67,12 @@ service:
   # matches ingested logs against them. Requires a service restart to
   # change.
   alertsEnabled: false
+  # Enable the health/system-status subsystem. When false (default), no
+  # health manager is constructed: the service_status table is never
+  # created and osctrl-tls writes no heartbeat. When true, osctrl-tls
+  # writes a heartbeat row (version, uptime, goroutines, worker
+  # counters) every 60s. Requires a service restart to change.
+  healthEnabled: false
   # DB health monitor. When enabled, osctrl-tls pings the database
   # every dbHealthInterval seconds. After dbHealthThreshold
   # consecutive failures, EnvCache and SettingsCache switch to

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -51,6 +51,7 @@ services:
       - SERVICE_POSTURE_ENABLED=true
       - SERVICE_ALERTS_ENABLED=true
       - SERVICE_CONFIG_ENABLED=true
+      - SERVICE_HEALTH_ENABLED=true
       #### Database settings ####
       - DB_HOST=osctrl-postgres
       - DB_NAME=${POSTGRES_DB_NAME}
@@ -107,6 +108,7 @@ services:
       - SERVICE_POSTURE_ENABLED=true
       - SERVICE_ALERTS_ENABLED=true
       - SERVICE_CONFIG_ENABLED=true
+      - SERVICE_HEALTH_ENABLED=true
       #### osquery settings ####
       - OSQUERY_TABLES=/usr/src/app/deploy/osquery/data/${OSQUERY_VERSION}.json
       - OSQUERY_ACCELERATED=true

--- a/frontend/src/api/features.ts
+++ b/frontend/src/api/features.ts
@@ -8,6 +8,9 @@ export interface Features {
   /** Alerting subsystem (--alerts-enabled). When false the alerts
    * routes are absent and the SPA hides the Alerts section. */
   alerts?: boolean;
+  /** Health/system status (--health-enabled). When false the health routes
+   * are absent and the SPA hides the Health section. */
+  health?: boolean;
   accelerated: boolean;
   console?: boolean;
   file_explorer: boolean;

--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -1,0 +1,46 @@
+/**
+ * Health API client.
+ *
+ * One request returns every component plus upgrade status, so the page's
+ * drill-downs expand what is already loaded instead of fetching again.
+ */
+import { apiFetch } from './client';
+
+export type HealthStatusValue =
+  | 'operational'
+  | 'degraded'
+  | 'down'
+  | 'stale'
+  | 'unknown';
+
+export interface HealthComponent {
+  id: string;
+  name: string;
+  status: HealthStatusValue;
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+export interface UpgradeInfo {
+  current: string;
+  suggested?: string;
+  latest?: string;
+  up_to_date: boolean;
+  checked: boolean;
+  checked_at?: string;
+  more_information?: string;
+  api_version?: string;
+  tls_version?: string;
+  skew: boolean;
+}
+
+export interface HealthStatus {
+  generated_at: string;
+  components: HealthComponent[];
+  upgrade: UpgradeInfo;
+}
+
+/** GET /api/v1/health/status — admin only, 503 when --health-enabled is off. */
+export function getHealthStatus(): Promise<HealthStatus> {
+  return apiFetch<HealthStatus>('/api/v1/health/status');
+}

--- a/frontend/src/components/chrome/SideNav.tsx
+++ b/frontend/src/components/chrome/SideNav.tsx
@@ -10,6 +10,7 @@ import {
   Download,
   FileSearch,
   FileStack,
+  HeartPulse,
   LayoutDashboard,
   ListChecks,
   Monitor,
@@ -253,6 +254,7 @@ export function SideNav({ className, collapsed, previewsEnabled = true }: SideNa
     pathname.startsWith('/_app/log-sinks') || pathname.startsWith('/log-sinks');
   const isAlertsActive =
     pathname.startsWith('/_app/alerts') || pathname.startsWith('/alerts');
+  const isHealth = pathname.startsWith('/_app/health') || pathname.startsWith('/health');
   const isAuthProvidersActive =
     pathname.startsWith('/_app/auth-providers') || pathname.startsWith('/auth-providers');
   const isAuditActive = pathname.startsWith('/_app/audit') || pathname === '/audit';
@@ -575,6 +577,15 @@ export function SideNav({ className, collapsed, previewsEnabled = true }: SideNa
               icon={<Bell size={14} strokeWidth={1.8} />}
             >
               Alerts
+            </NavItem>}
+            {features?.health && <NavItem
+              collapsed={collapsed}
+              active={isHealth}
+              to="/_app/health"
+              tone="green"
+              icon={<HeartPulse size={14} strokeWidth={1.8} />}
+            >
+              Health
             </NavItem>}
             {features?.auth_providers && <NavItem
               collapsed={collapsed}

--- a/frontend/src/features/health/HealthPage.test.tsx
+++ b/frontend/src/features/health/HealthPage.test.tsx
@@ -86,4 +86,14 @@ describe('HealthPage', () => {
     renderPage();
     expect(await screen.findByText(/version mismatch/i)).toBeInTheDocument();
   });
+
+  it('shows the check has not run instead of a stale verdict when upgrade.checked is false', async () => {
+    mockGetHealth.mockResolvedValue(makeStatus({
+      upgrade: { current: '0.5.8', up_to_date: false, checked: false, skew: false },
+    }));
+    renderPage();
+    expect(await screen.findByText(/upstream check has not run yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/up to date/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('no')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/health/HealthPage.test.tsx
+++ b/frontend/src/features/health/HealthPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {

--- a/frontend/src/features/health/HealthPage.test.tsx
+++ b/frontend/src/features/health/HealthPage.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createMemoryHistory, createRouter, createRoute, createRootRoute,
+  RouterProvider, Outlet,
+} from '@tanstack/react-router';
+import { HealthPage } from './HealthPage';
+import type { HealthStatus } from '$/api/health';
+
+const mockGetHealth = vi.fn<() => Promise<HealthStatus>>();
+vi.mock('$/api/health', () => ({
+  getHealthStatus: () => mockGetHealth(),
+}));
+
+function makeStatus(overrides: Partial<HealthStatus> = {}): HealthStatus {
+  return {
+    generated_at: new Date().toISOString(),
+    components: [
+      { id: 'database', name: 'Database', status: 'operational', summary: 'reachable in 2ms' },
+      { id: 'redis', name: 'Redis', status: 'operational', summary: 'PING ok in 1ms' },
+      {
+        id: 'api', name: 'osctrl-api', status: 'operational', summary: 'up 1h0m0s, 56 goroutines',
+        details: { version: '0.5.8', goroutines: 56, runtime: { heap_alloc: 70254592, num_gc: 26440 } },
+      },
+      { id: 'tls', name: 'osctrl-tls', status: 'stale', summary: 'last reported 4m0s ago' },
+      { id: 'workers', name: 'Workers', status: 'degraded', summary: 'alerts worker dropped 12 hits' },
+    ],
+    upgrade: { current: '0.5.8', suggested: '0.5.8', latest: '0.5.9', up_to_date: true, checked: true, skew: false },
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const pageRoute = createRoute({ getParentRoute: () => rootRoute, path: '/', component: HealthPage });
+  const history = createMemoryHistory({ initialEntries: ['/'] });
+  const router = createRouter({ routeTree: rootRoute.addChildren([pageRoute]), history });
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('HealthPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHealth.mockResolvedValue(makeStatus());
+  });
+
+  it('lists every component with its status', async () => {
+    renderPage();
+    expect(await screen.findByText('Database')).toBeInTheDocument();
+    expect(screen.getByText('osctrl-tls')).toBeInTheDocument();
+    expect(screen.getAllByText('Operational').length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText('Stale')).toBeInTheDocument();
+    expect(screen.getByText('Degraded')).toBeInTheDocument();
+  });
+
+  it('expands a component to show its details without refetching', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: /osctrl-api/ }));
+    // Exact match on the capitalized detail-row label: the row's own
+    // summary text already contains the lowercase substring "goroutines"
+    // ("up 1h0m0s, 56 goroutines"), so a case-insensitive /goroutines/i
+    // regex matches both it and the expanded label and throws for
+    // multiple matches. The exact string only matches the label.
+    expect(await screen.findByText('Goroutines')).toBeInTheDocument();
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows upgrade status and hides the skew row when versions agree', async () => {
+    renderPage();
+    expect(await screen.findByText('0.5.9')).toBeInTheDocument();
+    expect(screen.queryByText(/version mismatch/i)).not.toBeInTheDocument();
+  });
+
+  it('calls out version skew between services', async () => {
+    mockGetHealth.mockResolvedValue(makeStatus({
+      upgrade: { current: '0.5.8', suggested: '0.5.8', latest: '0.5.9', up_to_date: true, checked: true, skew: true, api_version: '0.5.8', tls_version: '0.5.7' },
+    }));
+    renderPage();
+    expect(await screen.findByText(/version mismatch/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/health/HealthPage.test.tsx
+++ b/frontend/src/features/health/HealthPage.test.tsx
@@ -73,6 +73,27 @@ describe('HealthPage', () => {
     expect(mockGetHealth).toHaveBeenCalledTimes(1);
   });
 
+  it('labels each runtime card live or as-of, so stale numbers are obvious', async () => {
+    const reported = '2026-09-06T10:00:00.000Z';
+    mockGetHealth.mockResolvedValue(makeStatus({
+      components: [
+        {
+          id: 'api', name: 'osctrl-api', status: 'operational', summary: 'up 1h0m0s, 56 goroutines',
+          details: { version: '0.5.8', goroutines: 56, runtime: { heap_alloc: 70254592, num_gc: 26440 } },
+        },
+        {
+          id: 'tls', name: 'osctrl-tls', status: 'operational', summary: 'up 2h0m0s, 71 goroutines',
+          details: { version: '0.5.8', reported_at: reported, goroutines: 71, runtime: { heap_alloc: 12345678, num_gc: 99 } },
+        },
+      ],
+    }));
+    renderPage();
+    // The API reads its own runtime while serving the request.
+    expect(await screen.findByText('live')).toBeInTheDocument();
+    // The TLS card came from a heartbeat, so it is timestamped.
+    expect(screen.getByText(new RegExp(`as of ${new Date(reported).toLocaleTimeString()}`))).toBeInTheDocument();
+  });
+
   it('shows upgrade status and hides the skew row when versions agree', async () => {
     renderPage();
     expect(await screen.findByText('0.5.9')).toBeInTheDocument();

--- a/frontend/src/features/health/HealthPage.tsx
+++ b/frontend/src/features/health/HealthPage.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { HeartPulse, RefreshCw } from 'lucide-react';
+import { getHealthStatus, type HealthComponent, type HealthStatusValue } from '$/api/health';
+import { usePageTitle } from '$/lib/usePageTitle';
+import { StatusBadge } from '$/components/data/StatusBadge';
+import { Skeleton } from '$/components/data/Skeleton';
+import { EmptyState } from '$/components/data/EmptyState';
+import { Button } from '$/components/atoms/Button';
+import { cn } from '$/lib/cn';
+
+/** Status → badge variant. Stale is a warning, not a failure: the service may
+ * be fine and simply not reporting. */
+const VARIANTS: Record<HealthStatusValue, 'success' | 'warning' | 'danger' | 'dim'> = {
+  operational: 'success',
+  degraded: 'warning',
+  down: 'danger',
+  stale: 'warning',
+  unknown: 'dim',
+};
+
+const LABELS: Record<HealthStatusValue, string> = {
+  operational: 'Operational',
+  degraded: 'Degraded',
+  down: 'Down',
+  stale: 'Stale',
+  unknown: 'Unknown',
+};
+
+/** Byte counts are unreadable raw; the runtime card is mostly byte counts. */
+function formatBytes(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = n;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value >= 10 || unit === 0 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
+}
+
+const BYTE_FIELDS = new Set([
+  'alloc', 'total_alloc', 'sys', 'heap_alloc', 'heap_sys', 'heap_idle', 'heap_inuse',
+  'heap_released', 'stack_inuse', 'stack_sys', 'mspan_inuse', 'mspan_sys',
+  'mcache_inuse', 'mcache_sys', 'buck_hash_sys', 'gc_sys', 'other_sys', 'next_gc',
+]);
+
+function formatValue(key: string, value: unknown): string {
+  if (typeof value === 'number' && BYTE_FIELDS.has(key)) return formatBytes(value);
+  if (typeof value === 'number') return value.toLocaleString();
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function label(key: string): string {
+  return key.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase());
+}
+
+function DetailRows({ details }: { details: Record<string, unknown> }) {
+  return (
+    <dl className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-1 px-4 py-3 text-xs">
+      {Object.entries(details)
+        .filter(([key]) => key !== 'runtime')
+        .map(([key, value]) => (
+          <div key={key} className="contents">
+            <dt className="text-[color:var(--text-3)]">{label(key)}</dt>
+            <dd className="text-right tabular-nums text-[color:var(--text-1)]">{formatValue(key, value)}</dd>
+          </div>
+        ))}
+    </dl>
+  );
+}
+
+function ComponentRow({ component }: { component: HealthComponent }) {
+  const [open, setOpen] = useState(false);
+  const details = component.details;
+  return (
+    <div className="border-b border-[color:var(--border)] last:border-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="w-full flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-[color:var(--bg-2)] transition-colors"
+      >
+        <span className="font-medium text-[color:var(--text-1)]">{component.name}</span>
+        <span className="text-xs text-[color:var(--text-3)] truncate">{component.summary}</span>
+        <span className="ml-auto flex-shrink-0">
+          <StatusBadge variant={VARIANTS[component.status]} label={LABELS[component.status]} />
+        </span>
+      </button>
+      {open && details && <DetailRows details={details} />}
+    </div>
+  );
+}
+
+/** The Go runtime card, one per service that reports runtime detail. */
+function RuntimeCard({ component }: { component: HealthComponent }) {
+  const runtime = component.details?.runtime as Record<string, unknown> | undefined;
+  if (!runtime) return null;
+  return (
+    <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-2)]">
+      <div className="px-4 py-2 border-b border-[color:var(--border)] text-xs font-semibold uppercase tracking-wide text-[color:var(--text-2)]">
+        {component.name}
+      </div>
+      <DetailRows details={runtime} />
+    </div>
+  );
+}
+
+export function HealthPage() {
+  usePageTitle('Health');
+  const { data, isLoading, error, refetch, isFetching } = useQuery({
+    queryKey: ['health-status'],
+    queryFn: () => getHealthStatus(),
+    staleTime: 15_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="p-6 space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => <Skeleton key={i} className="h-10 w-full" />)}
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <EmptyState
+        icon={<HeartPulse />}
+        title="Health data unavailable"
+        description={error instanceof Error ? error.message : 'Could not load deployment health.'}
+      />
+    );
+  }
+
+  const { components, upgrade } = data;
+
+  return (
+    <div className="p-6 space-y-8 max-w-4xl">
+      <section>
+        <div className="flex items-center gap-3 mb-1">
+          <h2 className="font-display text-lg font-semibold text-[color:var(--text-1)]">Health Status</h2>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="ml-auto"
+            disabled={isFetching}
+            onClick={() => void refetch()}
+          >
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+            {isFetching ? 'Refreshing…' : 'Refresh'}
+          </Button>
+        </div>
+        <p className="text-xs text-[color:var(--text-3)] mb-3">How your deployment is doing</p>
+        <div className="rounded-md border border-[color:var(--border)]">
+          {components.map((c) => <ComponentRow key={c.id} component={c} />)}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg font-semibold text-[color:var(--text-1)] mb-1">Upgrade Status</h2>
+        <p className="text-xs text-[color:var(--text-3)] mb-3">Version running versus what is available</p>
+        <div className="rounded-md border border-[color:var(--border)]">
+          <DetailRows
+            details={{
+              current: upgrade.current,
+              suggested: upgrade.suggested ?? '—',
+              latest: upgrade.latest ?? '—',
+              up_to_date: upgrade.up_to_date,
+              checked_at: upgrade.checked_at ?? 'never',
+            }}
+          />
+          {upgrade.skew && (
+            <p className={cn('px-4 py-2 text-xs border-t border-[color:var(--border)]', 'text-[color:var(--warning)]')}>
+              Version mismatch — osctrl-api {upgrade.api_version} / osctrl-tls {upgrade.tls_version}
+            </p>
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg font-semibold text-[color:var(--text-1)] mb-3">System status</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          {components.map((c) => <RuntimeCard key={c.id} component={c} />)}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/health/HealthPage.tsx
+++ b/frontend/src/features/health/HealthPage.tsx
@@ -96,14 +96,28 @@ function ComponentRow({ component }: { component: HealthComponent }) {
   );
 }
 
-/** The Go runtime card, one per service that reports runtime detail. */
+/**
+ * The Go runtime card, one per service that reports runtime detail.
+ *
+ * osctrl-api's numbers are read while serving this request; osctrl-tls's ride
+ * its heartbeat and are up to a minute old. The card says which, so nobody
+ * debugs a memory spike against stale numbers.
+ */
 function RuntimeCard({ component }: { component: HealthComponent }) {
   const runtime = component.details?.runtime as Record<string, unknown> | undefined;
   if (!runtime) return null;
+  const reportedAt = component.details?.reported_at;
+  const asOf =
+    typeof reportedAt === 'string' && !Number.isNaN(Date.parse(reportedAt))
+      ? `as of ${new Date(reportedAt).toLocaleTimeString()}`
+      : 'live';
   return (
     <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-2)]">
-      <div className="px-4 py-2 border-b border-[color:var(--border)] text-xs font-semibold uppercase tracking-wide text-[color:var(--text-2)]">
+      <div className="flex items-baseline gap-2 px-4 py-2 border-b border-[color:var(--border)] text-xs font-semibold uppercase tracking-wide text-[color:var(--text-2)]">
         {component.name}
+        <span className="ml-auto font-normal normal-case tracking-normal text-[color:var(--text-3)]">
+          {asOf}
+        </span>
       </div>
       <DetailRows details={runtime} />
     </div>

--- a/frontend/src/features/health/HealthPage.tsx
+++ b/frontend/src/features/health/HealthPage.tsx
@@ -166,13 +166,20 @@ export function HealthPage() {
         <p className="text-xs text-[color:var(--text-3)] mb-3">Version running versus what is available</p>
         <div className="rounded-md border border-[color:var(--border)]">
           <DetailRows
-            details={{
-              current: upgrade.current,
-              suggested: upgrade.suggested ?? '—',
-              latest: upgrade.latest ?? '—',
-              up_to_date: upgrade.up_to_date,
-              checked_at: upgrade.checked_at ?? 'never',
-            }}
+            details={
+              upgrade.checked
+                ? {
+                    current: upgrade.current,
+                    suggested: upgrade.suggested ?? '—',
+                    latest: upgrade.latest ?? '—',
+                    up_to_date: upgrade.up_to_date,
+                    checked_at: upgrade.checked_at ?? 'never',
+                  }
+                : {
+                    current: upgrade.current,
+                    status: 'Upstream check has not run yet',
+                  }
+            }
           />
           {upgrade.skew && (
             <p className={cn('px-4 py-2 text-xs border-t border-[color:var(--border)]', 'text-[color:var(--warning)]')}>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -27,6 +27,7 @@ import { serviceConfigRoute } from './routes/_app/config.$service'
 import { logSinksRoute } from './routes/_app/log-sinks'
 import { authProvidersRoute } from './routes/_app/auth-providers'
 import { alertsRoute } from './routes/_app/alerts'
+import { healthRoute } from './routes/_app/health'
 import { auditRoute } from './routes/_app/audit'
 import { devComponentsRoute } from './routes/dev.components'
 
@@ -44,6 +45,7 @@ const routeTree = rootRoute.addChildren([
     logSinksRoute,
     authProvidersRoute,
     alertsRoute,
+    healthRoute,
     auditRoute,
     envRoute.addChildren([
       envIndexRoute,

--- a/frontend/src/routes/_app/health.tsx
+++ b/frontend/src/routes/_app/health.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { appRoute } from './route';
+import { HealthPage } from '$/features/health/HealthPage';
+
+export const healthRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: 'health',
+  component: HealthPage,
+});

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -3375,6 +3375,40 @@ paths:
       summary: Update enrolling package URL
       tags:
         - environments
+  /api/v1/health/status:
+    get:
+      description: Component health, per-service runtime detail and upgrade status.
+        Admin only.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/handlers.healthStatusResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "503":
+          description: Health reporting disabled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Deployment health
+      tags:
+        - health
   /api/v1/log-sinks:
     get:
       description: Returns log sink rows, optionally filtered by environment. Secrets
@@ -9652,6 +9686,17 @@ components:
         updated_at:
           type: string
       type: object
+    handlers.healthStatusResponse:
+      properties:
+        components:
+          items:
+            $ref: "#/components/schemas/health.Component"
+          type: array
+        generated_at:
+          type: string
+        upgrade:
+          $ref: "#/components/schemas/health.UpgradeInfo"
+      type: object
     handlers.logSinkDTO:
       properties:
         bytes_sent:
@@ -9684,6 +9729,46 @@ components:
           type: string
         updated_at:
           type: string
+      type: object
+    health.Component:
+      properties:
+        details:
+          additionalProperties: {}
+          type: object
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+        summary:
+          type: string
+      type: object
+    health.UpgradeInfo:
+      properties:
+        api_version:
+          description: |-
+            API and TLS expose the per-service versions behind Skew so the page
+            can name both sides of a mismatch.
+          type: string
+        checked:
+          type: boolean
+        checked_at:
+          type: string
+        current:
+          type: string
+        latest:
+          type: string
+        more_information:
+          type: string
+        skew:
+          type: boolean
+        suggested:
+          type: string
+        tls_version:
+          type: string
+        up_to_date:
+          type: boolean
       type: object
     nodes.OsqueryNode:
       properties:

--- a/pkg/alerts/worker.go
+++ b/pkg/alerts/worker.go
@@ -48,6 +48,35 @@ func (w *Worker) QueueDepth() int {
 	return len(w.queue)
 }
 
+// WorkerSnapshot is a point-in-time read of the worker counters, for callers
+// outside this package (the health heartbeat). Plain values, not atomics, so
+// the caller cannot mutate live counters.
+type WorkerSnapshot struct {
+	QueueDepth    int
+	QueueCapacity int
+	Matched       uint64
+	Dispatched    uint64
+	Collapsed     uint64
+	Dropped       uint64
+	Failed        uint64
+}
+
+// MetricsSnapshot reads the counters. Safe on a nil worker (alerts disabled).
+func (w *Worker) MetricsSnapshot() WorkerSnapshot {
+	if w == nil {
+		return WorkerSnapshot{}
+	}
+	return WorkerSnapshot{
+		QueueDepth:    len(w.queue),
+		QueueCapacity: cap(w.queue),
+		Matched:       w.metrics.Matched.Load(),
+		Dispatched:    w.metrics.Dispatched.Load(),
+		Collapsed:     w.metrics.Collapsed.Load(),
+		Dropped:       w.metrics.Dropped.Load(),
+		Failed:        w.metrics.Failed.Load(),
+	}
+}
+
 // claimGate is the cooldown surface the worker needs. *State
 // implements it; tests substitute their own.
 type claimGate interface {

--- a/pkg/alerts/worker_test.go
+++ b/pkg/alerts/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/stretchr/testify/require"
 )
 
 // recordingSink captures dispatched hits in order.
@@ -221,4 +222,20 @@ func TestIngestMatcherAdapts(t *testing.T) {
 	nilMatcher.MatchResultLogs(1, "dev", nil)
 	nilMatcher.MatchStatusLogs(1, "dev", nil)
 	nilMatcher.MatchQueryResult(1, "dev", "q", nil, 0, "")
+}
+
+func TestMetricsSnapshotReadsCounters(t *testing.T) {
+	var w *Worker
+	require.Equal(t, WorkerSnapshot{}, w.MetricsSnapshot(), "nil worker must be safe")
+
+	w = NewWorker(NewStore(), nil, nil, nil, 16, 1)
+	defer w.Close()
+	w.metrics.Dispatched.Add(7)
+	w.metrics.Dropped.Add(2)
+
+	snap := w.MetricsSnapshot()
+	require.EqualValues(t, 7, snap.Dispatched)
+	require.EqualValues(t, 2, snap.Dropped)
+	require.Equal(t, 16, snap.QueueCapacity)
+	require.Equal(t, 0, snap.QueueDepth)
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -36,7 +36,13 @@ func (rm *RedisManager) GetRedis() *redis.Client {
 
 // Check to verify if connection is open and ready
 func (rm *RedisManager) Check() error {
-	ctx := context.TODO()
+	return rm.CheckContext(context.TODO())
+}
+
+// CheckContext is Check with a caller-supplied context, so callers that need
+// a bounded deadline (e.g. the health endpoint) are not left waiting forever
+// on a blackholed connection.
+func (rm *RedisManager) CheckContext(ctx context.Context) error {
 	if err := rm.Client.Ping(ctx).Err(); err != nil {
 		return err
 	}

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -287,6 +287,13 @@ func initServiceFlags(params *ServiceParameters) []cli.Flag {
 			Destination: &params.Service.AlertsEnabled,
 		},
 		&cli.BoolFlag{
+			Name:        "health-enabled",
+			Value:       false,
+			Usage:       "Enable the health/system-status subsystem: component health, service heartbeats and runtime stats in the SPA. Disabled by default; when enabled osctrl-tls writes a heartbeat row every 60s and osctrl-api serves /api/v1/health/status. Requires a service restart to change.",
+			Sources:     cli.EnvVars("SERVICE_HEALTH_ENABLED"),
+			Destination: &params.Service.HealthEnabled,
+		},
+		&cli.BoolFlag{
 			Name:        "service-config-enabled",
 			Value:       false,
 			Usage:       "Serve the service-config API and show the matching section in the SPA. Disabled by default: the YAML sections are still seeded into the database at every boot and resolved back at startup, but none of the /api/v1/service-config routes are registered — change the rows or the YAML file directly instead.",

--- a/pkg/config/flags_test.go
+++ b/pkg/config/flags_test.go
@@ -191,3 +191,23 @@ func TestRateLimitFlagsWireDefaults(t *testing.T) {
 		t.Fatal("login burst flag destination does not wire RateLimits.Login.Burst")
 	}
 }
+
+func TestServiceHealthEnabledFlagDefaultsOff(t *testing.T) {
+	params := &ServiceParameters{Service: &YAMLConfigurationService{}}
+	flags := initServiceFlags(params)
+	if params.Service.HealthEnabled {
+		t.Fatal("health must be disabled by default: it creates a table and writes heartbeats")
+	}
+	var found bool
+	for _, flag := range flags {
+		if f, ok := flag.(*cli.BoolFlag); ok && f.Name == "health-enabled" {
+			found = true
+			if f.Value {
+				t.Fatal("health-enabled flag default: got true want false")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("missing health-enabled service flag")
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -137,6 +137,11 @@ type YAMLConfigurationService struct {
 	// alert tables are not created. The feature is fully inert —
 	// enabling requires a service restart (same as PostureEnabled).
 	AlertsEnabled bool `yaml:"alertsEnabled"`
+	// HealthEnabled controls whether the health/system-status subsystem is
+	// active. When false (default) no health manager is constructed, so the
+	// service_status table is never created, osctrl-tls writes no
+	// heartbeat, and the /api/v1/health routes are not registered.
+	HealthEnabled bool `yaml:"healthEnabled"`
 	// ServiceConfigEnabled controls whether the service-config API and the
 	// matching SPA section exist. It does not change how configuration is
 	// loaded: every boot seeds the YAML sections into the database and

--- a/pkg/health/components.go
+++ b/pkg/health/components.go
@@ -1,0 +1,168 @@
+package health
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Status values a component can report.
+const (
+	StatusOperational = "operational"
+	StatusDegraded    = "degraded"
+	StatusDown        = "down"
+	StatusStale       = "stale"
+	StatusUnknown     = "unknown"
+)
+
+// Component is one row on the health page.
+type Component struct {
+	ID      string         `json:"id"`
+	Name    string         `json:"name"`
+	Status  string         `json:"status"`
+	Summary string         `json:"summary"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// WorkerPayload is the JSON osctrl-tls writes in ServiceStatus.Payload. Every
+// field comes from a counter that is free to read; nothing here stops the
+// world. Subsystems that are disabled are omitted, so the page shows what the
+// deployment actually runs.
+type WorkerPayload struct {
+	Alerts *AlertsWorkerStats `json:"alerts,omitempty"`
+}
+
+// AlertsWorkerStats mirrors alerts.WorkerSnapshot.
+type AlertsWorkerStats struct {
+	Enabled       bool   `json:"enabled"`
+	QueueDepth    int    `json:"queue_depth"`
+	QueueCapacity int    `json:"queue_capacity"`
+	Matched       uint64 `json:"matched"`
+	Dispatched    uint64 `json:"dispatched"`
+	Collapsed     uint64 `json:"collapsed"`
+	Dropped       uint64 `json:"dropped"`
+	Failed        uint64 `json:"failed"`
+}
+
+// DatabaseComponent reports the backend database. degraded comes from the
+// existing pkg/backend health monitor; pingErr from a live ping.
+func DatabaseComponent(degraded bool, pingErr error, latency time.Duration) Component {
+	c := Component{ID: "database", Name: "Database", Details: map[string]any{
+		"latency_ms": latency.Milliseconds(),
+		"degraded":   degraded,
+	}}
+	switch {
+	case pingErr != nil:
+		c.Status = StatusDown
+		c.Summary = pingErr.Error()
+	case degraded:
+		c.Status = StatusDegraded
+		c.Summary = "health monitor reports the database as degraded"
+	default:
+		c.Status = StatusOperational
+		c.Summary = fmt.Sprintf("reachable in %dms", latency.Milliseconds())
+	}
+	return c
+}
+
+// RedisComponent reports Redis reachability from a PING.
+func RedisComponent(pingErr error, latency time.Duration) Component {
+	c := Component{ID: "redis", Name: "Redis", Details: map[string]any{
+		"latency_ms": latency.Milliseconds(),
+	}}
+	if pingErr != nil {
+		c.Status = StatusDown
+		c.Summary = pingErr.Error()
+		return c
+	}
+	c.Status = StatusOperational
+	c.Summary = fmt.Sprintf("PING ok in %dms", latency.Milliseconds())
+	return c
+}
+
+// ServiceComponent turns a heartbeat row into a component. apiVersion is the
+// version of the process serving the request, so skew between services is
+// visible rather than silent.
+func ServiceComponent(row ServiceStatus, err error, now time.Time, apiVersion string) Component {
+	c := Component{ID: "tls", Name: "osctrl-tls"}
+	if err != nil {
+		c.Status = StatusUnknown
+		if errors.Is(err, ErrNotReporting) {
+			c.Summary = "not reporting — enable --health-enabled on osctrl-tls"
+		} else {
+			c.Summary = err.Error()
+		}
+		return c
+	}
+
+	age := now.Sub(row.ReportedAt)
+	mismatch := apiVersion != "" && row.Version != "" && row.Version != apiVersion
+	c.Details = map[string]any{
+		"version":          row.Version,
+		"reported_at":      row.ReportedAt,
+		"uptime_seconds":   int64(now.Sub(row.StartedAt).Seconds()),
+		"goroutines":       row.Goroutines,
+		"version_mismatch": mismatch,
+	}
+
+	switch {
+	case age > StaleAfter:
+		c.Status = StatusStale
+		c.Summary = fmt.Sprintf("last reported %s ago", age.Round(time.Second))
+	case mismatch:
+		c.Status = StatusDegraded
+		c.Summary = fmt.Sprintf("running %s while osctrl-api runs %s", row.Version, apiVersion)
+	default:
+		c.Status = StatusOperational
+		c.Summary = fmt.Sprintf("up %s, %d goroutines", now.Sub(row.StartedAt).Round(time.Minute), row.Goroutines)
+	}
+	return c
+}
+
+// WorkersComponent reports the background workers inside osctrl-tls, decoded
+// from the heartbeat payload. It inherits staleness from the heartbeat:
+// counters from a dead process say nothing about now.
+func WorkersComponent(row ServiceStatus, err error, now time.Time) Component {
+	c := Component{ID: "workers", Name: "Workers"}
+	if err != nil {
+		c.Status = StatusUnknown
+		c.Summary = "no worker data — osctrl-tls is not reporting"
+		return c
+	}
+	if now.Sub(row.ReportedAt) > StaleAfter {
+		c.Status = StatusStale
+		c.Summary = "worker counters are stale"
+		return c
+	}
+
+	var payload WorkerPayload
+	if row.Payload != "" {
+		if decodeErr := json.Unmarshal([]byte(row.Payload), &payload); decodeErr != nil {
+			c.Status = StatusUnknown
+			c.Summary = "worker payload could not be decoded"
+			return c
+		}
+	}
+	if payload.Alerts == nil || !payload.Alerts.Enabled {
+		c.Status = StatusOperational
+		c.Summary = "no workers enabled"
+		return c
+	}
+
+	a := payload.Alerts
+	c.Details = map[string]any{"alerts": a}
+	nearlyFull := a.QueueCapacity > 0 && a.QueueDepth*10 >= a.QueueCapacity*9
+	switch {
+	case a.Dropped > 0:
+		c.Status = StatusDegraded
+		c.Summary = fmt.Sprintf("alerts worker dropped %d hits", a.Dropped)
+	case nearlyFull:
+		c.Status = StatusDegraded
+		c.Summary = fmt.Sprintf("alerts queue %d/%d", a.QueueDepth, a.QueueCapacity)
+	default:
+		c.Status = StatusOperational
+		c.Summary = fmt.Sprintf("alerts worker: %d dispatched, queue %d/%d", a.Dispatched, a.QueueDepth, a.QueueCapacity)
+	}
+	return c
+}

--- a/pkg/health/components.go
+++ b/pkg/health/components.go
@@ -127,7 +127,11 @@ func WorkersComponent(row ServiceStatus, err error, now time.Time) Component {
 	c := Component{ID: "workers", Name: "Workers"}
 	if err != nil {
 		c.Status = StatusUnknown
-		c.Summary = "no worker data — osctrl-tls is not reporting"
+		if errors.Is(err, ErrNotReporting) {
+			c.Summary = "no worker data — osctrl-tls is not reporting"
+		} else {
+			c.Summary = fmt.Sprintf("worker data unavailable: %s", err.Error())
+		}
 		return c
 	}
 	if now.Sub(row.ReportedAt) > StaleAfter {

--- a/pkg/health/components.go
+++ b/pkg/health/components.go
@@ -25,12 +25,16 @@ type Component struct {
 	Details map[string]any `json:"details,omitempty"`
 }
 
-// WorkerPayload is the JSON osctrl-tls writes in ServiceStatus.Payload. Every
-// field comes from a counter that is free to read; nothing here stops the
-// world. Subsystems that are disabled are omitted, so the page shows what the
-// deployment actually runs.
+// WorkerPayload is the JSON osctrl-tls writes in ServiceStatus.Payload.
+// Everything in it is free to read — atomics, channel lengths, and
+// runtime/metrics counters; nothing here stops the world. Subsystems that are
+// disabled are omitted, so the page shows what the deployment actually runs.
 type WorkerPayload struct {
 	Alerts *AlertsWorkerStats `json:"alerts,omitempty"`
+	// Runtime is the reporting service's Go runtime state, sampled through
+	// runtime/metrics rather than ReadMemStats — see SampleRuntimeMetrics for
+	// why, and for the two fields that sampler cannot fill.
+	Runtime *RuntimeStats `json:"runtime,omitempty"`
 }
 
 // AlertsWorkerStats mirrors alerts.WorkerSnapshot.
@@ -43,6 +47,18 @@ type AlertsWorkerStats struct {
 	Collapsed     uint64 `json:"collapsed"`
 	Dropped       uint64 `json:"dropped"`
 	Failed        uint64 `json:"failed"`
+}
+
+// decodePayload reads the heartbeat's JSON payload. A payload that will not
+// decode is reported as such by the caller rather than silently rendering as
+// "nothing enabled".
+func decodePayload(row ServiceStatus) (WorkerPayload, error) {
+	var payload WorkerPayload
+	if row.Payload == "" {
+		return payload, nil
+	}
+	err := json.Unmarshal([]byte(row.Payload), &payload)
+	return payload, err
 }
 
 // DatabaseComponent reports the backend database. degraded comes from the
@@ -105,6 +121,14 @@ func ServiceComponent(row ServiceStatus, err error, now time.Time, apiVersion st
 		"goroutines":       row.Goroutines,
 		"version_mismatch": mismatch,
 	}
+	// The SPA renders a runtime card for any component carrying "runtime", so
+	// forwarding the sampled block is all it takes for osctrl-tls to appear
+	// beside osctrl-api under System status. Unlike the API's, these numbers
+	// are up to one heartbeat interval old — "reported_at" above is what says
+	// how old.
+	if payload, err := decodePayload(row); err == nil && payload.Runtime != nil {
+		c.Details["runtime"] = payload.Runtime
+	}
 
 	switch {
 	case age > StaleAfter:
@@ -140,13 +164,11 @@ func WorkersComponent(row ServiceStatus, err error, now time.Time) Component {
 		return c
 	}
 
-	var payload WorkerPayload
-	if row.Payload != "" {
-		if decodeErr := json.Unmarshal([]byte(row.Payload), &payload); decodeErr != nil {
-			c.Status = StatusUnknown
-			c.Summary = "worker payload could not be decoded"
-			return c
-		}
+	payload, decodeErr := decodePayload(row)
+	if decodeErr != nil {
+		c.Status = StatusUnknown
+		c.Summary = "worker payload could not be decoded"
+		return c
 	}
 	if payload.Alerts == nil || !payload.Alerts.Enabled {
 		c.Status = StatusOperational

--- a/pkg/health/components_test.go
+++ b/pkg/health/components_test.go
@@ -60,3 +60,12 @@ func TestWorkersComponentReportsDrops(t *testing.T) {
 
 	require.Equal(t, StatusUnknown, WorkersComponent(ServiceStatus{}, ErrNotReporting, now).Status)
 }
+
+func TestWorkersComponentDoesNotBlameTLSForDBError(t *testing.T) {
+	now := time.Now()
+	dbErr := errors.New("dial tcp: connection refused")
+	got := WorkersComponent(ServiceStatus{}, dbErr, now)
+	require.Equal(t, StatusUnknown, got.Status)
+	require.NotContains(t, got.Summary, "osctrl-tls is not reporting")
+	require.Contains(t, got.Summary, "connection refused")
+}

--- a/pkg/health/components_test.go
+++ b/pkg/health/components_test.go
@@ -46,6 +46,29 @@ func TestServiceComponentFlagsVersionSkew(t *testing.T) {
 	require.Equal(t, true, got.Details["version_mismatch"])
 }
 
+// TestServiceComponentSurfacesRuntime pins the contract the SPA relies on: a
+// component carrying "runtime" gets a System status card, so forwarding the
+// heartbeat's sampled block is what puts osctrl-tls beside osctrl-api there.
+func TestServiceComponentSurfacesRuntime(t *testing.T) {
+	now := time.Now()
+	row := ServiceStatus{
+		Service: "tls", Version: "0.5.8", ReportedAt: now, StartedAt: now.Add(-time.Hour),
+		Payload: `{"runtime":{"heap_alloc":1048576,"goroutines":71,"num_gc":42}}`,
+	}
+	got := ServiceComponent(row, nil, now, "0.5.8")
+	require.Equal(t, StatusOperational, got.Status)
+	rt, ok := got.Details["runtime"].(*RuntimeStats)
+	require.True(t, ok, "runtime must be forwarded as a RuntimeStats, got %T", got.Details["runtime"])
+	require.EqualValues(t, 1048576, rt.HeapAlloc)
+	require.EqualValues(t, 42, rt.NumGC)
+
+	// A heartbeat without runtime data must not invent an empty card.
+	bare := ServiceComponent(ServiceStatus{
+		Service: "tls", ReportedAt: now, StartedAt: now.Add(-time.Hour), Payload: `{}`,
+	}, nil, now, "")
+	require.NotContains(t, bare.Details, "runtime")
+}
+
 func TestWorkersComponentReportsDrops(t *testing.T) {
 	now := time.Now()
 	healthy := ServiceStatus{Service: "tls", ReportedAt: now,

--- a/pkg/health/components_test.go
+++ b/pkg/health/components_test.go
@@ -1,0 +1,62 @@
+package health
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseComponentStatuses(t *testing.T) {
+	require.Equal(t, StatusOperational, DatabaseComponent(false, nil, 2*time.Millisecond).Status)
+	require.Equal(t, StatusDegraded, DatabaseComponent(true, nil, 2*time.Millisecond).Status)
+	require.Equal(t, StatusDown, DatabaseComponent(false, errors.New("boom"), 0).Status)
+}
+
+func TestRedisComponentStatuses(t *testing.T) {
+	require.Equal(t, StatusOperational, RedisComponent(nil, time.Millisecond).Status)
+	down := RedisComponent(errors.New("connection refused"), 0)
+	require.Equal(t, StatusDown, down.Status)
+	require.Contains(t, down.Summary, "connection refused")
+}
+
+func TestServiceComponentHeartbeatAges(t *testing.T) {
+	now := time.Now()
+	fresh := ServiceStatus{Service: "tls", Version: "0.5.8", ReportedAt: now.Add(-30 * time.Second), StartedAt: now.Add(-time.Hour)}
+	require.Equal(t, StatusOperational, ServiceComponent(fresh, nil, now, "0.5.8").Status)
+
+	stale := fresh
+	stale.ReportedAt = now.Add(-4 * time.Minute)
+	got := ServiceComponent(stale, nil, now, "0.5.8")
+	require.Equal(t, StatusStale, got.Status)
+	require.Contains(t, got.Summary, "last reported")
+
+	missing := ServiceComponent(ServiceStatus{}, ErrNotReporting, now, "0.5.8")
+	require.Equal(t, StatusUnknown, missing.Status)
+	require.Contains(t, missing.Summary, "--health-enabled")
+}
+
+func TestServiceComponentFlagsVersionSkew(t *testing.T) {
+	now := time.Now()
+	row := ServiceStatus{Service: "tls", Version: "0.5.7", ReportedAt: now, StartedAt: now.Add(-time.Hour)}
+	got := ServiceComponent(row, nil, now, "0.5.8")
+	require.Equal(t, StatusDegraded, got.Status)
+	require.Contains(t, got.Summary, "0.5.7")
+	require.Equal(t, true, got.Details["version_mismatch"])
+}
+
+func TestWorkersComponentReportsDrops(t *testing.T) {
+	now := time.Now()
+	healthy := ServiceStatus{Service: "tls", ReportedAt: now,
+		Payload: `{"alerts":{"enabled":true,"queue_depth":3,"queue_capacity":8192,"dropped":0}}`}
+	require.Equal(t, StatusOperational, WorkersComponent(healthy, nil, now).Status)
+
+	dropping := healthy
+	dropping.Payload = `{"alerts":{"enabled":true,"queue_depth":8100,"queue_capacity":8192,"dropped":12}}`
+	got := WorkersComponent(dropping, nil, now)
+	require.Equal(t, StatusDegraded, got.Status)
+	require.Contains(t, got.Summary, "12")
+
+	require.Equal(t, StatusUnknown, WorkersComponent(ServiceStatus{}, ErrNotReporting, now).Status)
+}

--- a/pkg/health/manager.go
+++ b/pkg/health/manager.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -44,11 +45,18 @@ func (m *Manager) Report(s ServiceStatus) error {
 
 // Get returns one service's heartbeat, or ErrNotReporting.
 func (m *Manager) Get(service string) (ServiceStatus, error) {
+	return m.GetContext(context.Background(), service)
+}
+
+// GetContext is Get with a caller-supplied context, so callers that need a
+// bounded deadline (e.g. the health endpoint) are not left waiting forever
+// on a saturated connection pool.
+func (m *Manager) GetContext(ctx context.Context, service string) (ServiceStatus, error) {
 	if m == nil {
 		return ServiceStatus{}, ErrNotReporting
 	}
 	var row ServiceStatus
-	if err := m.DB.Where("service = ?", service).First(&row).Error; err != nil {
+	if err := m.DB.WithContext(ctx).Where("service = ?", service).First(&row).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ServiceStatus{}, ErrNotReporting
 		}

--- a/pkg/health/manager.go
+++ b/pkg/health/manager.go
@@ -1,0 +1,58 @@
+package health
+
+import (
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ErrNotReporting is returned when a service has no heartbeat row: it never
+// ran with --health-enabled, or never started. It is deliberately distinct
+// from "unhealthy" — the API renders it as unknown, not down.
+var ErrNotReporting = errors.New("service has never reported health")
+
+// Manager owns the service_status table.
+type Manager struct {
+	DB *gorm.DB
+}
+
+// NewManager initializes the manager and auto-migrates its table. It is
+// only called when --health-enabled is set, so a deployment with the
+// feature off never creates the table.
+func NewManager(db *gorm.DB) *Manager {
+	m := &Manager{DB: db}
+	if err := db.AutoMigrate(&ServiceStatus{}); err != nil {
+		panic(fmt.Sprintf("Failed to AutoMigrate health tables: %v", err))
+	}
+	return m
+}
+
+// Report upserts one service's heartbeat.
+func (m *Manager) Report(s ServiceStatus) error {
+	if m == nil {
+		return nil
+	}
+	return m.DB.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "service"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"version", "started_at", "reported_at", "goroutines", "payload", "updated_at",
+		}),
+	}).Create(&s).Error
+}
+
+// Get returns one service's heartbeat, or ErrNotReporting.
+func (m *Manager) Get(service string) (ServiceStatus, error) {
+	if m == nil {
+		return ServiceStatus{}, ErrNotReporting
+	}
+	var row ServiceStatus
+	if err := m.DB.Where("service = ?", service).First(&row).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ServiceStatus{}, ErrNotReporting
+		}
+		return ServiceStatus{}, err
+	}
+	return row, nil
+}

--- a/pkg/health/manager_test.go
+++ b/pkg/health/manager_test.go
@@ -1,0 +1,52 @@
+package health
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func testManager(t *testing.T) *Manager {
+	t.Helper()
+	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	db, err := gorm.Open(sqlite.Open("file:"+name+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	return NewManager(db)
+}
+
+func TestReportUpsertsOneRowPerService(t *testing.T) {
+	m := testManager(t)
+	started := time.Now().Add(-time.Hour)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, m.Report(ServiceStatus{
+			Service:    "tls",
+			Version:    "0.5.8",
+			StartedAt:  started,
+			ReportedAt: time.Now(),
+			Goroutines: 40 + i,
+			Payload:    `{"alerts":{"enabled":true}}`,
+		}))
+	}
+
+	var count int64
+	require.NoError(t, m.DB.Model(&ServiceStatus{}).Where("service = ?", "tls").Count(&count).Error)
+	require.EqualValues(t, 1, count, "heartbeat must upsert, not append")
+
+	row, err := m.Get("tls")
+	require.NoError(t, err)
+	require.Equal(t, "0.5.8", row.Version)
+	require.Equal(t, 42, row.Goroutines, "last write wins")
+	require.Equal(t, `{"alerts":{"enabled":true}}`, row.Payload)
+	require.WithinDuration(t, started, row.StartedAt, time.Second)
+}
+
+func TestGetUnknownServiceReturnsErrNotReporting(t *testing.T) {
+	m := testManager(t)
+	_, err := m.Get("tls")
+	require.ErrorIs(t, err, ErrNotReporting)
+}

--- a/pkg/health/metrics.go
+++ b/pkg/health/metrics.go
@@ -1,0 +1,148 @@
+package health
+
+import (
+	"math"
+	"runtime"
+	"runtime/metrics"
+	"time"
+)
+
+// metrics.go — the same numbers Snapshot reports, sampled without stopping
+// the world.
+//
+// Snapshot (runtime.go) calls runtime.ReadMemStats, which STOPS THE WORLD.
+// That is acceptable on the API request path, where it runs when an operator
+// opens a page. It is not acceptable inside osctrl-tls, which samples on a
+// 60s heartbeat while serving the log ingest path — so osctrl-tls uses this
+// instead. runtime/metrics reads the same underlying counters without a
+// global pause.
+//
+// Two fields have no runtime/metrics equivalent and stay zero here:
+//
+//   - LastGC (wall-clock time of the last collection) — the package exposes
+//     cycle counts, not timestamps.
+//   - Lookups — deprecated in MemStats and always zero there too.
+//
+// PauseTotalNs is derived from the /gc/pauses:seconds histogram, so it is an
+// approximation (bucket midpoints), not the exact figure ReadMemStats gives.
+
+// Metric names sampled for one runtime snapshot. Kept in one block so an
+// upstream rename shows up as a zero value in exactly one place.
+const (
+	mHeapObjectsBytes = "/memory/classes/heap/objects:bytes"
+	mHeapUnusedBytes  = "/memory/classes/heap/unused:bytes"
+	mHeapFreeBytes    = "/memory/classes/heap/free:bytes"
+	mHeapReleased     = "/memory/classes/heap/released:bytes"
+	mHeapStacks       = "/memory/classes/heap/stacks:bytes"
+	mOSStacks         = "/memory/classes/os-stacks:bytes"
+	mMSpanInuse       = "/memory/classes/metadata/mspan/inuse:bytes"
+	mMSpanFree        = "/memory/classes/metadata/mspan/free:bytes"
+	mMCacheInuse      = "/memory/classes/metadata/mcache/inuse:bytes"
+	mMCacheFree       = "/memory/classes/metadata/mcache/free:bytes"
+	mMetadataOther    = "/memory/classes/metadata/other:bytes"
+	mProfilingBuckets = "/memory/classes/profiling/buckets:bytes"
+	mOtherBytes       = "/memory/classes/other:bytes"
+	mTotalBytes       = "/memory/classes/total:bytes"
+	mAllocsBytes      = "/gc/heap/allocs:bytes"
+	mAllocsObjects    = "/gc/heap/allocs:objects"
+	mFreesObjects     = "/gc/heap/frees:objects"
+	mLiveObjects      = "/gc/heap/objects:objects"
+	mHeapGoal         = "/gc/heap/goal:bytes"
+	mGCCycles         = "/gc/cycles/total:gc-cycles"
+	mGCPauses         = "/gc/pauses:seconds"
+)
+
+// SampleRuntimeMetrics reports the runtime state without stopping the world.
+// Use it anywhere sampling happens on a timer; use Snapshot on a request path
+// where the exact MemStats numbers are worth a brief pause.
+func SampleRuntimeMetrics(startedAt time.Time) RuntimeStats {
+	samples := []metrics.Sample{
+		{Name: mHeapObjectsBytes}, {Name: mHeapUnusedBytes}, {Name: mHeapFreeBytes},
+		{Name: mHeapReleased}, {Name: mHeapStacks}, {Name: mOSStacks},
+		{Name: mMSpanInuse}, {Name: mMSpanFree}, {Name: mMCacheInuse}, {Name: mMCacheFree},
+		{Name: mMetadataOther}, {Name: mProfilingBuckets}, {Name: mOtherBytes},
+		{Name: mTotalBytes}, {Name: mAllocsBytes}, {Name: mAllocsObjects},
+		{Name: mFreesObjects}, {Name: mLiveObjects}, {Name: mHeapGoal},
+		{Name: mGCCycles}, {Name: mGCPauses},
+	}
+	metrics.Read(samples)
+
+	v := make(map[string]uint64, len(samples))
+	var pauseTotalNs uint64
+	for _, s := range samples {
+		switch s.Value.Kind() {
+		case metrics.KindUint64:
+			v[s.Name] = s.Value.Uint64()
+		case metrics.KindFloat64Histogram:
+			if s.Name == mGCPauses {
+				pauseTotalNs = histogramTotalNs(s.Value.Float64Histogram())
+			}
+		default:
+			// KindBad means this Go build does not know the metric. Leave it
+			// at zero rather than guessing — a zeroed field is honest, a
+			// fabricated one is not.
+		}
+	}
+
+	heapAlloc := v[mHeapObjectsBytes]
+	heapInuse := heapAlloc + v[mHeapUnusedBytes]
+	heapIdle := v[mHeapFreeBytes] + v[mHeapReleased]
+
+	return RuntimeStats{
+		UptimeSeconds: int64(time.Since(startedAt).Seconds()),
+		Goroutines:    runtime.NumGoroutine(),
+		Alloc:         heapAlloc,
+		TotalAlloc:    v[mAllocsBytes],
+		Sys:           v[mTotalBytes],
+		Mallocs:       v[mAllocsObjects],
+		Frees:         v[mFreesObjects],
+		HeapAlloc:     heapAlloc,
+		HeapSys:       heapInuse + heapIdle,
+		HeapIdle:      heapIdle,
+		HeapInuse:     heapInuse,
+		HeapReleased:  v[mHeapReleased],
+		HeapObjects:   v[mLiveObjects],
+		StackInuse:    v[mHeapStacks],
+		StackSys:      v[mHeapStacks] + v[mOSStacks],
+		MSpanInuse:    v[mMSpanInuse],
+		MSpanSys:      v[mMSpanInuse] + v[mMSpanFree],
+		MCacheInuse:   v[mMCacheInuse],
+		MCacheSys:     v[mMCacheInuse] + v[mMCacheFree],
+		BuckHashSys:   v[mProfilingBuckets],
+		GCSys:         v[mMetadataOther],
+		OtherSys:      v[mOtherBytes],
+		NextGC:        v[mHeapGoal],
+		PauseTotalNs:  pauseTotalNs,
+		NumGC:         uint32(v[mGCCycles]),
+		// LastGC and LastPauseNs have no runtime/metrics equivalent; see the
+		// package comment above.
+	}
+}
+
+// histogramTotalNs approximates total time from a seconds histogram by
+// weighting each bucket's count by its midpoint. Buckets with an infinite
+// edge are counted at their finite edge, which under-counts the tail — an
+// approximation the caller is told about rather than a hidden fudge.
+func histogramTotalNs(h *metrics.Float64Histogram) uint64 {
+	if h == nil {
+		return 0
+	}
+	var total float64
+	for i, count := range h.Counts {
+		if count == 0 {
+			continue
+		}
+		lo, hi := h.Buckets[i], h.Buckets[i+1]
+		switch {
+		case math.IsInf(lo, -1) && math.IsInf(hi, 1):
+			continue
+		case math.IsInf(lo, -1):
+			total += float64(count) * hi
+		case math.IsInf(hi, 1):
+			total += float64(count) * lo
+		default:
+			total += float64(count) * (lo + hi) / 2
+		}
+	}
+	return uint64(total * float64(time.Second))
+}

--- a/pkg/health/metrics_test.go
+++ b/pkg/health/metrics_test.go
@@ -1,0 +1,56 @@
+package health
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSampleRuntimeMetricsReportsLiveNumbers is the guard against an upstream
+// metric rename: every field below is mapped from a runtime/metrics name, and
+// a renamed metric silently returns zero.
+func TestSampleRuntimeMetricsReportsLiveNumbers(t *testing.T) {
+	// Force a collection so the GC-derived fields cannot be zero by accident.
+	runtime.GC()
+
+	started := time.Now().Add(-90 * time.Second)
+	s := SampleRuntimeMetrics(started)
+
+	require.InDelta(t, 90, s.UptimeSeconds, 2)
+	require.Greater(t, s.Goroutines, 0)
+	require.Greater(t, s.HeapAlloc, uint64(0), "metric %q may have been renamed", mHeapObjectsBytes)
+	require.Greater(t, s.Sys, uint64(0), "metric %q may have been renamed", mTotalBytes)
+	require.Greater(t, s.TotalAlloc, uint64(0), "metric %q may have been renamed", mAllocsBytes)
+	require.Greater(t, s.HeapObjects, uint64(0), "metric %q may have been renamed", mLiveObjects)
+	require.Greater(t, s.NextGC, uint64(0), "metric %q may have been renamed", mHeapGoal)
+	require.Greater(t, s.NumGC, uint32(0), "metric %q may have been renamed", mGCCycles)
+	require.Greater(t, s.PauseTotalNs, uint64(0), "metric %q may have been renamed", mGCPauses)
+	require.GreaterOrEqual(t, s.Mallocs, s.Frees, "mallocs cannot trail frees")
+	require.GreaterOrEqual(t, s.HeapSys, s.HeapAlloc)
+}
+
+// TestSampleRuntimeMetricsAgreesWithReadMemStats pins the two samplers to the
+// same order of magnitude. They read the same counters at slightly different
+// instants, so this is a sanity band, not an equality check.
+func TestSampleRuntimeMetricsAgreesWithReadMemStats(t *testing.T) {
+	started := time.Now()
+	stw := Snapshot(started)
+	cheap := SampleRuntimeMetrics(started)
+
+	require.InEpsilon(t, float64(stw.Sys), float64(cheap.Sys), 0.25,
+		"total memory should agree closely between the two samplers")
+	require.InEpsilon(t, float64(stw.HeapObjects), float64(cheap.HeapObjects), 0.75,
+		"live object counts should be in the same ballpark")
+	require.Equal(t, stw.NumGC, cheap.NumGC, "GC cycle counts are exact in both")
+}
+
+// TestSampleRuntimeMetricsLeavesUnavailableFieldsZero documents the two fields
+// runtime/metrics cannot supply, so a future reader does not mistake them for
+// a bug.
+func TestSampleRuntimeMetricsLeavesUnavailableFieldsZero(t *testing.T) {
+	s := SampleRuntimeMetrics(time.Now())
+	require.Zero(t, s.LastGC, "no runtime/metrics equivalent for the last-GC timestamp")
+	require.Zero(t, s.Lookups, "deprecated in MemStats too")
+}

--- a/pkg/health/models.go
+++ b/pkg/health/models.go
@@ -1,0 +1,55 @@
+// Package health reports whether an osctrl deployment is working: the
+// database and Redis it depends on, the services that make it up, and the
+// background workers inside them.
+//
+// Two collection strategies, because osctrl-api and osctrl-tls are separate
+// processes in separate containers:
+//
+//   - Anything osctrl-api can reach itself (DB ping, Redis PING, its own Go
+//     runtime) is computed when the operator asks for it.
+//   - osctrl-tls upserts one heartbeat row that osctrl-api reads. The
+//     database is the only channel between the two, the same conclusion
+//     pkg/servicecommands reached for restarts.
+package health
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	// HeartbeatInterval is how often a service upserts its row. Fixed, not
+	// a setting: the staleness threshold is derived from it and a second
+	// knob would only let the two drift apart.
+	HeartbeatInterval = 60 * time.Second
+	// StaleAfter is when a heartbeat stops counting as live. Three missed
+	// writes: one or two are scheduling noise, three mean something broke.
+	StaleAfter = 3 * HeartbeatInterval
+)
+
+// ServiceStatus is the heartbeat one service writes for the others to read.
+// Upserted on Service, so the table holds one row per service forever and
+// needs no retention sweep.
+type ServiceStatus struct {
+	gorm.Model
+	// Service is "tls" or "api". v1 only ever writes "tls": osctrl-api
+	// reports live because it serves the request. The column accepts both
+	// so a future API-side writer needs no migration.
+	Service string `gorm:"uniqueIndex;size:16"`
+	// Version is the build version of the reporting process, so the API can
+	// spot version skew between services.
+	Version string `gorm:"size:64"`
+	// StartedAt is when the reporting process booted (uptime = now - this).
+	StartedAt time.Time
+	// ReportedAt is when this row was last written (liveness).
+	ReportedAt time.Time
+	// Goroutines is runtime.NumGoroutine() at write time — a plain load,
+	// free to sample, unlike ReadMemStats which stops the world.
+	Goroutines int
+	// Payload is the JSON worker snapshot. See WorkerPayload.
+	Payload string `gorm:"type:text"`
+}
+
+// TableName pins the table so a struct rename cannot silently orphan rows.
+func (ServiceStatus) TableName() string { return "service_status" }

--- a/pkg/health/runtime.go
+++ b/pkg/health/runtime.go
@@ -1,0 +1,91 @@
+package health
+
+import (
+	"runtime"
+	"time"
+)
+
+// RuntimeStats is the Go runtime detail shown per service. Field set mirrors
+// what an operator expects from runtime.MemStats.
+type RuntimeStats struct {
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	Goroutines    int    `json:"goroutines"`
+	Alloc         uint64 `json:"alloc"`
+	TotalAlloc    uint64 `json:"total_alloc"`
+	Sys           uint64 `json:"sys"`
+	Lookups       uint64 `json:"lookups"`
+	Mallocs       uint64 `json:"mallocs"`
+	Frees         uint64 `json:"frees"`
+	HeapAlloc     uint64 `json:"heap_alloc"`
+	HeapSys       uint64 `json:"heap_sys"`
+	HeapIdle      uint64 `json:"heap_idle"`
+	HeapInuse     uint64 `json:"heap_inuse"`
+	HeapReleased  uint64 `json:"heap_released"`
+	HeapObjects   uint64 `json:"heap_objects"`
+	StackInuse    uint64 `json:"stack_inuse"`
+	StackSys      uint64 `json:"stack_sys"`
+	MSpanInuse    uint64 `json:"mspan_inuse"`
+	MSpanSys      uint64 `json:"mspan_sys"`
+	MCacheInuse   uint64 `json:"mcache_inuse"`
+	MCacheSys     uint64 `json:"mcache_sys"`
+	BuckHashSys   uint64 `json:"buck_hash_sys"`
+	GCSys         uint64 `json:"gc_sys"`
+	OtherSys      uint64 `json:"other_sys"`
+	NextGC        uint64 `json:"next_gc"`
+	LastGC        int64  `json:"last_gc_unix_ms"`
+	PauseTotalNs  uint64 `json:"pause_total_ns"`
+	LastPauseNs   uint64 `json:"last_pause_ns"`
+	NumGC         uint32 `json:"num_gc"`
+}
+
+// Snapshot reads the current runtime state.
+//
+// runtime.ReadMemStats STOPS THE WORLD. The pause is short (tens of µs) and
+// harmless when an operator loads a page, which is the only thing that calls
+// this. Do not put it on a ticker inside osctrl-tls — the heartbeat carries
+// NumGoroutine and existing atomics instead, and runtime/metrics (no STW) is
+// the tool if periodic memory sampling is ever wanted.
+func Snapshot(startedAt time.Time) RuntimeStats {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	var lastPause uint64
+	if m.NumGC > 0 {
+		lastPause = m.PauseNs[(m.NumGC+255)%256]
+	}
+	var lastGC int64
+	if m.LastGC > 0 {
+		lastGC = int64(m.LastGC / uint64(time.Millisecond))
+	}
+
+	return RuntimeStats{
+		UptimeSeconds: int64(time.Since(startedAt).Seconds()),
+		Goroutines:    runtime.NumGoroutine(),
+		Alloc:         m.Alloc,
+		TotalAlloc:    m.TotalAlloc,
+		Sys:           m.Sys,
+		Lookups:       m.Lookups,
+		Mallocs:       m.Mallocs,
+		Frees:         m.Frees,
+		HeapAlloc:     m.HeapAlloc,
+		HeapSys:       m.HeapSys,
+		HeapIdle:      m.HeapIdle,
+		HeapInuse:     m.HeapInuse,
+		HeapReleased:  m.HeapReleased,
+		HeapObjects:   m.HeapObjects,
+		StackInuse:    m.StackInuse,
+		StackSys:      m.StackSys,
+		MSpanInuse:    m.MSpanInuse,
+		MSpanSys:      m.MSpanSys,
+		MCacheInuse:   m.MCacheInuse,
+		MCacheSys:     m.MCacheSys,
+		BuckHashSys:   m.BuckHashSys,
+		GCSys:         m.GCSys,
+		OtherSys:      m.OtherSys,
+		NextGC:        m.NextGC,
+		LastGC:        lastGC,
+		PauseTotalNs:  m.PauseTotalNs,
+		LastPauseNs:   lastPause,
+		NumGC:         m.NumGC,
+	}
+}

--- a/pkg/health/runtime_test.go
+++ b/pkg/health/runtime_test.go
@@ -1,0 +1,19 @@
+package health
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotReportsLiveRuntimeNumbers(t *testing.T) {
+	started := time.Now().Add(-90 * time.Second)
+	s := Snapshot(started)
+
+	require.InDelta(t, 90, s.UptimeSeconds, 2)
+	require.Greater(t, s.Goroutines, 0)
+	require.Greater(t, s.HeapAlloc, uint64(0))
+	require.Greater(t, s.Sys, uint64(0))
+	require.GreaterOrEqual(t, s.Mallocs, s.Frees, "mallocs cannot trail frees")
+}

--- a/pkg/health/version.go
+++ b/pkg/health/version.go
@@ -1,0 +1,86 @@
+package health
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/version"
+)
+
+// UpgradeInfo is the upgrade block on the health page.
+type UpgradeInfo struct {
+	Current   string    `json:"current"`
+	Suggested string    `json:"suggested,omitempty"`
+	Latest    string    `json:"latest,omitempty"`
+	UpToDate  bool      `json:"up_to_date"`
+	Checked   bool      `json:"checked"`
+	CheckedAt time.Time `json:"checked_at,omitempty"`
+	MoreInfo  string    `json:"more_information,omitempty"`
+	// API and TLS expose the per-service versions behind Skew so the page
+	// can name both sides of a mismatch.
+	API  string `json:"api_version,omitempty"`
+	TLS  string `json:"tls_version,omitempty"`
+	Skew bool   `json:"skew"`
+}
+
+// VersionCache holds the last upstream version check.
+//
+// version.RetrieveVersionData performs an external HTTP request, so it must
+// never run on the request path. Refresh is called at boot and on a 24h
+// ticker; Info only reads memory.
+type VersionCache struct {
+	mu        sync.RWMutex
+	current   string
+	data      version.VersionData
+	checkedAt time.Time
+	checked   bool
+}
+
+// NewVersionCache returns a cache for the running build version.
+func NewVersionCache(current string) *VersionCache {
+	return &VersionCache{current: current}
+}
+
+// Set stores version data without fetching. Used by Refresh and by tests.
+func (c *VersionCache) Set(data version.VersionData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = data
+	c.checkedAt = time.Now()
+	c.checked = true
+}
+
+// Refresh fetches upstream version data. Errors are returned, not stored: a
+// failed check leaves the previous answer in place rather than blanking the
+// page because stats.osctrl.net was briefly unreachable.
+func (c *VersionCache) Refresh(url string) error {
+	data, err := version.RetrieveVersionData(url)
+	if err != nil {
+		return err
+	}
+	c.Set(*data)
+	return nil
+}
+
+// Info renders the upgrade block. tlsVersion comes from the heartbeat row and
+// may be empty when osctrl-tls is not reporting.
+func (c *VersionCache) Info(tlsVersion string) UpgradeInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	info := UpgradeInfo{
+		Current: c.current,
+		Checked: c.checked,
+		API:     c.current,
+		TLS:     tlsVersion,
+		Skew:    tlsVersion != "" && tlsVersion != c.current,
+	}
+	if c.checked {
+		info.Suggested = c.data.SuggestedRelease
+		info.Latest = c.data.LatestRelease
+		info.MoreInfo = c.data.MoreInformation
+		info.CheckedAt = c.checkedAt
+		info.UpToDate = version.CheckSuggestedRelease(c.data.SuggestedRelease)
+	}
+	return info
+}

--- a/pkg/health/version_test.go
+++ b/pkg/health/version_test.go
@@ -1,0 +1,35 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeInfoBeforeAnyCheck(t *testing.T) {
+	c := NewVersionCache("0.5.8")
+	info := c.Info("0.5.8")
+	require.Equal(t, "0.5.8", info.Current)
+	require.Empty(t, info.Latest, "no check has run yet")
+	require.False(t, info.Checked)
+}
+
+func TestUpgradeInfoAfterCheck(t *testing.T) {
+	c := NewVersionCache("0.5.8")
+	c.Set(version.VersionData{LatestRelease: "0.5.9", SuggestedRelease: "0.5.8"})
+	info := c.Info("0.5.8")
+	require.True(t, info.Checked)
+	require.Equal(t, "0.5.9", info.Latest)
+	require.Equal(t, "0.5.8", info.Suggested)
+	require.False(t, info.Skew)
+}
+
+func TestUpgradeInfoReportsServiceSkew(t *testing.T) {
+	c := NewVersionCache("0.5.8")
+	c.Set(version.VersionData{LatestRelease: "0.5.9", SuggestedRelease: "0.5.8"})
+	info := c.Info("0.5.7")
+	require.True(t, info.Skew)
+	require.Equal(t, "0.5.7", info.TLS)
+	require.Equal(t, "0.5.8", info.API)
+}


### PR DESCRIPTION
## Health / System Status

Adds an admin page answering "is my deployment healthy?" — Database, Redis,
osctrl-api, osctrl-tls and the TLS workers, with Go runtime detail per service
and upgrade status. Behind `--health-enabled`, **off by default**.

### Why

The signals existed but were invisible. `pkg/backend.DBHealth` tracked database
degradation and only ever surfaced as a 204 on the unauthenticated `/health`
probe. Redis was checked once at boot. osctrl-tls ran the ingest path, the
alerts dispatcher, the batch writer and the activity writer entirely in its own
process — a wedged worker looked exactly like a healthy one. The upgrade check
already ran at boot and was thrown into a log line. Version skew between
osctrl-api and osctrl-tls was observable nowhere.

### Costs nothing when off

`--health-enabled` / `SERVICE_HEALTH_ENABLED`, default false, declared in
`initServiceFlags` so both services take it. With the flag unset: the manager is
never constructed, so **`AutoMigrate` never runs and `service_status` is never
created**; no route is registered; no heartbeat is written; no goroutine starts;
`features.health` is false and the SPA hides the section. Residual cost is one
bool in the flag struct. The final review traced all five of those through both
`main.go` files.

### How it collects

Nothing expensive on a timer, nothing cross-process on a request:

| Source | When |
|---|---|
| DB degraded flag + live ping, Redis PING, osctrl-api's own runtime | on request |
| osctrl-tls: uptime, goroutines, worker counters, runtime stats | heartbeat, every 60s |
| Upgrade check (external HTTP) | cached, refreshed every 24h |

`runtime.ReadMemStats` stops the world, so it runs only on the API request path.
osctrl-tls samples the same numbers through **`runtime/metrics`**, which reads
the same counters without a global pause. The heartbeat rides the existing 5s
`service_commands` poll loop, firing every 12th tick — **no new goroutine, no
new ticker**: ~1,440 writes/day against the 17,280 selects that loop already
issues, into a table that holds one upserted row per service forever.

### Endpoint and page

`GET /api/v1/health/status` — admin only, 503 when the flag is off, one response
carrying every component so the page's drill-downs expand rather than refetch.
Statuses are `operational | degraded | down | stale | unknown`; a missing
heartbeat is **unknown, never down** ("not reporting — enable `--health-enabled`
on osctrl-tls"), since a service that was never enabled is not a dead one.
Version skew between services surfaces as `degraded`, naming both sides.

The page (`/_app/health`, nav gated on `features.health`) mirrors the three
sections: component list with expandable details, upgrade status, and a runtime
card per reporting service. Each card is labelled **live** (osctrl-api, read
while serving) or **as of HH:MM:SS** (osctrl-tls, up to a heartbeat old) so
nobody debugs a memory spike against stale numbers.

### Two defects the whole-branch review caught

- **The endpoint could hang during the outage it exists to report.** Its DB and
  Redis checks had no deadline — `r.Context()` carries none — so a saturated
  pool blocked instead of returning `down`. Now bounded by a 3s budget threaded
  through all three checks, via new context-aware `Manager.GetContext` and
  `RedisManager.CheckContext` (existing callers unchanged).
- **`WorkersComponent` blamed osctrl-tls for database outages.** `Manager.Get`
  returns `ErrNotReporting` only for a missing row; any other DB error rendered
  as "osctrl-tls is not reporting", pointing operators at a healthy service. It
  now mirrors `ServiceComponent`'s branch and surfaces the real error.

### Known limitations (documented in ARCHITECTURE.md)

- Needs the flag on **both** services for a complete picture; api-only shows tls
  as not reporting.
- Multiple osctrl-tls replicas share one row (last writer wins). Liveness stays
  correct; per-replica detail is lost. Upgrade path is a `(service, instance_id)`
  key plus pruning.
- `LastGC` and `Lookups` have no `runtime/metrics` equivalent and stay zero for
  osctrl-tls; `PauseTotalNs` there is a histogram approximation. All documented
  at the sampler.
- Snapshot only — no history.

### Files

37 files, +1,976/−6. New: `pkg/health` (model/manager, two runtime samplers,
status derivation, version cache), `cmd/tls/health.go`, `cmd/api/handlers/health_status.go`,
`frontend/src/{api/health.ts,features/health/}`. Modified: both `main.go`s,
`pkg/config` (flag), `pkg/cache` + `pkg/alerts` (context/accessor additions),
SPA router/nav/features, README, ARCHITECTURE, sample configs, regenerated
`osctrl-api.yaml`.

### Verification

`go build ./...` clean; full `go test ./...` green; frontend 329 tests pass;
`tsc --noEmit` clean; `make openapi-check` exits 0. Every task was
spec-and-quality reviewed, plus a whole-branch review whose two findings are
fixed above.

**Not verified:** the runtime smoke test — nobody booted the services against a
fresh database to confirm the table is absent with the flag off, or watched a
heartbeat flip to `stale` after stopping osctrl-tls. Both properties were traced
statically and hold.