### PR TITLE
Better backend and cache performance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -278,6 +278,14 @@ Concrete example for config:
 6. It queues a `lastSeenUpdate` in the batch writer.
 7. It returns `env.Configuration` as the osquery config payload.
 
+### Steady-state database load
+
+- Node check-ins are coalesced per TLS process and persisted in parameterized bulk updates of at most 100 nodes. Each node retains its observation timestamp, normalized to database precision; older observations cannot replace newer timestamps or IPs. Equal stored timestamps keep the first persisted IP. The existing writer batch size, timeout, and buffer settings still control collection. The queue remains process-local and best-effort on shutdown or database errors; it is not a durable heartbeat store.
+- Empty distributed-query results are cached in Redis for two minutes by default, configurable through `osquery.queryDispatchTTL`, `--query-dispatch-ttl`, or `QUERY_DISPATCH_TTL`. Non-positive values select the default. Query creation invalidates targeted nodes; Redis `WATCH` prevents an in-flight empty SQL result from refilling an invalidated entry. SQL errors are not cached, and TLS returns HTTP 503 so agents can retry.
+- When acceleration is disabled, query reads skip session checks entirely. Otherwise, shared console/file-explorer hints cache absence for two minutes and presence for at most five seconds, bounded by the existing 30-second session freshness window. Session mutations invalidate hints after committing; token-checked refills reject obsolete lookups. These hints control polling only, never authorization.
+- Redis failures fall back to SQL. Failed invalidations can delay query discovery by the configured dispatch TTL or session acceleration by two minutes. Direct-database CLI mode has no Redis connection and also relies on dispatch TTL expiry; use API-mode query/carve submission for immediate invalidation. Upgrade all API/TLS replicas before relying on race-safe invalidation; old replicas do not implement the new refill protocol. Longer TTLs trade fewer SQL reads for a larger failure-time staleness window.
+- Real-engine regression tests are opt-in: `OSCTRL_TEST_POSTGRES_DSN` and `OSCTRL_TEST_MYSQL_DSN` exercise bulk updates using temporary prefixed tables. `OSCTRL_TEST_REDIS_ADDR` exercises query/session cache races against a disposable Redis instance; the optional `OSCTRL_TEST_REDIS_CONTAINER` test restarts that disposable container and requires a fixed host port.
+
 ### operator/API flow
 
 ```text

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -255,6 +256,8 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 		apiErrorResponse(w, "error creating query", http.StatusInternalServerError, err)
 		return
 	}
+	// The commit is durable even if the HTTP request was canceled.
+	h.Queries.Cache.InvalidateMany(context.Background(), targetNodesID)
 	// Return query name as serialized response
 	log.Debug().Msgf("Created query %s with id %d", newQuery.Name, newQuery.ID)
 	h.AuditLog.NewQuery(ctx[ctxUser], newQuery.Query, strings.Split(r.RemoteAddr, ":")[0], env.ID)

--- a/cmd/api/handlers/query_dispatch_test.go
+++ b/cmd/api/handlers/query_dispatch_test.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/jmpsec/osctrl/pkg/auditlog"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestCreateQueryInvalidatesDispatchAfterCommit(t *testing.T) {
+	addr := os.Getenv("OSCTRL_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("set OSCTRL_TEST_REDIS_ADDR to a disposable Redis instance")
+	}
+	for _, name := range []string{"commit", "rollback", "canceled-request"} {
+		t.Run(name, func(t *testing.T) {
+			rollback := name == "rollback"
+			db, h, env, node := setupConsoleHandlers(t)
+			h.AuditLog = &auditlog.AuditLogManager{}
+			h.DebugHTTPConfig = &config.YAMLConfigurationDebug{}
+			client := redis.NewClient(&redis.Options{Addr: addr})
+			t.Cleanup(func() { _ = client.Close() })
+			h.Queries.Cache = queries.NewQueryDispatchCache(client, 0)
+			h.Queries.Cache.Invalidate(context.Background(), node.ID)
+			t.Cleanup(func() { h.Queries.Cache.Invalidate(context.Background(), node.ID) })
+			result, _, err := h.Queries.NodeQueries(node)
+			require.NoError(t, err)
+			require.Empty(t, result)
+			cached, err := h.Queries.Cache.HasNoPendingQueries(context.Background(), node.ID)
+			require.NoError(t, err)
+			require.True(t, cached)
+
+			body, err := json.Marshal(types.ApiDistributedQueryRequest{Query: "SELECT 1", UUIDs: []string{node.UUID}})
+			require.NoError(t, err)
+			req := consoleRequest(http.MethodPost, "/queries", body, "alice")
+			requestCtx, cancel := context.WithCancel(req.Context())
+			defer cancel()
+			req = req.WithContext(requestCtx)
+			req.SetPathValue("env", env.Name)
+			checkedBeforeCommit := false
+			require.NoError(t, db.Callback().Create().Before("gorm:create").Register("test:before_target", func(tx *gorm.DB) {
+				if tx.Statement.Table != "distributed_query_targets" {
+					return
+				}
+				checkedBeforeCommit = true
+				cached, err := h.Queries.Cache.HasNoPendingQueries(context.Background(), node.ID)
+				require.NoError(t, err)
+				require.True(t, cached, "do not invalidate while query creation is uncommitted")
+				if rollback {
+					tx.AddError(errors.New("target write failed"))
+				}
+				if name == "canceled-request" {
+					cancel()
+				}
+			}))
+			rr := httptest.NewRecorder()
+			h.QueriesRunHandler(rr, req)
+			require.True(t, checkedBeforeCommit, rr.Body.String())
+			cached, err = h.Queries.Cache.HasNoPendingQueries(context.Background(), node.ID)
+			require.NoError(t, err)
+			if rollback {
+				require.Equal(t, http.StatusInternalServerError, rr.Code, rr.Body.String())
+				require.True(t, cached, "rollback must preserve the idle hint")
+				var count int64
+				require.NoError(t, db.Model(&queries.NodeQuery{}).Count(&count).Error)
+				require.Zero(t, count)
+				return
+			}
+			require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+			require.False(t, cached, "commit must invalidate the idle hint")
+			var response types.ApiQueriesResponse
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+			result, _, err = h.Queries.NodeQueries(node)
+			require.NoError(t, err)
+			require.Equal(t, queries.QueryReadQueries{response.Name: "SELECT 1"}, result)
+		})
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -450,8 +450,11 @@ func osctrlAPIService() {
 	queriesmgr.Cache = queries.NewQueryDispatchCache(redis.Client, 0)
 	log.Info().Msg("Initialize console")
 	consolemgr = console.NewManager(db.Conn, queriesmgr)
+	sessionHints := cache.NewSessionHints(redis.Client)
+	consolemgr.SessionHints = sessionHints
 	log.Info().Msg("Initialize file explorer")
 	fileexplorermgr = fileexplorer.NewManager(db.Conn, queriesmgr)
+	fileexplorermgr.SessionHints = sessionHints
 	// Construct the log reader. When the TLS logger ships logs to S3 the
 	// osquery_*_data tables are empty, so the API/console/file-explorer
 	// read logs back from S3 instead. For every other logger the data

--- a/cmd/tls/config_test.go
+++ b/cmd/tls/config_test.go
@@ -1,13 +1,49 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/urfave/cli/v3"
 )
+
+func TestQueryDispatchTTLConfiguration(t *testing.T) {
+	cfg, err := loadYAMLConfiguration(writeTempTLSConfig(t, "service:\n  auth: none\nosquery:\n  queryDispatchTTL: 45s\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	params := loadedYAMLToServiceParams(cfg, "tls.yml")
+	if got := params.Osquery.QueryDispatchTTL; got != 45*time.Second {
+		t.Fatalf("YAML queryDispatchTTL = %s, want 45s", got)
+	}
+
+	var dispatchFlag *cli.DurationFlag
+	for _, flag := range flags {
+		if f, ok := flag.(*cli.DurationFlag); ok && f.Name == "query-dispatch-ttl" {
+			copy := *f
+			dispatchFlag = &copy
+		}
+	}
+	if dispatchFlag == nil {
+		t.Fatal("missing query-dispatch-ttl flag")
+	}
+	if dispatchFlag.Destination != &flagParams.Osquery.QueryDispatchTTL {
+		t.Fatal("query-dispatch-ttl flag has wrong destination")
+	}
+	dispatchFlag.Destination = &params.Osquery.QueryDispatchTTL
+	t.Setenv("QUERY_DISPATCH_TTL", "90s")
+	command := &cli.Command{Flags: []cli.Flag{dispatchFlag}, Action: func(context.Context, *cli.Command) error { return nil }}
+	if err := command.Run(context.Background(), []string{"tls"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := params.Osquery.QueryDispatchTTL; got != 90*time.Second {
+		t.Fatalf("environment queryDispatchTTL = %s, want 90s", got)
+	}
+}
 
 func writeTempTLSConfig(t *testing.T, body string) string {
 	t.Helper()

--- a/cmd/tls/handlers/console_acceleration_test.go
+++ b/cmd/tls/handlers/console_acceleration_test.go
@@ -25,7 +25,7 @@ func TestShouldAccelerateQueryReadForActiveConsoleSession(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&console.Session{}))
 	queryManager := queries.CreateQueries(db)
-	handler := &HandlersTLS{Queries: queryManager, OsqueryValues: &config.YAMLConfigurationOsquery{Console: true}}
+	handler := &HandlersTLS{Queries: queryManager, OsqueryValues: &config.YAMLConfigurationOsquery{Accelerated: true, Console: true}}
 	node := nodes.OsqueryNode{ID: 7, UUID: "NODE-UUID", EnvironmentID: 1}
 	otherNode := nodes.OsqueryNode{ID: 8, UUID: "OTHER-NODE-UUID", EnvironmentID: 1}
 
@@ -96,7 +96,7 @@ func TestShouldNotAccelerateQueryReadForConsoleWhenConsoleDisabled(t *testing.T)
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&console.Session{}))
 	queryManager := queries.CreateQueries(db)
-	handler := &HandlersTLS{Queries: queryManager, OsqueryValues: &config.YAMLConfigurationOsquery{}}
+	handler := &HandlersTLS{Queries: queryManager, OsqueryValues: &config.YAMLConfigurationOsquery{Accelerated: true}}
 	node := nodes.OsqueryNode{ID: 7, UUID: "NODE-UUID", EnvironmentID: 1}
 
 	require.NoError(t, db.Create(&console.Session{
@@ -130,7 +130,7 @@ func TestShouldAccelerateQueryReadForActiveFileExplorerSession(t *testing.T) {
 	}).Error)
 
 	require.False(t, handler.shouldAccelerateQueryRead(node, false))
-	handler.OsqueryValues = &config.YAMLConfigurationOsquery{FileExplorer: true}
+	handler.OsqueryValues = &config.YAMLConfigurationOsquery{Accelerated: true, FileExplorer: true}
 	require.True(t, handler.shouldAccelerateQueryRead(node, false))
 }
 
@@ -203,4 +203,19 @@ func queryReadResponse(t *testing.T, handler *HandlersTLS, envUUID, nodeKey stri
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
 	return resp
+}
+
+func TestDisabledAccelerationSkipsSessionSQL(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&console.Session{}, &fileexplorer.Session{}))
+	reads := 0
+	require.NoError(t, db.Callback().Query().Before("gorm:query").Register("count_session_reads", func(*gorm.DB) { reads++ }))
+	h := &HandlersTLS{Queries: &queries.Queries{DB: db}, OsqueryValues: &config.YAMLConfigurationOsquery{Console: true, FileExplorer: true}}
+	node := nodes.OsqueryNode{ID: 7, UUID: "NODE-UUID", EnvironmentID: 1}
+	require.False(t, h.shouldAccelerateQueryRead(node, false))
+	require.False(t, h.shouldAccelerateQueryRead(node, true))
+	require.Zero(t, reads, "disabled acceleration must not query session tables")
+	h.OsqueryValues = nil
+	require.False(t, h.shouldAccelerateQueryRead(node, true))
 }

--- a/cmd/tls/handlers/handlers.go
+++ b/cmd/tls/handlers/handlers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jmpsec/osctrl/pkg/auditlog"
 	"github.com/jmpsec/osctrl/pkg/backend"
+	"github.com/jmpsec/osctrl/pkg/cache"
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
@@ -38,7 +39,7 @@ var validAction = map[string]bool{
 	settings.ScriptRemove: true,
 }
 
-const consoleSessionFreshness = 30 * time.Second
+const consoleSessionFreshness = cache.SessionFreshness
 
 // Valid values for enroll packages
 var validEnrollPackage = map[string]bool{
@@ -65,6 +66,7 @@ type HandlersTLS struct {
 	Carves          *carves.Carves
 	Settings        *settings.Settings
 	SettingsCache   *settings.RedisSettingsCache
+	SessionHints    *cache.SessionHints
 	Logs            *logging.LoggerTLS
 	WriteHandler    *batchWriter
 	ActivityWriter  *activityWriter
@@ -124,6 +126,13 @@ func WithSettings(settings *settings.Settings) Option {
 func WithSettingsCache(settingsCache *settings.RedisSettingsCache) Option {
 	return func(h *HandlersTLS) {
 		h.SettingsCache = settingsCache
+	}
+}
+
+// WithSessionHints shares interactive session polling hints with the API.
+func WithSessionHints(hints *cache.SessionHints) Option {
+	return func(h *HandlersTLS) {
+		h.SessionHints = hints
 	}
 }
 
@@ -286,6 +295,9 @@ func (h *HandlersTLS) allowsAcceleratedQueries(queryAccelerated bool) bool {
 }
 
 func (h *HandlersTLS) shouldAccelerateQueryRead(node nodes.OsqueryNode, queryAccelerated bool) bool {
+	if h.OsqueryValues == nil || !h.OsqueryValues.Accelerated {
+		return false
+	}
 	if queryAccelerated {
 		return true
 	}
@@ -296,34 +308,32 @@ func (h *HandlersTLS) hasActiveConsoleSession(node nodes.OsqueryNode) bool {
 	if h.OsqueryValues == nil || !h.OsqueryValues.Console {
 		return false
 	}
-	if node.ID == 0 || node.UUID == "" || node.EnvironmentID == 0 || h.Queries == nil || h.Queries.DB == nil {
-		return false
-	}
-	var count int64
-	if err := h.Queries.DB.Model(&console.Session{}).
-		Where("node_id = ? AND node_uuid = ? AND environment_id = ? AND active = ? AND updated_at >= ?", node.ID, node.UUID, node.EnvironmentID, true, time.Now().Add(-consoleSessionFreshness)).
-		Count(&count).Error; err != nil {
-		log.Debug().Err(err).Msg("error checking active console session for accelerated query read")
-		return false
-	}
-	return count > 0
+	return h.hasActiveSession(node, "console", &console.Session{})
 }
 
 func (h *HandlersTLS) hasActiveFileExplorerSession(node nodes.OsqueryNode) bool {
 	if h.OsqueryValues == nil || !h.OsqueryValues.FileExplorer {
 		return false
 	}
+	return h.hasActiveSession(node, "fileexplorer", &fileexplorer.Session{})
+}
+
+func (h *HandlersTLS) hasActiveSession(node nodes.OsqueryNode, kind string, model any) bool {
 	if node.ID == 0 || node.UUID == "" || node.EnvironmentID == 0 || h.Queries == nil || h.Queries.DB == nil {
 		return false
 	}
-	var count int64
-	if err := h.Queries.DB.Model(&fileexplorer.Session{}).
-		Where("node_id = ? AND node_uuid = ? AND environment_id = ? AND active = ? AND updated_at >= ?", node.ID, node.UUID, node.EnvironmentID, true, time.Now().Add(-consoleSessionFreshness)).
-		Count(&count).Error; err != nil {
-		log.Debug().Err(err).Msg("error checking active file explorer session for accelerated query read")
+	active, err := h.SessionHints.Active(context.Background(), kind, node.EnvironmentID, node.ID, node.UUID, func() (time.Time, error) {
+		var session struct{ UpdatedAt time.Time }
+		err := h.Queries.DB.Model(model).Select("updated_at").
+			Where("node_id = ? AND node_uuid = ? AND environment_id = ? AND active = ? AND updated_at >= ?", node.ID, node.UUID, node.EnvironmentID, true, time.Now().Add(-consoleSessionFreshness)).
+			Order("updated_at DESC").Limit(1).Find(&session).Error
+		return session.UpdatedAt, err
+	})
+	if err != nil {
+		log.Debug().Err(err).Str("kind", kind).Msg("error checking active session for accelerated query read")
 		return false
 	}
-	return count > 0
+	return active
 }
 
 func (h *HandlersTLS) acceleratedSeconds(ctx context.Context) int {

--- a/cmd/tls/handlers/post.go
+++ b/cmd/tls/handlers/post.go
@@ -237,9 +237,6 @@ func (h *HandlersTLS) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		// Node and environment match, so we can proceed to update the node
 		ip := utils.GetIP(r)
-		if ip == node.IPAddress {
-			ip = ""
-		}
 		h.WriteHandler.addEvent(lastSeenUpdate{NodeID: node.ID, IP: ip, SeenAt: time.Now()})
 		log.Debug().Msgf("node-uuid: %s with nodeid %d added to batch writer for config update", node.UUID, node.ID)
 		h.recordActivity(env.UUID, node.UUID, activity.EventConfig)
@@ -451,21 +448,18 @@ func (h *HandlersTLS) QueryReadHandler(w http.ResponseWriter, r *http.Request) {
 		// Record ingested data
 		requestSize.WithLabelValues(string(env.UUID), "QueryRead").Observe(float64(len(body)))
 		log.Debug().Msgf("node UUID: %s in %s environment ingested %d bytes for QueryReadHandler endpoint", node.UUID, env.Name, len(body))
+		// Authentication succeeded even if dispatch SQL is temporarily unavailable.
+		h.WriteHandler.addEvent(lastSeenUpdate{NodeID: node.ID, IP: utils.GetIP(r), SeenAt: time.Now()})
+		h.recordActivity(env.UUID, node.UUID, activity.EventQueryRead)
 		// Get queries and update node
 		nodeInvalid = false
 		qs, accelerate, err = h.Queries.NodeQueries(node)
 		if err != nil {
 			log.Err(err).Msg("error getting queries from db")
+			utils.HTTPResponse(w, "", http.StatusServiceUnavailable, []byte(""))
+			return
 		}
 		accelerate = h.shouldAccelerateQueryRead(node, accelerate)
-		// Refresh node last seen
-		ip := utils.GetIP(r)
-		if ip == node.IPAddress {
-			ip = ""
-		}
-		h.WriteHandler.addEvent(lastSeenUpdate{NodeID: node.ID, IP: ip, SeenAt: time.Now()})
-		log.Debug().Msgf("node-uuid: %s with nodeid %d added to batch writer for query read update", node.UUID, node.ID)
-		h.recordActivity(env.UUID, node.UUID, activity.EventQueryRead)
 	} else {
 		log.Err(nodeErr).Msg("GetByKey")
 		nodeInvalid = true
@@ -566,9 +560,6 @@ func (h *HandlersTLS) QueryWriteHandler(w http.ResponseWriter, r *http.Request) 
 		}
 		// Refresh node last seen
 		ip := utils.GetIP(r)
-		if ip == node.IPAddress {
-			ip = ""
-		}
 		h.WriteHandler.addEvent(lastSeenUpdate{NodeID: node.ID, IP: ip, SeenAt: time.Now()})
 		// Process submitted results and mark query as processed
 		h.recordActivity(env.UUID, node.UUID, activity.EventQueryWrite)
@@ -814,9 +805,6 @@ func (h *HandlersTLS) CarveInitHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		// Refresh last seen
 		ip := utils.GetIP(r)
-		if ip == node.IPAddress {
-			ip = ""
-		}
 		h.WriteHandler.addEvent(lastSeenUpdate{NodeID: node.ID, IP: ip, SeenAt: time.Now()})
 	}
 	// Prepare response

--- a/cmd/tls/handlers/query_read_error_test.go
+++ b/cmd/tls/handlers/query_read_error_test.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestQueryReadDatabaseFailureIsRetryable(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	envs := environments.CreateEnvironment(db)
+	nodesRepo := nodes.CreateNodes(db)
+	t.Cleanup(nodesRepo.Cache.Close)
+	env := environments.TLSEnvironment{UUID: "11111111-1111-4111-8111-111111111111", Name: "test"}
+	require.NoError(t, db.Create(&env).Error)
+	node := nodes.OsqueryNode{NodeKey: "key", UUID: "NODE", EnvironmentID: env.ID}
+	require.NoError(t, db.Create(&node).Error)
+	writer := &batchWriter{events: make(chan lastSeenUpdate, 1)}
+	// No query tables: the authenticated request reaches a failing SQL read.
+	h := CreateHandlersTLS(WithEnvCache(environments.NewEnvCache(*envs)), WithNodes(nodesRepo),
+		WithQueries(&queries.Queries{DB: db}), WithWriteHandler(writer))
+	req := httptest.NewRequest(http.MethodPost, "/"+env.UUID+"/read", bytes.NewBufferString(`{"node_key":"key"}`))
+	req.SetPathValue("env", env.UUID)
+	w := httptest.NewRecorder()
+	h.QueryReadHandler(w, req)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.NotContains(t, w.Body.String(), "node_queries", "do not expose SQL details")
+	require.Len(t, writer.events, 1, "an authenticated check-in still updates liveness")
+}

--- a/cmd/tls/handlers/session_hints_test.go
+++ b/cmd/tls/handlers/session_hints_test.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+	"github.com/jmpsec/osctrl/pkg/cache"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/console"
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/fileexplorer"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/jmpsec/osctrl/pkg/queries"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSessionHintsReduceSQLAndFollowSessionLifecycle(t *testing.T) {
+	addr := os.Getenv("OSCTRL_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("set OSCTRL_TEST_REDIS_ADDR to run Redis session hint integration tests")
+	}
+	for _, kind := range []string{"console", "fileexplorer"} {
+		t.Run(kind, func(t *testing.T) {
+			client := redis.NewClient(&redis.Options{Addr: addr, MaxRetries: -1})
+			t.Cleanup(func() { _ = client.Close() })
+			require.NoError(t, client.Ping(context.Background()).Err())
+			db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+			require.NoError(t, err)
+			queryManager := queries.CreateQueries(db)
+			cm := console.NewManager(db, queryManager)
+			fm := fileexplorer.NewManager(db, queryManager)
+			cm.SessionHints = cache.NewSessionHints(client)
+			fm.SessionHints = cache.NewSessionHints(client)
+			h := CreateHandlersTLS(WithQueries(queryManager), WithSessionHints(cache.NewSessionHints(client)),
+				WithOsqueryValues(&config.YAMLConfigurationOsquery{Accelerated: true, Console: true, FileExplorer: true}))
+			env := environments.TLSEnvironment{ID: 1, UUID: "env"}
+			node := nodes.OsqueryNode{ID: 7, UUID: uuid.NewString(), EnvironmentID: 1}
+			reads := 0
+			require.NoError(t, db.Callback().Query().Before("gorm:query").Register("count_session_reads", func(tx *gorm.DB) {
+				if tx.Statement.Table == "console_sessions" || tx.Statement.Table == "file_explorer_sessions" {
+					reads++
+				}
+			}))
+			for range 10 {
+				require.False(t, h.shouldAccelerateQueryRead(node, false))
+			}
+			require.Equal(t, 2, reads, "idle polls should read each session table only once")
+			create := func() uint {
+				if kind == "console" {
+					s, err := cm.CreateSession(env, node, "alice")
+					require.NoError(t, err)
+					return s.ID
+				}
+				s, err := fm.CreateSession(env, node, "alice")
+				require.NoError(t, err)
+				return s.ID
+			}
+			touch := func(id uint) {
+				if kind == "console" {
+					_, err := cm.TouchSession(id)
+					require.NoError(t, err)
+				} else {
+					_, err := fm.TouchSession(id)
+					require.NoError(t, err)
+				}
+			}
+			closeSession := cm.CloseSession
+			var model any = &console.Session{}
+			if kind == "fileexplorer" {
+				closeSession = fm.CloseSession
+				model = &fileexplorer.Session{}
+			}
+			id := create()
+			require.True(t, h.shouldAccelerateQueryRead(node, false), "create must invalidate absence")
+			reads = 0
+			for range 10 {
+				require.True(t, h.shouldAccelerateQueryRead(node, false))
+			}
+			require.Zero(t, reads, "warm active hints must also skip SQL")
+			for _, other := range []nodes.OsqueryNode{
+				{ID: 8, UUID: node.UUID, EnvironmentID: 1},
+				{ID: 7, UUID: node.UUID + "-other", EnvironmentID: 1},
+				{ID: 7, UUID: node.UUID, EnvironmentID: 2},
+			} {
+				require.False(t, h.shouldAccelerateQueryRead(other, false), "all node identity fields must be scoped")
+			}
+			require.NoError(t, db.Model(model).Where("id = ?", id).UpdateColumn("updated_at", time.Now().Add(-time.Minute)).Error)
+			h.SessionHints.Invalidate(context.Background(), kind, env.ID, node.ID, node.UUID)
+			require.False(t, h.shouldAccelerateQueryRead(node, false))
+			touch(id)
+			require.True(t, h.shouldAccelerateQueryRead(node, false), "refresh must invalidate stale absence")
+			second := create()
+			require.NoError(t, closeSession(id))
+			require.True(t, h.shouldAccelerateQueryRead(node, false), "closing one session must preserve the other")
+			require.NoError(t, closeSession(second))
+			require.False(t, h.shouldAccelerateQueryRead(node, false), "close must invalidate presence")
+			touch(second)
+			require.False(t, h.shouldAccelerateQueryRead(node, false), "refresh must not revive a closed session")
+			third := create()
+			require.NoError(t, client.Close())
+			require.True(t, h.shouldAccelerateQueryRead(node, false), "Redis failure must use SQL")
+			require.NoError(t, closeSession(third), "Redis failure must not fail a committed close")
+			require.False(t, h.shouldAccelerateQueryRead(node, false))
+			deleted := create()
+			require.NoError(t, db.Delete(model, deleted).Error)
+			require.False(t, h.shouldAccelerateQueryRead(node, false), "SQL fallback must exclude soft-deleted sessions")
+		})
+	}
+}

--- a/cmd/tls/handlers/writers.go
+++ b/cmd/tls/handlers/writers.go
@@ -8,15 +8,7 @@ import (
 )
 
 // lastSeenUpdate represents a single update request.
-type lastSeenUpdate struct {
-	NodeID uint
-	IP     string
-	// SeenAt is when the node actually checked in. Stored per-event so
-	// the batch flush doesn't stamp every node with the same wall-clock
-	// time — without this, all nodes in a batch show identical last_seen
-	// values in the UI, masking per-node check-in cadence.
-	SeenAt time.Time
-}
+type lastSeenUpdate = nodes.Checkin
 
 // batchWriter encapsulates the batching logic.
 type batchWriter struct {
@@ -40,6 +32,9 @@ func NewBatchWriter(batchSize int, timeout time.Duration, bufferSize int, repo n
 
 // addEvent sends a new write event to the batch writer.
 func (bw *batchWriter) addEvent(ev lastSeenUpdate) {
+	if ev.SeenAt.IsZero() {
+		ev.SeenAt = time.Now()
+	}
 	bw.events <- ev
 }
 
@@ -58,17 +53,14 @@ func (bw *batchWriter) run() {
 				}
 				return
 			}
-			// Overwrite any existing event for the same NodeID.
-			batch[ev.NodeID] = ev
+			mergeCheckin(batch, ev)
 
 			// Flush if we have reached the batch size threshold.
 			if len(batch) >= bw.batchSize {
-				if !timer.Stop() {
-					<-timer.C // drain the timer channel if necessary
-				}
+				timer.Stop()
 				bw.flush(batch)
 				batch = make(map[uint]lastSeenUpdate)
-				timer.Reset(bw.timeout)
+				resetTimer(timer, bw.timeout)
 			}
 		case <-timer.C:
 			if len(batch) > 0 {
@@ -80,49 +72,23 @@ func (bw *batchWriter) run() {
 	}
 }
 
+func mergeCheckin(batch map[uint]lastSeenUpdate, ev lastSeenUpdate) {
+	previous := batch[ev.NodeID]
+	if ev.SeenAt.Before(previous.SeenAt) {
+		return
+	}
+	batch[ev.NodeID] = ev
+}
+
 // flush performs the bulk update for a batch of events.
 func (bw *batchWriter) flush(batch map[uint]lastSeenUpdate) {
 	start := time.Now()
-	batchSize := len(batch)
-
-	for _, ev := range batch {
-		// Update the node's IP address.
-		// Since the IP address changes infrequently, no need to update in bulk.
-		if ev.IP != "" {
-			ipStart := time.Now()
-			if err := bw.nodesRepo.UpdateIP(ev.NodeID, ev.IP); err != nil {
-				log.Err(err).Uint("node_id", ev.NodeID).Str("ip", ev.IP).Msg("updating IP failed")
-			}
-			ipDuration := time.Since(ipStart).Seconds()
-			batchFlushDuration.WithLabelValues("ip_update").Observe(ipDuration)
-		}
+	if err := bw.nodesRepo.UpdateCheckins(batch); err != nil {
+		log.Err(err).Int("count", len(batch)).Msg("updating node check-ins failed")
 	}
-
-	log.Info().Int("count", batchSize).Msg("flushing batch")
-
-	// Update last_seen per-node with each event's actual check-in time.
-	// The old RefreshLastSeenBatch stamped every node in the batch with the
-	// same time.Now(), making all nodes appear to check in simultaneously.
-	lastSeenStart := time.Now()
-	for _, ev := range batch {
-		seenAt := ev.SeenAt
-		if seenAt.IsZero() {
-			seenAt = time.Now()
-		}
-		if err := bw.nodesRepo.UpdateLastSeen(ev.NodeID, seenAt); err != nil {
-			log.Err(err).Uint("node_id", ev.NodeID).Msg("updating last_seen failed")
-		}
-	}
-	lastSeenDuration := time.Since(lastSeenStart).Seconds()
-
-	// Record total flush duration and batch last_seen update duration
 	totalDuration := time.Since(start).Seconds()
 	batchFlushDuration.WithLabelValues("total").Observe(totalDuration)
-	batchFlushDuration.WithLabelValues("last_seen_update").Observe(lastSeenDuration)
-
-	log.Info().
-		Int("count", batchSize).
-		Float64("duration_seconds", totalDuration).
-		Float64("last_seen_update_seconds", lastSeenDuration).
+	batchFlushDuration.WithLabelValues("last_seen_update").Observe(totalDuration)
+	log.Debug().Int("count", len(batch)).Float64("duration_seconds", totalDuration).
 		Msg("batch flush completed")
 }

--- a/cmd/tls/handlers/writers_test.go
+++ b/cmd/tls/handlers/writers_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestConfigCheckinKeepsObservedIP(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	envs := environments.CreateEnvironment(db)
+	nodesRepo := nodes.CreateNodes(db)
+	t.Cleanup(nodesRepo.Cache.Close)
+	env := environments.TLSEnvironment{UUID: "11111111-1111-4111-8111-111111111111", Name: "test", Configuration: "{}"}
+	require.NoError(t, db.Create(&env).Error)
+	node := nodes.OsqueryNode{NodeKey: "key", UUID: "NODE", EnvironmentID: env.ID, IPAddress: "192.0.2.1"}
+	require.NoError(t, db.Create(&node).Error)
+	writer := &batchWriter{events: make(chan lastSeenUpdate, 1)}
+	h := CreateHandlersTLS(WithEnvCache(environments.NewEnvCache(*envs)), WithNodes(nodesRepo), WithWriteHandler(writer))
+	req := httptest.NewRequest(http.MethodPost, "/"+env.UUID+"/config", bytes.NewBufferString(`{"node_key":"key"}`))
+	req.SetPathValue("env", env.UUID)
+	req.RemoteAddr = "192.0.2.1:1234"
+	w := httptest.NewRecorder()
+	h.ConfigHandler(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, writer.events, 1)
+	ev := <-writer.events
+	require.Equal(t, node.IPAddress, ev.IP, "cached IP may be stale after a move away and back")
+	require.False(t, ev.SeenAt.IsZero())
+}
+
+func TestMergeCheckinKeepsLatestObservation(t *testing.T) {
+	now := time.Now()
+	batch := make(map[uint]lastSeenUpdate)
+	mergeCheckin(batch, lastSeenUpdate{NodeID: 1, SeenAt: now, IP: "new"})
+	mergeCheckin(batch, lastSeenUpdate{NodeID: 1, SeenAt: now.Add(-time.Second), IP: "old"})
+	require.Equal(t, "new", batch[1].IP)
+	require.Equal(t, now, batch[1].SeenAt)
+	mergeCheckin(batch, lastSeenUpdate{NodeID: 1, SeenAt: now.Add(time.Second)})
+	require.Empty(t, batch[1].IP, "do not give an older IP a newer observation timestamp")
+	require.Equal(t, now.Add(time.Second), batch[1].SeenAt)
+}
+
+func TestBatchWriterFlushes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		size    int
+		timeout time.Duration
+	}{{"timeout", 50, 10 * time.Millisecond}, {"size", 1, time.Hour}} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+			require.NoError(t, err)
+			sqlDB, err := db.DB()
+			require.NoError(t, err)
+			sqlDB.SetMaxOpenConns(1)
+			t.Cleanup(func() { _ = sqlDB.Close() })
+			require.NoError(t, db.AutoMigrate(&nodes.OsqueryNode{}))
+			node := nodes.OsqueryNode{ID: 1}
+			require.NoError(t, db.Create(&node).Error)
+			writer := &batchWriter{events: make(chan lastSeenUpdate, 1), batchSize: tc.size,
+				timeout: tc.timeout, nodesRepo: nodes.NodeManager{DB: db}}
+			done := make(chan struct{})
+			go func() { defer close(done); writer.run() }()
+			t.Cleanup(func() { close(writer.events); <-done })
+			seen := time.Now().UTC()
+			writer.addEvent(lastSeenUpdate{NodeID: 1, SeenAt: seen, IP: "192.0.2.1"})
+			require.Eventually(t, func() bool {
+				var got nodes.OsqueryNode
+				return db.First(&got, 1).Error == nil && got.LastSeen.Equal(seen) && got.IPAddress == "192.0.2.1"
+			}, time.Second, 5*time.Millisecond)
+		})
+	}
+}

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -304,8 +304,6 @@ func osctrlService() {
 	tagsmgr = tags.CreateTagManager(db.Conn)
 	log.Info().Msg("Initialize queries")
 	queriesmgr = queries.CreateQueries(db.Conn)
-	queriesmgr.Cache = queries.NewQueryDispatchCache(redis.Client, 0)
-	log.Info().Msg("Query dispatch cache wired to Redis")
 	log.Info().Msg("Initialize carves")
 	filecarves = carves.CreateFileCarves(db.Conn, flagParams.Carver.Type, carvers3)
 	log.Info().Msg("Loading service settings")
@@ -322,6 +320,12 @@ func osctrlService() {
 	if err := serviceConfigMgr.Resolve(config.ServiceTLS, flagParams, settings.NoEnvironmentID); err != nil {
 		log.Fatal().Msgf("Error resolving service config - %v", err)
 	}
+	var queryDispatchTTL time.Duration
+	if flagParams.Osquery != nil {
+		queryDispatchTTL = flagParams.Osquery.QueryDispatchTTL
+	}
+	queriesmgr.Cache = queries.NewQueryDispatchCache(redis.Client, queryDispatchTTL)
+	log.Info().Msg("Query dispatch cache wired to Redis")
 	// Report whether this process can write its own config file. Only this
 	// process can know — osctrl-api runs elsewhere and cannot stat it.
 	if err := serviceConfigMgr.ReportFile(config.ServiceTLS, flagParams.ConfigFilePath()); err != nil {
@@ -472,6 +476,7 @@ func osctrlService() {
 		handlers.WithCarves(filecarves),
 		handlers.WithSettings(settingsmgr),
 		handlers.WithSettingsCache(settingsCache),
+		handlers.WithSessionHints(cache.NewSessionHints(redis.Client)),
 		handlers.WithLogs(loggerTLS),
 		handlers.WithWriteHandler(tlsWriter),
 		handlers.WithActivityWriter(activityWriter),

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -179,6 +179,8 @@ rateLimits:
 
 # osquery remote API feature switches.
 osquery:
+  # Empty-query dispatch cache lifetime; <=0 uses 2m. New queries invalidate it.
+  queryDispatchTTL: 2m
   # osquery schema version used for table metadata.
   version: 5.23.1
   # JSON schema file with osquery table metadata.

--- a/pkg/cache/session-hints.go
+++ b/pkg/cache/session-hints.go
@@ -1,0 +1,105 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+// SessionFreshness is the maximum age of an interactive session heartbeat.
+const SessionFreshness = 30 * time.Second
+
+const (
+	sessionHintTTL    = 5 * time.Second
+	sessionAbsenceTTL = 2 * time.Minute
+)
+
+// SessionHints caches polling hints only; session authorization stays in SQL.
+// Absence lasts two minutes to cover normal 60-second polling; presence lasts
+// at most five seconds and never beyond the session heartbeat's freshness.
+type SessionHints struct {
+	client *redis.Client
+}
+
+func NewSessionHints(client *redis.Client) *SessionHints {
+	return &SessionHints{client: client}
+}
+
+type sessionHint struct {
+	Active bool
+	Until  time.Time
+}
+
+// Active loads the latest active session's updated_at (zero means absent).
+// A token acquired before SQL and atomically checked at refill prevents a
+// concurrent invalidation from being overwritten, including on an empty key.
+func (c *SessionHints) Active(ctx context.Context, kind string, envID, nodeID uint, nodeUUID string, load func() (time.Time, error)) (bool, error) {
+	if c == nil || c.client == nil {
+		updated, err := load()
+		return !updated.IsZero() && time.Now().Before(updated.Add(SessionFreshness)), err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	key := sessionHintKey(kind, envID, nodeID, nodeUUID)
+	value, err := c.client.Get(ctx, key).Bytes()
+	var hint sessionHint
+	if err == nil && json.Unmarshal(value, &hint) == nil && time.Now().Before(hint.Until) {
+		return hint.Active, nil
+	}
+	if err != nil && !errors.Is(err, redis.Nil) {
+		log.Debug().Err(err).Msg("session hint read failed; falling back to SQL")
+		updated, sqlErr := load()
+		return !updated.IsZero() && time.Now().Before(updated.Add(SessionFreshness)), sqlErr
+	}
+	token := uuid.NewString()
+	owned, _ := c.client.SetNX(ctx, key, token, sessionHintTTL).Result()
+	checkedAt := time.Now()
+	updated, err := load()
+	if err != nil {
+		return false, err
+	}
+	active := !updated.IsZero() && time.Now().Before(updated.Add(SessionFreshness))
+	ttl := sessionHintTTL
+	if !active {
+		ttl = sessionAbsenceTTL
+	}
+	deadline := checkedAt.Add(ttl)
+	if active && updated.Add(SessionFreshness).Before(deadline) {
+		deadline = updated.Add(SessionFreshness)
+	}
+	if owned && time.Until(deadline) >= time.Millisecond {
+		value, _ := json.Marshal(sessionHint{Active: active, Until: deadline})
+		if err := c.client.Eval(ctx, `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3])
+end
+return 0`, []string{key}, token, value, time.Until(deadline).Milliseconds()).Err(); err != nil {
+			log.Debug().Err(err).Msg("session hint refill failed")
+		}
+	}
+	return active, nil
+}
+
+// Invalidate must run after the SQL mutation commits. A failed invalidation
+// can hide a new/refreshed session for two minutes; stale presence lasts at
+// most five seconds, never beyond session freshness.
+func (c *SessionHints) Invalidate(ctx context.Context, kind string, envID, nodeID uint, nodeUUID string) {
+	if c == nil || c.client == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	if err := c.client.Del(ctx, sessionHintKey(kind, envID, nodeID, nodeUUID)).Err(); err != nil {
+		log.Debug().Err(err).Msg("session hint invalidation failed")
+	}
+}
+
+func sessionHintKey(kind string, envID, nodeID uint, nodeUUID string) string {
+	return fmt.Sprintf("osctrl:tls:session:%s:%d:%d:%s", kind, envID, nodeID, nodeUUID)
+}

--- a/pkg/cache/session-hints_test.go
+++ b/pkg/cache/session-hints_test.go
@@ -1,0 +1,145 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// OSCTRL_TEST_REDIS_ADDR must point to a disposable Redis instance.
+func sessionHintTestClient(t *testing.T) *redis.Client {
+	t.Helper()
+	addr := os.Getenv("OSCTRL_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("set OSCTRL_TEST_REDIS_ADDR to run Redis session hint integration tests")
+	}
+	c := redis.NewClient(&redis.Options{Addr: addr, MaxRetries: -1})
+	t.Cleanup(func() { _ = c.Close() })
+	require.NoError(t, c.Ping(context.Background()).Err())
+	return c
+}
+
+func TestSessionHintsCachePresenceAndAbsence(t *testing.T) {
+	for _, present := range []bool{false, true} {
+		t.Run(map[bool]string{false: "absent", true: "present"}[present], func(t *testing.T) {
+			nodeUUID := uuid.NewString()
+			c := NewSessionHints(sessionHintTestClient(t))
+			reads := 0
+			load := func() (time.Time, error) {
+				reads++
+				if present {
+					return time.Now(), nil
+				}
+				return time.Time{}, nil
+			}
+			for range 3 {
+				got, err := c.Active(context.Background(), "console", 1, 7, nodeUUID, load)
+				require.NoError(t, err)
+				require.Equal(t, present, got)
+			}
+			require.Equal(t, 1, reads)
+		})
+	}
+}
+
+func TestSessionHintsInvalidationPreventsStaleRefill(t *testing.T) {
+	for _, wasPresent := range []bool{false, true} {
+		t.Run(map[bool]string{false: "create", true: "close"}[wasPresent], func(t *testing.T) {
+			nodeUUID := uuid.NewString()
+			client := sessionHintTestClient(t)
+			reader, writer := NewSessionHints(client), NewSessionHints(client)
+			ctx := context.Background()
+			_, err := reader.Active(ctx, "console", 1, 7, nodeUUID, func() (time.Time, error) {
+				writer.Invalidate(ctx, "console", 1, 7, nodeUUID)
+				if wasPresent {
+					return time.Now(), nil
+				}
+				return time.Time{}, nil
+			})
+			require.NoError(t, err)
+			reads := 0
+			got, err := reader.Active(ctx, "console", 1, 7, nodeUUID, func() (time.Time, error) {
+				reads++
+				if !wasPresent {
+					return time.Now(), nil
+				}
+				return time.Time{}, nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, !wasPresent, got)
+			require.Equal(t, 1, reads, "invalidation must reject the earlier SQL result")
+		})
+	}
+}
+
+func TestSessionHintsDoNotOutliveFreshness(t *testing.T) {
+	c := NewSessionHints(sessionHintTestClient(t))
+	nodeUUID := uuid.NewString()
+	updated := time.Now().Add(-30*time.Second + 500*time.Millisecond)
+	reads := 0
+	load := func() (time.Time, error) { reads++; return updated, nil }
+	got, err := c.Active(context.Background(), "console", 1, 7, nodeUUID, load)
+	require.NoError(t, err)
+	require.True(t, got)
+	time.Sleep(550 * time.Millisecond)
+	got, err = c.Active(context.Background(), "console", 1, 7, nodeUUID, load)
+	require.NoError(t, err)
+	require.False(t, got)
+	require.Equal(t, 2, reads)
+}
+
+func TestSessionHintsFallbackOnRedisAndSQLErrors(t *testing.T) {
+	nodeUUID := uuid.NewString()
+	client := sessionHintTestClient(t)
+	c := NewSessionHints(client)
+	sqlErr := errors.New("SQL unavailable")
+	_, err := c.Active(context.Background(), "console", 1, 7, nodeUUID, func() (time.Time, error) { return time.Time{}, sqlErr })
+	require.ErrorIs(t, err, sqlErr)
+	got, err := c.Active(context.Background(), "console", 1, 7, nodeUUID, func() (time.Time, error) { return time.Now(), nil })
+	require.NoError(t, err)
+	require.True(t, got, "SQL errors must not cache absence")
+	require.NoError(t, client.Close())
+	got, err = c.Active(context.Background(), "console", 1, 7, nodeUUID, func() (time.Time, error) { return time.Now(), nil })
+	require.NoError(t, err)
+	require.True(t, got, "Redis errors must fall back to SQL")
+}
+
+func TestSessionHintsWithoutRedis(t *testing.T) {
+	for _, c := range []*SessionHints{nil, NewSessionHints(nil)} {
+		for _, tc := range []struct {
+			updated time.Time
+			want    bool
+		}{{time.Time{}, false}, {time.Now().Add(-time.Minute), false}, {time.Now(), true}} {
+			got, err := c.Active(context.Background(), "console", 1, 7, "node", func() (time.Time, error) { return tc.updated, nil })
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		}
+	}
+}
+
+func TestSessionHintsExpireAbsence(t *testing.T) {
+	client := sessionHintTestClient(t)
+	c := NewSessionHints(client)
+	nodeUUID := uuid.NewString()
+	got, err := c.Active(context.Background(), "console", 1, 7, nodeUUID, func() (time.Time, error) { return time.Time{}, nil })
+	require.NoError(t, err)
+	require.False(t, got)
+	key := sessionHintKey("console", 1, 7, nodeUUID)
+	ttl, err := client.PTTL(context.Background(), key).Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Minute, "negative hints must survive a normal 60-second idle poll")
+	require.LessOrEqual(t, ttl, 2*time.Minute)
+	// Expedite Redis expiration so recovery after a missed invalidation does
+	// not require a two-minute integration test.
+	require.NoError(t, client.PExpire(context.Background(), key, time.Millisecond).Err())
+	time.Sleep(10 * time.Millisecond)
+	got, err = c.Active(context.Background(), "console", 1, 7, nodeUUID, func() (time.Time, error) { return time.Now(), nil })
+	require.NoError(t, err)
+	require.True(t, got)
+}

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -103,6 +103,12 @@ func initAuthFlag(params *ServiceParameters, defaultValue string, usage string) 
 // InitTLSFlags initializes all the flags needed for the TLS service
 func InitTLSFlags(params *ServiceParameters) []cli.Flag {
 	var allFlags []cli.Flag
+	allFlags = append(allFlags, &cli.DurationFlag{
+		Name:        "query-dispatch-ttl",
+		Usage:       "Empty distributed-query cache TTL; non-positive values use the 2m default",
+		Sources:     cli.EnvVars("QUERY_DISPATCH_TTL"),
+		Destination: &params.Osquery.QueryDispatchTTL,
+	})
 	// Add flags by category
 	allFlags = append(allFlags, initConfigFlags(params, ServiceTLS)...)
 	allFlags = append(allFlags, initServiceFlags(params)...)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -237,6 +237,8 @@ type YAMLConfigurationOsquery struct {
 	Console      bool   `yaml:"console"`
 	FileExplorer bool   `yaml:"fileExplorer"`
 	ReadOnly     bool   `yaml:"readOnly"`
+
+	QueryDispatchTTL time.Duration `yaml:"queryDispatchTTL" mapstructure:"queryDispatchTTL"`
 }
 
 // YAMLConfigurationEndpoints to hold the configuration endpoints that will receive osquery configuration updates

--- a/pkg/console/manager.go
+++ b/pkg/console/manager.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jmpsec/osctrl/pkg/cache"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/nodes"
@@ -32,9 +33,10 @@ const defaultCommandTimeout = 10 * time.Second
 const PrimingMetadataSQL = "select version, build_platform, build_distro, start_time, config_valid, optimizations from osquery_info"
 
 type Manager struct {
-	DB        *gorm.DB
-	Queries   *queries.Queries
-	LogReader logging.LogReader
+	DB           *gorm.DB
+	Queries      *queries.Queries
+	LogReader    logging.LogReader
+	SessionHints *cache.SessionHints
 }
 
 func NewManager(db *gorm.DB, queryManager *queries.Queries) *Manager {
@@ -72,6 +74,7 @@ func (m *Manager) CreateSession(env environments.TLSEnvironment, node nodes.Osqu
 	if err := m.DB.Create(&session).Error; err != nil {
 		return Session{}, err
 	}
+	m.invalidateSessionHint(session)
 	return session, nil
 }
 
@@ -89,7 +92,15 @@ func (m *Manager) TouchSession(sessionID uint) (Session, error) {
 		UpdateColumn("updated_at", time.Now()).Error; err != nil {
 		return Session{}, err
 	}
-	return m.GetSession(sessionID)
+	session, err := m.GetSession(sessionID)
+	if err == nil {
+		m.invalidateSessionHint(session)
+	}
+	return session, err
+}
+
+func (m *Manager) invalidateSessionHint(session Session) {
+	m.SessionHints.Invalidate(context.Background(), "console", session.EnvironmentID, session.NodeID, session.NodeUUID)
 }
 
 func (m *Manager) SubmitCommand(sessionID uint, input string, osqueryModeOpt ...bool) (Command, ParsedCommand, error) {
@@ -291,7 +302,13 @@ func (m *Manager) PrimingCommand(sessionID uint) (Command, error) {
 
 func (m *Manager) CloseSession(sessionID uint) error {
 	now := time.Now()
-	return m.DB.Transaction(func(tx *gorm.DB) error {
+	var session Session
+	err := m.DB.Transaction(func(tx *gorm.DB) error {
+		if m.SessionHints != nil {
+			if err := tx.Where("id = ?", sessionID).Find(&session).Error; err != nil {
+				return err
+			}
+		}
 		if err := tx.Model(&Session{}).Where("id = ?", sessionID).
 			Updates(map[string]any{"active": false, "closed_at": &now}).Error; err != nil {
 			return err
@@ -300,6 +317,10 @@ func (m *Manager) CloseSession(sessionID uint) error {
 			Where("session_id = ? AND status IN ?", sessionID, []string{StatusQueued, StatusDelivered}).
 			Updates(map[string]any{"status": StatusExpired, "expired_at": &now}).Error
 	})
+	if err == nil && session.ID != 0 {
+		m.invalidateSessionHint(session)
+	}
+	return err
 }
 
 func (m *Manager) GetCommand(sessionID, commandID uint) (Command, error) {
@@ -470,6 +491,7 @@ func (m *Manager) completedStatusForCommand(command Command) (string, string, er
 	if err := m.DB.Model(&session).Update("cwd", parsed.Path).Error; err != nil {
 		return StatusError, "", err
 	}
+	m.invalidateSessionHint(session)
 	return StatusCompleted, "", nil
 }
 

--- a/pkg/fileexplorer/manager.go
+++ b/pkg/fileexplorer/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jmpsec/osctrl/pkg/cache"
 	"github.com/jmpsec/osctrl/pkg/environments"
 	"github.com/jmpsec/osctrl/pkg/filequery"
 	"github.com/jmpsec/osctrl/pkg/logging"
@@ -30,9 +31,10 @@ const (
 )
 
 type Manager struct {
-	DB        *gorm.DB
-	Queries   *queries.Queries
-	LogReader logging.LogReader
+	DB           *gorm.DB
+	Queries      *queries.Queries
+	LogReader    logging.LogReader
+	SessionHints *cache.SessionHints
 }
 
 func NewManager(db *gorm.DB, queryManager *queries.Queries) *Manager {
@@ -70,6 +72,7 @@ func (m *Manager) CreateSession(env environments.TLSEnvironment, node nodes.Osqu
 	if err := m.DB.Create(&session).Error; err != nil {
 		return Session{}, err
 	}
+	m.invalidateSessionHint(session)
 	return session, nil
 }
 
@@ -87,12 +90,26 @@ func (m *Manager) TouchSession(sessionID uint) (Session, error) {
 		UpdateColumn("updated_at", time.Now()).Error; err != nil {
 		return Session{}, err
 	}
-	return m.GetSession(sessionID)
+	session, err := m.GetSession(sessionID)
+	if err == nil {
+		m.invalidateSessionHint(session)
+	}
+	return session, err
+}
+
+func (m *Manager) invalidateSessionHint(session Session) {
+	m.SessionHints.Invalidate(context.Background(), "fileexplorer", session.EnvironmentID, session.NodeID, session.NodeUUID)
 }
 
 func (m *Manager) CloseSession(sessionID uint) error {
 	now := time.Now()
-	return m.DB.Transaction(func(tx *gorm.DB) error {
+	var session Session
+	err := m.DB.Transaction(func(tx *gorm.DB) error {
+		if m.SessionHints != nil {
+			if err := tx.Where("id = ?", sessionID).Find(&session).Error; err != nil {
+				return err
+			}
+		}
 		if err := tx.Model(&Session{}).Where("id = ?", sessionID).
 			Updates(map[string]any{"active": false, "closed_at": &now}).Error; err != nil {
 			return err
@@ -101,6 +118,10 @@ func (m *Manager) CloseSession(sessionID uint) error {
 			Where("session_id = ? AND status = ?", sessionID, StatusQueued).
 			Updates(map[string]any{"status": StatusExpired, "expired_at": &now}).Error
 	})
+	if err == nil && session.ID != 0 {
+		m.invalidateSessionHint(session)
+	}
+	return err
 }
 
 func (m *Manager) ListDirectory(sessionID uint, target string, timeout time.Duration) (Request, error) {

--- a/pkg/nodes/checkins.go
+++ b/pkg/nodes/checkins.go
@@ -1,0 +1,71 @@
+package nodes
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Checkin carries the observation time, not the later database flush time.
+type Checkin struct {
+	NodeID uint
+	IP     string
+	SeenAt time.Time
+}
+
+// UpdateCheckins persists each node's latest observation without resurrecting
+// deleted nodes or allowing a delayed replica to move last_seen backwards.
+func (n *NodeManager) UpdateCheckins(updates map[uint]Checkin) error {
+	ids := make([]uint, 0, len(updates))
+	for id, ev := range updates {
+		if id == 0 || id != ev.NodeID || ev.SeenAt.IsZero() {
+			return fmt.Errorf("invalid check-in for node %d", id)
+		}
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	precision := time.Nanosecond
+	switch n.DB.Dialector.Name() {
+	case "mysql":
+		precision = time.Millisecond // GORM's default DATETIME(3).
+	case "postgres":
+		precision = time.Microsecond
+	}
+	// At most 700 bind parameters, including IDs, for older SQLite limits.
+	const chunkSize = 100
+	for start := 0; start < len(ids); start += chunkSize {
+		chunk := ids[start:min(start+chunkSize, len(ids))]
+		var seen, ip strings.Builder
+		seen.WriteString("CASE")
+		ip.WriteString("CASE")
+		var seenArgs, ipArgs []any
+		for _, id := range chunk {
+			ev := updates[id]
+			// Compare at storage precision. The first persisted observation wins
+			// ties, preventing a delayed event from exploiting timestamp rounding.
+			ev.SeenAt = ev.SeenAt.Truncate(precision)
+			seen.WriteString(" WHEN id = ? AND (last_seen IS NULL OR last_seen < ?) THEN ?")
+			seenArgs = append(seenArgs, id, ev.SeenAt, ev.SeenAt)
+			if ev.IP != "" {
+				ip.WriteString(" WHEN id = ? AND (last_seen IS NULL OR last_seen < ?) THEN ?")
+				ipArgs = append(ipArgs, id, ev.SeenAt, ev.IP)
+			}
+		}
+		seen.WriteString(" ELSE last_seen END")
+		columns := map[string]any{"last_seen": gorm.Expr(seen.String(), seenArgs...)}
+		if len(ipArgs) > 0 {
+			ip.WriteString(" ELSE ip_address END")
+			columns["ip_address"] = gorm.Expr(ip.String(), ipArgs...)
+		}
+		// Each chunk is one atomic statement; avoid a BEGIN/COMMIT round trip
+		// around it. GORM keeps the soft-delete predicate and binds all values.
+		if err := n.DB.Session(&gorm.Session{SkipDefaultTransaction: true}).
+			Model(&OsqueryNode{}).Where("id IN ?", chunk).UpdateColumns(columns).Error; err != nil {
+			return fmt.Errorf("update node check-ins: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/nodes/checkins_test.go
+++ b/pkg/nodes/checkins_test.go
@@ -1,0 +1,120 @@
+package nodes
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func TestUpdateCheckins(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	testUpdateCheckins(t, db)
+}
+
+// Optional real-engine checks; each uses and removes its own prefixed table.
+func TestUpdateCheckinsExternalBackend(t *testing.T) {
+	for _, backend := range []string{"POSTGRES", "MYSQL"} {
+		t.Run(backend, func(t *testing.T) {
+			dsn := os.Getenv("OSCTRL_TEST_" + backend + "_DSN")
+			if dsn == "" {
+				t.Skip("set OSCTRL_TEST_" + backend + "_DSN to test this engine")
+			}
+			var dialect gorm.Dialector = postgres.Open(dsn)
+			if backend == "MYSQL" {
+				dialect = mysql.Open(dsn)
+			}
+			db, err := gorm.Open(dialect, &gorm.Config{NamingStrategy: schema.NamingStrategy{
+				TablePrefix: fmt.Sprintf("checkin_%d_", time.Now().UnixNano()),
+			}})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, db.Migrator().DropTable(&OsqueryNode{})) })
+			testUpdateCheckins(t, db)
+		})
+	}
+}
+
+func testUpdateCheckins(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.AutoMigrate(&OsqueryNode{}))
+	repo := NodeManager{DB: db}
+	now := time.Now().UTC().Truncate(time.Second)
+	rows := []OsqueryNode{
+		{ID: 1, LastSeen: now, IPAddress: "old"},
+		{ID: 2, LastSeen: now, IPAddress: "keep"},
+		{ID: 3, LastSeen: now, IPAddress: "deleted"},
+	}
+	require.NoError(t, db.Create(&rows).Error)
+	require.NoError(t, db.Delete(&rows[2]).Error)
+	writes := 0
+	require.NoError(t, db.Callback().Update().After("gorm:update").Register("count_updates", func(*gorm.DB) { writes++ }))
+	updates := map[uint]Checkin{
+		1: {NodeID: 1, SeenAt: now.Add(time.Second), IP: "new'quoted"},
+		2: {NodeID: 2, SeenAt: now.Add(2 * time.Second)},
+		3: {NodeID: 3, SeenAt: now.Add(time.Second), IP: "must-not-change"},
+		4: {NodeID: 4, SeenAt: now.Add(time.Second)},
+	}
+	require.NoError(t, repo.UpdateCheckins(updates))
+	require.Equal(t, 1, writes, "one SQL update for the batch, not per node")
+	var got []OsqueryNode
+	require.NoError(t, db.Unscoped().Order("id").Find(&got).Error)
+	require.Len(t, got, 3, "missing nodes must not be inserted")
+	require.Equal(t, "new'quoted", got[0].IPAddress)
+	require.True(t, got[0].LastSeen.Equal(updates[1].SeenAt))
+	require.Equal(t, "keep", got[1].IPAddress)
+	require.True(t, got[1].LastSeen.Equal(updates[2].SeenAt))
+	require.Equal(t, "deleted", got[2].IPAddress)
+	require.True(t, got[2].LastSeen.Equal(now))
+	require.True(t, got[0].UpdatedAt.Equal(rows[0].UpdatedAt), "heartbeat must not change metadata timestamp")
+
+	// A delayed replica must not move either timestamp or IP backwards.
+	require.NoError(t, repo.UpdateCheckins(map[uint]Checkin{1: {NodeID: 1, SeenAt: now, IP: "stale"}}))
+	var node OsqueryNode
+	require.NoError(t, db.First(&node, 1).Error)
+	require.Equal(t, "new'quoted", node.IPAddress)
+	require.True(t, node.LastSeen.Equal(updates[1].SeenAt))
+
+	// Database timestamp precision must not allow a delayed sub-millisecond
+	// observation to overwrite the IP associated with a newer observation.
+	newer := now.Add(3*time.Second + 123400*time.Microsecond)
+	older := newer.Add(-100 * time.Microsecond)
+	require.NoError(t, repo.UpdateCheckins(map[uint]Checkin{1: {NodeID: 1, SeenAt: newer, IP: "latest"}}))
+	require.NoError(t, repo.UpdateCheckins(map[uint]Checkin{1: {NodeID: 1, SeenAt: older, IP: "out-of-order"}}))
+	require.NoError(t, db.First(&node, 1).Error)
+	require.Equal(t, "latest", node.IPAddress)
+}
+
+func TestUpdateCheckinsChunksAndErrors(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&OsqueryNode{}))
+	repo := NodeManager{DB: db}
+	updates := make(map[uint]Checkin)
+	for id := uint(1); id <= 250; id++ {
+		updates[id] = Checkin{NodeID: id, SeenAt: time.Now(), IP: "127.0.0.1"}
+	}
+	writes := 0
+	require.NoError(t, db.Callback().Update().After("gorm:update").Register("count_updates", func(*gorm.DB) { writes++ }))
+	require.NoError(t, repo.UpdateCheckins(updates))
+	require.Equal(t, 3, writes, "bound statement size even when configured writer batches are large")
+	require.NoError(t, repo.UpdateCheckins(nil))
+	require.Equal(t, 3, writes)
+	for _, invalid := range []map[uint]Checkin{
+		{0: {SeenAt: time.Now()}},
+		{1: {NodeID: 2, SeenAt: time.Now()}},
+		{1: {NodeID: 1}},
+	} {
+		require.Error(t, repo.UpdateCheckins(invalid))
+	}
+	require.Equal(t, 3, writes, "invalid observations must fail before SQL")
+	require.NoError(t, db.Migrator().DropTable(&OsqueryNode{}))
+	require.Error(t, repo.UpdateCheckins(map[uint]Checkin{1: updates[1]}))
+}

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -172,51 +172,40 @@ func CreateQueries(backend *gorm.DB) *Queries {
 }
 
 func (q *Queries) NodeQueries(node nodes.OsqueryNode) (QueryReadQueries, bool, error) {
-	// Fast path: check the Redis cache. If we recently determined this
-	// node has no pending queries, skip the DB entirely. This eliminates
-	// ~99% of DB lookups at scale (10K+ nodes checking in every 60s).
-	if q.Cache != nil {
-		cached, err := q.Cache.HasNoPendingQueries(context.Background(), node.ID)
+	return q.Cache.read(context.Background(), node.ID, func() (QueryReadQueries, bool, error) {
+		var results []struct {
+			Name  string
+			Query string
+			Type  string
+		}
+
+		now := time.Now()
+		err := q.DB.Table("distributed_queries dq").
+			Select("dq.name, dq.query, dq.type").
+			Joins("JOIN node_queries nq ON dq.id = nq.query_id").
+			Where("nq.node_id = ? AND nq.status = ?", node.ID, DistributedQueryStatusPending).
+			Where("dq.active = ? AND dq.completed = ? AND dq.deleted = ? AND dq.expired = ?", true, false, false, false).
+			Where("(dq.expiration = ? OR dq.expiration > ?)", time.Time{}, now).
+			Scan(&results).Error
 		if err != nil {
-			log.Debug().Err(err).Uint("node_id", node.ID).Msg("query dispatch cache: read error, falling through to DB")
-		} else if cached {
+			return nil, false, err
+		}
+
+		if len(results) == 0 {
 			return QueryReadQueries{}, false, nil
 		}
-	}
 
-	var results []struct {
-		Name  string
-		Query string
-		Type  string
-	}
-
-	now := time.Now()
-	q.DB.Table("distributed_queries dq").
-		Select("dq.name, dq.query, dq.type").
-		Joins("JOIN node_queries nq ON dq.id = nq.query_id").
-		Where("nq.node_id = ? AND nq.status = ?", node.ID, DistributedQueryStatusPending).
-		Where("dq.active = ? AND dq.completed = ? AND dq.deleted = ? AND dq.expired = ?", true, false, false, false).
-		Where("(dq.expiration = ? OR dq.expiration > ?)", time.Time{}, now).
-		Scan(&results)
-
-	if len(results) == 0 {
-		// Cache the empty result so subsequent check-ins skip the DB.
-		if q.Cache != nil {
-			q.Cache.SetNoPendingQueries(context.Background(), node.ID)
+		qs := make(QueryReadQueries)
+		accelerate := false
+		for _, _q := range results {
+			qs[_q.Name] = _q.Query
+			if IsInternalQueryType(_q.Type) {
+				accelerate = true
+			}
 		}
-		return QueryReadQueries{}, false, nil
-	}
 
-	qs := make(QueryReadQueries)
-	accelerate := false
-	for _, _q := range results {
-		qs[_q.Name] = _q.Query
-		if IsInternalQueryType(_q.Type) {
-			accelerate = true
-		}
-	}
-
-	return qs, accelerate, nil
+		return qs, accelerate, nil
+	})
 }
 
 func IsInternalQueryType(qtype string) bool {

--- a/pkg/queries/query-dispatch-cache.go
+++ b/pkg/queries/query-dispatch-cache.go
@@ -11,10 +11,9 @@ import (
 
 // QueryDispatchCache caches the result of NodeQueries per node in Redis.
 // The primary goal is to skip the DB JOIN when a node has no pending
-// queries — which is the common case (99%+ of check-ins). A short TTL
-// (default 5s) ensures the cache doesn't serve stale queries for long;
-// when a new query is created, affected nodes' cache entries are
-// invalidated explicitly.
+// queries. When a new query is created, affected nodes' cache entries
+// are invalidated explicitly; WATCH prevents an in-flight empty lookup
+// from overwriting that invalidation.
 //
 // The cache stores a boolean: true means "no pending queries for this
 // node" (the DB returned empty). A cache miss or false falls through to
@@ -28,10 +27,9 @@ type QueryDispatchCache struct {
 const queryDispatchCachePrefix = "osctrl:tls:query-dispatch"
 
 // DefaultQueryDispatchTTL is the TTL for "no queries pending" cache
-// entries. Short enough that a newly created query is visible within a
-// few seconds, long enough to absorb repeated check-ins from the same
-// node within the osquery distributed_interval (default 60s).
-const DefaultQueryDispatchTTL = 5 * time.Second
+// entries. It spans the default 60s poll interval and bounds staleness
+// if explicit invalidation fails.
+const DefaultQueryDispatchTTL = 2 * time.Minute
 
 // NewQueryDispatchCache creates a Redis-backed cache for query dispatch.
 // Pass nil to disable caching (tests, standalone mode).
@@ -59,27 +57,68 @@ func (c *QueryDispatchCache) HasNoPendingQueries(ctx context.Context, nodeID uin
 	return string(val) == "1", nil
 }
 
-// SetNoPendingQueries caches that this node currently has no pending
-// queries. Called after a DB lookup returns empty.
-func (c *QueryDispatchCache) SetNoPendingQueries(ctx context.Context, nodeID uint) {
+// read caches only successful empty lookups. Redis failures fall back to SQL;
+// an invalidated lookup still returns its SQL result but cannot refill the cache.
+func (c *QueryDispatchCache) read(ctx context.Context, nodeID uint, lookup func() (QueryReadQueries, bool, error)) (QueryReadQueries, bool, error) {
 	if c == nil || c.client == nil {
-		return
+		return lookup()
 	}
-	if err := c.client.Set(ctx, cacheKey(nodeID), "1", c.ttl).Err(); err != nil {
-		log.Debug().Err(err).Uint("node_id", nodeID).Msg("query dispatch cache: failed to set")
+	cached, err := c.HasNoPendingQueries(ctx, nodeID)
+	if err != nil {
+		log.Debug().Err(err).Uint("node_id", nodeID).Msg("query dispatch cache: read error")
+		return lookup()
 	}
+	if cached {
+		return QueryReadQueries{}, false, nil
+	}
+
+	var result QueryReadQueries
+	var accelerate, loaded bool
+	var lookupErr error
+	key := cacheKey(nodeID)
+	err = c.client.Watch(ctx, func(tx *redis.Tx) error {
+		value, err := tx.Get(ctx, key).Result()
+		if err != nil && !errors.Is(err, redis.Nil) {
+			return err
+		}
+		if value == "1" {
+			result, loaded = QueryReadQueries{}, true
+			return nil
+		}
+		result, accelerate, lookupErr = lookup()
+		loaded = true
+		if lookupErr != nil || len(result) != 0 {
+			return nil
+		}
+		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Set(ctx, key, "1", c.ttl)
+			return nil
+		})
+		return err
+	}, key)
+	if err != nil && !errors.Is(err, redis.TxFailedErr) {
+		log.Debug().Err(err).Uint("node_id", nodeID).Msg("query dispatch cache: fill error")
+	}
+	if !loaded {
+		return lookup()
+	}
+	return result, accelerate, lookupErr
 }
 
-// Invalidate removes the cache entry for a single node. Called when a
+// Invalidate clears the empty hint for a single node. Called when a
 // new query is created that targets this node.
 func (c *QueryDispatchCache) Invalidate(ctx context.Context, nodeID uint) {
 	if c == nil || c.client == nil {
 		return
 	}
-	c.client.Del(ctx, cacheKey(nodeID))
+	// DEL on an absent key does not invalidate WATCH. SET also fences readers
+	// that started their SQL lookup with a cache miss.
+	if err := c.client.Set(ctx, cacheKey(nodeID), "0", c.ttl).Err(); err != nil {
+		log.Debug().Err(err).Uint("node_id", nodeID).Msg("query dispatch cache: invalidate failed")
+	}
 }
 
-// InvalidateMany removes cache entries for multiple nodes. Called when a
+// InvalidateMany clears empty hints for multiple nodes. Called when a
 // new query is created targeting many nodes. Uses pipelining to avoid
 // N round-trips.
 func (c *QueryDispatchCache) InvalidateMany(ctx context.Context, nodeIDs []uint) {
@@ -88,7 +127,7 @@ func (c *QueryDispatchCache) InvalidateMany(ctx context.Context, nodeIDs []uint)
 	}
 	pipe := c.client.Pipeline()
 	for _, id := range nodeIDs {
-		pipe.Del(ctx, cacheKey(id))
+		pipe.Set(ctx, cacheKey(id), "0", c.ttl)
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		log.Debug().Err(err).Int("count", len(nodeIDs)).Msg("query dispatch cache: invalidate many failed")

--- a/pkg/queries/query-dispatch-cache_redis_test.go
+++ b/pkg/queries/query-dispatch-cache_redis_test.go
@@ -1,0 +1,139 @@
+package queries
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/jmpsec/osctrl/pkg/nodes"
+	"github.com/stretchr/testify/require"
+)
+
+func dispatchRedisClient(t *testing.T) *redis.Client {
+	t.Helper()
+	addr := os.Getenv("OSCTRL_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("set OSCTRL_TEST_REDIS_ADDR to a disposable Redis instance")
+	}
+	client := redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() { _ = client.Close() })
+	require.NoError(t, client.Ping(context.Background()).Err())
+	return client
+}
+
+func TestQueryDispatchRedisInvalidationDuringFill(t *testing.T) {
+	for _, name := range []string{"single", "many", "expired-invalidation"} {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			reader := NewQueryDispatchCache(dispatchRedisClient(t), 0)
+			writer := NewQueryDispatchCache(dispatchRedisClient(t), 0)
+			if name == "expired-invalidation" {
+				writer.ttl = 20 * time.Millisecond
+			}
+			db := setupTestDB(t)
+			q := setupQueries(t, db)
+			q.Cache = writer
+			node := nodes.OsqueryNode{ID: uint(time.Now().UnixNano())}
+			t.Cleanup(func() { _ = reader.client.Del(ctx, cacheKey(node.ID)).Err() })
+			dq := DistributedQuery{Name: "race-query", Query: "SELECT 1", Type: ConsoleQueryType, Active: true}
+			require.NoError(t, q.Create(&dq))
+
+			// The reader's SQL snapshot is empty; a writer commits and invalidates
+			// before the reader attempts to cache that snapshot.
+			_, _, err := reader.read(ctx, node.ID, func() (QueryReadQueries, bool, error) {
+				if name == "many" {
+					require.NoError(t, q.CreateNodeQueries([]uint{node.ID}, dq.ID))
+				} else {
+					require.NoError(t, db.Create(&NodeQuery{NodeID: node.ID, QueryID: dq.ID}).Error)
+					writer.Invalidate(ctx, node.ID)
+				}
+				if name == "expired-invalidation" {
+					require.Eventually(t, func() bool {
+						count, err := writer.client.Exists(ctx, cacheKey(node.ID)).Result()
+						return err == nil && count == 0
+					}, 2*time.Second, 10*time.Millisecond)
+				}
+				return QueryReadQueries{}, false, nil
+			})
+			require.NoError(t, err)
+			cached, err := reader.HasNoPendingQueries(ctx, node.ID)
+			require.NoError(t, err)
+			require.False(t, cached)
+			q.Cache = reader
+			result, accelerate, err := q.NodeQueries(node)
+			require.NoError(t, err)
+			require.Equal(t, QueryReadQueries{"race-query": "SELECT 1"}, result)
+			require.True(t, accelerate)
+		})
+	}
+}
+
+func TestQueryDispatchRedisExpiryAndClientRestart(t *testing.T) {
+	ctx := context.Background()
+	client := dispatchRedisClient(t)
+	nodeID := uint(time.Now().UnixNano())
+	t.Cleanup(func() { _ = client.Del(ctx, cacheKey(nodeID)).Err() })
+	cache := NewQueryDispatchCache(client, 0)
+	reads := 0
+	load := func() (QueryReadQueries, bool, error) { reads++; return QueryReadQueries{}, false, nil }
+	_, _, err := cache.read(ctx, nodeID, load)
+	require.NoError(t, err)
+	ttl, err := client.PTTL(ctx, cacheKey(nodeID)).Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Minute)
+	require.LessOrEqual(t, ttl, 2*time.Minute)
+	cache = NewQueryDispatchCache(dispatchRedisClient(t), 50*time.Millisecond)
+	_, _, err = cache.read(ctx, nodeID, load)
+	require.NoError(t, err)
+	require.Equal(t, 1, reads, "new process must reuse the shared empty hint")
+	cache.Invalidate(ctx, nodeID)
+	_, _, err = cache.read(ctx, nodeID, load)
+	require.NoError(t, err)
+	require.Equal(t, 2, reads)
+	require.Eventually(t, func() bool {
+		cached, err := cache.HasNoPendingQueries(ctx, nodeID)
+		return err == nil && !cached
+	}, 2*time.Second, 10*time.Millisecond)
+	_, _, err = cache.read(ctx, nodeID, load)
+	require.NoError(t, err)
+	require.Equal(t, 3, reads, "expiry must force a fresh lookup")
+	require.NoError(t, cache.client.Close())
+	_, _, err = cache.read(ctx, nodeID, load)
+	require.NoError(t, err)
+	require.Equal(t, 4, reads, "Redis failure must fall back to SQL")
+}
+
+func TestQueryDispatchRedisRestartDuringFill(t *testing.T) {
+	container := os.Getenv("OSCTRL_TEST_REDIS_CONTAINER")
+	if container == "" {
+		t.Skip("set OSCTRL_TEST_REDIS_CONTAINER to a disposable Redis container without persistence and with a fixed host port")
+	}
+	ctx := context.Background()
+	client := dispatchRedisClient(t)
+	cache := NewQueryDispatchCache(client, 0)
+	nodeID := uint(time.Now().UnixNano())
+	t.Cleanup(func() { _ = client.Del(ctx, cacheKey(nodeID)).Err() })
+	_, _, err := cache.read(ctx, nodeID, func() (QueryReadQueries, bool, error) {
+		output, err := exec.Command("docker", "restart", container).CombinedOutput()
+		require.NoError(t, err, "%s", output)
+		return QueryReadQueries{}, false, nil
+	})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return client.Ping(ctx).Err() == nil }, 5*time.Second, 20*time.Millisecond)
+	cached, err := cache.HasNoPendingQueries(ctx, nodeID)
+	require.NoError(t, err)
+	require.False(t, cached, "a lost WATCH connection must not repopulate Redis with an old result")
+	reads := 0
+	_, _, err = cache.read(ctx, nodeID, func() (QueryReadQueries, bool, error) {
+		reads++
+		return QueryReadQueries{}, false, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, reads)
+	cached, err = cache.HasNoPendingQueries(ctx, nodeID)
+	require.NoError(t, err)
+	require.True(t, cached, "fresh lookups should refill after Redis restarts")
+}

--- a/pkg/queries/query-dispatch-cache_test.go
+++ b/pkg/queries/query-dispatch-cache_test.go
@@ -2,6 +2,7 @@ package queries
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -26,17 +27,25 @@ import (
 // ──────────────────────────────────────────────────────────────────────────────
 
 type fakeRedisStore struct {
-	mu     sync.Mutex
-	values map[string]string
+	mu       sync.Mutex
+	values   map[string]string
+	versions map[string]int
+	expires  map[string]time.Duration
+	now      time.Duration
 }
 
 func newFakeRedisClient(t *testing.T) *redis.Client {
+	client, _ := newFakeRedis(t)
+	return client
+}
+
+func newFakeRedis(t *testing.T) (*redis.Client, *fakeRedisStore) {
 	t.Helper()
-	store := &fakeRedisStore{values: make(map[string]string)}
+	store := &fakeRedisStore{values: make(map[string]string), versions: make(map[string]int), expires: make(map[string]time.Duration)}
 
 	client := redis.NewClient(&redis.Options{
 		Addr:     "fake-redis",
-		PoolSize: 1,
+		PoolSize: 4,
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			serverConn, clientConn := net.Pipe()
 			go serveFakeRedis(serverConn, store)
@@ -44,12 +53,15 @@ func newFakeRedisClient(t *testing.T) *redis.Client {
 		},
 	})
 	t.Cleanup(func() { _ = client.Close() })
-	return client
+	return client, store
 }
 
 func serveFakeRedis(conn net.Conn, store *fakeRedisStore) {
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
+	watched := make(map[string]int)
+	var queued [][]string
+	inTransaction := false
 	for {
 		args, err := readRESPArray(reader)
 		if err != nil {
@@ -58,37 +70,89 @@ func serveFakeRedis(conn net.Conn, store *fakeRedisStore) {
 		if len(args) == 0 {
 			return
 		}
-		handleFakeRedisCmd(conn, store, args)
+		store.mu.Lock()
+		for key, expires := range store.expires {
+			if store.now >= expires {
+				delete(store.values, key)
+				delete(store.expires, key)
+				store.versions[key]++
+			}
+		}
+		var response bytes.Buffer
+		switch strings.ToUpper(args[0]) {
+		case "WATCH":
+			for _, key := range args[1:] {
+				watched[key] = store.versions[key]
+			}
+			response.WriteString("+OK\r\n")
+		case "UNWATCH":
+			clear(watched)
+			response.WriteString("+OK\r\n")
+		case "MULTI":
+			inTransaction = true
+			response.WriteString("+OK\r\n")
+		case "EXEC":
+			conflict := false
+			for key, version := range watched {
+				conflict = conflict || store.versions[key] != version
+			}
+			if conflict {
+				response.WriteString("*-1\r\n")
+			} else {
+				fmt.Fprintf(&response, "*%d\r\n", len(queued))
+				for _, command := range queued {
+					handleFakeRedisCmd(&response, store, command)
+				}
+			}
+			clear(watched)
+			queued = nil
+			inTransaction = false
+		default:
+			if inTransaction {
+				queued = append(queued, args)
+				response.WriteString("+QUEUED\r\n")
+			} else {
+				handleFakeRedisCmd(&response, store, args)
+			}
+		}
+		store.mu.Unlock()
+		_, _ = conn.Write(response.Bytes())
 	}
 }
 
-func handleFakeRedisCmd(conn net.Conn, store *fakeRedisStore, args []string) {
+func handleFakeRedisCmd(conn io.Writer, store *fakeRedisStore, args []string) {
 	cmd := strings.ToUpper(args[0])
 	switch cmd {
 	case "GET":
-		store.mu.Lock()
 		val, ok := store.values[args[1]]
-		store.mu.Unlock()
 		if !ok {
 			_, _ = conn.Write([]byte("$-1\r\n"))
 		} else {
 			_, _ = fmt.Fprintf(conn, "$%d\r\n%s\r\n", len(val), val)
 		}
 	case "SET":
-		store.mu.Lock()
 		store.values[args[1]] = args[2]
-		store.mu.Unlock()
+		store.versions[args[1]]++
+		delete(store.expires, args[1])
+		if len(args) >= 5 {
+			ttl, _ := strconv.Atoi(args[4])
+			unit := time.Second
+			if strings.EqualFold(args[3], "PX") {
+				unit = time.Millisecond
+			}
+			store.expires[args[1]] = store.now + time.Duration(ttl)*unit
+		}
 		_, _ = conn.Write([]byte("+OK\r\n"))
 	case "DEL":
 		n := 0
-		store.mu.Lock()
 		for _, k := range args[1:] {
 			if _, ok := store.values[k]; ok {
 				delete(store.values, k)
+				delete(store.expires, k)
+				store.versions[k]++
 				n++
 			}
 		}
-		store.mu.Unlock()
 		_, _ = fmt.Fprintf(conn, ":%d\r\n", n)
 	case "PING":
 		_, _ = conn.Write([]byte("+PONG\r\n"))
@@ -145,6 +209,13 @@ func setupQueries(t *testing.T, db *gorm.DB) *Queries {
 	q := CreateQueries(db)
 	require.NotNil(t, q)
 	return q
+}
+
+// Prime entries through the same guarded fill used by NodeQueries.
+func (c *QueryDispatchCache) SetNoPendingQueries(ctx context.Context, nodeID uint) {
+	_, _, _ = c.read(ctx, nodeID, func() (QueryReadQueries, bool, error) {
+		return QueryReadQueries{}, false, nil
+	})
 }
 
 // NodeQueries with a nil cache should behave exactly as before — always
@@ -286,6 +357,81 @@ func TestQueryDispatchCache_MissReturnsFalse(t *testing.T) {
 	ok, err := c.HasNoPendingQueries(context.Background(), 999)
 	require.NoError(t, err)
 	assert.False(t, ok)
+}
+
+func TestNodeQueries_InvalidationDuringEmptyLookup(t *testing.T) {
+	for _, many := range []bool{false, true} {
+		t.Run(fmt.Sprintf("many=%t", many), func(t *testing.T) {
+			db := setupTestDB(t)
+			q := setupQueries(t, db)
+			q.Cache = NewQueryDispatchCache(newFakeRedisClient(t), 0)
+			node := nodes.OsqueryNode{ID: 1}
+			invalidated := false
+			require.NoError(t, db.Callback().Row().After("gorm:row").Register("test:invalidate", func(tx *gorm.DB) {
+				invalidated = true
+				if many {
+					q.Cache.InvalidateMany(context.Background(), []uint{node.ID})
+				} else {
+					q.Cache.Invalidate(context.Background(), node.ID)
+				}
+			}))
+
+			result, _, err := q.NodeQueries(node)
+			require.NoError(t, err)
+			require.Empty(t, result)
+			require.True(t, invalidated, "invalidation must occur between SQL lookup and cache refill")
+			cached, err := q.Cache.HasNoPendingQueries(context.Background(), node.ID)
+			require.NoError(t, err)
+			require.False(t, cached, "empty refill must not overwrite concurrent invalidation")
+		})
+	}
+}
+
+func TestNodeQueries_SQLFailureIsNotCached(t *testing.T) {
+	db := setupTestDB(t)
+	q := setupQueries(t, db)
+	q.Cache = NewQueryDispatchCache(newFakeRedisClient(t), 0)
+	require.NoError(t, db.Migrator().DropTable(&NodeQuery{}))
+	for range 2 {
+		_, _, err := q.NodeQueries(nodes.OsqueryNode{ID: 1})
+		require.Error(t, err)
+		cached, err := q.Cache.HasNoPendingQueries(context.Background(), 1)
+		require.NoError(t, err)
+		require.False(t, cached)
+	}
+}
+
+func TestQueryDispatchCache_DefaultAndConfiguredTTL(t *testing.T) {
+	require.Equal(t, 2*time.Minute, NewQueryDispatchCache(nil, 0).ttl)
+	require.Equal(t, 30*time.Second, NewQueryDispatchCache(nil, 30*time.Second).ttl)
+}
+
+func TestNodeQueries_CacheSurvivesPollAndExpires(t *testing.T) {
+	for _, ttl := range []time.Duration{0, 3 * time.Minute} {
+		t.Run(ttl.String(), func(t *testing.T) {
+			db := setupTestDB(t)
+			q := setupQueries(t, db)
+			client, store := newFakeRedis(t)
+			q.Cache = NewQueryDispatchCache(client, ttl)
+			node := nodes.OsqueryNode{ID: 1}
+			reads := 0
+			require.NoError(t, db.Callback().Row().After("gorm:row").Register("test:count", func(tx *gorm.DB) { reads++ }))
+			_, _, err := q.NodeQueries(node)
+			require.NoError(t, err)
+			store.mu.Lock()
+			store.now = time.Minute
+			store.mu.Unlock()
+			_, _, err = q.NodeQueries(node)
+			require.NoError(t, err)
+			require.Equal(t, 1, reads, "60s poll should reuse the empty cache")
+			store.mu.Lock()
+			store.now = q.Cache.ttl
+			store.mu.Unlock()
+			_, _, err = q.NodeQueries(node)
+			require.NoError(t, err)
+			require.Equal(t, 2, reads, "expiry should force a fresh SQL lookup")
+		})
+	}
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/pkg/serviceconfig/query_dispatch_test.go
+++ b/pkg/serviceconfig/query_dispatch_test.go
@@ -1,0 +1,43 @@
+package serviceconfig
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateSectionQueryDispatchTTL(t *testing.T) {
+	for _, value := range []string{`1e30`, `"2m"`, `true`, `1.5`, `9223372036854775808`, `-9223372036854775809`, `{}`, `[]`} {
+		t.Run("reject/"+value, func(t *testing.T) {
+			m := &ServiceConfigManager{DB: setupTestDB(t)}
+			require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), 0))
+			before, err := m.GetSection(config.ServiceTLS, "osquery", 0)
+			require.NoError(t, err)
+			_, err = m.UpdateSection(config.ServiceTLS, "osquery", `{"QueryDispatchTTL":`+value+`}`, 0)
+			require.Error(t, err)
+			after, err := m.GetSection(config.ServiceTLS, "osquery", 0)
+			require.NoError(t, err)
+			require.Equal(t, before.Value, after.Value)
+			require.Equal(t, before.Source, after.Source)
+			require.NoError(t, m.Resolve(config.ServiceTLS, testTLSParams(), 0))
+		})
+	}
+	for _, duration := range []time.Duration{0, -1, 2 * time.Minute, 1<<63 - 1, -1 << 63} {
+		t.Run(fmt.Sprintf("roundtrip/%d", duration), func(t *testing.T) {
+			m := &ServiceConfigManager{DB: setupTestDB(t)}
+			require.NoError(t, m.Seed(config.ServiceTLS, testTLSParams(), 0))
+			value := fmt.Sprintf(`{"queryDispatchTTL":%d}`, duration)
+			_, err := m.UpdateSection(config.ServiceTLS, "osquery", value, 0)
+			require.NoError(t, err)
+			params := testTLSParams()
+			require.NoError(t, m.Resolve(config.ServiceTLS, params, 0))
+			require.Equal(t, duration, params.Osquery.QueryDispatchTTL)
+			stored, err := m.GetSection(config.ServiceTLS, "osquery", 0)
+			require.NoError(t, err)
+			require.JSONEq(t, value, stored.Value)
+		})
+	}
+}

--- a/pkg/serviceconfig/serviceconfig.go
+++ b/pkg/serviceconfig/serviceconfig.go
@@ -359,6 +359,12 @@ func (m *ServiceConfigManager) UpdateSection(service, name, value string, envID 
 	if !json.Valid([]byte(value)) {
 		return ServiceConfig{}, fmt.Errorf("value is not valid JSON")
 	}
+	if name == "osquery" {
+		var osquery config.YAMLConfigurationOsquery
+		if err := json.Unmarshal([]byte(value), &osquery); err != nil {
+			return ServiceConfig{}, fmt.Errorf("unmarshal osquery: %w", err)
+		}
+	}
 	if name == "rateLimits" {
 		var limits config.YAMLConfigurationRateLimits
 		if err := json.Unmarshal([]byte(value), &limits); err != nil {


### PR DESCRIPTION
Implementation of https://github.com/jmpsec/osctrl/issues/562

## Summary
- Replace per-node heartbeat writes with bounded bulk updates while preserving timestamps and preventing stale IP updates.
- Add race-safe query caching with a configurable two-minute default and post-commit invalidation.
- Cache console/file-explorer session checks and skip them when acceleration is disabled.
- Return retryable errors for query-dispatch failures and validate persisted TTL settings.

## Validation
- Full Go suite and targeted race tests passed.
- PostgreSQL, MySQL, and Redis integration tests passed.
- OpenAPI consistency check passed.

## Operational Notes
- Upgrade all API/TLS replicas for race-safe invalidation.
- Direct-database CLI submissions rely on cache expiry; API-mode submissions invalidate immediately.