### PR TITLE
Fix osquery version check and RPM upgrade in the enroll script

### DIFF
--- a/pkg/environments/scripts.go
+++ b/pkg/environments/scripts.go
@@ -75,7 +75,7 @@ installOsquery() {
 			local _OSQUERY_RPM=$(osquery_downloadable $_OSQUERY_VER rpm)
       local _RPM="$(echo $_OSQUERY_RPM | cut -d"/" -f5)"
       sudo curl -# "$_OSQUERY_RPM" -o "/tmp/$_RPM"
-      sudo rpm -ivh "/tmp/$_RPM"
+      sudo rpm -Uvh "/tmp/$_RPM"
     else
       log "DEB based system detected"
 			local _OSQUERY_DEB=$(osquery_downloadable $_OSQUERY_VER deb)
@@ -97,6 +97,30 @@ installOsquery() {
   fi
 }
 
+# osqueryNeedsInstall prints "install" when the installed version is missing or
+# older than the required one, and "skip" otherwise. A node that is AHEAD is
+# left alone: silently downgrading a fleet is worse than running newer than
+# asked. Kept as a named function so the decision can be extracted and tested
+# without running the whole script — see scripts_test.go.
+osqueryNeedsInstall() {
+  _required="$1"
+  _installed="$2"
+  if [ -z "$_installed" ]; then
+    echo "install"
+    return
+  fi
+  if [ "$_installed" = "$_required" ]; then
+    echo "skip"
+    return
+  fi
+  _highest=$(printf '%s\n%s\n' "$_required" "$_installed" | sort -rV | head -n 1)
+  if [ "$_highest" = "$_required" ]; then
+    echo "install"
+  else
+    echo "skip"
+  fi
+}
+
 verifyOsquery() {
   which osqueryi
   if [ "$?" != "0" ]; then
@@ -110,8 +134,8 @@ verifyOsquery() {
     installOsquery
   else
     local osquery_version=$(osqueryi -version | cut -d' ' -f3)
-    if [ "$(echo "$_OSQUERY_VER:$osquery_version" | tr ':' '\n' | sort -rV | head -n 1)" != "$_OSQUERY_VER" ]; then
-      log "Installed version of osquery is $osquery_version, needs to upgrade to $_OSQUERY_VER"
+    if [ "$(osqueryNeedsInstall "$_OSQUERY_VER" "$osquery_version")" = "install" ]; then
+      log "Installed version of osquery is $osquery_version, needs osquery $_OSQUERY_VER"
       installOsquery
     else
       log "Installed version of osquery is $osquery_version"

--- a/pkg/environments/scripts_test.go
+++ b/pkg/environments/scripts_test.go
@@ -1,0 +1,87 @@
+package environments
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The enroll templates are shell embedded in Go string constants, so nothing
+// compiles or lints them and a logic bug ships straight to every endpoint.
+// That is not hypothetical: the version check here used to be inverted — it
+// reinstalled only when a node was AHEAD of the required version and did
+// nothing when it was behind, so "keep osquery up to date" silently never
+// upgraded anyone.
+//
+// These tests pull the decision function out of the template and run it under
+// /bin/sh, so the assertions are about the shipped text, not a copy of it.
+
+// extractShellFunc returns the body of a POSIX shell function defined in src,
+// from "name() {" through its closing brace at column 0.
+func extractShellFunc(t *testing.T, src, name string) string {
+	t.Helper()
+	start := strings.Index(src, name+"() {")
+	if start < 0 {
+		t.Fatalf("function %q not found in the template — was it renamed?", name)
+	}
+	rest := src[start:]
+	end := strings.Index(rest, "\n}\n")
+	if end < 0 {
+		t.Fatalf("function %q has no closing brace at column 0", name)
+	}
+	return rest[:end+len("\n}\n")]
+}
+
+func TestOsqueryNeedsInstallDecision(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no POSIX shell available")
+	}
+	fn := extractShellFunc(t, QuickAddScriptShell, "osqueryNeedsInstall")
+
+	cases := []struct {
+		name      string
+		required  string
+		installed string
+		want      string
+	}{
+		{"behind must upgrade", "5.23.1", "5.19.0", "install"},
+		{"behind by a patch must upgrade", "5.23.1", "5.23.0", "install"},
+		{"exact match is a no-op", "5.23.1", "5.23.1", "skip"},
+		{"ahead is left alone, never downgraded", "5.19.0", "5.23.1", "skip"},
+		{"nothing installed", "5.23.1", "", "install"},
+		{"double-digit minor sorts numerically, not lexically", "5.9.0", "5.10.0", "skip"},
+	}
+
+	dir := t.TempDir()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			script := filepath.Join(dir, "decide.sh")
+			body := fn + "\nosqueryNeedsInstall \"$1\" \"$2\"\n"
+			if err := os.WriteFile(script, []byte(body), 0o600); err != nil {
+				t.Fatalf("writing harness: %v", err)
+			}
+			out, err := exec.Command("sh", script, tc.required, tc.installed).CombinedOutput()
+			if err != nil {
+				t.Fatalf("running the extracted function: %v (output %q)", err, out)
+			}
+			if got := strings.TrimSpace(string(out)); got != tc.want {
+				t.Errorf("required=%s installed=%s: got %q, want %q",
+					tc.required, tc.installed, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRPMInstallUsesUpgradeFlag guards the other half of the same bug: `rpm -i`
+// fails outright when the package is already present, which is exactly the
+// upgrade path, so the RPM branch could never upgrade anything.
+func TestRPMInstallUsesUpgradeFlag(t *testing.T) {
+	if strings.Contains(QuickAddScriptShell, "rpm -ivh") {
+		t.Error("rpm -ivh cannot upgrade an installed package; use rpm -Uvh")
+	}
+	if !strings.Contains(QuickAddScriptShell, "rpm -Uvh") {
+		t.Error("the RPM branch should install or upgrade with rpm -Uvh")
+	}
+}


### PR DESCRIPTION
## Fix osquery version check and RPM upgrade in the enroll script

The quick-enroll shell template — the one osctrld fetches to keep osquery installed and current — could never upgrade a node that was behind.

### The version comparison was inverted

```sh
if [ "$(echo "$_OSQUERY_VER:$osquery_version" | tr ':' '\n' | sort -rV | head -n 1)" != "$_OSQUERY_VER" ]
```

`sort -rV | head -1` yields the *higher* of the two versions, so the branch fired only when the installed version was **ahead** of the required one:

| required | installed | old behavior | new behavior |
|---|---|---|---|
| 5.23.1 | 5.19.0 | **nothing** — stayed behind forever | upgrade |
| 5.19.0 | 5.23.1 | downgrade | leave alone, log it |
| 5.23.1 | 5.23.1 | nothing | nothing |

The decision now lives in a named `osqueryNeedsInstall()` function. A node that is **ahead is left alone** rather than downgraded — the old code attempted a silent fleet-wide downgrade, which is worse than running newer than asked. Flip one line if exact-version pinning is what you want instead.

### `rpm -ivh` could not upgrade

`rpm -i` fails outright when the package is already installed — exactly the upgrade case — so even with the comparison fixed, RPM hosts would error. Now `rpm -Uvh` (install or upgrade). Debian (`dpkg -i`) and macOS (`installer -pkg`) already handled both.

### Tests

These templates are shell embedded in Go string constants: nothing compiles or lints them, which is how an inverted comparison shipped. `scripts_test.go` **extracts `osqueryNeedsInstall` from the shipped template text** and runs it under `/bin/sh` — assertions are against what endpoints actually receive, not a copy. Six cases, including `5.9.0` vs `5.10.0`, which lexical comparison gets backwards. Verified failing against the pre-patch template.

### Not fixed here: Windows

The PowerShell template installs only when `osqueryd.exe` is absent (`if (!(Test-Path $osqueryDaemon))`) — it never reads or compares a version, so a Windows node behind the required version stays behind. Same defect by omission. Fixing it means adding version detection and an MSI upgrade path to a ~279-line template that no CI exercises; writing blind upgrade logic into an untested template is how these bugs arrived. It belongs in the native osctrld install path, where `GOOS=windows` code is testable with an injected command runner.