### PR TITLE
Fix for spanish and other lazy loaded locales

### DIFF
--- a/frontend/src/i18n/boot-debug3.test.ts
+++ b/frontend/src/i18n/boot-debug3.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, vi, expect } from 'vitest';
+import { useLocalStorageStub } from '$/lib/test-storage';
+
+vi.mock('$/api/users', () => ({ patchMe: vi.fn().mockResolvedValue({}) }));
+
+describe('boot debug 3', () => {
+  useLocalStorageStub();
+
+  it('with reconcile part', async () => {
+    window.localStorage.setItem('osctrl.language', 'es');
+    vi.resetModules();
+    const mod = await import('./i18n');
+    for (let i = 0; i < 50; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+      if (mod.i18n.t('common.signOut') === 'Cerrar sesión') break;
+    }
+    console.log('after poll:', mod.i18n.language, mod.i18n.t('common.signOut'));
+    await mod.reconcileLanguageFromServer('es');
+    console.log('after reconcile:', mod.i18n.language, mod.i18n.t('common.signOut'));
+    expect(mod.i18n.t('common.signOut')).toBe('Cerrar sesión');
+  });
+});

--- a/frontend/src/i18n/boot-render.test.tsx
+++ b/frontend/src/i18n/boot-render.test.tsx
@@ -1,0 +1,83 @@
+import { createElement } from 'react';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { useTranslation } from 'react-i18next';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useLocalStorageStub } from '$/lib/test-storage';
+
+describe('lazy language startup', () => {
+  useLocalStorageStub();
+
+  let releasePending: (() => void) | undefined;
+
+  afterEach(async () => {
+    cleanup();
+    releasePending?.();
+    await vi.dynamicImportSettled();
+    vi.doUnmock('./locales/es/common');
+    vi.doUnmock('i18next');
+  });
+
+  async function bootSpanish() {
+    window.localStorage.setItem('osctrl.language', 'es');
+    vi.resetModules();
+    vi.doMock('i18next', async () => {
+      const actual = await vi.importActual<typeof import('i18next')>('i18next');
+      return { ...actual, default: actual.createInstance() };
+    });
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    releasePending = release;
+    vi.doMock('./locales/es/common', async () => {
+      await pending;
+      return vi.importActual('./locales/es/common');
+    });
+    const mod = await import('./i18n');
+    function Label() {
+      const { t, i18n } = useTranslation(undefined, { i18n: mod.i18n });
+      return createElement('span', { lang: i18n.resolvedLanguage }, t('common.signOut'));
+    }
+    render(createElement(Label));
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+    return { ...mod, release };
+  }
+
+  it('updates mounted React text when the stored Spanish catalog arrives', async () => {
+    const mod = await bootSpanish();
+    await act(async () => {
+      mod.release();
+      await vi.dynamicImportSettled();
+    });
+    expect(await screen.findByText('Cerrar sesión')).toBeInTheDocument();
+    expect(screen.getByText('Cerrar sesión')).toHaveAttribute('lang', 'es');
+    expect(mod.i18n.resolvedLanguage).toBe('es');
+    expect(mod.i18n.getResource('es', 'translation', 'common.signOut')).toBe('Cerrar sesión');
+    expect(mod.i18n.t('common.signOut')).toBe('Cerrar sesión');
+  });
+
+  it('waits for a pending Spanish catalog when profile reconciliation agrees', async () => {
+    const mod = await bootSpanish();
+    let settled = false;
+    const reconciliation = mod.reconcileLanguageFromServer('es').then(() => { settled = true; });
+    await act(async () => { await Promise.resolve(); });
+    expect(settled).toBe(false);
+    await act(async () => {
+      mod.release();
+      await reconciliation;
+      await vi.dynamicImportSettled();
+    });
+    expect(await screen.findByText('Cerrar sesión')).toBeInTheDocument();
+  });
+
+  it('does not overwrite a newer language choice with a slow boot catalog', async () => {
+    const mod = await bootSpanish();
+    await act(async () => { await mod.setLanguage('en', false); });
+    await act(async () => {
+      mod.release();
+      await vi.dynamicImportSettled();
+    });
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+    expect(mod.i18n.language).toBe('en');
+    expect(document.documentElement.lang).toBe('en');
+    expect(window.localStorage.getItem('osctrl.language')).toBe('en');
+  });
+});

