### PR TITLE
Inactive nodes configurable per environment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,6 +189,34 @@ Patterns in the current implementation:
 - Sensitive or connection-bearing sections are read-only through the service-config API. Log sinks and federated auth providers have dedicated tables and APIs.
 - `osctrl-tls` reads its settings map through `RedisSettingsCache`; the normal cache TTL is five minutes unless a TLS-scoped `refresh_settings` row is present. The API reads scalar settings directly from the database.
 
+Node inactivity uses `api/inactive_hours`: an environment override, then the
+global row (`EnvironmentID = 0`), then 72 hours. Values are positive whole hours,
+bounded at 2,562,047 to avoid overflowing Go durations. Missing or invalid legacy
+rows inherit; new invalid values are rejected. Existing installations keep their
+global value without a migration or per-environment backfill.
+
+Environment Settings exposes an override and a "Use global default" control.
+`GET /api/v1/environments/inactive-hours/{env}` returns `override_hours` (nullable),
+effective `inactive_hours`, and `source` (`environment`, `global`, or `default`).
+Environment users can read; environment admins can `PUT {"inactive_hours": 2}`
+or `DELETE` to restore inheritance. Global settings remain global-admin-only.
+Override writes serialize on the environment row; deleting an environment also
+removes its inactivity override.
+
+Node filters, health, dashboard counts, CLI, active query/carve selectors, and TLS
+inactivity alerts use the node's environment threshold. Per-environment stats
+include their effective `inactive_hours`; the top-level field is retained as the
+global default, not a universal fleet cutoff. A node is inactive at or before
+`now - inactive_hours`, including never-seen nodes.
+
+Inactivity thresholds are read directly from SQL by API and TLS (not the TLS
+settings cache), so no restart is needed. Browser views refresh on their normal
+polling interval and invalidate relevant queries after saves. Alert sweeps use
+the new threshold on their next pass: shortening it may emit inactive alerts;
+lengthening it may emit recovery alerts even without a new check-in. Existing
+alert transition deduplication remains in effect. Update all service/client
+consumers before configuring overrides during a rolling deployment.
+
 ## Logs / Activity Data
 
 There are three different operational data streams:
@@ -370,7 +398,7 @@ Redis-only state such as activity rollups, query-dispatch hints, and alert coold
 - The API and TLS services share tables and packages directly. API config restart is signaled in-process; restart/reload/persist requests targeting TLS use the database-backed `service_commands` queue rather than a service-to-service API.
 - Database-backed auth-provider activation is incomplete. Provider discovery advertises ID-scoped login URLs, but the API registers only the legacy YAML-gated OIDC/SAML public routes. In addition, `POST /api/v1/auth-providers/apply` targets `osctrl-tls` with `reload-auth-providers`; the TLS watcher does not handle that action and the API has no command consumer. Use YAML/flag providers for working federated login until the ID-scoped routes and API-side reload path are completed.
 - Authentication is centralized in route wrappers, but environment authorization remains a handler-by-handler `CheckPermissions` responsibility. There is no declarative policy layer to prevent permission drift between related endpoints.
-- Scalar-setting changes do not explicitly invalidate `osctrl-tls`'s Redis settings entry, so TLS can observe them only after its cache TTL. Environment mutations do invalidate the shared Redis environment cache.
+- Scalar-setting changes do not explicitly invalidate `osctrl-tls`'s Redis settings entry, so cached TLS settings change after its cache TTL. Inactivity thresholds bypass this cache. Environment mutations do invalidate the shared Redis environment cache.
 - Retention is feature-specific: activity rollups expire in Redis and alert history is pruned daily when alerting is enabled, but osquery log rows, distributed-query/carve records, and console/file-explorer rows have no uniform background retention policy. Query expiration changes lifecycle state rather than deleting rows.
 - Relationships mostly use indexed numeric IDs, UUIDs, or names without database foreign-key constraints. External routes also mix environment names/UUIDs, node UUIDs/names, and numeric configuration IDs, which matters when integrating or troubleshooting.
 - SAML assertion replay protection uses a per-process TTL cache. In a multi-replica API deployment, the same assertion can be presented once to each replica within its validity window unless a shared replay layer is added.

--- a/cmd/api/handlers/carves.go
+++ b/cmd/api/handlers/carves.go
@@ -405,18 +405,18 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data := handlers.ProcessingQuery{
-		Envs:          c.Environments,
-		Platforms:     c.Platforms,
-		UUIDs:         c.UUIDs,
-		Hosts:         c.Hosts,
-		Tags:          c.Tags,
-		EnvID:         env.ID,
-		InactiveHours: h.Settings.InactiveHours(settings.NoEnvironmentID),
+		Envs:      c.Environments,
+		Platforms: c.Platforms,
+		UUIDs:     c.UUIDs,
+		Hosts:     c.Hosts,
+		Tags:      c.Tags,
+		EnvID:     env.ID,
 	}
 	manager := handlers.Managers{
-		Nodes: h.Nodes,
-		Envs:  h.Envs,
-		Tags:  h.Tags,
+		Settings: h.Settings,
+		Nodes:    h.Nodes,
+		Envs:     h.Envs,
+		Tags:     h.Tags,
 	}
 	targetNodesID, err := handlers.CreateQueryCarve(data, manager, newQuery)
 	if err != nil {

--- a/cmd/api/handlers/environments_inactivity.go
+++ b/cmd/api/handlers/environments_inactivity.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/jmpsec/osctrl/pkg/utils"
+	"gorm.io/gorm"
+)
+
+type InactiveHoursRequest struct {
+	InactiveHours *int64 `json:"inactive_hours" binding:"required" minimum:"1" maximum:"2562047"`
+}
+
+// EnvironmentInactiveHoursHandler returns the effective node inactivity policy.
+// @Summary Get environment inactivity threshold
+// @Tags environments
+// @Produce json
+// @Param env path string true "Environment name or UUID"
+// @Success 200 {object} settings.InactivityPolicy
+// @Failure 401 {object} types.ApiErrorResponse
+// @Failure 403 {object} types.ApiErrorResponse
+// @Failure 404 {object} types.ApiErrorResponse
+// @Failure 500 {object} types.ApiErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/environments/inactive-hours/{env} [get]
+func (h *HandlersApi) EnvironmentInactiveHoursHandler(w http.ResponseWriter, r *http.Request) {
+	env, _, ok := h.inactivityEnvironment(w, r, users.UserLevel)
+	if !ok {
+		return
+	}
+	policy, err := h.Settings.InactivityPolicy(env.ID)
+	if err != nil {
+		apiErrorResponse(w, "error reading inactivity threshold", http.StatusInternalServerError, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, policy)
+}
+
+// EnvironmentInactiveHoursSetHandler saves an environment override.
+// @Summary Set environment inactivity threshold
+// @Tags environments
+// @Accept json
+// @Produce json
+// @Param env path string true "Environment name or UUID"
+// @Param request body InactiveHoursRequest true "Positive whole hours (1 to 2562047)"
+// @Success 200 {object} settings.InactivityPolicy
+// @Failure 400 {object} types.ApiErrorResponse
+// @Failure 401 {object} types.ApiErrorResponse
+// @Failure 403 {object} types.ApiErrorResponse
+// @Failure 404 {object} types.ApiErrorResponse
+// @Failure 500 {object} types.ApiErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/environments/inactive-hours/{env} [put]
+func (h *HandlersApi) EnvironmentInactiveHoursSetHandler(w http.ResponseWriter, r *http.Request) {
+	h.changeEnvironmentInactiveHours(w, r)
+}
+
+// EnvironmentInactiveHoursResetHandler restores global inheritance.
+// @Summary Reset environment inactivity threshold
+// @Tags environments
+// @Produce json
+// @Param env path string true "Environment name or UUID"
+// @Success 200 {object} settings.InactivityPolicy
+// @Failure 401 {object} types.ApiErrorResponse
+// @Failure 403 {object} types.ApiErrorResponse
+// @Failure 404 {object} types.ApiErrorResponse
+// @Failure 500 {object} types.ApiErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/environments/inactive-hours/{env} [delete]
+func (h *HandlersApi) EnvironmentInactiveHoursResetHandler(w http.ResponseWriter, r *http.Request) {
+	h.changeEnvironmentInactiveHours(w, r)
+}
+
+func (h *HandlersApi) inactivityEnvironment(w http.ResponseWriter, r *http.Request, level users.AccessLevel) (environments.TLSEnvironment, ContextValue, bool) {
+	ctx, ok := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	if !ok {
+		apiErrorResponse(w, "missing auth context", http.StatusUnauthorized, nil)
+		return environments.TLSEnvironment{}, nil, false
+	}
+	env, err := h.Envs.Get(r.PathValue("env"))
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			status = http.StatusNotFound
+		}
+		apiErrorResponse(w, "error getting environment", status, err)
+		return env, ctx, false
+	}
+	if !h.Users.CheckPermissions(ctx[ctxUser], level, env.UUID) {
+		h.denyEnv(w, r, ctx, env.ID, "permission check failed")
+		return env, ctx, false
+	}
+	return env, ctx, true
+}
+
+func (h *HandlersApi) changeEnvironmentInactiveHours(w http.ResponseWriter, r *http.Request) {
+	env, ctx, ok := h.inactivityEnvironment(w, r, users.AdminLevel)
+	if !ok {
+		return
+	}
+	var body InactiveHoursRequest
+	if r.Method == http.MethodPut {
+		decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&body); err != nil {
+			apiErrorResponse(w, "invalid inactivity threshold", http.StatusBadRequest, err)
+			return
+		}
+		if err := decoder.Decode(new(any)); err != io.EOF || body.InactiveHours == nil {
+			apiErrorResponse(w, "provide one inactive_hours integer", http.StatusBadRequest, err)
+			return
+		}
+		if err := settings.ValidateInactiveHours(*body.InactiveHours); err != nil {
+			apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
+			return
+		}
+	}
+	before, after, err := h.Envs.SetInactiveHours(env.ID, body.InactiveHours)
+	if err != nil {
+		apiErrorResponse(w, "error updating inactivity threshold", http.StatusInternalServerError, err)
+		return
+	}
+	h.AuditLog.EnvAction(ctx[ctxUser], fmt.Sprintf("inactive_hours: %d (%s) -> %d (%s)", before.InactiveHours, before.Source, after.InactiveHours, after.Source), utils.GetIP(r), env.ID)
+	w.Header().Set("Cache-Control", "no-store")
+	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, after)
+}

--- a/cmd/api/handlers/environments_inactivity_test.go
+++ b/cmd/api/handlers/environments_inactivity_test.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentInactiveHoursAPI(t *testing.T) {
+	db, h, env, _ := setupConsoleHandlers(t)
+	var err error
+	h.AuditLog, err = auditlog.CreateAuditLogManager(db, "api", true)
+	require.NoError(t, err)
+	require.NoError(t, h.Settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 168, 0))
+	require.NoError(t, h.Users.CreatePermission(users.UserPermission{Username: "bob", AccessType: int(users.UserLevel), AccessValue: true, Environment: env.UUID, EnvironmentID: env.ID}))
+	other := environments.TLSEnvironment{Name: "other", UUID: "other-uuid"}
+	require.NoError(t, db.Create(&other).Error)
+
+	run := func(method, identifier, username, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := consoleRequest(method, "/api/v1/environments/inactive-hours/"+identifier, []byte(body), username)
+		req.SetPathValue("env", identifier)
+		rr := httptest.NewRecorder()
+		switch method {
+		case http.MethodGet:
+			h.EnvironmentInactiveHoursHandler(rr, req)
+		case http.MethodPut:
+			h.EnvironmentInactiveHoursSetHandler(rr, req)
+		case http.MethodDelete:
+			h.EnvironmentInactiveHoursResetHandler(rr, req)
+		}
+		return rr
+	}
+	check := func(rr *httptest.ResponseRecorder, hours int64, source string) {
+		t.Helper()
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+		var policy settings.InactivityPolicy
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &policy))
+		require.Equal(t, hours, policy.InactiveHours)
+		require.Equal(t, source, policy.Source)
+		if source == "environment" {
+			require.NotNil(t, policy.OverrideHours)
+			require.Equal(t, hours, *policy.OverrideHours)
+		} else {
+			require.Nil(t, policy.OverrideHours)
+		}
+	}
+
+	check(run(http.MethodGet, env.Name, "bob", ""), 168, "global")
+	check(run(http.MethodPut, env.UUID, "alice", `{"inactive_hours":2}`), 2, "environment")
+	check(run(http.MethodGet, env.Name, "bob", ""), 2, "environment")
+	require.Equal(t, int64(168), h.Settings.InactiveHours(other.ID))
+
+	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
+		require.Equal(t, http.StatusForbidden, run(method, other.Name, "alice", `{"inactive_hours":2}`).Code)
+		require.Equal(t, http.StatusNotFound, run(method, "missing", "alice", `{"inactive_hours":2}`).Code)
+	}
+	for _, method := range []string{http.MethodPut, http.MethodDelete} {
+		require.Equal(t, http.StatusForbidden, run(method, env.Name, "bob", `{"inactive_hours":2}`).Code)
+	}
+	for _, body := range []string{
+		`{}`, `null`, `{"inactive_hours":null}`, `{"inactive_hours":0}`, `{"inactive_hours":-1}`,
+		`{"inactive_hours":2.5}`, `{"inactive_hours":"2"}`, `{"inactive_hours":2562048}`,
+		`{"inactive_hours":2,"extra":true}`, `{"inactive_hours":2} {}`, strings.Repeat(" ", 1025),
+	} {
+		rr := run(http.MethodPut, env.Name, "alice", body)
+		require.Equal(t, http.StatusBadRequest, rr.Code, body+": "+rr.Body.String())
+	}
+	check(run(http.MethodGet, env.Name, "alice", ""), 2, "environment")
+	check(run(http.MethodDelete, env.Name, "alice", ""), 168, "global")
+	check(run(http.MethodDelete, env.Name, "alice", ""), 168, "global")
+	var logs []auditlog.AuditLog
+	require.NoError(t, db.Where("environment_id = ? AND log_type = ?", env.ID, auditlog.LogTypeEnvironment).Find(&logs).Error)
+	encoded, err := json.Marshal(logs)
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), "168 (global) -")
+	require.Contains(t, string(encoded), "2 (environment)")
+}
+
+func TestGlobalInactiveHoursAPIValidation(t *testing.T) {
+	db, h, _, _ := setupConsoleHandlers(t)
+	h.DebugHTTPConfig = &config.YAMLConfigurationDebug{}
+	var err error
+	h.AuditLog, err = auditlog.CreateAuditLogManager(db, "api", false)
+	require.NoError(t, err)
+	require.NoError(t, h.Settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 72, 0))
+	patch := func(username, body string) *httptest.ResponseRecorder {
+		req := consoleRequest(http.MethodPatch, "/api/v1/settings/api/inactive_hours", []byte(body), username)
+		req.SetPathValue("service", config.ServiceAPI)
+		req.SetPathValue("name", settings.InactiveHours)
+		rr := httptest.NewRecorder()
+		h.SettingPatchHandler(rr, req)
+		return rr
+	}
+	require.Equal(t, http.StatusForbidden, patch("alice", `{"integer":2}`).Code)
+	require.NoError(t, h.Users.ChangeAdmin("alice", true))
+	for _, body := range []string{`{"integer":0}`, `{"integer":-1}`, `{"integer":2.5}`, `{"integer":2562048}`, `{"integer":null}`} {
+		rr := patch("alice", body)
+		require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+	rr := patch("alice", `{"integer":24}`)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	require.Equal(t, int64(24), h.Settings.InactiveHours(0))
+}

