### PR TITLE
Add cross-device preferred language

### DIFF
--- a/cmd/api/handlers/users_profile.go
+++ b/cmd/api/handlers/users_profile.go
@@ -505,15 +505,16 @@ func (h *HandlersApi) MeHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	resp := types.UserMeResponse{
-		Username:    user.Username,
-		Email:       user.Email,
-		Fullname:    user.Fullname,
-		Admin:       user.Admin,
-		Service:     user.Service,
-		UUID:        user.UUID,
-		TokenExpire: user.TokenExpire,
-		LastAccess:  user.LastAccess,
-		Permissions: perms,
+		Username:          user.Username,
+		Email:             user.Email,
+		Fullname:          user.Fullname,
+		Admin:             user.Admin,
+		Service:           user.Service,
+		UUID:              user.UUID,
+		TokenExpire:       user.TokenExpire,
+		LastAccess:        user.LastAccess,
+		PreferredLanguage: user.PreferredLanguage,
+		Permissions:       perms,
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, resp)
 }
@@ -552,6 +553,7 @@ func (h *HandlersApi) MePatchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	body.Email = strings.TrimSpace(body.Email)
 	body.Fullname = strings.TrimSpace(body.Fullname)
+	body.PreferredLanguage = strings.TrimSpace(body.PreferredLanguage)
 
 	if body.Email != "" {
 		if err := h.Users.ChangeEmail(requester, body.Email); err != nil {
@@ -565,6 +567,16 @@ func (h *HandlersApi) MePatchHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if body.PreferredLanguage != "" {
+		if _, ok := types.SupportedLanguages[body.PreferredLanguage]; !ok {
+			apiErrorResponse(w, "unsupported language", http.StatusBadRequest, nil)
+			return
+		}
+		if err := h.Users.ChangePreferredLanguage(requester, body.PreferredLanguage); err != nil {
+			apiErrorResponse(w, "error updating preferred language", http.StatusInternalServerError, err)
+			return
+		}
+	}
 
 	user, err := h.Users.Get(requester)
 	if err != nil {
@@ -573,14 +585,15 @@ func (h *HandlersApi) MePatchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	h.AuditLog.UserAction(requester, "updated own profile", strings.Split(r.RemoteAddr, ":")[0])
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.UserMeResponse{
-		Username:    user.Username,
-		Email:       user.Email,
-		Fullname:    user.Fullname,
-		Admin:       user.Admin,
-		Service:     user.Service,
-		UUID:        user.UUID,
-		TokenExpire: user.TokenExpire,
-		LastAccess:  user.LastAccess,
+		Username:          user.Username,
+		Email:             user.Email,
+		Fullname:          user.Fullname,
+		Admin:             user.Admin,
+		Service:           user.Service,
+		UUID:              user.UUID,
+		TokenExpire:       user.TokenExpire,
+		LastAccess:        user.LastAccess,
+		PreferredLanguage: user.PreferredLanguage,
 	})
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -549,6 +549,9 @@ export interface UserMeResponse {
   uuid: string;
   token_expire: string;
   last_access: string;
+  // UI language the operator picked (server-side, cross-device).
+  // Empty means "no server preference" — the SPA uses its own detection.
+  preferred_language: string;
   // env UUID → EnvAccess for the CURRENT user. Drives the SideNav's
   // per-env gating. Envs the user has no rows in are omitted; treat
   // absence as "no access" (zero-value EnvAccess).

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -236,8 +236,12 @@ export function getMe(): Promise<UserMeResponse> {
   return apiFetch<UserMeResponse>('/api/v1/users/me');
 }
 
-/** PATCH /api/v1/users/me — update own email and/or fullname. */
-export function patchMe(body: { email?: string; fullname?: string }): Promise<UserMeResponse> {
+/** PATCH /api/v1/users/me — update own email, fullname, and/or UI language. */
+export function patchMe(body: {
+  email?: string;
+  fullname?: string;
+  preferred_language?: string;
+}): Promise<UserMeResponse> {
   return apiFetch<UserMeResponse>('/api/v1/users/me', {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/features/profile/ProfilePage.test.tsx
+++ b/frontend/src/features/profile/ProfilePage.test.tsx
@@ -60,6 +60,7 @@ function makeMe(): UserMeResponse {
     uuid: 'aaaa',
     token_expire: new Date(Date.now() + 86_400_000).toISOString(),
     last_access: new Date(Date.now() - 60_000).toISOString(),
+    preferred_language: '',
     permissions: {},
   };
 }

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -94,8 +94,13 @@ async function loadCatalog(language: SupportedLanguage): Promise<void> {
  * Switch the active language, loading its catalog chunk if needed.
  * Resolves only after the UI language has actually flipped, so callers
  * can treat failures (network) as "language unchanged".
+ *
+ * `mirror` (default true) additionally persists the choice server-side
+ * via PATCH /users/me so it follows the operator across devices.
+ * Pass false for boot-time reconciliation, where applying the server
+ * value must not echo back a redundant write.
  */
-export async function setLanguage(language: SupportedLanguage): Promise<void> {
+export async function setLanguage(language: SupportedLanguage, mirror = true): Promise<void> {
   if (!isSupportedLanguage(language)) return;
   if (i18next.language !== language) await loadCatalog(language);
   await i18next.changeLanguage(language);
@@ -104,6 +109,61 @@ export async function setLanguage(language: SupportedLanguage): Promise<void> {
     window.localStorage?.setItem(LANGUAGE_STORAGE_KEY, language);
   } catch {
     /* localStorage blocked — session-only preference */
+  }
+  if (mirror) void mirrorLanguageToServer(language);
+}
+
+/** Local cache of the last value we pushed to / saw from the server. */
+let mirroredLanguage: string | null = null;
+
+async function mirrorLanguageToServer(language: SupportedLanguage): Promise<void> {
+  if (mirroredLanguage === language) return;
+  mirroredLanguage = language;
+  try {
+    const { patchMe } = await import('$/api/users');
+    await patchMe({ preferred_language: language });
+  } catch {
+    // Offline, 401, or API unreachable — the local preference still
+    // applies for this session; retried on the next explicit switch.
+    mirroredLanguage = null;
+  }
+}
+
+/**
+ * Reconcile the local language preference with the operator's
+ * server-side PreferredLanguage (from GET /users/me).
+ *
+ * localStorage is the boot source (it is available synchronously before
+ * first paint); this runs once the profile query resolves and makes the
+ * server the tie-breaker: the server value reflects the most recent
+ * explicit choice on ANY device, because every switch mirrors to it.
+ *
+ * The applied value is recorded in `mirroredLanguage` so the switch is
+ * not echoed back as a redundant PATCH.
+ */
+export async function reconcileLanguageFromServer(
+  serverLanguage: string,
+): Promise<void> {
+  if (!serverLanguage) return;
+  let language: SupportedLanguage | undefined;
+  try {
+    const stored = window.localStorage?.getItem(LANGUAGE_STORAGE_KEY);
+    if (stored === serverLanguage) return;
+  } catch {
+    /* localStorage blocked — fall through and apply the server value */
+  }
+  language = matchLanguage(serverLanguage);
+  if (!language) return;
+  mirroredLanguage = language;
+  try {
+    window.localStorage?.setItem(LANGUAGE_STORAGE_KEY, language);
+  } catch {
+    /* localStorage blocked — session-only preference */
+  }
+  if (i18next.language !== language) {
+    await loadCatalog(language);
+    await i18next.changeLanguage(language);
+    applyLanguageSideEffects(language);
   }
 }
 

--- a/frontend/src/i18n/sync.test.ts
+++ b/frontend/src/i18n/sync.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  i18n,
+  LANGUAGE_STORAGE_KEY,
+  reconcileLanguageFromServer,
+  setLanguage,
+  setLanguageEphemeral,
+} from './i18n';
+import { useLocalStorageStub } from '$/lib/test-storage';
+
+// Mirror writes go through the API client; stub the module so no
+// network (or CSRF dance) happens in tests. vi.mock is hoisted.
+vi.mock('$/api/users', () => ({
+  patchMe: vi.fn().mockResolvedValue({}),
+}));
+
+describe('cross-device language sync', () => {
+  useLocalStorageStub();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    await setLanguageEphemeral('en');
+  });
+
+  it('applies the server preference when the local value differs', async () => {
+    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+    await reconcileLanguageFromServer('fr');
+    expect(i18n.language).toBe('fr');
+    expect(window.localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('fr');
+    expect(document.documentElement.getAttribute('lang')).toBe('fr');
+  });
+
+  it('is a no-op when both sides agree', async () => {
+    await setLanguageEphemeral('de');
+    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, 'de');
+    await reconcileLanguageFromServer('de');
+    expect(i18n.language).toBe('de');
+  });
+
+  it('ignores unsupported server values', async () => {
+    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+    await reconcileLanguageFromServer('xx');
+    expect(i18n.language).toBe('en');
+  });
+
+  it('ignores an empty server preference', async () => {
+    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, 'es');
+    await setLanguageEphemeral('es');
+    await reconcileLanguageFromServer('');
+    expect(i18n.language).toBe('es');
+  });
+
+  it('mirrors explicit switches to the server via patchMe', async () => {
+    const { patchMe } = await import('$/api/users');
+    await setLanguage('it');
+    // The mirror is fire-and-forget; let the microtask queue drain.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(patchMe).toHaveBeenCalledWith({ preferred_language: 'it' });
+  });
+
+  it('does not re-mirror the same language twice', async () => {
+    const { patchMe } = await import('$/api/users');
+    await setLanguage('ru');
+    await setLanguage('ru');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(patchMe).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a failed mirror without changing the active language', async () => {
+    const { patchMe } = await import('$/api/users');
+    (patchMe as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('offline'));
+    await setLanguage('ja');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(i18n.language).toBe('ja');
+    expect(window.localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('ja');
+  });
+});

--- a/frontend/src/routes/_app/route.tsx
+++ b/frontend/src/routes/_app/route.tsx
@@ -2,12 +2,14 @@
  * /_app layout route — requires in-memory CSRF token.
  * If not authenticated, redirects to /login.
  */
+import { useEffect } from 'react';
 import { createRoute, redirect, Outlet } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { rootRoute } from '../__root';
 import { AppShell } from '$/components/chrome/AppShell';
 import { isAuthenticated } from '$/api/client';
 import { getMe } from '$/api/users';
+import { reconcileLanguageFromServer } from '$/i18n/i18n';
 
 export const appRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -31,6 +33,18 @@ export const appRoute = createRoute({
       staleTime: 5 * 60_000,
       retry: 1,
     });
+
+    // Cross-device language: once the profile arrives, make the
+    // server-side PreferredLanguage the tie-breaker against the
+    // locally cached one (the server sees the latest switch from
+    // ANY device because switches mirror to it). No-op when both
+    // agree; never blocks first paint.
+    useEffect(() => {
+      if (me?.preferred_language) {
+        void reconcileLanguageFromServer(me.preferred_language);
+      }
+    }, [me?.preferred_language]);
+
     return (
       <AppShell username={me?.username}>
         <Outlet />

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -11294,6 +11294,13 @@ components:
           type: string
         fullname:
           type: string
+        preferred_language:
+          description: |-
+            PreferredLanguage is the UI language tag the operator picked.
+            Validated against the supported-language list; an empty value
+            leaves the stored preference unchanged (same semantics as the
+            other patch fields).
+          type: string
       type: object
     types.UserMeResponse:
       properties:
@@ -11309,6 +11316,12 @@ components:
           additionalProperties:
             $ref: "#/components/schemas/types.EnvAccessView"
           type: object
+        preferred_language:
+          description: |-
+            PreferredLanguage mirrors AdminUser.PreferredLanguage — the
+            UI language the operator picked. Empty means "no server-side
+            preference"; the SPA falls back to its own detection.
+          type: string
         service:
           type: boolean
         token_expire:

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -399,6 +399,18 @@ type TokenResponse struct {
 // per-env check at the server layer, so the SPA hides nothing for
 // them. Envs with no permission rows are omitted from the map; the
 // SPA treats absence as "no access" (zero-value EnvAccess).
+
+// SupportedLanguages is the allowlist for preferred_language values —
+// it MUST mirror the frontend registry in frontend/src/i18n/locales.ts.
+// Adding a UI language requires updating both sides; the API rejects
+// anything else so the column cannot be used to store arbitrary data.
+var SupportedLanguages = map[string]struct{}{
+	"en": {}, "es": {}, "fr": {}, "de": {}, "pt": {},
+	"ca": {}, "it": {}, "nl": {}, "ja": {}, "ko": {},
+	"zh": {}, "pl": {}, "ru": {},
+}
+
+// UserMeResponse is the GET/PATCH /api/v1/users/me payload.
 type UserMeResponse struct {
 	Username    string                   `json:"username"`
 	Email       string                   `json:"email"`
@@ -408,7 +420,11 @@ type UserMeResponse struct {
 	UUID        string                   `json:"uuid"`
 	TokenExpire time.Time                `json:"token_expire"`
 	LastAccess  time.Time                `json:"last_access"`
-	Permissions map[string]EnvAccessView `json:"permissions"`
+	// PreferredLanguage mirrors AdminUser.PreferredLanguage — the
+	// UI language the operator picked. Empty means "no server-side
+	// preference"; the SPA falls back to its own detection.
+	PreferredLanguage string                   `json:"preferred_language"`
+	Permissions       map[string]EnvAccessView `json:"permissions"`
 }
 
 // UserMePatchRequest is the body for PATCH /api/v1/users/me — operators can
@@ -416,6 +432,11 @@ type UserMeResponse struct {
 type UserMePatchRequest struct {
 	Email    string `json:"email"`
 	Fullname string `json:"fullname"`
+	// PreferredLanguage is the UI language tag the operator picked.
+	// Validated against the supported-language list; an empty value
+	// leaves the stored preference unchanged (same semantics as the
+	// other patch fields).
+	PreferredLanguage string `json:"preferred_language"`
 }
 
 // PasswordChangeRequest is the body for POST /api/v1/users/me/password.

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -51,6 +51,14 @@ type AdminUser struct {
 	// (an OIDC user with a password set later can log in either
 	// way, by design).
 	AuthSource string
+	// PreferredLanguage is the UI language the operator picked in
+	// the SPA (BCP-47 base tag, e.g. "en", "es", "pt"). It is
+	// cross-device state: the frontend reconciles its local
+	// preference against this value at login and mirrors every
+	// switch back via PATCH /users/me. Validation happens in the
+	// API handler against the frontend's supported-language list;
+	// anything stored here is advisory, never load-bearing.
+	PreferredLanguage string
 }
 
 // TokenClaims to hold user claims when using JWT
@@ -546,6 +554,23 @@ func (m *UserManager) ChangeFullname(username, fullname string) error {
 	}
 	if fullname != user.Fullname {
 		if err := m.DB.Model(&user).Update("fullname", fullname).Error; err != nil {
+			return fmt.Errorf("update %w", err)
+		}
+	}
+	return nil
+}
+
+// ChangePreferredLanguage records the operator's preferred UI language.
+// An empty value clears the preference (the SPA falls back to browser
+// detection). Validation of the tag against the supported-language list
+// belongs to the API layer; the manager accepts what it is given.
+func (m *UserManager) ChangePreferredLanguage(username, language string) error {
+	user, err := m.Get(username)
+	if err != nil {
+		return fmt.Errorf("error getting user %w", err)
+	}
+	if language != user.PreferredLanguage {
+		if err := m.DB.Model(&user).Update("preferred_language", language).Error; err != nil {
 			return fmt.Errorf("update %w", err)
 		}
 	}

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -166,8 +166,8 @@ func TestCreateUser(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(
-		regexp.QuoteMeta(`INSERT INTO "admin_users" ("created_at","updated_at","deleted_at","username","email","fullname","pass_hash","api_token","token_expire","admin","service","uuid","csrf_token","last_ip_address","last_user_agent","last_access","last_token_use","environment_id","auth_source") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19) RETURNING "id"`)).
-		WithArgs(tt, tt, nil, user.Username, user.Email, user.Fullname, user.PassHash, user.APIToken, tt, user.Admin, user.Service, user.UUID, user.CSRFToken, user.LastIPAddress, user.LastUserAgent, tt, tt, user.EnvironmentID, user.AuthSource).
+		regexp.QuoteMeta(`INSERT INTO "admin_users" ("created_at","updated_at","deleted_at","username","email","fullname","pass_hash","api_token","token_expire","admin","service","uuid","csrf_token","last_ip_address","last_user_agent","last_access","last_token_use","environment_id","auth_source","preferred_language") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20) RETURNING "id"`)).
+		WithArgs(tt, tt, nil, user.Username, user.Email, user.Fullname, user.PassHash, user.APIToken, tt, user.Admin, user.Service, user.UUID, user.CSRFToken, user.LastIPAddress, user.LastUserAgent, tt, tt, user.EnvironmentID, user.AuthSource, user.PreferredLanguage).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(456))
 	mock.ExpectCommit()
 	err := manager.Create(user)
@@ -351,6 +351,45 @@ func TestUserChangeFullname(t *testing.T) {
 	mock.ExpectCommit()
 
 	err := manager.ChangeFullname("testUser", "Test User")
+
+	assert.NoError(t, err)
+}
+
+func TestUserChangePreferredLanguage(t *testing.T) {
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "preferred_language"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).
+		WithArgs("es", sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.ChangePreferredLanguage("testUser", "es")
+
+	assert.NoError(t, err)
+}
+
+func TestUserChangePreferredLanguageClear(t *testing.T) {
+	// An empty value clears the stored preference.
+	manager, mock := setupTestManager(t)
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "admin_users" WHERE username = $1 AND "admin_users"."deleted_at" IS NULL ORDER BY "admin_users"."id" LIMIT $2`)).
+		WithArgs("testUser", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		regexp.QuoteMeta(`UPDATE "admin_users" SET "preferred_language"=$1,"updated_at"=$2 WHERE "admin_users"."deleted_at" IS NULL AND "id" = $3`)).
+		WithArgs("", sqlmock.AnyArg(), 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := manager.ChangePreferredLanguage("testUser", "")
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Add cross-device preferred language (backend column + SPA sync)

### Problem
The language preference was localStorage-only: switching languages on
one device did not follow the operator to another device or browser.

### Change
**Backend** (additive; startup AutoMigrate adds the column):
- `AdminUser.PreferredLanguage` — the operator's UI language tag
  (BCP-47 base, e.g. "es"). Documented as advisory state: never
  load-bearing for authentication or authorization.
- `UserManager.ChangePreferredLanguage`, following the existing
  ChangeEmail/ChangeFullname pattern.
- `types.SupportedLanguages` allowlist shared by the PATCH handler —
  mirrors the frontend registry; unsupported tags are rejected with
  400 so the column cannot store arbitrary data.
- `GET/PATCH /api/v1/users/me` extended with `preferred_language`
  (empty value = unchanged, same semantics as the other patch fields).
  The existing "updated own profile" audit entry covers the write.
- OpenAPI regenerated (`make openapi`); `make openapi-check` passes.

**Frontend sync protocol**:
- Boot source stays localStorage — synchronous, no flash of wrong
  language, first paint never blocked on the network.
- Reconcile: once the shared `users-me` query resolves, the `_app`
  layout applies the server value when it disagrees with the local
  one. The server is the tie-breaker because every explicit switch
  mirrors to it — it always reflects the latest choice on any device.
  No-op when both agree; unsupported or empty server values ignored.
- Mirror: `setLanguage` fire-and-forgets `PATCH /users/me` after each
  switch, deduplicated, and failures (offline/401) are tolerated — the
  session-local preference still applies.

### Security/operational impact
- Auth-area change reviewed against the security lens: the column is
  write-only via the authenticated self-profile PATCH, validated
  against a fixed allowlist, never consulted by any auth decision.
- Additive and reversible: existing deployments pick up the column via
  AutoMigrate; removing it breaks nothing.

### Validation
- Go: full `go test ./...` passes — new ChangePreferredLanguage tests
  (set + clear); TestCreateUser sqlmock fixture updated for the new
  column.
- Frontend: typecheck clean, 369/369 tests — 7 new sync tests covering
  reconcile apply/no-op/unsupported/empty, mirror call, dedup, and
  offline survival.
- Production build verified.