--- a/frontend/src/i18n/boot.test.ts
+++ b/frontend/src/i18n/boot.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Boot-preload regression test — kept in its own file with NO static
+ * import of ./i18n: a static import would run the boot sequence (and
+ * initialize the shared i18next singleton) before the test seeds
+ * localStorage, so the re-import's init() would hit an already-
+ * initialized singleton. Importing only after seeding + resetModules
+ * replays the boot exactly as a real page load does.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { useLocalStorageStub } from '$/lib/test-storage';
+
+// Mirror writes go through the API client; stub the module so no
+// network (or CSRF dance) happens in tests. vi.mock is hoisted.
+vi.mock('$/api/users', () => ({
+  patchMe: vi.fn().mockResolvedValue({}),
+}));
+
+const STORAGE_KEY = 'osctrl.language';
+
+describe('boot language preload', () => {
+  useLocalStorageStub();
+
+  it('renders the stored language on load instead of falling back to English', async () => {
+    // Regression: boot initialized i18next with lng='es' (from the
+    // stored preference) but never loaded the Spanish catalog chunk —
+    // every key silently fell back to English on page load, and
+    // reconcile was a no-op because both sides agreed.
+    window.localStorage.setItem(STORAGE_KEY, 'es');
+    vi.resetModules();
+    const mod = await import('./i18n');
+
+    // The boot preload is sequenced after the async i18next init +
+    // dynamic chunk import; poll until it lands. The real UI flips
+    // reactively at the same point, so this mirrors production.
+    let ok = false;
+    for (let i = 0; i < 200; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      if (mod.i18n.t('common.signOut') === 'Cerrar sesión') { ok = true; break; }
+    }
+    expect(ok).toBe(true);
+    expect(mod.i18n.language).toBe('es');
+    expect(mod.i18n.t('nav.nodes')).toBe('Nodos');
+    expect(document.documentElement.getAttribute('lang')).toBe('es');
+
+    // Reconcile with the same value stays a no-op but keeps Spanish
+    // (previously the early return skipped ensuring the catalog).
+    await mod.reconcileLanguageFromServer('es');
+    expect(mod.i18n.t('common.signOut')).toBe('Cerrar sesión');
+
+    // The reconcile no-op path must not echo a PATCH for the boot value.
+    const { patchMe } = await import('$/api/users');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(patchMe).not.toHaveBeenCalled();
+  });
+});
+
+describe('boot language preload (english)', () => {
+  useLocalStorageStub();
+
+  it('boots straight into English when that is what is stored', async () => {
+    window.localStorage.setItem(STORAGE_KEY, 'en');
+    vi.resetModules();
+    const mod = await import('./i18n');
+    for (let i = 0; i < 200; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      if (mod.i18n.t('common.signOut') === 'Sign out') break;
+    }
+    expect(mod.i18n.language).toBe('en');
+    expect(mod.i18n.t('common.signOut')).toBe('Sign out');
+  });
+});

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -2,7 +2,7 @@
  * i18n.ts — i18next instance and language lifecycle.
  *
  * Resolution order (mirrors lib/theme.ts so both preferences behave the
- * same at boot, with no flash of wrong language):
+ * same at boot):
  *   1. localStorage["osctrl.language"]   — user's explicit choice
  *   2. navigator.languages                 — browser preference (base match)
  *   3. "en"                                — fallback/source language
@@ -72,8 +72,9 @@ const catalogs: Record<SupportedLanguage, () => Promise<CatalogModule>> = {
   el: () => import('./locales/el/common'),
 };
 