--- a/cmd/api/handlers/nodes.go
+++ b/cmd/api/handlers/nodes.go
@@ -128,7 +128,7 @@ func (h *HandlersApi) ActiveNodesHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// Get nodes — scoped to this environment (resolves audit finding U-DB-2)
-	hours := h.Settings.InactiveHours(settings.NoEnvironmentID)
+	hours := h.Settings.InactiveHours(env.ID)
 	nodeList, err := h.Nodes.GetByEnv(env.Name, nodes.ActiveNodes, hours)
 	if err != nil {
 		apiErrorResponse(w, "error getting nodes", http.StatusInternalServerError, err)
@@ -185,7 +185,7 @@ func (h *HandlersApi) InactiveNodesHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Get nodes — scoped to this environment (resolves audit finding U-DB-2)
-	hours := h.Settings.InactiveHours(settings.NoEnvironmentID)
+	hours := h.Settings.InactiveHours(env.ID)
 	nodeList, err := h.Nodes.GetByEnv(env.Name, nodes.InactiveNodes, hours)
 	if err != nil {
 		apiErrorResponse(w, "error getting nodes", http.StatusInternalServerError, err)
@@ -477,7 +477,7 @@ func (h *HandlersApi) projectNode(node nodes.OsqueryNode) types.NodeView {
 			nodeTags = nil
 		}
 	}
-	health := types.CalculateNodeHealth(node, h.inactiveHours(), h.PostureEnabled, postureSummary)
+	health := types.CalculateNodeHealth(node, h.inactiveHours(node.EnvironmentID), h.PostureEnabled, postureSummary)
 	return types.ProjectNodeWithCountryUptimePostureTagsAndHealth(node, countryCode, uptime, postureSummary, nodeTags, health)
 }
 
@@ -519,8 +519,13 @@ func (h *HandlersApi) projectNodesWithGeo(in []nodes.OsqueryNode) []types.NodeVi
 		}
 	}
 	healthByNode := make(map[uint]types.NodeHealth, len(in))
-	inactiveHours := h.inactiveHours()
+	hoursByEnv := make(map[uint]int64)
 	for _, node := range in {
+		inactiveHours, ok := hoursByEnv[node.EnvironmentID]
+		if !ok {
+			inactiveHours = h.inactiveHours(node.EnvironmentID)
+			hoursByEnv[node.EnvironmentID] = inactiveHours
+		}
 		posture := postureSummaries[node.UUID]
 		if posture == nil {
 			posture = postureSummaries[strings.ToUpper(node.UUID)]
@@ -530,11 +535,11 @@ func (h *HandlersApi) projectNodesWithGeo(in []nodes.OsqueryNode) []types.NodeVi
 	return types.ProjectNodesWithCountryUptimePostureTagsAndHealth(in, lookup, uptimes, postureSummaries, nodeTags, healthByNode)
 }
 
-func (h *HandlersApi) inactiveHours() int64 {
+func (h *HandlersApi) inactiveHours(envID uint) int64 {
 	if h.Settings == nil {
 		return settings.DefaultInactiveHours
 	}
-	return h.Settings.InactiveHours(settings.NoEnvironmentID)
+	return h.Settings.InactiveHours(envID)
 }
 
 // NodesPagedHandler returns paginated, sorted, searchable nodes for an env.
@@ -646,7 +651,7 @@ func (h *HandlersApi) NodesPagedHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	hours := h.Settings.InactiveHours(settings.NoEnvironmentID)
+	hours := h.Settings.InactiveHours(env.ID)
 	pageData, err := h.Nodes.GetByEnvPaged(env.Name, status, hours, search, page, pageSize, sortCol, desc, platformBucket)
 	if err != nil {
 		apiErrorResponse(w, "failed to query nodes", http.StatusInternalServerError, err)

--- a/cmd/api/handlers/nodes_inactivity_test.go
+++ b/cmd/api/handlers/nodes_inactivity_test.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/apiclient"
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestNodeConsumersEnvironmentThresholds(t *testing.T) {
+	db, h, env, node := setupConsoleHandlers(t)
+	h.DebugHTTPConfig = &config.YAMLConfigurationDebug{}
+	var err error
+	h.AuditLog, err = auditlog.CreateAuditLogManager(db, config.ServiceAPI, false)
+	require.NoError(t, err)
+	require.NoError(t, h.Settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 24, 0))
+	require.NoError(t, h.Settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 2, env.ID))
+	node.Environment = env.Name
+	node.LastSeen = time.Now().Add(-48 * time.Hour)
+	require.NoError(t, db.Save(&node).Error)
+	fixtures := []nodes.OsqueryNode{node}
+	envFixtures := []environments.TLSEnvironment{env}
+	for _, name := range []string{"long", "inherited"} {
+		e := h.Envs.Empty(name, name+".example.com")
+		require.NoError(t, h.Envs.Create(&e))
+		if name == "long" {
+			require.NoError(t, h.Settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 168, e.ID))
+		}
+		n := nodes.OsqueryNode{UUID: name, Environment: e.Name, EnvironmentID: e.ID, LastSeen: node.LastSeen}
+		require.NoError(t, db.Create(&n).Error)
+		fixtures = append(fixtures, n)
+		envFixtures = append(envFixtures, e)
+		require.NoError(t, h.Users.CreatePermission(users.UserPermission{Username: "alice", AccessType: int(users.AdminLevel), AccessValue: true, Environment: e.UUID, EnvironmentID: e.ID}))
+	}
+
+	// A batch must read settings once per distinct environment, even for repeated nodes.
+	reads := 0
+	require.NoError(t, db.Callback().Query().Before("gorm:query").Register("count_inactivity_reads", func(tx *gorm.DB) {
+		if tx.Statement.Table == "setting_values" {
+			reads++
+		}
+	}))
+	batch := h.projectNodesWithGeo(append(fixtures, fixtures[0]))
+	require.Equal(t, 3, reads)
+	require.NoError(t, db.Callback().Query().Remove("count_inactivity_reads"))
+	for i, want := range []string{"offline", "healthy", "offline"} {
+		require.Equal(t, want, batch[i].Health.Status)
+		require.Equal(t, want, h.projectNode(fixtures[i]).Health.Status)
+	}
+
+	for i, e := range envFixtures {
+		for _, tc := range []struct {
+			name    string
+			handler http.HandlerFunc
+			active  bool
+			paged   bool
+		}{
+			{"active", h.ActiveNodesHandler, true, false},
+			{"inactive", h.InactiveNodesHandler, false, false},
+			{"active", h.NodesPagedHandler, true, true},
+			{"inactive", h.NodesPagedHandler, false, true},
+		} {
+			req := consoleRequest(http.MethodGet, "/nodes?status="+tc.name, nil, "alice")
+			req.SetPathValue("env", e.Name)
+			rr := httptest.NewRecorder()
+			tc.handler(rr, req)
+			want := int64(0)
+			if tc.active == (i == 1) {
+				want = 1
+			}
+			if tc.paged {
+				require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+				var page types.NodesPagedResponse
+				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &page))
+				require.Equal(t, want, page.TotalItems)
+			} else if want == 0 {
+				require.Equal(t, http.StatusNotFound, rr.Code, rr.Body.String())
+			} else {
+				require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+				var got []nodes.OsqueryNode
+				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+				require.Len(t, got, 1)
+				require.Equal(t, fixtures[i].ID, got[0].ID)
+			}
+		}
+	}
+
+	rr := httptest.NewRecorder()
+	h.StatsHandler(rr, consoleRequest(http.MethodGet, "/stats", nil, "alice"))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var stats apiclient.StatsResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &stats))
+	require.Equal(t, int64(24), stats.InactiveHours)
+	require.Equal(t, int64(1), stats.ActiveNodes)
+	require.Equal(t, int64(2), stats.InactiveNodes)
+	require.Len(t, stats.Environments, 3)
+	for _, e := range stats.Environments {
+		require.Equal(t, map[string]int64{env.Name: 2, "long": 168, "inherited": 24}[e.Name], e.InactiveHours)
+		require.Equal(t, int64(1), e.TotalNodes)
+		if e.Name == "long" {
+			require.Equal(t, int64(1), e.ActiveNodes)
+		} else {
+			require.Equal(t, int64(1), e.InactiveNodes)
+		}
+	}
+
+	// Threshold changes must not grant access to other environments.
+	rr = httptest.NewRecorder()
+	h.StatsHandler(rr, consoleRequest(http.MethodGet, "/stats", nil, "bob"))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &stats))
+	require.Empty(t, stats.Environments)
+}

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -197,18 +197,18 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	// Prepare data for the handler code
 	data := handlers.ProcessingQuery{
-		Envs:          q.Environments,
-		Platforms:     q.Platforms,
-		UUIDs:         q.UUIDs,
-		Hosts:         q.Hosts,
-		Tags:          q.Tags,
-		EnvID:         env.ID,
-		InactiveHours: h.Settings.InactiveHours(settings.NoEnvironmentID),
+		Envs:      q.Environments,
+		Platforms: q.Platforms,
+		UUIDs:     q.UUIDs,
+		Hosts:     q.Hosts,
+		Tags:      q.Tags,
+		EnvID:     env.ID,
 	}
 	manager := handlers.Managers{
-		Nodes: h.Nodes,
-		Envs:  h.Envs,
-		Tags:  h.Tags,
+		Settings: h.Settings,
+		Nodes:    h.Nodes,
+		Envs:     h.Envs,
+		Tags:     h.Tags,
 	}
 	targetNodesID, err := handlers.CreateQueryCarve(data, manager, queries.DistributedQuery{})
 	if err != nil {

--- a/cmd/api/handlers/settings_patch.go
+++ b/cmd/api/handlers/settings_patch.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/jmpsec/osctrl/pkg/users"
@@ -101,6 +102,12 @@ func (h *HandlersApi) SettingPatchHandler(w http.ResponseWriter, r *http.Request
 			apiErrorResponse(w, "setting is integer — provide `integer` in body", http.StatusBadRequest, nil)
 			return
 		}
+		if service == config.ServiceAPI && name == settings.InactiveHours {
+			if err := settings.ValidateInactiveHours(*body.Integer); err != nil {
+				apiErrorResponse(w, err.Error(), http.StatusBadRequest, err)
+				return
+			}
+		}
 		if err := h.Settings.SetInteger(*body.Integer, service, name, settings.NoEnvironmentID); err != nil {
 			apiErrorResponse(w, "error updating setting", http.StatusInternalServerError, err)
 			return
@@ -124,7 +131,11 @@ func (h *HandlersApi) SettingPatchHandler(w http.ResponseWriter, r *http.Request
 		apiErrorResponse(w, "error reading updated setting", http.StatusInternalServerError, err)
 		return
 	}
-	h.AuditLog.SettingsAction(ctx[ctxUser], fmt.Sprintf("patch %s/%s", service, name), strings.Split(r.RemoteAddr, ":")[0])
+	action := fmt.Sprintf("patch %s/%s", service, name)
+	if service == config.ServiceAPI && name == settings.InactiveHours {
+		action += fmt.Sprintf(": %d -> %d", existing.Integer, updated.Integer)
+	}
+	h.AuditLog.SettingsAction(ctx[ctxUser], action, strings.Split(r.RemoteAddr, ":")[0])
 	log.Debug().Msgf("Patched setting %s/%s", service, name)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, updated)
 }

--- a/cmd/api/handlers/stats.go
+++ b/cmd/api/handlers/stats.go
@@ -24,6 +24,8 @@ import (
 
 // EnvStats is one row in the per-env breakdown returned by /api/v1/stats.
 type EnvStats struct {
+	// InactiveHours is the effective threshold for this environment, including inheritance.
+	InactiveHours int64  `json:"inactive_hours"`
 	UUID          string `json:"uuid"`
 	Name          string `json:"name"`
 	Active        int64  `json:"active"`
@@ -45,6 +47,7 @@ type StatsResponse struct {
 	TotalNodes    int64 `json:"total_nodes"`
 	ActiveNodes   int64 `json:"active_nodes"`
 	InactiveNodes int64 `json:"inactive_nodes"`
+	// InactiveHours is the global default only; node counts use each environment's effective threshold.
 	InactiveHours int64 `json:"inactive_hours"`
 	// TotalActiveQueries counts standard query-type active queries (excludes carves).
 	TotalActiveQueries int `json:"total_active_queries"`
@@ -67,10 +70,6 @@ type StatsResponse struct {
 //   - GetActive(envID) returns ALL active rows regardless of type (union).
 //   - To avoid double-counting we call GetQueries("active", envID) for
 //     standard queries and GetCarves("active", envID) for carves separately.
-//   - Unit test for this handler is deferred: the underlying pkg/queries
-//     functions are exercised by existing tests in pkg/queries; a full
-//     integration test would require DB fixture setup that is out of scope
-//     for Track 2.
 //
 // @Summary Get dashboard stats
 // @Description Returns cross-environment dashboard statistics.
@@ -114,7 +113,8 @@ func (h *HandlersApi) StatsHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		ns, err := h.Nodes.GetStatsByEnv(e.Name, hours)
+		envHours := h.Settings.InactiveHours(e.ID)
+		ns, err := h.Nodes.GetStatsByEnv(e.Name, envHours)
 		if err != nil {
 			log.Warn().Err(err).Str("env", e.Name).Msg("stats: failed to get node stats, skipping env")
 			continue
@@ -144,6 +144,7 @@ func (h *HandlersApi) StatsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		row := EnvStats{
+			InactiveHours:  envHours,
 			UUID:           e.UUID,
 			Name:           e.Name,
 			Active:         ns.Active,

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1048,6 +1048,15 @@ func osctrlAPIService() {
 		"PATCH "+_apiPath(apiEnvironmentsPath)+"/expiration/{env}",
 		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentExpirationPatchHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// API: environment packages (multi-architecture)
+	muxAPI.Handle(
+		"GET "+_apiPath(apiEnvironmentsPath)+"/inactive-hours/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentInactiveHoursHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"PUT "+_apiPath(apiEnvironmentsPath)+"/inactive-hours/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentInactiveHoursSetHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	muxAPI.Handle(
+		"DELETE "+_apiPath(apiEnvironmentsPath)+"/inactive-hours/{env}",
+		handlerAuthCheck(http.HandlerFunc(handlersApi.EnvironmentInactiveHoursResetHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
 	// Uses /packages/{env} shape (literal in segment 1) to avoid conflicts
 	// with /map/{target} — same pattern as /config/{env} and /intervals/{env}.
 	muxAPI.Handle(

--- a/cmd/cli/carve.go
+++ b/cmd/cli/carve.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/handlers"
 	"github.com/jmpsec/osctrl/pkg/queries"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v3"
 )
@@ -374,18 +373,18 @@ func runCarve(ctx context.Context, cmd *cli.Command) error {
 		}
 		// Prepare data for the handler code
 		data := handlers.ProcessingQuery{
-			Envs:          []string{},
-			Platforms:     platformList,
-			UUIDs:         uuidList,
-			Hosts:         hostList,
-			Tags:          tagList,
-			EnvID:         e.ID,
-			InactiveHours: settingsmgr.InactiveHours(settings.NoEnvironmentID),
+			Envs:      []string{},
+			Platforms: platformList,
+			UUIDs:     uuidList,
+			Hosts:     hostList,
+			Tags:      tagList,
+			EnvID:     e.ID,
 		}
 		manager := handlers.Managers{
-			Nodes: nodesmgr,
-			Envs:  envs,
-			Tags:  tagsmgr,
+			Settings: settingsmgr,
+			Nodes:    nodesmgr,
+			Envs:     envs,
+			Tags:     tagsmgr,
 		}
 		targetNodesID, err := handlers.CreateQueryCarve(data, manager, newQuery)
 		if err != nil {

--- a/cmd/cli/node.go
+++ b/cmd/cli/node.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/jmpsec/osctrl/pkg/nodes"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v3"
@@ -63,7 +62,11 @@ func listNodes(ctx context.Context, cmd *cli.Command) error {
 	// Retrieve data
 	var nds []nodes.OsqueryNode
 	if dbFlag {
-		nds, err = nodesmgr.Gets(target, settingsmgr.InactiveHours(settings.NoEnvironmentID))
+		e, lookupErr := envs.Get(env)
+		if lookupErr != nil {
+			return fmt.Errorf("error getting environment - %w", lookupErr)
+		}
+		nds, err = nodesmgr.GetByEnv(e.Name, target, settingsmgr.InactiveHours(e.ID))
 		if err != nil {
 			return fmt.Errorf("error getting nodes - %w", err)
 		}

--- a/cmd/cli/query.go
+++ b/cmd/cli/query.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/jmpsec/osctrl/pkg/handlers"
 	"github.com/jmpsec/osctrl/pkg/queries"
-	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v3"
 )
@@ -307,18 +306,18 @@ func runQuery(ctx context.Context, cmd *cli.Command) error {
 		}
 		// Prepare data for the handler code
 		data := handlers.ProcessingQuery{
-			Envs:          []string{},
-			Platforms:     platformList,
-			UUIDs:         uuidList,
-			Hosts:         hostList,
-			Tags:          tagList,
-			EnvID:         e.ID,
-			InactiveHours: settingsmgr.InactiveHours(settings.NoEnvironmentID),
+			Envs:      []string{},
+			Platforms: platformList,
+			UUIDs:     uuidList,
+			Hosts:     hostList,
+			Tags:      tagList,
+			EnvID:     e.ID,
 		}
 		manager := handlers.Managers{
-			Nodes: nodesmgr,
-			Envs:  envs,
-			Tags:  tagsmgr,
+			Settings: settingsmgr,
+			Nodes:    nodesmgr,
+			Envs:     envs,
+			Tags:     tagsmgr,
 		}
 		targetNodesID, err := handlers.CreateQueryCarve(data, manager, newQuery)
 		if err != nil {

--- a/cmd/cli/shell_commands.go
+++ b/cmd/cli/shell_commands.go
@@ -147,15 +147,15 @@ func (s *shellState) cmdStats(_ *shellState, _ []string) {
 		errf("%v", err)
 		return
 	}
-	fmt.Printf("%s %s\n", paint(cCyan, "🖥️  Nodes"), fmt.Sprintf("total %s · active %s · inactive %s (offline after %dh)", paint(cBold, itoa(st.TotalNodes)), paint(cGreen, itoa(st.ActiveNodes)), paint(cRed, itoa(st.InactiveNodes)), st.InactiveHours))
+	fmt.Printf("%s %s\n", paint(cCyan, "🖥️  Nodes"), fmt.Sprintf("total %s · active %s · inactive %s", paint(cBold, itoa(st.TotalNodes)), paint(cGreen, itoa(st.ActiveNodes)), paint(cRed, itoa(st.InactiveNodes))))
 	fmt.Printf("%s queries %s · carves %s\n", paint(cCyan, "🔍 Active"), paint(cBold, itoa(int64(st.TotalActiveQueries))), paint(cBold, itoa(int64(st.TotalActiveCarves))))
 	fmt.Printf("%s linux %s · darwin %s · windows %s · other %s\n", paint(cCyan, "💻 Platforms"), itoa(st.Platforms.Linux), itoa(st.Platforms.Darwin), itoa(st.Platforms.Windows), itoa(st.Platforms.Other))
 	fmt.Println()
 	rows := make([][]string, 0, len(st.Environments))
 	for _, e := range st.Environments {
-		rows = append(rows, []string{e.Name, itoa(e.Active), itoa(e.Inactive), itoa(e.Total), itoa(int64(e.ActiveQueries)), itoa(int64(e.ActiveCarves))})
+		rows = append(rows, []string{e.Name, itoa(e.Active), itoa(e.Inactive), itoa(e.Total), itoa(e.InactiveHours), itoa(int64(e.ActiveQueries)), itoa(int64(e.ActiveCarves))})
 	}
-	printTable([]string{"Env", "Active", "Inactive", "Total", "Queries", "Carves"}, rows)
+	printTable([]string{"Env", "Active", "Inactive", "Total", "Inactive hours", "Queries", "Carves"}, rows)
 }
 
 func itoa(i int64) string {

--- a/cmd/cli/shell_inactivity_test.go
+++ b/cmd/cli/shell_inactivity_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/apiclient"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type inactivityTransport func(*http.Request) (*http.Response, error)
+
+func (f inactivityTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestUpdateInactiveHoursPreservesExistingValue(t *testing.T) {
+	oldSettings := settingsmgr
+	t.Cleanup(func() { settingsmgr = oldSettings })
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	settingsmgr = settings.NewSettings(db)
+	require.NoError(t, settingsmgr.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 168, 0))
+	before, err := settingsmgr.RetrieveValue(config.ServiceAPI, settings.InactiveHours, 0)
+	require.NoError(t, err)
+	store := &dbStore{}
+	for _, tc := range []struct{ typ, value string }{
+		{"integer", "0"}, {"integer", "-1"}, {"int", "2562048"},
+		{"integer", "2.5"}, {"integer", "9223372036854775808"},
+		{"string", "24"}, {"boolean", "true"}, {"unknown", "24"},
+	} {
+		t.Run(tc.typ+"_"+tc.value, func(t *testing.T) {
+			require.Error(t, store.UpdateSetting(config.ServiceAPI, settings.InactiveHours, tc.typ, tc.value))
+			after, err := settingsmgr.RetrieveValue(config.ServiceAPI, settings.InactiveHours, 0)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+		})
+	}
+	require.NoError(t, store.UpdateSetting(config.ServiceAPI, settings.InactiveHours, "int", "24"))
+	after, err := settingsmgr.RetrieveValue(config.ServiceAPI, settings.InactiveHours, 0)
+	require.NoError(t, err)
+	require.Equal(t, before.ID, after.ID)
+	require.Equal(t, int64(24), after.Integer)
+}
+
+func TestCLIEnvironmentThresholds(t *testing.T) {
+	oldEnvs, oldNodes, oldQueries, oldSettings := envs, nodesmgr, queriesmgr, settingsmgr
+	t.Cleanup(func() { envs, nodesmgr, queriesmgr, settingsmgr = oldEnvs, oldNodes, oldQueries, oldSettings })
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	envs, nodesmgr, queriesmgr, settingsmgr = environments.CreateEnvironment(db), nodes.CreateNodes(db), queries.CreateQueries(db), settings.NewSettings(db)
+	require.NoError(t, settingsmgr.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 24, 0))
+	fixtures := map[string]nodes.OsqueryNode{}
+	envFixtures := map[string]environments.TLSEnvironment{}
+	hours := map[string]int64{"short": 2, "long": 168, "inherited": 24}
+	for _, name := range []string{"short", "long", "inherited"} {
+		e := envs.Empty(name, name+".example.com")
+		require.NoError(t, envs.Create(&e))
+		if name != "inherited" {
+			require.NoError(t, settingsmgr.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, hours[name], e.ID))
+		}
+		n := nodes.OsqueryNode{UUID: strings.ToUpper(name), Environment: name, EnvironmentID: e.ID, LastSeen: time.Now().Add(-48 * time.Hour)}
+		require.NoError(t, db.Create(&n).Error)
+		fixtures[name], envFixtures[name] = n, e
+	}
+	dbStore := &dbStore{}
+	stats, err := dbStore.Stats()
+	require.NoError(t, err)
+	require.Equal(t, int64(24), stats.InactiveHours)
+	require.Equal(t, int64(3), stats.TotalNodes)
+	require.Equal(t, int64(1), stats.ActiveNodes)
+	require.Equal(t, int64(2), stats.InactiveNodes)
+	require.Len(t, stats.Environments, 3)
+	for _, e := range stats.Environments {
+		require.Equal(t, hours[e.Name], e.InactiveHours)
+	}
+
+	thresholdRequests := 0
+	api, err := apiclient.CreateAPIWithTransport(apiclient.JSONConfigurationAPI{URL: "http://osctrl.test", Token: "test"}, inactivityTransport(func(r *http.Request) (*http.Response, error) {
+		parts := strings.Split(r.URL.Path, "/")
+		var body any
+		switch {
+		case r.URL.Path == "/api/v1/stats":
+			body = stats
+		case strings.HasPrefix(r.URL.Path, "/api/v1/environments/inactive-hours/"):
+			thresholdRequests++
+			name := parts[5]
+			for n, e := range envFixtures {
+				if name == e.UUID {
+					name = n
+				}
+			}
+			body = map[string]any{"inactive_hours": hours[name], "source": "environment", "override_hours": hours[name]}
+		case strings.HasPrefix(r.URL.Path, "/api/v1/nodes/"):
+			name := parts[4]
+			for n, e := range envFixtures {
+				if name == e.UUID {
+					name = n
+				}
+			}
+			if len(parts) == 7 {
+				body = fixtures[name]
+			} else {
+				body = []nodes.OsqueryNode{fixtures[name]}
+			}
+		default:
+			t.Fatalf("unexpected API request: %s", r.URL.Path)
+		}
+		raw, err := json.Marshal(body)
+		require.NoError(t, err)
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(string(raw)))}, nil
+	}))
+	require.NoError(t, err)
+	for _, store := range []DataStore{dbStore, newAPIStore(api)} {
+		t.Run(store.Mode(), func(t *testing.T) {
+			gotStats, err := store.Stats()
+			require.NoError(t, err)
+			require.Equal(t, stats, gotStats)
+			for name, e := range envFixtures {
+				for _, env := range []string{name, e.UUID} {
+					rows, err := store.Nodes(env, "all")
+					require.NoError(t, err)
+					require.Len(t, rows, 1)
+					require.Equal(t, name == "long", rows[0].Active, env)
+					row, err := store.Node(env, fixtures[name].UUID)
+					require.NoError(t, err)
+					require.Equal(t, rows[0].Active, row.Active, env)
+				}
+			}
+		})
+	}
+	require.Equal(t, 12, thresholdRequests)
+	for name := range envFixtures {
+		rows, err := dbStore.Nodes(name, "active")
+		require.NoError(t, err)
+		if name == "long" {
+			require.Len(t, rows, 1)
+		} else {
+			require.Empty(t, rows)
+		}
+	}
+}

--- a/cmd/cli/shell_store.go
+++ b/cmd/cli/shell_store.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/carves"
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/handlers"
 	"github.com/jmpsec/osctrl/pkg/nodes"
@@ -43,6 +44,7 @@ type tuiPlatformCounts struct {
 }
 
 type tuiEnvStats struct {
+	InactiveHours int64             `json:"inactive_hours"`
 	UUID          string            `json:"uuid"`
 	Name          string            `json:"name"`
 	Active        int64             `json:"active"`
@@ -54,9 +56,10 @@ type tuiEnvStats struct {
 }
 
 type tuiStats struct {
-	TotalNodes         int64             `json:"total_nodes"`
-	ActiveNodes        int64             `json:"active_nodes"`
-	InactiveNodes      int64             `json:"inactive_nodes"`
+	TotalNodes    int64 `json:"total_nodes"`
+	ActiveNodes   int64 `json:"active_nodes"`
+	InactiveNodes int64 `json:"inactive_nodes"`
+	// InactiveHours is the global default only; counts use per-environment thresholds.
 	InactiveHours      int64             `json:"inactive_hours"`
 	TotalActiveQueries int               `json:"total_active_queries"`
 	TotalActiveCarves  int               `json:"total_active_carves"`
@@ -230,7 +233,7 @@ type DataStore interface {
 
 func isActive(lastSeen time.Time, hours int64) bool {
 	if hours <= 0 {
-		hours = 24
+		hours = settings.DefaultInactiveHours
 	}
 	return time.Since(lastSeen) < time.Duration(hours)*time.Hour
 }
@@ -499,9 +502,13 @@ func (s *apiStore) Nodes(env, target string) ([]nodeRow, error) {
 	if err != nil {
 		return nil, err
 	}
+	hours, err := s.api.GetEnvironmentInactiveHours(env)
+	if err != nil {
+		return nil, err
+	}
 	out := make([]nodeRow, 0, len(nds))
 	for _, n := range nds {
-		out = append(out, nodeToRow(n, 24))
+		out = append(out, nodeToRow(n, hours))
 	}
 	return out, nil
 }
@@ -511,7 +518,11 @@ func (s *apiStore) Node(env, identifier string) (nodeRow, error) {
 	if err != nil {
 		return nodeRow{}, err
 	}
-	return nodeToRow(n, 24), nil
+	hours, err := s.api.GetEnvironmentInactiveHours(env)
+	if err != nil {
+		return nodeRow{}, err
+	}
+	return nodeToRow(n, hours), nil
 }
 
 func (s *apiStore) Queries(env, target string) ([]queryRow, error) {
@@ -649,17 +660,11 @@ func newDBStore() DataStore { return &dbStore{} }
 
 func (s *dbStore) Mode() string { return "db" }
 
-func (s *dbStore) inactiveHours() int64 {
+func (s *dbStore) inactiveHours(envID uint) int64 {
 	if settingsmgr == nil {
-		return 24
+		return settings.DefaultInactiveHours
 	}
-	h := settingsmgr.InactiveHours(settings.NoEnvironmentID)
-	if h <= 0 {
-		// Missing/unset inactive_hours setting — default to a sane 24h so the
-		// active/inactive filter and status column aren't degenerate.
-		return 24
-	}
-	return h
+	return settingsmgr.InactiveHours(envID)
 }
 
 func (s *dbStore) Stats() (tuiStats, error) {
@@ -667,9 +672,10 @@ func (s *dbStore) Stats() (tuiStats, error) {
 	if err != nil {
 		return tuiStats{}, fmt.Errorf("envs: %w", err)
 	}
-	hours := s.inactiveHours()
+	hours := s.inactiveHours(settings.NoEnvironmentID)
 	out := tuiStats{InactiveHours: hours, Environments: make([]tuiEnvStats, 0, len(allEnvs))}
 	for _, e := range allEnvs {
+		hours := s.inactiveHours(e.ID)
 		ns, err := nodesmgr.GetStatsByEnv(e.Name, hours)
 		if err != nil {
 			continue
@@ -685,7 +691,8 @@ func (s *dbStore) Stats() (tuiStats, error) {
 			}
 		}
 		row := tuiEnvStats{
-			UUID: e.UUID, Name: e.Name,
+			InactiveHours: hours,
+			UUID:          e.UUID, Name: e.Name,
 			Active: ns.Active, Inactive: ns.Inactive, Total: ns.Total,
 			ActiveQueries: aq, ActiveCarves: ac,
 			Platforms: tuiPlatformCounts{Linux: pc.Linux, Darwin: pc.Darwin, Windows: pc.Windows, Other: pc.Other},
@@ -725,12 +732,16 @@ func (s *dbStore) EnvNames() ([]string, error) {
 }
 
 func (s *dbStore) Nodes(env, target string) ([]nodeRow, error) {
-	nds, err := nodesmgr.GetByEnv(env, target, s.inactiveHours())
+	e, err := envs.Get(env)
+	if err != nil {
+		return nil, fmt.Errorf("env: %w", err)
+	}
+	hours := s.inactiveHours(e.ID)
+	nds, err := nodesmgr.GetByEnv(e.Name, target, hours)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]nodeRow, 0, len(nds))
-	hours := s.inactiveHours()
 	for _, n := range nds {
 		out = append(out, nodeToRow(n, hours))
 	}
@@ -750,7 +761,7 @@ func (s *dbStore) Node(env, identifier string) (nodeRow, error) {
 	if err != nil {
 		return nodeRow{}, err
 	}
-	return nodeToRow(n, s.inactiveHours()), nil
+	return nodeToRow(n, s.inactiveHours(e.ID)), nil
 }
 
 func (s *dbStore) Queries(env, target string) ([]queryRow, error) {
@@ -946,15 +957,14 @@ func runDistributedQuery(req runQueryReq) (types.ApiQueriesResponse, error) {
 		return types.ApiQueriesResponse{}, fmt.Errorf("query create: %w", err)
 	}
 	data := handlers.ProcessingQuery{
-		Envs:          []string{},
-		Platforms:     req.Platforms,
-		UUIDs:         req.UUIDs,
-		Hosts:         req.Hosts,
-		Tags:          req.Tags,
-		EnvID:         e.ID,
-		InactiveHours: settingsmgr.InactiveHours(settings.NoEnvironmentID),
+		Envs:      []string{},
+		Platforms: req.Platforms,
+		UUIDs:     req.UUIDs,
+		Hosts:     req.Hosts,
+		Tags:      req.Tags,
+		EnvID:     e.ID,
 	}
-	manager := handlers.Managers{Nodes: nodesmgr, Envs: envs, Tags: tagsmgr}
+	manager := handlers.Managers{Nodes: nodesmgr, Envs: envs, Tags: tagsmgr, Settings: settingsmgr}
 	targetNodesID, err := handlers.CreateQueryCarve(data, manager, newQuery)
 	if err != nil {
 		return types.ApiQueriesResponse{}, fmt.Errorf("query targets: %w", err)
@@ -1000,15 +1010,14 @@ func runDistributedCarve(req runQueryReq) (types.ApiQueriesResponse, error) {
 		return types.ApiQueriesResponse{}, fmt.Errorf("carve create: %w", err)
 	}
 	data := handlers.ProcessingQuery{
-		Envs:          []string{},
-		Platforms:     req.Platforms,
-		UUIDs:         req.UUIDs,
-		Hosts:         req.Hosts,
-		Tags:          req.Tags,
-		EnvID:         e.ID,
-		InactiveHours: settingsmgr.InactiveHours(settings.NoEnvironmentID),
+		Envs:      []string{},
+		Platforms: req.Platforms,
+		UUIDs:     req.UUIDs,
+		Hosts:     req.Hosts,
+		Tags:      req.Tags,
+		EnvID:     e.ID,
 	}
-	manager := handlers.Managers{Nodes: nodesmgr, Envs: envs, Tags: tagsmgr}
+	manager := handlers.Managers{Nodes: nodesmgr, Envs: envs, Tags: tagsmgr, Settings: settingsmgr}
 	targetNodesID, err := handlers.CreateQueryCarve(data, manager, newQuery)
 	if err != nil {
 		return types.ApiQueriesResponse{}, fmt.Errorf("carve targets: %w", err)
@@ -1280,6 +1289,16 @@ func (s *dbStore) AddSetting(service, name, typ, value string) error {
 }
 
 func (s *dbStore) UpdateSetting(service, name, typ, value string) error {
+	if service == config.ServiceAPI && name == settings.InactiveHours {
+		if typ = strings.ToLower(typ); typ != "integer" && typ != "int" {
+			return fmt.Errorf("inactive_hours must be an integer")
+		}
+		hours, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("integer: %w", err)
+		}
+		return settingsmgr.SetInteger(hours, service, name, settings.NoEnvironmentID)
+	}
 	// Delete-then-create keeps the value fresh without a generic setter.
 	if err := settingsmgr.DeleteValue(service, name, settings.NoEnvironmentID); err != nil {
 		return err

--- a/cmd/cli/shell_store_test.go
+++ b/cmd/cli/shell_store_test.go
@@ -20,6 +20,7 @@ func TestNodeToRowActiveInactive(t *testing.T) {
 		{"just_within", now.Add(-23 * time.Hour), 24, true},
 		{"stale", now.Add(-48 * time.Hour), 24, false},
 		{"zero_hours_defaults_active", now.Add(-1 * time.Hour), 0, true},
+		{"zero_hours_defaults_to_72", now.Add(-48 * time.Hour), 0, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/cmd/tls/tls_alerts_test.go
+++ b/cmd/tls/tls_alerts_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestTLSNodeSourceEnvironmentThresholds(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	s := newTLSNodeSource(nodes.CreateNodes(db), settings.NewSettings(db), environments.CreateEnvironment(db))
+	require.Equal(t, settings.DefaultInactiveHours, s.threshold(1))
+	require.Equal(t, settings.DefaultInactiveHours, (&tlsNodeSource{}).threshold(1))
+	require.NoError(t, s.settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 24, 0))
+	for i, name := range []string{"short", "long", "inherited"} {
+		e := s.envs.Empty(name, name+".example.com")
+		require.NoError(t, s.envs.Create(&e))
+		if i < 2 {
+			require.NoError(t, s.settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, []int64{2, 168}[i], e.ID))
+		}
+		require.NoError(t, db.Create(&nodes.OsqueryNode{UUID: strings.ToUpper(name), Environment: e.Name, EnvironmentID: e.ID, LastSeen: time.Now().Add(-48 * time.Hour)}).Error)
+	}
+	active, err := s.ActiveNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, active, 1)
+	require.Equal(t, "LONG", active[0].UUID)
+	require.True(t, active[0].Active)
+	inactive, err := s.InactiveNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, inactive, 2)
+	require.ElementsMatch(t, []string{"SHORT", "INHERITED"}, []string{inactive[0].UUID, inactive[1].UUID})
+	require.False(t, inactive[0].Active)
+	require.False(t, inactive[1].Active)
+}

--- a/frontend/src/api/environments.ts
+++ b/frontend/src/api/environments.ts
@@ -111,6 +111,30 @@ export function getEnvironment(env: string): Promise<TLSEnvironment> {
   return apiFetch<TLSEnvironment>(`/api/v1/environments/${encodeURIComponent(env)}`);
 }
 
+export interface EnvironmentInactiveHours {
+  override_hours: number | null;
+  inactive_hours: number;
+  source: 'environment' | 'global' | 'default';
+}
+
+export function getEnvironmentInactiveHours(env: string): Promise<EnvironmentInactiveHours> {
+  return apiFetch<EnvironmentInactiveHours>(`/api/v1/environments/inactive-hours/${encodeURIComponent(env)}`);
+}
+
+export function setEnvironmentInactiveHours(env: string, hours: number): Promise<EnvironmentInactiveHours> {
+  return apiFetch<EnvironmentInactiveHours>(`/api/v1/environments/inactive-hours/${encodeURIComponent(env)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ inactive_hours: hours }),
+  });
+}
+
+export function resetEnvironmentInactiveHours(env: string): Promise<EnvironmentInactiveHours> {
+  return apiFetch<EnvironmentInactiveHours>(`/api/v1/environments/inactive-hours/${encodeURIComponent(env)}`, {
+    method: 'DELETE',
+  });
+}
+
 /** POST /api/v1/environments — create. */
 export function createEnvironment(body: EnvCreateRequest): Promise<TLSEnvironment> {
   return apiFetch<TLSEnvironment>('/api/v1/environments', {

--- a/frontend/src/api/mock-data.ts
+++ b/frontend/src/api/mock-data.ts
@@ -548,6 +548,9 @@ export function resolveMockApiRequest(path: string, init: RequestInit = {}): Moc
   }
 
   // Dashboard and activity surfaces.
+  if (method === 'GET' && pathname.startsWith('/api/v1/environments/inactive-hours/')) {
+    return hit({ override_hours: null, inactive_hours: 72, source: 'default' });
+  }
   if (method === 'GET' && pathname === '/api/v1/stats') {
     const active = mockNodes.filter(activeNode).length;
     const activeQueries = mockQueries.filter((query) => query.active).length;
@@ -563,6 +566,7 @@ export function resolveMockApiRequest(path: string, init: RequestInit = {}): Moc
       environments: [{
         uuid: 'dev',
         name: 'dev',
+        inactive_hours: 72,
         active,
         inactive: mockNodes.length - active,
         total: mockNodes.length,

--- a/frontend/src/api/stats.test.ts
+++ b/frontend/src/api/stats.test.ts
@@ -26,6 +26,7 @@ const STUB_RESPONSE: StatsResponse = {
     {
       uuid: 'env-uuid-1',
       name: 'prod',
+      inactive_hours: 24,
       active: 7,
       inactive: 3,
       total: 10,
@@ -64,6 +65,7 @@ describe('getStats — URL construction', () => {
     expect(result.environments).toHaveLength(1);
     expect(result.environments[0].uuid).toBe('env-uuid-1');
     expect(result.environments[0].name).toBe('prod');
+    expect(result.environments[0].inactive_hours).toBe(24);
   });
 
   it('propagates errors from apiFetch', async () => {

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -14,6 +14,7 @@ export interface PlatformCounts {
 }
 
 export interface EnvStats {
+  inactive_hours: number;
   uuid: string;
   name: string;
   active: number;
@@ -29,6 +30,7 @@ export interface StatsResponse {
   total_nodes: number;
   active_nodes: number;
   inactive_nodes: number;
+  /** Global default only; environments may override this threshold. */
   inactive_hours: number;
   total_active_queries: number;
   total_active_carves: number;

--- a/frontend/src/features/dashboard/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.test.tsx
@@ -85,6 +85,7 @@ function makeStatsResponse(overrides: Partial<StatsResponse> = {}): StatsRespons
       {
         uuid: 'env-uuid-1',
         name: 'prod',
+        inactive_hours: 72,
         active: 5,
         inactive: 2,
         total: 7,
@@ -95,6 +96,7 @@ function makeStatsResponse(overrides: Partial<StatsResponse> = {}): StatsRespons
       {
         uuid: 'env-uuid-2',
         name: 'staging',
+        inactive_hours: 24,
         active: 2,
         inactive: 1,
         total: 3,
@@ -393,13 +395,16 @@ describe('DashboardPage', () => {
     expect(errorColor).toHaveValue('#ff4d4f');
   });
 
-  it('uses the backend stats threshold for inactive labeling', async () => {
-    mockGetStats.mockResolvedValue(makeStatsResponse({ inactive_hours: 168 }));
+  it('uses the selected environment threshold instead of the global default', async () => {
+    const stats = makeStatsResponse({ inactive_hours: 168 });
+    stats.environments[0].inactive_hours = 48;
+    mockGetStats.mockResolvedValue(stats);
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => expect(screen.getByText('Active Nodes')).toBeInTheDocument());
 
-    expect(screen.getByText('Inactive ≥ 168h')).toBeInTheDocument();
+    expect(screen.getByText('Inactive ≥ 48h')).toBeInTheDocument();
+    expect(screen.queryByText('Inactive ≥ 168h')).not.toBeInTheDocument();
   });
 
   it('renders one tile per environment', async () => {
@@ -457,16 +462,13 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Retry')).toBeInTheDocument();
   });
 
-  // Regression: when the backend returns inactive_hours: 0 (e.g. setting
-  // missing from DB), the dashboard must fall back to the default 72h
-  // label rather than showing "Inactive >= 0h".
-  it('falls back to default inactive threshold when API returns 0', async () => {
-    mockGetStats.mockResolvedValue(makeStatsResponse({ inactive_hours: 0 }));
+  it('does not imply a universal cutoff for fleet-wide counts', async () => {
+    mockGetStats.mockResolvedValue(makeStatsResponse({ environments: [] }));
     renderWithProviders(makeTestRouter());
 
     await waitFor(() => expect(screen.getByText('Active Nodes')).toBeInTheDocument());
 
-    expect(screen.getByText('Inactive \u2265 72h')).toBeInTheDocument();
-    expect(screen.queryByText('Inactive \u2265 0h')).not.toBeInTheDocument();
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+    expect(screen.queryByText(/Inactive ≥/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -41,7 +41,6 @@ import { StatusPip } from '$/components/data/StatusPip';
 import { StatusBadge } from '$/components/data/StatusBadge';
 import { cn } from '$/lib/cn';
 import { formatRelative } from '$/lib/time';
-import { DEFAULT_INACTIVE_HOURS } from '$/lib/node-status';
 import type { DistributedQuery } from '$/api/types';
 
 // ---------------------------------------------------------------------------
@@ -446,7 +445,7 @@ interface DashboardKpiSetProps {
   activeNodes: number;
   totalNodes: number;
   inactiveNodes: number;
-  inactiveHours: number;
+  inactiveHours: number | undefined;
   reportedErrors: number;
   onReportedErrorsClick?: () => void;
   activeQueries: number;
@@ -482,7 +481,7 @@ function DashboardKpiSet({
             deltaLabel={totalNodes > 0 ? t('dashboardExt.kpi.ofFleet', { pct: Math.round((activeNodes / totalNodes) * 100) }) : t('dashboardExt.kpi.noNodes')}
           />
           <KpiCard
-            label={t('dashboardExt.kpi.inactiveNodes', { hours: inactiveHours })}
+            label={inactiveHours === undefined ? t('commonExt.inactive') : t('dashboardExt.kpi.inactiveNodes', { hours: inactiveHours })}
             value={inactiveNodes}
             sparkline={chartSeries.status}
             halo="warning"
@@ -1546,11 +1545,6 @@ export function DashboardPage() {
     refetchInterval: 30_000,
     refetchIntervalInBackground: false,
   });
-  const inactiveHours =
-    data?.inactive_hours && data.inactive_hours > 0
-      ? data.inactive_hours
-      : DEFAULT_INACTIVE_HOURS;
-
   const [palette, setPaletteEntry, resetPalette] = useChartPalette();
 
   const is401 = isError && error instanceof AuthError;
@@ -1882,10 +1876,10 @@ export function DashboardPage() {
       <section aria-label="Environment KPIs" aria-busy={isLoading}>
         <DashboardKpiSet
           loading={isLoading || (isError && !is401)}
-          activeNodes={data?.active_nodes ?? 0}
-          totalNodes={data?.total_nodes ?? 0}
-          inactiveNodes={data?.inactive_nodes ?? 0}
-          inactiveHours={inactiveHours}
+          activeNodes={envMeta?.active ?? data?.active_nodes ?? 0}
+          totalNodes={envMeta?.total ?? data?.total_nodes ?? 0}
+          inactiveNodes={envMeta?.inactive ?? data?.inactive_nodes ?? 0}
+          inactiveHours={envMeta?.inactive_hours}
           reportedErrors={reportedErrors}
           onReportedErrorsClick={
             reportedErrors > 0 && effectiveEnv

--- a/frontend/src/features/environments/EnvConfigPage.test.tsx
+++ b/frontend/src/features/environments/EnvConfigPage.test.tsx
@@ -23,6 +23,10 @@ const {
   mockPatchExpiration,
   mockGetPostureProfiles,
   mockGetFeatures,
+  mockGetInactiveHours,
+  mockSetInactiveHours,
+  mockResetInactiveHours,
+  mockGetMe,
 } = vi.hoisted(() => ({
   mockGetEnvironment: vi.fn<() => Promise<TLSEnvironment>>(),
   mockGetConfig: vi.fn<() => Promise<EnvConfigResponse>>(),
@@ -32,16 +36,25 @@ const {
   mockPatchExpiration: vi.fn(),
   mockGetPostureProfiles: vi.fn(),
   mockGetFeatures: vi.fn<() => Promise<Features>>(),
+  mockGetInactiveHours: vi.fn(),
+  mockSetInactiveHours: vi.fn(),
+  mockResetInactiveHours: vi.fn(),
+  mockGetMe: vi.fn(),
 }));
 
 vi.mock('$/api/environments', () => ({
   getEnvironment: mockGetEnvironment,
+  getEnvironmentInactiveHours: mockGetInactiveHours,
+  setEnvironmentInactiveHours: mockSetInactiveHours,
+  resetEnvironmentInactiveHours: mockResetInactiveHours,
   getEnvironmentConfig: mockGetConfig,
   getEnvironmentAssembledConfig: mockGetAssembledConfig,
   patchEnvironmentConfig: (...args: unknown[]) => mockPatchConfig(...args),
   patchEnvironmentIntervals: (...args: unknown[]) => mockPatchIntervals(...args),
   patchEnvironmentExpiration: (...args: unknown[]) => mockPatchExpiration(...args),
 }));
+
+vi.mock('$/api/users', () => ({ getMe: mockGetMe }));
 
 vi.mock('$/api/client', () => ({
   AuthError: class AuthError extends Error {
@@ -152,10 +165,9 @@ function makeRouter(initialPath = '/_app/env/dev/config') {
   return createRouter({ routeTree, history });
 }
 
-function renderWithProviders() {
-  const queryClient = new QueryClient({
+function renderWithProviders(queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
-  });
+  })) {
   const router = makeRouter();
   return render(
     <QueryClientProvider client={queryClient}>
@@ -168,6 +180,8 @@ describe('EnvConfigPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetEnvironment.mockResolvedValue(makeEnv());
+    mockGetMe.mockResolvedValue({ admin: true, permissions: {} });
+    mockGetInactiveHours.mockResolvedValue({ override_hours: null, inactive_hours: 168, source: 'global' });
     mockGetConfig.mockResolvedValue({
       options: '{"logger_plugin":"tls"}',
       schedule: '{}',
@@ -181,6 +195,108 @@ describe('EnvConfigPage', () => {
     });
     mockGetPostureProfiles.mockResolvedValue([]);
     mockGetFeatures.mockResolvedValue({ posture: false, service_config: false, accelerated: false, file_explorer: false });
+  });
+
+  it('inherits the global value, saves an override, and resets to inheritance', async () => {
+    const user = userEvent.setup();
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const keys = [['inactive-hours', 'other-env'], ['nodes', 'dev'], ['node', 'dev', 'uuid'], ['stats']];
+    keys.forEach((key) => qc.setQueryData(key, {}));
+    const override = { override_hours: 24, inactive_hours: 24, source: 'environment' };
+    mockSetInactiveHours.mockImplementation(async () => {
+      mockGetInactiveHours.mockResolvedValue(override);
+      return override;
+    });
+    mockResetInactiveHours.mockImplementation(async () => {
+      const inherited = { override_hours: null, inactive_hours: 168, source: 'global' };
+      mockGetInactiveHours.mockResolvedValue(inherited);
+      return inherited;
+    });
+    renderWithProviders(qc);
+    const checkbox = await screen.findByRole('checkbox', { name: 'Use global default' });
+    const hours = screen.getByRole('spinbutton', { name: 'Inactive hours' });
+    const save = screen.getByRole('button', { name: 'Save inactive hours' });
+    expect(checkbox).toBeChecked();
+    expect(hours).toHaveValue(168);
+    expect(hours).toBeDisabled();
+    expect(save).toBeDisabled();
+    await user.click(checkbox);
+    await user.clear(hours);
+    await user.type(hours, '24');
+    await user.click(save);
+    await waitFor(() => expect(mockSetInactiveHours).toHaveBeenCalledWith('dev', 24));
+    await waitFor(() => expect(save).toBeDisabled());
+    expect(checkbox).not.toBeChecked();
+    keys.forEach((key) => expect(qc.getQueryState(key)?.isInvalidated).toBe(true));
+    keys.forEach((key) => qc.setQueryData(key, {}));
+    await user.click(checkbox);
+    await user.click(save);
+    await waitFor(() => expect(mockResetInactiveHours).toHaveBeenCalledWith('dev'));
+    await waitFor(() => expect(hours).toHaveValue(168));
+    expect(checkbox).toBeChecked();
+    keys.forEach((key) => expect(qc.getQueryState(key)?.isInvalidated).toBe(true));
+  });
+
+  it('locks the form while saving and adopts the returned effective default', async () => {
+    const user = userEvent.setup();
+    mockGetInactiveHours.mockResolvedValue({ override_hours: 24, inactive_hours: 24, source: 'environment' });
+    let finish!: (value: unknown) => void;
+    mockResetInactiveHours.mockReturnValue(new Promise((resolve) => { finish = resolve; }));
+    renderWithProviders();
+    const checkbox = await screen.findByRole('checkbox', { name: 'Use global default' });
+    await user.click(checkbox);
+    const save = screen.getByRole('button', { name: 'Save inactive hours' });
+    await user.click(save);
+    expect(checkbox).toBeDisabled();
+    expect(save).toBeDisabled();
+    expect(save).toHaveTextContent('Saving');
+    const inherited = { override_hours: null, inactive_hours: 72, source: 'default' };
+    mockGetInactiveHours.mockResolvedValue(inherited);
+    finish(inherited);
+    await waitFor(() => expect(screen.getByRole('spinbutton', { name: 'Inactive hours' })).toHaveValue(72));
+    expect(checkbox).toBeChecked();
+  });
+
+  it('validates override hours and preserves edits after a failed save', async () => {
+    const user = userEvent.setup();
+    mockSetInactiveHours.mockRejectedValue(new Error('Save unavailable'));
+    renderWithProviders();
+    await user.click(await screen.findByRole('checkbox', { name: 'Use global default' }));
+    const hours = screen.getByRole('spinbutton', { name: 'Inactive hours' });
+    const save = screen.getByRole('button', { name: 'Save inactive hours' });
+    for (const value of ['', '0', '-1', '1.5', '2562048']) {
+      await user.clear(hours);
+      if (value) await user.type(hours, value);
+      expect(save).toBeDisabled();
+    }
+    await user.clear(hours);
+    await user.type(hours, '2562047');
+    await user.click(save);
+    expect(await screen.findByText('Save unavailable')).toBeInTheDocument();
+    expect(hours).toHaveValue(2562047);
+    expect(save).toBeEnabled();
+  });
+
+  it('shows fetch errors with retry and no guessed threshold', async () => {
+    const user = userEvent.setup();
+    mockGetInactiveHours.mockRejectedValueOnce(new Error('Threshold unavailable'));
+    renderWithProviders();
+    expect(await screen.findByText('Threshold unavailable')).toBeInTheDocument();
+    expect(screen.queryByRole('spinbutton', { name: 'Inactive hours' })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry inactive hours' }));
+    expect(await screen.findByRole('spinbutton', { name: 'Inactive hours' })).toHaveValue(168);
+  });
+
+  it.each([false, true])('uses environment admin permission: %s', async (admin) => {
+    const user = userEvent.setup();
+    mockGetMe.mockResolvedValue({ admin: false, permissions: { [makeEnv().uuid]: { admin, user: true } } });
+    renderWithProviders();
+    const checkbox = await screen.findByRole('checkbox', { name: 'Use global default' });
+    await waitFor(() => expect(checkbox).toHaveProperty('disabled', !admin));
+    if (admin) {
+      await user.click(checkbox);
+      expect(screen.getByRole('button', { name: 'Save inactive hours' })).toBeEnabled();
+    }
   });
 
   it('loads the fully rendered tab from the assembled config endpoint', async () => {

--- a/frontend/src/features/environments/EnvConfigPage.tsx
+++ b/frontend/src/features/environments/EnvConfigPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { InactiveHoursSetting } from './InactiveHoursSetting';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
 import { useParams, useNavigate, Link } from '@tanstack/react-router';
@@ -390,6 +391,7 @@ export function EnvConfigPage() {
       <div className="flex-1 overflow-auto min-h-0 p-4 space-y-4">
         {activeTab === 'settings' && (
           <>
+            {envInfo && <InactiveHoursSetting key={env} env={env} envUuid={envInfo.uuid} />}
             {envInfo && (
               <IntervalsCard env={env} envInfo={envInfo} qc={qc} />
             )}

--- a/frontend/src/features/environments/InactiveHoursSetting.tsx
+++ b/frontend/src/features/environments/InactiveHoursSetting.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Save } from 'lucide-react';
+import { AuthError } from '$/api/client';
+import { resetEnvironmentInactiveHours, setEnvironmentInactiveHours } from '$/api/environments';
+import { getMe } from '$/api/users';
+import { useInactiveHours, invalidateNodeStatusQueries } from '$/lib/node-status';
+import { buttonClasses } from '$/components/atoms/Button';
+
+export function InactiveHoursSetting({ env, envUuid }: { env: string; envUuid: string }) {
+  const qc = useQueryClient();
+  const query = useInactiveHours(env);
+  const { data: me } = useQuery({ queryKey: ['users-me'], queryFn: getMe, staleTime: 60_000 });
+  const canEdit = me?.admin === true || me?.permissions?.[envUuid]?.admin === true;
+  const [draft, setDraft] = useState<{ useGlobal: boolean; hours: string } | null>(null);
+  const value = draft ?? {
+    useGlobal: query.data?.override_hours == null,
+    hours: String(query.data?.inactive_hours ?? ''),
+  };
+  const hours = Number(value.hours);
+  const valid = value.useGlobal || (Number.isInteger(hours) && hours >= 1 && hours <= 2562047);
+  const dirty = query.data && (value.useGlobal
+    ? query.data.override_hours !== null
+    : hours !== query.data.override_hours);
+  const mutation = useMutation({
+    mutationFn: () => value.useGlobal
+      ? resetEnvironmentInactiveHours(env)
+      : setEnvironmentInactiveHours(env, hours),
+    onSuccess: async (data) => {
+      qc.setQueryData(['inactive-hours', env], data);
+      setDraft(null);
+      await invalidateNodeStatusQueries(qc);
+    },
+    onError: (error) => {
+      if (error instanceof AuthError) window.location.href = '/login';
+    },
+  });
+  const error = mutation.error ?? query.error;
+
+  return (
+    <section aria-labelledby="inactive-hours-heading" className="border-t border-[color:var(--border)] py-4 space-y-3">
+      <h2 id="inactive-hours-heading" className="font-display text-sm font-semibold text-[color:var(--text-1)]">
+        Node inactivity
+      </h2>
+      {query.isPending && <p role="status" className="text-xs text-[color:var(--text-3)]">Loading inactive hours...</p>}
+      {query.data && (
+        <form className="flex flex-wrap items-center gap-4 text-xs" onSubmit={(event) => {
+          event.preventDefault();
+          if (canEdit && dirty && valid && !mutation.isPending) mutation.mutate();
+        }}>
+          <label className="flex items-center gap-2">
+            <input type="checkbox" checked={value.useGlobal} disabled={!canEdit || mutation.isPending}
+              onChange={(event) => { setDraft({ ...value, useGlobal: event.target.checked }); mutation.reset(); }} />
+            Use global default
+          </label>
+          <label className="flex items-center gap-2">
+            Inactive hours
+            <input type="number" min={1} max={2562047} step={1} required value={value.hours}
+              disabled={!canEdit || value.useGlobal || mutation.isPending}
+              onChange={(event) => { setDraft({ ...value, hours: event.target.value }); mutation.reset(); }}
+              className="w-28 rounded border border-[color:var(--border)] bg-[color:var(--bg-3)] px-2 py-1.5 tabular-nums disabled:opacity-50" />
+          </label>
+          <span className="text-[color:var(--text-3)]">Effective: {query.data.inactive_hours}h ({query.data.source})</span>
+          {canEdit && <button type="submit" aria-label="Save inactive hours"
+            disabled={!dirty || !valid || mutation.isPending} className={buttonClasses({ variant: 'primary' })}>
+            <Save className="h-3.5 w-3.5" aria-hidden="true" />
+            {mutation.isPending ? 'Saving...' : 'Save'}
+          </button>}
+        </form>
+      )}
+      {error && <p role="alert" className="text-xs text-[color:var(--danger)]">{error.message}</p>}
+      {query.isError && <button type="button" aria-label="Retry inactive hours" disabled={query.isFetching}
+        onClick={() => void query.refetch()} className={buttonClasses({ variant: 'ghost' })}>Retry</button>}
+    </section>
+  );
+}

--- a/frontend/src/features/nodes/NodeDetailPage.test.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.test.tsx
@@ -13,7 +13,6 @@ import {
 import { NodeDetailPage } from './NodeDetailPage';
 import type { NodePosture, OsqueryNode, SavedQueriesPagedResponse, AdminTag, PostureScore } from '$/api/types';
 import type { NodeActivityBucket, NodeTileSeries } from '$/api/stats';
-import type { SettingValue } from '$/api/settings';
 import type { Features } from '$/api/features';
 
 const mockGetNode = vi.fn<() => Promise<OsqueryNode>>();
@@ -25,7 +24,7 @@ const mockGetMe = vi.fn<() => Promise<unknown>>();
 const mockListEnvironments = vi.fn<() => Promise<Array<{ id: number; name: string; uuid: string }>>>();
 const mockGetNodeActivity = vi.fn<() => Promise<NodeActivityBucket[]>>();
 const mockGetNodeActivityTiles = vi.fn<() => Promise<NodeTileSeries>>();
-const mockListServiceSettings = vi.fn<() => Promise<SettingValue[]>>();
+const mockGetInactiveHours = vi.fn();
 const mockGetFeatures = vi.fn<() => Promise<Features>>();
 const mockListSavedQueries = vi.fn<() => Promise<SavedQueriesPagedResponse>>();
 const mockRunQuery = vi.fn<() => Promise<{ query_name: string }>>();
@@ -46,6 +45,7 @@ vi.mock('$/api/users', () => ({
 }));
 
 vi.mock('$/api/environments', () => ({
+  getEnvironmentInactiveHours: (...args: unknown[]) => mockGetInactiveHours(...args),
   listEnvironments: (...args: unknown[]) => mockListEnvironments(...(args as [])),
 }));
 
@@ -57,10 +57,6 @@ vi.mock('$/api/stats', async () => {
     getNodeActivityTiles: (...args: unknown[]) => mockGetNodeActivityTiles(...(args as [])),
   };
 });
-
-vi.mock('$/api/settings', () => ({
-  listServiceSettings: (...args: unknown[]) => mockListServiceSettings(...(args as [])),
-}));
 
 vi.mock('$/api/features', () => ({
   getFeatures: (...args: unknown[]) => mockGetFeatures(...(args as [])),
@@ -311,7 +307,7 @@ describe('NodeDetailPage', () => {
       query_write: [],
       total: [],
     });
-    mockListServiceSettings.mockResolvedValue([]);
+    mockGetInactiveHours.mockResolvedValue({ override_hours: null, inactive_hours: 72, source: 'default' });
     mockGetFeatures.mockResolvedValue({ posture: false, service_config: false, accelerated: false, file_explorer: false });
     mockGetNodePostureScore.mockResolvedValue({
       node_uuid: 'abc12345-0000-0000-0000-000000000001',
@@ -367,6 +363,14 @@ describe('NodeDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Active')).toBeInTheDocument();
     });
+  });
+
+  it.each([24, 168])('uses the environment threshold %s in the detail status', async (hours) => {
+    mockGetInactiveHours.mockResolvedValue({ override_hours: hours, inactive_hours: hours, source: 'environment' });
+    mockGetNode.mockResolvedValue(makeNode({ last_seen: new Date(Date.now() - 48 * 3600_000).toISOString() }));
+    renderWithProviders(makeTestRouter());
+    expect(await screen.findByText(hours === 24 ? 'Inactive' : 'Active')).toBeInTheDocument();
+    expect(mockGetInactiveHours).toHaveBeenCalledWith('test-env');
   });
 
   it('copies the node key and refreshes the node view', async () => {

--- a/frontend/src/features/nodes/NodeDetailPage.tsx
+++ b/frontend/src/features/nodes/NodeDetailPage.tsx
@@ -169,7 +169,7 @@ interface HeroStripProps {
     last_seen: string;
     bytes_received: number;
   };
-  isActive: boolean;
+  isActive: boolean | undefined;
 }
 
 function HeroStrip({ node, isActive }: HeroStripProps) {
@@ -178,14 +178,14 @@ function HeroStrip({ node, isActive }: HeroStripProps) {
       label: 'Status',
       value: (
         <span className="inline-flex items-center gap-1.5">
-          <StatusPip variant={isActive ? 'success' : 'dim'} live={isActive} />
+          {isActive !== undefined && <StatusPip variant={isActive ? 'success' : 'dim'} live={isActive} />}
           <span
             className={cn(
               'text-xs font-medium',
               isActive ? 'text-[color:var(--success)]' : 'text-[color:var(--text-3)]',
             )}
           >
-            {isActive ? 'Active' : 'Inactive'}
+            {isActive === undefined ? 'Unknown' : isActive ? 'Active' : 'Inactive'}
           </span>
         </span>
       ),
@@ -682,7 +682,7 @@ export function NodeDetailPage() {
   usePageTitle(t('pageTitle.node'));
   const { env, uuid } = useParams({ from: '/_app/env/$env/nodes/$uuid' as const });
   const navigate = useNavigate();
-  const inactiveHours = useInactiveHours();
+  const { data: inactivity } = useInactiveHours(env);
   const [activeTab, setActiveTab] = useState<Tab>('details');
   const [activityInterval, setActivityInterval] = useState<ActivityInterval>('6h');
   const [copiedNodeKey, setCopiedNodeKey] = useState(false);
@@ -888,7 +888,7 @@ export function NodeDetailPage() {
     return null;
   }
 
-  const isActive = node ? isNodeActive(node.last_seen, inactiveHours) : false;
+  const isActive = node ? isNodeActive(node.last_seen, inactivity?.inactive_hours) : undefined;
 
   return (
     <div className="flex flex-col h-full min-h-0 px-6 py-4 max-w-5xl mx-auto w-full">

--- a/frontend/src/features/nodes/NodesTablePage.test.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
@@ -13,7 +13,6 @@ import {
 import { NodesTablePage } from './NodesTablePage';
 import { nodesSearchSchema } from '$/routes/_app/env/$env/nodes';
 import type { NodesPagedResponse } from '$/api/types';
-import type { SettingValue } from '$/api/settings';
 import type { Features } from '$/api/features';
 import type { NodeTileSeries, StatsResponse } from '$/api/stats';
 
@@ -21,7 +20,7 @@ import type { NodeTileSeries, StatsResponse } from '$/api/stats';
 // Mock the nodes API module
 // ---------------------------------------------------------------------------
 const mockListNodes = vi.fn<() => Promise<NodesPagedResponse>>();
-const mockListServiceSettings = vi.fn<() => Promise<SettingValue[]>>();
+const mockGetInactiveHours = vi.fn();
 const mockGetFeatures = vi.fn<() => Promise<Features>>();
 const mockGetStats = vi.fn<() => Promise<StatsResponse>>();
 const mockGetNodeActivityTilesBatch = vi.fn<() => Promise<Record<string, NodeTileSeries>>>();
@@ -30,8 +29,9 @@ vi.mock('$/api/nodes', () => ({
   listNodes: (...args: unknown[]) => mockListNodes(...(args as [])),
 }));
 
-vi.mock('$/api/settings', () => ({
-  listServiceSettings: (...args: unknown[]) => mockListServiceSettings(...(args as [])),
+vi.mock('$/api/environments', () => ({
+  getEnvironmentInactiveHours: (...args: unknown[]) => mockGetInactiveHours(...args),
+  listEnvironments: () => Promise.resolve([]),
 }));
 
 vi.mock('$/api/features', () => ({
@@ -122,6 +122,7 @@ function makeStatsResponse(overrides: Partial<StatsResponse> = {}): StatsRespons
       {
         uuid: 'test-env',
         name: 'test-env',
+        inactive_hours: 72,
         active: 1,
         inactive: 0,
         total: 1,
@@ -226,7 +227,7 @@ describe('NodesTablePage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockListServiceSettings.mockResolvedValue([]);
+    mockGetInactiveHours.mockResolvedValue({ override_hours: null, inactive_hours: 72, source: 'default' });
     mockGetFeatures.mockResolvedValue({ posture: false, service_config: false, accelerated: false, file_explorer: false });
     mockGetStats.mockResolvedValue(makeStatsResponse());
     mockGetNodeActivityTilesBatch.mockResolvedValue({
@@ -419,6 +420,30 @@ describe('NodesTablePage', () => {
     });
 
     expect(screen.getAllByText('Active').length).toBeGreaterThan(1);
+  });
+
+  it.each([24, 168])('uses the environment threshold %s for node badges', async (hours) => {
+    mockGetInactiveHours.mockResolvedValue({ override_hours: hours, inactive_hours: hours, source: 'environment' });
+    const response = makeResponse();
+    response.items[0].last_seen = new Date(Date.now() - 48 * 3600_000).toISOString();
+    mockListNodes.mockResolvedValue(response);
+    renderWithProviders(makeTestRouter());
+    const row = (await screen.findByText('web-server-01')).closest('tr')!;
+    await waitFor(() => expect(within(row).getByText(hours === 24 ? 'Inactive' : 'Active')).toBeInTheDocument());
+    expect(mockGetInactiveHours).toHaveBeenCalledWith('test-env');
+  });
+
+  it('does not guess a node status while its threshold loads or fails', async () => {
+    let reject!: (error: Error) => void;
+    mockGetInactiveHours.mockReturnValue(new Promise((_, fail) => { reject = fail; }));
+    mockListNodes.mockResolvedValue(makeResponse());
+    renderWithProviders(makeTestRouter());
+    const row = (await screen.findByText('web-server-01')).closest('tr')!;
+    expect(within(row).queryByText('Active')).not.toBeInTheDocument();
+    expect(within(row).queryByText('Inactive')).not.toBeInTheDocument();
+    await act(async () => reject(new Error('Unavailable')));
+    expect(within(row.children[1] as HTMLElement).getByText('Unknown')).toBeInTheDocument();
+    expect(within(row.children[1] as HTMLElement).queryByRole('img', { name: 'inactive' })).not.toBeInTheDocument();
   });
 
   it('shows uptime and posture risk badge when posture is enabled', async () => {

--- a/frontend/src/features/nodes/NodesTablePage.tsx
+++ b/frontend/src/features/nodes/NodesTablePage.tsx
@@ -430,7 +430,7 @@ export function NodesTablePage() {
   const { env } = useParams({ from: '/_app/env/$env/nodes' });
   const search = useSearch({ from: '/_app/env/$env/nodes' });
   const navigate = useNavigate({ from: '/_app/env/$env/nodes' });
-  const inactiveHours = useInactiveHours();
+  const { data: inactivity } = useInactiveHours(env);
 
   const status: NodeStatus = search.status ?? 'all';
   const q: string = search.q ?? '';
@@ -894,7 +894,7 @@ export function NodesTablePage() {
             {!isLoading &&
               !isError &&
               nodes.map((node) => {
-                const isActive = isNodeActive(node.last_seen, inactiveHours);
+                const isActive = isNodeActive(node.last_seen, inactivity?.inactive_hours);
                 const isSelected = selectedUuids.has(node.uuid);
 
                 return (
@@ -918,10 +918,10 @@ export function NodesTablePage() {
 
                     {/* Status — pip + label */}
                     <td className="px-4 py-2.5 align-middle">
-                      <StatusBadge
+                      {isActive === undefined ? <span className="text-xs text-[color:var(--text-3)]">Unknown</span> : <StatusBadge
                         variant={isActive ? 'success' : 'dim'}
                         label={isActive ? 'Active' : 'Inactive'}
-                      />
+                      />}
                     </td>
 
                     {/* Health — server-side compact triage calculation */}

--- a/frontend/src/features/settings/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/SettingsPage.test.tsx
@@ -78,10 +78,9 @@ function makeTestRouter(initialPath = '/_app/settings/api') {
   return createRouter({ routeTree, history });
 }
 
-function renderWithProviders(router: ReturnType<typeof makeTestRouter>) {
-  const queryClient = new QueryClient({
+function renderWithProviders(router: ReturnType<typeof makeTestRouter>, queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
-  });
+  })) {
   return render(
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
@@ -139,6 +138,21 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('No settings for api.')).toBeInTheDocument();
     });
+  });
+
+  it('invalidates environment thresholds, nodes, and stats after a global threshold write', async () => {
+    const user = userEvent.setup();
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const keys = [['inactive-hours', 'dev'], ['nodes', 'dev'], ['node', 'dev', 'uuid'], ['stats']];
+    keys.forEach((key) => qc.setQueryData(key, {}));
+    mockList.mockResolvedValue([makeSetting({ Name: 'inactive_hours', Type: 'integer', Integer: 72 })]);
+    mockPatch.mockResolvedValue(makeSetting({ Integer: 24 }));
+    renderWithProviders(makeTestRouter(), qc);
+    const input = await screen.findByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '24');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => keys.forEach((key) => expect(qc.getQueryState(key)?.isInvalidated).toBe(true)));
   });
 
   it('patches an integer setting when Save is clicked', async () => {

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -16,6 +16,7 @@ import { EmptyState } from '$/components/data/EmptyState';
 import { formatRelative } from '$/lib/time';
 import { StatusBadge } from '$/components/data/StatusBadge';
 import { MetadataBadge } from '$/components/data/MetadataBadge';
+import { invalidateNodeStatusQueries } from '$/lib/node-status';
 
 // Services are constant in the backend (pkg/settings.ValidServices = {tls, admin, api}).
 // The raw values are the strings the API accepts on /api/v1/settings/{service};
@@ -168,7 +169,12 @@ export function SettingsPage() {
                 key={s.ID}
                 setting={s}
                 service={service}
-                onSaved={() => qc.invalidateQueries({ queryKey: ['settings', service] })}
+                onSaved={() => {
+                  void qc.invalidateQueries({ queryKey: ['settings', service] });
+                  if (service === 'api' && s.Name === 'inactive_hours') {
+                    void invalidateNodeStatusQueries(qc);
+                  }
+                }}
               />
             ))}
           </section>

--- a/frontend/src/lib/node-status.test.tsx
+++ b/frontend/src/lib/node-status.test.tsx
@@ -1,0 +1,37 @@
+import { act, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, focusManager } from '@tanstack/react-query';
+import { afterEach, expect, it, vi } from 'vitest';
+import type { PropsWithChildren } from 'react';
+import { useInactiveHours } from './node-status';
+
+const getHours = vi.hoisted(() => vi.fn());
+vi.mock('$/api/environments', () => ({ getEnvironmentInactiveHours: getHours }));
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+  vi.useRealTimers();
+});
+
+it('refreshes an open screen every 30 seconds and pauses polling in the background', async () => {
+  vi.useFakeTimers();
+  focusManager.setFocused(true);
+  getHours.mockResolvedValue({ override_hours: null, inactive_hours: 72, source: 'default' });
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const { result, unmount } = renderHook(() => useInactiveHours('dev'), {
+    wrapper: ({ children }: PropsWithChildren) => <QueryClientProvider client={qc}>{children}</QueryClientProvider>,
+  });
+  await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+  expect(result.current.data?.inactive_hours).toBe(72);
+  getHours.mockResolvedValue({ override_hours: 24, inactive_hours: 24, source: 'environment' });
+  await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+  expect(result.current.data?.inactive_hours).toBe(24);
+  focusManager.setFocused(false);
+  getHours.mockResolvedValue({ override_hours: 168, inactive_hours: 168, source: 'environment' });
+  await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+  expect(result.current.data?.inactive_hours).toBe(24);
+  focusManager.setFocused(true);
+  await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+  expect(result.current.data?.inactive_hours).toBe(168);
+  unmount();
+  qc.clear();
+});

--- a/frontend/src/lib/node-status.ts
+++ b/frontend/src/lib/node-status.ts
@@ -1,32 +1,26 @@
-import { useQuery } from '@tanstack/react-query';
-import { listServiceSettings, type SettingValue } from '$/api/settings';
+import { useQuery, type QueryClient } from '@tanstack/react-query';
+import { getEnvironmentInactiveHours } from '$/api/environments';
 import { isWithinHours } from '$/lib/time';
 
-export const DEFAULT_INACTIVE_HOURS = 72;
-
-function normalizeSettingName(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
-}
-
-export function getInactiveHoursFromSettings(settings?: SettingValue[]): number {
-  const match = settings?.find((setting) => normalizeSettingName(setting.Name) === 'inactivehours');
-  if (!match || match.Type !== 'integer' || !Number.isFinite(match.Integer) || match.Integer <= 0) {
-    return DEFAULT_INACTIVE_HOURS;
-  }
-  return match.Integer;
-}
-
-export function isNodeActive(lastSeen: string, inactiveHours = DEFAULT_INACTIVE_HOURS): boolean {
+export function isNodeActive(lastSeen: string, inactiveHours: number | undefined): boolean | undefined {
+  if (inactiveHours === undefined) return undefined;
   return isWithinHours(lastSeen, inactiveHours);
 }
 
-export function useInactiveHours(): number {
-  const { data } = useQuery({
-    queryKey: ['settings', 'admin'],
-    queryFn: () => listServiceSettings('admin'),
+export function useInactiveHours(env: string) {
+  return useQuery({
+    queryKey: ['inactive-hours', env],
+    queryFn: () => getEnvironmentInactiveHours(env),
+    enabled: !!env,
     staleTime: 30_000,
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
     retry: false,
   });
+}
 
-  return getInactiveHoursFromSettings(data);
+export function invalidateNodeStatusQueries(qc: QueryClient) {
+  return Promise.all(['inactive-hours', 'nodes', 'node', 'stats'].map((key) =>
+    qc.invalidateQueries({ queryKey: [key] }),
+  ));
 }

--- a/frontend/src/lib/time.test.ts
+++ b/frontend/src/lib/time.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { formatRelative, formatTimeUntil, formatBucketAgo } from './time';
+import { formatRelative, formatTimeUntil, formatBucketAgo, isWithinHours } from './time';
 import { setLanguageEphemeral } from '$/i18n/i18n';
+
+it('treats the exact inactivity cutoff and never-seen nodes as inactive', () => {
+  const now = Date.now();
+  const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+  expect(isWithinHours(new Date(now - 24 * 3600_000).toISOString(), 24)).toBe(false);
+  expect(isWithinHours(new Date(now - 24 * 3600_000 + 1).toISOString(), 24)).toBe(true);
+  expect(isWithinHours('', 24)).toBe(false);
+  expect(isWithinHours('0001-01-01T00:00:00Z', 2562047)).toBe(false);
+  expect(isWithinHours('invalid', 24)).toBe(false);
+  clock.mockRestore();
+});
 
 describe('formatRelative', () => {
   const NOW = new Date('2024-03-14T15:09:26.000Z').getTime();

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -3161,6 +3161,152 @@ paths:
       summary: Update environment expiration
       tags:
         - environments
+  "/api/v1/environments/inactive-hours/{env}":
+    delete:
+      parameters:
+        - description: Environment name or UUID
+          in: path
+          name: env
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/settings.InactivityPolicy"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Reset environment inactivity threshold
+      tags:
+        - environments
+    get:
+      parameters:
+        - description: Environment name or UUID
+          in: path
+          name: env
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/settings.InactivityPolicy"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Get environment inactivity threshold
+      tags:
+        - environments
+    put:
+      parameters:
+        - description: Environment name or UUID
+          in: path
+          name: env
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/handlers.InactiveHoursRequest"
+        description: Positive whole hours (1 to 2562047)
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/settings.InactivityPolicy"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Set environment inactivity threshold
+      tags:
+        - environments
   "/api/v1/environments/intervals/{env}":
     patch:
       description: Updates osquery interval settings for an environment.
@@ -9435,6 +9581,10 @@ components:
           type: integer
         inactive:
           type: integer
+        inactive_hours:
+          description: InactiveHours is the effective threshold for this environment,
+            including inheritance.
+          type: integer
         name:
           type: string
         platform_counts:
@@ -9464,6 +9614,15 @@ components:
           type: string
         uuid:
           type: string
+      type: object
+    handlers.InactiveHoursRequest:
+      properties:
+        inactive_hours:
+          maximum: 2562047
+          minimum: 1
+          type: integer
+      required:
+        - inactive_hours
       type: object
     handlers.LogoutResponse:
       properties:
@@ -9611,6 +9770,8 @@ components:
             $ref: "#/components/schemas/handlers.EnvStats"
           type: array
         inactive_hours:
+          description: InactiveHours is the global default only; node counts use each
+            environment's effective threshold.
           type: integer
         inactive_nodes:
           type: integer
@@ -10106,6 +10267,24 @@ components:
         updatedAt:
           type: string
         value:
+          type: string
+      type: object
+    settings.InactivityPolicy:
+      properties:
+        inactive_hours:
+          maximum: 2562047
+          minimum: 1
+          type: integer
+        override_hours:
+          maximum: 2562047
+          minimum: 1
+          type: integer
+          nullable: true
+        source:
+          enum:
+            - environment
+            - global
+            - default
           type: string
       type: object
     settings.SettingValue:

--- a/pkg/apiclient/inactivity_test.go
+++ b/pkg/apiclient/inactivity_test.go
@@ -1,0 +1,51 @@
+package apiclient
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type inactivityTransport func(*http.Request) (*http.Response, error)
+
+func (f inactivityTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestGetEnvironmentInactiveHours(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		body   string
+		status int
+		want   int64
+	}{
+		{"override", `{"override_hours":2,"inactive_hours":2,"source":"environment"}`, 200, 2},
+		{"inherited", `{"override_hours":null,"inactive_hours":168,"source":"global"}`, 200, 168},
+		{"maximum", `{"inactive_hours":2562047}`, 200, 2562047},
+		{"missing", `{}`, 200, 0},
+		{"zero", `{"inactive_hours":0}`, 200, 0},
+		{"negative", `{"inactive_hours":-1}`, 200, 0},
+		{"overflow", `{"inactive_hours":2562048}`, 200, 0},
+		{"fraction", `{"inactive_hours":2.5}`, 200, 0},
+		{"invalid JSON", `not JSON`, 200, 0},
+		{"forbidden", `{"error":"forbidden"}`, 403, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api, err := CreateAPIWithTransport(JSONConfigurationAPI{URL: "http://osctrl.test", Token: "test"}, inactivityTransport(func(r *http.Request) (*http.Response, error) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, "/api/v1/environments/inactive-hours/dev%20fleet", r.URL.EscapedPath())
+				require.Equal(t, "Bearer test", r.Header.Get("Authorization"))
+				return &http.Response{StatusCode: tc.status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(tc.body))}, nil
+			}))
+			require.NoError(t, err)
+			got, err := api.GetEnvironmentInactiveHours("dev fleet")
+			if tc.want == 0 {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/apiclient/osquery.go
+++ b/pkg/apiclient/osquery.go
@@ -3,6 +3,7 @@ package apiclient
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"path"
 
 	"github.com/jmpsec/osctrl/pkg/types"
@@ -19,11 +20,12 @@ type PlatformCounts struct {
 
 // EnvStats is the per-environment slice of the stats response.
 type EnvStats struct {
+	InactiveHours  int64          `json:"inactive_hours"`
 	UUID           string         `json:"uuid"`
 	Name           string         `json:"name"`
-	TotalNodes     int64          `json:"total_nodes"`
-	ActiveNodes    int64          `json:"active_nodes"`
-	InactiveNodes  int64          `json:"inactive_nodes"`
+	TotalNodes     int64          `json:"total"`
+	ActiveNodes    int64          `json:"active"`
+	InactiveNodes  int64          `json:"inactive"`
 	PlatformCounts PlatformCounts `json:"platform_counts"`
 }
 
@@ -39,9 +41,10 @@ type EnvStats struct {
 // handler filters environments through Users.CheckPermissions, so a
 // restricted token gets a smaller Environments slice, not a 403.
 type StatsResponse struct {
-	TotalNodes         int64          `json:"total_nodes"`
-	ActiveNodes        int64          `json:"active_nodes"`
-	InactiveNodes      int64          `json:"inactive_nodes"`
+	TotalNodes    int64 `json:"total_nodes"`
+	ActiveNodes   int64 `json:"active_nodes"`
+	InactiveNodes int64 `json:"inactive_nodes"`
+	// InactiveHours is the global default only; counts use per-environment thresholds.
 	InactiveHours      int64          `json:"inactive_hours"`
 	TotalActiveQueries int            `json:"total_active_queries"`
 	TotalActiveCarves  int            `json:"total_active_carves"`
@@ -61,6 +64,25 @@ func (api *OsctrlAPI) GetStats() (StatsResponse, error) {
 		return s, fmt.Errorf("can not parse body - %w", err)
 	}
 	return s, nil
+}
+
+// GetEnvironmentInactiveHours returns the effective threshold, including inheritance.
+func (api *OsctrlAPI) GetEnvironmentInactiveHours(env string) (int64, error) {
+	var policy struct {
+		InactiveHours int64 `json:"inactive_hours"`
+	}
+	reqURL := fmt.Sprintf("%s%s/%s", api.Configuration.URL, path.Join(APIPath, "environments/inactive-hours"), url.PathEscape(env))
+	raw, err := api.GetGeneric(reqURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("error getting environment inactivity threshold: %w", err)
+	}
+	if err := json.Unmarshal(raw, &policy); err != nil {
+		return 0, fmt.Errorf("can not parse inactivity threshold: %w", err)
+	}
+	if policy.InactiveHours < 1 || policy.InactiveHours > 2562047 {
+		return 0, fmt.Errorf("invalid environment inactivity threshold: %d", policy.InactiveHours)
+	}
+	return policy.InactiveHours, nil
 }
 
 // GetOsqueryTables to retrieve the osquery schema osctrl was configured with

--- a/pkg/environments/environments.go
+++ b/pkg/environments/environments.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -355,10 +356,13 @@ func (environment *EnvManager) Delete(identifier string) error {
 	if err != nil {
 		return fmt.Errorf("error getting environment %w", err)
 	}
-	if err := environment.DB.Unscoped().Delete(&env).Error; err != nil {
-		return fmt.Errorf("delete %w", err)
-	}
-	return nil
+	return environment.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Unscoped().Delete(&env).Error; err != nil {
+			return fmt.Errorf("delete %w", err)
+		}
+		return tx.Unscoped().Where("service = ? AND name = ? AND environment_id = ?", config.ServiceAPI, settings.InactiveHours, env.ID).
+			Delete(&settings.SettingValue{}).Error
+	})
 }
 
 // Update TLS Environment

--- a/pkg/environments/inactivity.go
+++ b/pkg/environments/inactivity.go
@@ -1,0 +1,49 @@
+package environments
+
+import (
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"gorm.io/gorm"
+)
+
+// SetInactiveHours replaces the override atomically; nil restores inheritance.
+func (environment *EnvManager) SetInactiveHours(envID uint, hours *int64) (before, after settings.InactivityPolicy, err error) {
+	if envID == settings.NoEnvironmentID {
+		return before, after, gorm.ErrRecordNotFound
+	}
+	if hours != nil {
+		if err = settings.ValidateInactiveHours(*hours); err != nil {
+			return
+		}
+	}
+	err = environment.DB.Transaction(func(tx *gorm.DB) error {
+		// An existing parent row serializes even the first override insertion.
+		// A no-op write also takes the write lock on SQLite, unlike FOR UPDATE.
+		lock := tx.Model(&TLSEnvironment{}).Where("id = ?", envID).UpdateColumn("id", gorm.Expr("id"))
+		if lock.Error != nil {
+			return lock.Error
+		}
+		var env TLSEnvironment
+		if err := tx.First(&env, envID).Error; err != nil {
+			return err
+		}
+		mgr := &settings.Settings{DB: tx}
+		var readErr error
+		before, readErr = mgr.InactivityPolicy(envID)
+		if readErr != nil {
+			return readErr
+		}
+		if err := tx.Unscoped().Where("service = ? AND name = ? AND environment_id = ?", config.ServiceAPI, settings.InactiveHours, envID).
+			Delete(&settings.SettingValue{}).Error; err != nil {
+			return err
+		}
+		if hours != nil {
+			if err := mgr.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, *hours, envID); err != nil {
+				return err
+			}
+		}
+		after, readErr = mgr.InactivityPolicy(envID)
+		return readErr
+	})
+	return
+}

--- a/pkg/environments/inactivity_test.go
+++ b/pkg/environments/inactivity_test.go
@@ -1,0 +1,71 @@
+package environments
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestInactiveHoursConcurrentWritesAndReset(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "settings.db")+"?_busy_timeout=10000"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	require.NoError(t, db.AutoMigrate(&TLSEnvironment{}, &settings.SettingValue{}))
+	env := TLSEnvironment{Name: "prod"}
+	require.NoError(t, db.Create(&env).Error)
+	mgr := &EnvManager{DB: db}
+	conf := &settings.Settings{DB: db}
+	require.NoError(t, conf.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 168, 0))
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			hours := int64(i + 1)
+			_, after, err := mgr.SetInactiveHours(env.ID, &hours)
+			if err == nil && after.InactiveHours != hours {
+				err = fmt.Errorf("readback %d, want %d", after.InactiveHours, hours)
+			}
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	var count int64
+	require.NoError(t, db.Model(&settings.SettingValue{}).Where("environment_id = ?", env.ID).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+	before, after, err := mgr.SetInactiveHours(env.ID, nil)
+	require.NoError(t, err)
+	require.Equal(t, "environment", before.Source)
+	require.Equal(t, "global", after.Source)
+	require.Equal(t, int64(168), after.InactiveHours)
+	require.Nil(t, after.OverrideHours)
+	_, _, err = mgr.SetInactiveHours(env.ID, nil)
+	require.NoError(t, err, "reset is idempotent")
+	hours := int64(2)
+	_, _, err = mgr.SetInactiveHours(0, &hours)
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	_, _, err = mgr.SetInactiveHours(env.ID+1, &hours)
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	require.Equal(t, int64(168), conf.InactiveHours(0))
+	_, _, err = mgr.SetInactiveHours(env.ID, &hours)
+	require.NoError(t, err)
+	require.NoError(t, mgr.Delete(env.Name))
+	require.NoError(t, db.Unscoped().Model(&settings.SettingValue{}).Where("environment_id = ?", env.ID).Count(&count).Error)
+	require.Zero(t, count)
+	require.Equal(t, int64(168), conf.InactiveHours(0))
+}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -6,24 +6,25 @@ import (
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/jmpsec/osctrl/pkg/tags"
 	"github.com/jmpsec/osctrl/pkg/utils"
 )
 
 type ProcessingQuery struct {
-	Envs          []string
-	Platforms     []string
-	UUIDs         []string
-	Hosts         []string
-	Tags          []string
-	EnvID         uint
-	InactiveHours int64
+	Envs      []string
+	Platforms []string
+	UUIDs     []string
+	Hosts     []string
+	Tags      []string
+	EnvID     uint
 }
 
 type Managers struct {
-	Envs  *environments.EnvManager
-	Nodes *nodes.NodeManager
-	Tags  *tags.TagManager
+	Settings *settings.Settings
+	Envs     *environments.EnvManager
+	Nodes    *nodes.NodeManager
+	Tags     *tags.TagManager
 }
 
 type QueryTargetRecord struct {
@@ -41,7 +42,7 @@ func CreateQueryCarve(data ProcessingQuery, manager Managers, newQuery queries.D
 		if err != nil {
 			return targetNodesID, fmt.Errorf("error getting environment by ID: %w", err)
 		}
-		allNodes, err := manager.Nodes.GetByEnv(env.Name, nodes.AllNodes, data.InactiveHours)
+		allNodes, err := manager.Nodes.GetByEnv(env.Name, nodes.AllNodes, 0)
 		if err != nil {
 			return targetNodesID, fmt.Errorf("error getting all nodes: %w", err)
 		}
@@ -51,12 +52,25 @@ func CreateQueryCarve(data ProcessingQuery, manager Managers, newQuery queries.D
 		return targetNodesID, nil
 	}
 	// Environments target
+	hoursByEnv := make(map[uint]int64)
+	inactiveHours := func(envID uint) int64 {
+		if hours, ok := hoursByEnv[envID]; ok {
+			return hours
+		}
+		hours := manager.Settings.InactiveHours(envID)
+		hoursByEnv[envID] = hours
+		return hours
+	}
 	if len(data.Envs) > 0 {
 		expected = []uint{}
 		for _, e := range data.Envs {
 			// TODO: Check if user has permissions to query the environment
 			if (e != "") && manager.Envs.Exists(e) {
-				nodes, err := manager.Nodes.GetByEnv(e, nodes.ActiveNodes, data.InactiveHours)
+				env, err := manager.Envs.Get(e)
+				if err != nil {
+					return targetNodesID, fmt.Errorf("error getting environment: %w", err)
+				}
+				nodes, err := manager.Nodes.GetByEnv(env.Name, nodes.ActiveNodes, inactiveHours(env.ID))
 				if err != nil {
 					return targetNodesID, fmt.Errorf("error getting nodes by environment: %w", err)
 				}
@@ -73,7 +87,7 @@ func CreateQueryCarve(data ProcessingQuery, manager Managers, newQuery queries.D
 		platforms, _ := manager.Nodes.GetEnvIDPlatforms(data.EnvID)
 		for _, p := range data.Platforms {
 			if (p != "") && utils.Contains(platforms, p) {
-				nodes, err := manager.Nodes.GetByPlatform(data.EnvID, p, nodes.ActiveNodes, data.InactiveHours)
+				nodes, err := manager.Nodes.GetByPlatform(data.EnvID, p, nodes.ActiveNodes, inactiveHours(data.EnvID))
 				if err != nil {
 					return targetNodesID, fmt.Errorf("error getting nodes by platform: %w", err)
 				}

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1,16 +1,59 @@
 package handlers
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/settings"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+func TestCreateQueryCarveEnvironmentThresholds(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	manager := Managers{Envs: environments.CreateEnvironment(db), Nodes: nodes.CreateNodes(db), Settings: settings.NewSettings(db)}
+	require.NoError(t, manager.Settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, 24, 0))
+	var fixtures []nodes.OsqueryNode
+	var envUUIDs []string
+	for i, name := range []string{"short", "long", "inherited"} {
+		env := manager.Envs.Empty(name, name+".example.com")
+		require.NoError(t, manager.Envs.Create(&env))
+		envUUIDs = append(envUUIDs, env.UUID)
+		if i < 2 {
+			require.NoError(t, manager.Settings.NewIntegerValue(config.ServiceAPI, settings.InactiveHours, []int64{2, 168}[i], env.ID))
+		}
+		node := nodes.OsqueryNode{UUID: strings.ToUpper(name), Hostname: name, Platform: "linux", Environment: name, EnvironmentID: env.ID, LastSeen: time.Now().Add(-48 * time.Hour)}
+		require.NoError(t, db.Create(&node).Error)
+		fixtures = append(fixtures, node)
+	}
+	for _, tc := range []struct {
+		name string
+		data ProcessingQuery
+		want []uint
+	}{
+		{"environments", ProcessingQuery{EnvID: fixtures[0].EnvironmentID, Envs: []string{"short", "long", "inherited"}}, []uint{fixtures[1].ID}},
+		{"environment UUIDs", ProcessingQuery{EnvID: fixtures[0].EnvironmentID, Envs: envUUIDs}, []uint{fixtures[1].ID}},
+		{"short platform", ProcessingQuery{EnvID: fixtures[0].EnvironmentID, Platforms: []string{"linux"}}, nil},
+		{"long platform", ProcessingQuery{EnvID: fixtures[1].EnvironmentID, Platforms: []string{"linux"}}, []uint{fixtures[1].ID}},
+		{"inherited platform", ProcessingQuery{EnvID: fixtures[2].EnvironmentID, Platforms: []string{"linux"}}, nil},
+		{"explicit inactive uuid", ProcessingQuery{EnvID: fixtures[0].EnvironmentID, UUIDs: []string{fixtures[0].UUID}}, []uint{fixtures[0].ID}},
+		{"explicit inactive host", ProcessingQuery{EnvID: fixtures[0].EnvironmentID, Hosts: []string{fixtures[0].Hostname}}, []uint{fixtures[0].ID}},
+		{"no selectors includes inactive", ProcessingQuery{EnvID: fixtures[0].EnvironmentID}, []uint{fixtures[0].ID}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := CreateQueryCarve(tc.data, manager, queries.DistributedQuery{})
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.want, got)
+		})
+	}
+}
 
 func TestCreateQueryCarveWithoutTargetsIncludesAllEnvironmentNodes(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -49,8 +92,7 @@ func TestCreateQueryCarveWithoutTargetsIncludesAllEnvironmentNodes(t *testing.T)
 
 	targetNodesID, err := CreateQueryCarve(
 		ProcessingQuery{
-			EnvID:         env.ID,
-			InactiveHours: 24,
+			EnvID: env.ID,
 		},
 		Managers{
 			Envs:  envs,

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -36,10 +36,19 @@ func (f *fakeBackend) GetStats() (apiclient.StatsResponse, error) {
 		InactiveNodes: 1,
 		InactiveHours: 72,
 		Environments: []apiclient.EnvStats{
-			{Name: "dev", TotalNodes: 3, ActiveNodes: 2, InactiveNodes: 1,
+			{Name: "dev", TotalNodes: 3, ActiveNodes: 2, InactiveNodes: 1, InactiveHours: 2,
 				PlatformCounts: apiclient.PlatformCounts{Linux: 2, Darwin: 1}},
 		},
 	}, f.err
+}
+
+func TestFleetStatsEnvironmentThreshold(t *testing.T) {
+	s := connect(t, &fakeBackend{})
+	var out fleetStatsOut
+	call(t, s, "fleet_stats", nil, &out)
+	if out.InactiveHours != 72 || len(out.Environments) != 1 || out.Environments[0].InactiveHours != 2 {
+		t.Fatalf("thresholds lost in MCP response: %+v", out)
+	}
 }
 
 func (f *fakeBackend) GetNodes(env, target string) ([]nodes.OsqueryNode, error) {

--- a/pkg/mcp/tools_fleet.go
+++ b/pkg/mcp/tools_fleet.go
@@ -33,6 +33,7 @@ type fleetStatsIn struct{}
 
 // EnvironmentStats is the per-environment row of fleet_stats.
 type EnvironmentStats struct {
+	InactiveHours int64  `json:"inactive_hours"`
 	Name          string `json:"name"`
 	TotalNodes    int64  `json:"total_nodes"`
 	ActiveNodes   int64  `json:"active_nodes"`
@@ -44,9 +45,10 @@ type EnvironmentStats struct {
 }
 
 type fleetStatsOut struct {
-	TotalNodes         int64              `json:"total_nodes"`
-	ActiveNodes        int64              `json:"active_nodes"`
-	InactiveNodes      int64              `json:"inactive_nodes"`
+	TotalNodes    int64 `json:"total_nodes"`
+	ActiveNodes   int64 `json:"active_nodes"`
+	InactiveNodes int64 `json:"inactive_nodes"`
+	// InactiveHours is the global default only; counts use per-environment thresholds.
 	InactiveHours      int64              `json:"inactive_hours"`
 	TotalActiveQueries int                `json:"total_active_queries"`
 	TotalActiveCarves  int                `json:"total_active_carves"`
@@ -80,7 +82,8 @@ func addFleetTools(s *sdk.Server, b Backend) {
 		Name: "fleet_stats",
 		Description: "Fleet-wide node counts: totals, active vs inactive, and a " +
 			"per-platform and per-environment breakdown. A node counts as inactive " +
-			"once it has not checked in for inactive_hours. Use this for " +
+			"once it has not checked in for that environment's inactive_hours. " +
+			"Top-level inactive_hours is the global default; environment overrides apply to counts. Use this for " +
 			"\"how many nodes\" questions instead of listing nodes and counting them.",
 	}, func(ctx context.Context, _ *sdk.CallToolRequest, _ fleetStatsIn) (*sdk.CallToolResult, fleetStatsOut, error) {
 		st, err := b.GetStats()
@@ -103,6 +106,7 @@ func envStats(in []apiclient.EnvStats) []EnvironmentStats {
 	out := make([]EnvironmentStats, 0, len(in))
 	for _, e := range in {
 		out = append(out, EnvironmentStats{
+			InactiveHours: e.InactiveHours,
 			Name:          e.Name,
 			TotalNodes:    e.TotalNodes,
 			ActiveNodes:   e.ActiveNodes,

--- a/pkg/settings/inactivity.go
+++ b/pkg/settings/inactivity.go
@@ -1,0 +1,48 @@
+package settings
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+)
+
+const MaxInactiveHours int64 = math.MaxInt64 / int64(time.Hour)
+
+type InactivityPolicy struct {
+	OverrideHours *int64 `json:"override_hours" extensions:"x-nullable" minimum:"1" maximum:"2562047"`
+	InactiveHours int64  `json:"inactive_hours" minimum:"1" maximum:"2562047"`
+	Source        string `json:"source" enums:"environment,global,default"`
+}
+
+func ValidateInactiveHours(hours int64) error {
+	if hours < 1 || hours > MaxInactiveHours {
+		return fmt.Errorf("inactive_hours must be an integer between 1 and %d", MaxInactiveHours)
+	}
+	return nil
+}
+
+// InactivityPolicy reads both scopes together; invalid legacy rows inherit.
+func (conf *Settings) InactivityPolicy(envID uint) (InactivityPolicy, error) {
+	policy := InactivityPolicy{InactiveHours: DefaultInactiveHours, Source: "default"}
+	var values []SettingValue
+	err := conf.DB.Where("service = ? AND name = ? AND environment_id IN ?", config.ServiceAPI, InactiveHours, []uint{NoEnvironmentID, envID}).
+		Order("environment_id DESC, id ASC").Find(&values).Error
+	if err != nil {
+		return policy, err
+	}
+	for _, value := range values {
+		if value.Type != TypeInteger || ValidateInactiveHours(value.Integer) != nil {
+			continue
+		}
+		policy.InactiveHours = value.Integer
+		policy.Source = "global"
+		if value.EnvironmentID != NoEnvironmentID {
+			policy.Source = "environment"
+			policy.OverrideHours = &value.Integer
+		}
+		break
+	}
+	return policy, nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -88,10 +88,7 @@ const (
 )
 
 // DefaultInactiveHours is the fallback threshold (in hours) for classifying
-// nodes as active vs inactive when the inactive_hours setting is absent or
-// invalid. Keeps every service — including the API, which does not seed the
-// setting itself — from treating all nodes as inactive when the DB row is
-// missing.
+// nodes as active vs inactive when no valid environment or global value exists.
 const DefaultInactiveHours int64 = 72
 
 // DefaultAlertHistoryRetentionDays is the fallback retention (in days) for
@@ -154,6 +151,15 @@ func (conf *Settings) EmptyValue(service, name, typeValue string, envID uint) Se
 
 // NewValue creates a new settings value
 func (conf *Settings) NewValue(service, name, typeValue string, value interface{}, envID uint) error {
+	if service == config.ServiceAPI && name == InactiveHours {
+		hours, ok := value.(int64)
+		if typeValue != TypeInteger || !ok {
+			return fmt.Errorf("inactive_hours must be an integer")
+		}
+		if err := ValidateInactiveHours(hours); err != nil {
+			return err
+		}
+	}
 	// Empty new value
 	entry := conf.EmptyValue(service, name, typeValue, envID)
 	switch typeValue {
@@ -246,6 +252,11 @@ func (conf *Settings) GetMap(service string, envID uint) (MapSettings, error) {
 
 // SetInteger sets a numeric settings value by service and name
 func (conf *Settings) SetInteger(intValue int64, service, name string, envID uint) error {
+	if service == config.ServiceAPI && name == InactiveHours {
+		if err := ValidateInactiveHours(intValue); err != nil {
+			return err
+		}
+	}
 	// Retrieve current value
 	value, err := conf.RetrieveValue(service, name, envID)
 	if err != nil {
@@ -327,19 +338,14 @@ func (conf *Settings) RefreshSettings(service string) int64 {
 	return value.Integer
 }
 
-// InactiveHours gets the value in hours for a node to be inactive by service.
-// Returns DefaultInactiveHours when the setting is absent or invalid so that
-// callers never receive a zero threshold (which would make every node appear
-// inactive).
+// InactiveHours resolves an environment override, then the global setting.
 func (conf *Settings) InactiveHours(envID uint) int64 {
-	value, err := conf.RetrieveValue(config.ServiceAPI, InactiveHours, envID)
+	policy, err := conf.InactivityPolicy(envID)
 	if err != nil {
+		log.Error().Err(err).Uint("environment_id", envID).Msg("failed to resolve inactive_hours")
 		return DefaultInactiveHours
 	}
-	if value.Integer <= 0 {
-		return DefaultInactiveHours
-	}
-	return value.Integer
+	return policy.InactiveHours
 }
 
 // OnelinerExpiration checks if enrolling links will expire

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -48,7 +48,7 @@ func TestInactiveHours_DefaultsOnNonPositive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db := setupSettingsTestDB(t)
 			conf := &Settings{DB: db}
-			require.NoError(t, conf.NewIntegerValue(config.ServiceAPI, InactiveHours, tt.value, NoEnvironmentID))
+			require.NoError(t, db.Create(&SettingValue{Service: config.ServiceAPI, Name: InactiveHours, Type: TypeInteger, Integer: tt.value}).Error)
 			got := conf.InactiveHours(NoEnvironmentID)
 			assert.Equal(t, DefaultInactiveHours, got,
 				"InactiveHours should fall back to DefaultInactiveHours for non-positive stored value")
@@ -65,4 +65,47 @@ func TestInactiveHours_ReturnsConfigured(t *testing.T) {
 	got := conf.InactiveHours(NoEnvironmentID)
 	assert.Equal(t, configured, got,
 		"InactiveHours should return the stored positive value")
+}
+
+func TestInactiveHoursEnvironmentInheritance(t *testing.T) {
+	conf := &Settings{DB: setupSettingsTestDB(t)}
+	require.NoError(t, conf.NewIntegerValue(config.ServiceAPI, InactiveHours, 168, NoEnvironmentID))
+	assert.Equal(t, int64(168), conf.InactiveHours(1))
+	require.NoError(t, conf.NewIntegerValue(config.ServiceAPI, InactiveHours, 2, 1))
+	assert.Equal(t, int64(2), conf.InactiveHours(1))
+	assert.Equal(t, int64(168), conf.InactiveHours(2))
+	require.NoError(t, conf.SetInteger(24, config.ServiceAPI, InactiveHours, NoEnvironmentID))
+	assert.Equal(t, int64(2), conf.InactiveHours(1))
+	assert.Equal(t, int64(24), conf.InactiveHours(2))
+	require.NoError(t, conf.DeleteValue(config.ServiceAPI, InactiveHours, 1))
+	assert.Equal(t, int64(24), conf.InactiveHours(1))
+}
+
+func TestInactivityPolicyRejectsInvalidWritesAndInheritsInvalidRows(t *testing.T) {
+	conf := &Settings{DB: setupSettingsTestDB(t)}
+	require.NoError(t, conf.NewIntegerValue(config.ServiceAPI, InactiveHours, 168, NoEnvironmentID))
+	for _, hours := range []int64{0, -1, MaxInactiveHours + 1} {
+		require.Error(t, conf.NewIntegerValue(config.ServiceAPI, InactiveHours, hours, 1))
+		require.Error(t, conf.SetInteger(hours, config.ServiceAPI, InactiveHours, NoEnvironmentID))
+	}
+	require.Error(t, conf.NewStringValue(config.ServiceAPI, InactiveHours, "2", 1))
+	for _, row := range []SettingValue{
+		{EnvironmentID: 1, Type: TypeInteger, Integer: 0},
+		{EnvironmentID: 2, Type: TypeInteger, Integer: MaxInactiveHours + 1},
+		{EnvironmentID: 3, Type: TypeString, Integer: 2},
+	} {
+		row.Name, row.Service = InactiveHours, config.ServiceAPI
+		require.NoError(t, conf.DB.Create(&row).Error)
+		policy, err := conf.InactivityPolicy(row.EnvironmentID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(168), policy.InactiveHours)
+		assert.Equal(t, "global", policy.Source)
+		assert.Nil(t, policy.OverrideHours)
+	}
+	require.NoError(t, conf.NewIntegerValue(config.ServiceAPI, InactiveHours, MaxInactiveHours, 4))
+	policy, err := conf.InactivityPolicy(4)
+	require.NoError(t, err)
+	assert.Equal(t, "environment", policy.Source)
+	require.NotNil(t, policy.OverrideHours)
+	assert.Equal(t, MaxInactiveHours, *policy.OverrideHours)
 }


### PR DESCRIPTION
## Summary
- Add per-environment `inactive_hours` overrides with global inheritance and reset.
- Apply thresholds consistently across UI, API, CLI, targeting, and alerts.
- Include permissions, validation, audit logging, and concurrent-write protection.

## Validation
- Full Go suite and 111 frontend tests passed.
- TypeScript and OpenAPI checks passed.
- Desktop/mobile save and reset flows verified.

Implementation for #2 