-/** Languages whose catalog is already loaded (or being loaded). */
-const loaded = new Set<SupportedLanguage>([DEFAULT_LANGUAGE]);
+/** Concurrent requests share the same catalog load, including its completion. */
+const catalogLoads = new Map<SupportedLanguage, Promise<void>>();
+let languageRequest = 0;
 
 export function getInitialLanguage(): SupportedLanguage {
   if (typeof window === 'undefined') return DEFAULT_LANGUAGE;
@@ -91,18 +92,19 @@ export function getInitialLanguage(): SupportedLanguage {
 }
 
 async function loadCatalog(language: SupportedLanguage): Promise<void> {
-  if (loaded.has(language)) return;
-  loaded.add(language);
-  try {
-    const mod = await catalogs[language]();
-    // Every catalog module exports its bundle under a named export
-    // matching its own language code (`export const es`, etc.).
-    const bundle = (mod as Record<string, Record<string, unknown>>)[language];
-    i18next.addResourceBundle(language, 'translation', bundle, true, true);
-  } catch (err) {
-    loaded.delete(language);
-    throw err;
+  if (language === DEFAULT_LANGUAGE) return;
+  let load = catalogLoads.get(language);
+  if (!load) {
+    load = catalogs[language]().then((mod) => {
+      const bundle = (mod as Record<string, Record<string, unknown>>)[language];
+      i18next.addResourceBundle(language, 'translation', bundle, true, true);
+    }).catch((err) => {
+      catalogLoads.delete(language);
+      throw err;
+    });
+    catalogLoads.set(language, load);
   }
+  await load;
 }
 
 /**
@@ -117,9 +119,7 @@ async function loadCatalog(language: SupportedLanguage): Promise<void> {
  */
 export async function setLanguage(language: SupportedLanguage, mirror = true): Promise<void> {
   if (!isSupportedLanguage(language)) return;
-  if (i18next.language !== language) await loadCatalog(language);
-  await i18next.changeLanguage(language);
-  applyLanguageSideEffects(language);
+  if (!await ensureLanguageActive(language)) return;
   try {
     window.localStorage?.setItem(LANGUAGE_STORAGE_KEY, language);
   } catch {
@@ -159,35 +159,32 @@ async function mirrorLanguageToServer(language: SupportedLanguage): Promise<void
 export async function reconcileLanguageFromServer(
   serverLanguage: string,
 ): Promise<void> {
-  if (!serverLanguage) return;
-  let language: SupportedLanguage | undefined;
-  try {
-    const stored = window.localStorage?.getItem(LANGUAGE_STORAGE_KEY);
-    if (stored === serverLanguage) return;
-  } catch {
-    /* localStorage blocked — fall through and apply the server value */
-  }
-  language = matchLanguage(serverLanguage);
+  const language = matchLanguage(serverLanguage);
   if (!language) return;
+  if (!await ensureLanguageActive(language)) return;
   mirroredLanguage = language;
   try {
     window.localStorage?.setItem(LANGUAGE_STORAGE_KEY, language);
   } catch {
     /* localStorage blocked — session-only preference */
   }
-  if (i18next.language !== language) {
-    await loadCatalog(language);
-    await i18next.changeLanguage(language);
-    applyLanguageSideEffects(language);
-  }
+}
+
+/** Activate only the latest request, after initialization and catalog loading. */
+async function ensureLanguageActive(language: SupportedLanguage): Promise<boolean> {
+  const request = ++languageRequest;
+  await initPromise;
+  await loadCatalog(language);
+  if (request !== languageRequest) return false;
+  if (i18next.language !== language) await i18next.changeLanguage(language);
+  applyLanguageSideEffects(language);
+  return true;
 }
 
 /** Non-persisting variant used by the test setup and SSR-ish contexts. */
 export async function setLanguageEphemeral(language: SupportedLanguage): Promise<void> {
   if (!isSupportedLanguage(language)) return;
-  if (i18next.language !== language) await loadCatalog(language);
-  await i18next.changeLanguage(language);
-  applyLanguageSideEffects(language);
+  await ensureLanguageActive(language);
 }
 
 function applyLanguageSideEffects(language: SupportedLanguage): void {
@@ -202,12 +199,13 @@ const initial = getInitialLanguage();
 
 export const i18n: I18n = i18next;
 
-// initReactI18next wires the instance into useTranslation via a context.
-void i18next
+// Initialize with the bundled fallback; activate lazy languages only after
+// their catalog is ready so React and ICU never treat fallback text as loaded.
+const initPromise = i18next
   .use(initReactI18next)
   .use(ICU)
   .init({
-    lng: initial,
+    lng: DEFAULT_LANGUAGE,
     fallbackLng: DEFAULT_LANGUAGE,
     // The lazy-load path calls addResourceBundle manually, so i18next
     // must not try to fetch resources through a backend. The English
@@ -223,7 +221,13 @@ void i18next
     returnEmptyString: false,
   });
 
-// Ensure the html lang attribute matches even before first switch
-// (getInitialLanguage may resolve to a navigator-detected language
-// whose lazy chunk is not needed yet — the attribute is free).
-applyLanguageSideEffects(initial);
+// Load the stored/browser preference on boot, not just on explicit switches.
+if (initial !== DEFAULT_LANGUAGE) {
+  void ensureLanguageActive(initial)
+    .catch(() => {
+      // Catalog chunk failed (offline, CSP regression) — stay on the
+      // English fallback; reconcile retries on next login/switch.
+    });
+}
+
+applyLanguageSideEffects(DEFAULT_LANGUAGE);


### PR DESCRIPTION
## Summary
- Fix Spanish and other lazy-loaded languages remaining in English on startup.
- Activate languages only after their catalogs load, keeping translations and the language menu synchronized.
- Prevent concurrent loads and stale startup requests from overriding newer language choices.

## Validation
- All 397 frontend tests passed.
- Production build passed.
- Verified Spanish startup, reload, and desktop/mobile behavior.