### PR TITLE
Adds optional SSE notifications for live query and carve updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -139,6 +139,26 @@ Request controls are composed at route registration:
 
 There is no global middleware chain or declarative authorization policy. Authentication wrappers, rate limits, feature gates, and permission checks are attached explicitly to routes and handlers.
 
+Optional live updates use `GET /api/v1/events?env=<name-or-uuid>&topic=queries`
+(also `topic=carves`, repeatable). Enable `service.eventsEnabled` / `--events-enabled`
+on API and TLS and set `service.eventsNamespace` / `--events-namespace` to the same
+deployment-unique value. Both default to disabled/unset. The equivalent environment
+variables are `SERVICE_EVENTS_ENABLED` and `SERVICE_EVENTS_NAMESPACE`. Namespaces
+use 1–64 letters, digits, underscores, or hyphens and isolate deployments sharing
+Redis, including deployments using different Redis database numbers.
+
+`pkg/events` publishes bounded, best-effort Redis Pub/Sub invalidation hints and
+fans them out to API subscribers. Each connection is scoped to an environment
+and authorized query/carve topics; interactive query types are excluded. The API
+rechecks token validity and permissions before each batch and during idle
+heartbeats. Broker reconnects and slow-subscriber overflow close streams so the
+frontend obtains fresh REST snapshots. The environment layout shares one
+fetch-based SSE stream between query/carve views and keeps their existing polling
+as reconciliation and mixed-version fallback. Hints do not guarantee result
+persistence, operation completion, replay, or download availability. Commands,
+pagination, result data, and downloads continue through REST. The first release
+does not change console/file-explorer sessions or add WebSocket transport.
+
 ## Authentication / Session Model
 
 ### API
@@ -410,5 +430,5 @@ Redis-only state such as activity rollups, query-dispatch hints, and alert coold
 - Retention is feature-specific: activity rollups expire in Redis and alert history is pruned daily when alerting is enabled, but osquery log rows, distributed-query/carve records, and console/file-explorer rows have no uniform background retention policy. Query expiration changes lifecycle state rather than deleting rows.
 - Relationships mostly use indexed numeric IDs, UUIDs, or names without database foreign-key constraints. External routes also mix environment names/UUIDs, node UUIDs/names, and numeric configuration IDs, which matters when integrating or troubleshooting.
 - SAML assertion replay protection uses a per-process TTL cache. In a multi-replica API deployment, the same assertion can be presented once to each replica within its validity window unless a shared replay layer is added.
-- Graceful shutdown is limited. `osctrl-api` drains HTTP requests for an internally requested config restart, while `osctrl-tls` exits for its restart command; neither service currently installs a general OS-signal shutdown path.
+- Graceful shutdown is limited. `osctrl-api` closes event streams and drains HTTP requests for config restart, SIGINT, or SIGTERM. `osctrl-tls` exits for its restart command and has no general OS-signal drain path.
 - Health reporting needs `--health-enabled` on both services to show a complete picture: with only `osctrl-api` enabled, the page shows `osctrl-tls` as "not reporting" (unknown), never "down", since there is no heartbeat row to compare against. Multiple `osctrl-tls` replicas share the single `service_status` row for `"tls"` — the last writer wins, so overall liveness stays correct but per-replica detail (which instance, how many) is lost. The health page is a point-in-time snapshot with no history.

--- a/cmd/api/auth.go
+++ b/cmd/api/auth.go
@@ -108,7 +108,7 @@ func handlerAuthCheck(h http.Handler, auth, jwtSecret string) http.Handler {
 			// Set middleware values
 			token := extractHeaderToken(r)
 			if token == "" {
-				if utils.AcceptsJSON(r) {
+				if utils.AcceptsJSON(r) || r.URL.Path == "/api/v1/events" {
 					utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusUnauthorized,
 						types.ApiErrorResponse{Error: "unauthorized", Code: "unauthorized"})
 					return
@@ -120,7 +120,7 @@ func handlerAuthCheck(h http.Handler, auth, jwtSecret string) http.Handler {
 			}
 			claims, valid := apiUsers.CheckToken(jwtSecret, token)
 			if !valid {
-				if utils.AcceptsJSON(r) {
+				if utils.AcceptsJSON(r) || r.URL.Path == "/api/v1/events" {
 					utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusUnauthorized,
 						types.ApiErrorResponse{Error: "unauthorized", Code: "unauthorized"})
 					return
@@ -139,7 +139,7 @@ func handlerAuthCheck(h http.Handler, auth, jwtSecret string) http.Handler {
 			tokenMatches := uerr == nil && user.APIToken != "" &&
 				subtle.ConstantTimeCompare([]byte(user.APIToken), []byte(token)) == 1
 			if !tokenMatches {
-				if utils.AcceptsJSON(r) {
+				if utils.AcceptsJSON(r) || r.URL.Path == "/api/v1/events" {
 					utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusUnauthorized,
 						types.ApiErrorResponse{Error: "unauthorized", Code: "unauthorized"})
 					return
@@ -167,4 +167,23 @@ func handlerAuthCheck(h http.Handler, auth, jwtSecret string) http.Handler {
 			h.ServeHTTP(w, r.WithContext(ctx))
 		}
 	})
+}
+
+// eventSessionValid repeats the authoritative token check for an open stream.
+// It intentionally does not update last-login IP metadata on every event.
+func eventSessionValid(r *http.Request, auth, secret string) bool {
+	if auth == config.AuthNone {
+		return true
+	}
+	if auth != config.AuthJWT {
+		return false
+	}
+	token := extractHeaderToken(r)
+	claims, valid := apiUsers.CheckToken(secret, token)
+	if !valid {
+		return false
+	}
+	user, err := apiUsers.Get(claims.Username)
+	ctx, ok := r.Context().Value(handlers.ContextKey(contextAPI)).(handlers.ContextValue)
+	return ok && ctx["user"] == claims.Username && err == nil && user.APIToken != "" && subtle.ConstantTimeCompare([]byte(user.APIToken), []byte(token)) == 1
 }

--- a/cmd/api/events_auth_test.go
+++ b/cmd/api/events_auth_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jmpsec/osctrl/cmd/api/handlers"
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestEventsAuthErrorsAreJSON(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/v1/events?env=dev&topic=queries", nil)
+	r.Header.Set("Accept", "text/event-stream")
+	w := httptest.NewRecorder()
+	handlerAuthCheck(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("unauthenticated stream admitted") }), config.AuthJWT, "event-test-secret-at-least-thirty-two-bytes").ServeHTTP(w, r)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Empty(t, w.Header().Get("Location"))
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+}
+
+func TestEventSessionRechecksStoredTokenAndIdentity(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	previous := apiUsers
+	t.Cleanup(func() { apiUsers = previous })
+	apiUsers = users.CreateUserManager(db).WithJWT(&config.YAMLConfigurationJWT{JWTSecret: "event-test-secret-at-least-thirty-two-bytes", HoursToExpire: 1})
+	require.NoError(t, apiUsers.Create(users.AdminUser{Username: "alice"}))
+	token, expiry, err := apiUsers.CreateToken("alice", "api", 1)
+	require.NoError(t, err)
+	require.NoError(t, apiUsers.UpdateToken("alice", token, expiry))
+	r := httptest.NewRequest("GET", "/api/v1/events", nil)
+	r.AddCookie(&http.Cookie{Name: cookieNameToken, Value: token})
+	r = r.WithContext(context.WithValue(r.Context(), handlers.ContextKey(contextAPI), handlers.ContextValue{"user": "alice"}))
+	require.True(t, eventSessionValid(r, config.AuthJWT, "event-test-secret-at-least-thirty-two-bytes"))
+	wrongUser := r.WithContext(context.WithValue(r.Context(), handlers.ContextKey(contextAPI), handlers.ContextValue{"user": "bob"}))
+	require.False(t, eventSessionValid(wrongUser, config.AuthJWT, "event-test-secret-at-least-thirty-two-bytes"))
+	newToken, newExpiry, err := apiUsers.CreateToken("alice", "api", 1)
+	require.NoError(t, err)
+	require.NoError(t, apiUsers.UpdateToken("alice", newToken, newExpiry))
+	require.False(t, eventSessionValid(r, config.AuthJWT, "event-test-secret-at-least-thirty-two-bytes"), "rotated cookie must stop an existing stream")
+	expired, expiry, err := apiUsers.CreateToken("alice", "api", -1)
+	require.NoError(t, err)
+	require.NoError(t, apiUsers.UpdateToken("alice", expired, expiry))
+	r.Header.Set("Cookie", cookieNameToken+"="+expired)
+	require.False(t, eventSessionValid(r, config.AuthJWT, "event-test-secret-at-least-thirty-two-bytes"))
+}

--- a/cmd/api/handlers/carves.go
+++ b/cmd/api/handlers/carves.go
@@ -447,6 +447,7 @@ func (h *HandlersApi) CarvesRunHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Debug().Msgf("Created carve %s", newQuery.Name)
 	h.AuditLog.NewCarve(ctx[ctxUser], newQuery.Path, strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	h.Queries.NotifyChange(newQuery.Name, env.ID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusCreated, types.ApiQueriesResponse{Name: newQuery.Name})
 }
 
@@ -529,6 +530,7 @@ func (h *HandlersApi) CarvesActionHandler(w http.ResponseWriter, r *http.Request
 	}
 	log.Debug().Msgf("%s", msgReturn)
 	h.AuditLog.CarveAction(ctx[ctxUser], actionVar+" carve "+nameVar, strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	h.Queries.NotifyChange(nameVar, env.ID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: msgReturn})
 }
 

--- a/cmd/api/handlers/events.go
+++ b/cmd/api/handlers/events.go
@@ -1,0 +1,198 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/events"
+	"github.com/jmpsec/osctrl/pkg/users"
+)
+
+// ResourceChanged is a cache invalidation hint, never an operation result.
+type ResourceChanged struct {
+	SchemaVersion   int    `json:"schema_version"`
+	EnvironmentUUID string `json:"environment_uuid"`
+	Topic           string `json:"topic"`
+	Name            string `json:"name"`
+}
+
+// EventsHandler streams authorized query/carve invalidations.
+// @Summary Subscribe to resource change notifications
+// @Description Best-effort SSE invalidation hints. No replay; refetch REST snapshots after stream.ready and retain polling. Requires the corresponding environment query/carve permissions.
+// @Tags Events
+// @Produce text/event-stream json
+// @Param env query string true "Environment name or UUID"
+// @Param topic query []string true "Topics: queries, carves" collectionFormat(multi)
+// @Success 200 {string} string "SSE stream: stream.ready, resource.changed, auth.expired"
+// @Failure 400 {object} types.ApiErrorResponse
+// @Failure 401 {object} types.ApiErrorResponse
+// @Failure 403 {object} types.ApiErrorResponse
+// @Failure 404 {object} types.ApiErrorResponse
+// @Failure 429 {object} types.ApiErrorResponse
+// @Failure 503 {object} types.ApiErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/events [get]
+func (h *HandlersApi) EventsHandler(w http.ResponseWriter, r *http.Request) {
+	if h.Events == nil || h.EventsAuthenticate == nil {
+		apiErrorResponse(w, "events unavailable", http.StatusNotFound, nil)
+		return
+	}
+	if !eventOriginAllowed(r) {
+		apiErrorResponse(w, "origin not allowed", http.StatusForbidden, nil)
+		return
+	}
+	if len(r.URL.RawQuery) > 2048 {
+		apiErrorResponse(w, "event selectors too large", http.StatusBadRequest, nil)
+		return
+	}
+	selectors, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil || len(selectors["env"]) != 1 || len(selectors["env"][0]) == 0 || len(selectors["env"][0]) > 256 || len(selectors["topic"]) == 0 || len(selectors["topic"]) > 2 {
+		apiErrorResponse(w, "invalid event subscription", http.StatusBadRequest, nil)
+		return
+	}
+	for key := range selectors {
+		if key != "env" && key != "topic" {
+			apiErrorResponse(w, "invalid event selector", http.StatusBadRequest, nil)
+			return
+		}
+	}
+	topics := selectors["topic"]
+	for _, topic := range topics {
+		if topic != events.Queries && topic != events.Carves {
+			apiErrorResponse(w, "invalid event topic", http.StatusBadRequest, nil)
+			return
+		}
+	}
+	env, err := h.Envs.Get(selectors.Get("env"))
+	if err != nil {
+		apiErrorResponse(w, "environment not found", http.StatusNotFound, nil)
+		return
+	}
+	ctx := r.Context().Value(ContextKey(contextAPI)).(ContextValue)
+	username := ctx[ctxUser]
+	authorized := func() bool {
+		if !h.EventsAuthenticate(r) {
+			return false
+		}
+		// A deleted environment must stop an existing subscription too.
+		current, err := h.Envs.GetByID(env.ID)
+		if err != nil || current.UUID != env.UUID {
+			return false
+		}
+		for _, topic := range topics {
+			level := users.QueryLevel
+			if topic == events.Carves {
+				level = users.CarveLevel
+			}
+			if !h.Users.CheckPermissions(username, level, env.UUID) {
+				return false
+			}
+		}
+		return true
+	}
+	if !authorized() {
+		apiErrorResponse(w, "no access", http.StatusForbidden, nil)
+		return
+	}
+	stream, unsubscribe, err := h.Events.Subscribe(username, env.ID, topics)
+	if err != nil {
+		code := http.StatusServiceUnavailable
+		if errors.Is(err, events.ErrLimit) {
+			code = http.StatusTooManyRequests
+		}
+		apiErrorResponse(w, "event stream unavailable", code, nil)
+		return
+	}
+	defer unsubscribe()
+	controller := http.NewResponseController(w)
+	// Require bounded writes rather than silently running without deadlines.
+	if err := controller.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		apiErrorResponse(w, "streaming unsupported", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defer func() { _ = controller.SetWriteDeadline(time.Time{}) }()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Accel-Buffering", "no")
+	write := func(event string, value any) error {
+		if err := controller.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+			return err
+		}
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data); err != nil {
+			return err
+		}
+		return controller.Flush()
+	}
+	if err := write("stream.ready", map[string]any{"environment_uuid": env.UUID, "topics": topics, "replay": false}); err != nil {
+		return
+	}
+	flush := time.NewTicker(250 * time.Millisecond)
+	defer flush.Stop()
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+	pending := make(map[events.Hint]struct{})
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case hint, ok := <-stream:
+			if !ok {
+				return
+			}
+			pending[hint] = struct{}{}
+			// Bounded memory even if thousands of distinct queries change.
+			if len(pending) > 64 {
+				return
+			}
+		case <-flush.C:
+			if len(pending) == 0 {
+				continue
+			}
+			if !authorized() {
+				_ = write("auth.expired", struct{}{})
+				return
+			}
+			for hint := range pending {
+				if err := write("resource.changed", ResourceChanged{1, env.UUID, hint.Topic, hint.Name}); err != nil {
+					return
+				}
+				delete(pending, hint)
+			}
+		case <-heartbeat.C:
+			if !authorized() {
+				_ = write("auth.expired", struct{}{})
+				return
+			}
+			if err := controller.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				return
+			}
+			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+				return
+			}
+			if err := controller.Flush(); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func eventOriginAllowed(r *http.Request) bool {
+	if site := r.Header.Get("Sec-Fetch-Site"); site != "" && site != "same-origin" && site != "none" {
+		return false
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	} // Same-origin EventSource may omit Origin.
+	u, err := url.Parse(origin)
+	return err == nil && u.User == nil && u.RawQuery == "" && u.Fragment == "" && u.Path == "" && strings.EqualFold(u.Host, r.Host) && (u.Scheme == "https" || (u.Scheme == "http" && r.TLS == nil))
+}

--- a/cmd/api/handlers/events_test.go
+++ b/cmd/api/handlers/events_test.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jmpsec/osctrl/pkg/events"
+	"github.com/jmpsec/osctrl/pkg/users"
+	"github.com/stretchr/testify/require"
+)
+
+type testEventSource struct {
+	ch        chan events.Hint
+	cancelled atomic.Bool
+}
+
+func (s *testEventSource) Subscribe(string, uint, []string) (<-chan events.Hint, func(), error) {
+	return s.ch, func() { s.cancelled.Store(true) }, nil
+}
+
+func TestEventSubscriptionValidation(t *testing.T) {
+	_, h, _, _ := setupConsoleHandlers(t)
+	h.Events = &testEventSource{ch: make(chan events.Hint)}
+	h.EventsAuthenticate = func(*http.Request) bool { return true }
+	for _, tc := range []struct {
+		query, user string
+		code        int
+	}{
+		{"", "alice", 400},
+		{"?env=env&topic=console", "alice", 400},
+		{"?env=env&env=other&topic=queries", "alice", 400},
+		{"?env=env&topic=queries&token=secret", "alice", 400},
+		{"?env=env&topic=queries", "bob", 403},
+		{"?env=missing&topic=queries", "alice", 404},
+	} {
+		r := consoleRequest(http.MethodGet, "/api/v1/events"+tc.query, nil, tc.user)
+		w := httptest.NewRecorder()
+		h.EventsHandler(w, r)
+		require.Equal(t, tc.code, w.Code, tc.query)
+	}
+}
+
+func TestEventOriginValidation(t *testing.T) {
+	for _, tc := range []struct {
+		origin, site string
+		want         bool
+	}{
+		{"", "same-origin", true}, {"https://example.com", "same-origin", true},
+		{"https://evil.example", "cross-site", false}, {"https://example.com.evil", "", false},
+		{"null", "", false}, {"https://example.com/path", "", false}, {"", "same-site", false},
+	} {
+		r := httptest.NewRequest("GET", "https://example.com/api/v1/events", nil)
+		r.Header.Set("Origin", tc.origin)
+		r.Header.Set("Sec-Fetch-Site", tc.site)
+		require.Equal(t, tc.want, eventOriginAllowed(r), tc.origin+" "+tc.site)
+	}
+}
+
+func TestEventStreamRevocationAndCleanup(t *testing.T) {
+	for _, revokeToken := range []bool{true, false} {
+		t.Run(map[bool]string{true: "token", false: "permissions"}[revokeToken], func(t *testing.T) {
+			db, h, env, _ := setupConsoleHandlers(t)
+			source := &testEventSource{ch: make(chan events.Hint, 1)}
+			h.Events = source
+			var valid atomic.Bool
+			valid.Store(true)
+			h.EventsAuthenticate = func(*http.Request) bool { return valid.Load() }
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ctx := context.WithValue(r.Context(), ContextKey(contextAPI), ContextValue{ctxUser: "alice"})
+				h.EventsHandler(w, r.WithContext(ctx))
+			}))
+			defer srv.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			r, err := http.NewRequestWithContext(ctx, "GET", srv.URL+"/api/v1/events?env=env&topic=queries", nil)
+			require.NoError(t, err)
+			response, err := srv.Client().Do(r)
+			require.NoError(t, err)
+			defer response.Body.Close()
+			require.Equal(t, 200, response.StatusCode)
+			require.Equal(t, "no-store", response.Header.Get("Cache-Control"))
+			reader := bufio.NewReader(response.Body)
+			frame := func() string {
+				var result strings.Builder
+				for {
+					line, err := reader.ReadString('\n')
+					require.NoError(t, err)
+					result.WriteString(line)
+					if line == "\n" {
+						return result.String()
+					}
+				}
+			}
+			require.Contains(t, frame(), "stream.ready")
+			source.ch <- events.Hint{EnvironmentID: env.ID, Topic: events.Queries, Name: "query-1"}
+			require.Contains(t, frame(), "query-1")
+			if revokeToken {
+				valid.Store(false)
+			} else {
+				require.NoError(t, db.Model(&users.UserPermission{}).Where("username = ?", "alice").Update("access_value", false).Error)
+			}
+			source.ch <- events.Hint{EnvironmentID: env.ID, Topic: events.Queries, Name: "secret-after-revocation"}
+			last := frame()
+			require.Contains(t, last, "auth.expired")
+			require.NotContains(t, last, "secret-after-revocation")
+			require.Eventually(t, source.cancelled.Load, time.Second, time.Millisecond)
+		})
+	}
+}

--- a/cmd/api/handlers/features.go
+++ b/cmd/api/handlers/features.go
@@ -8,7 +8,9 @@ import (
 
 // FeaturesResponse advertises server-side feature switches consumed by the SPA.
 type FeaturesResponse struct {
-	Posture bool `json:"posture"`
+	Posture     bool     `json:"posture"`
+	Events      bool     `json:"events"`
+	EventTopics []string `json:"event_topics"`
 	// ServiceConfig gates the whole Service Config section in the SPA. When
 	// false the /api/v1/service-config routes are not registered at all.
 	ServiceConfig bool `json:"service_config"`
@@ -30,12 +32,21 @@ type FeaturesResponse struct {
 }
 
 // FeaturesHandler — GET /api/v1/features.
+// @Summary Get enabled API features
+// @Tags Features
+// @Produce json
+// @Success 200 {object} FeaturesResponse
+// @Failure 401 {object} types.ApiErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/features [get]
 func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 	if h.DebugHTTPConfig != nil && h.DebugHTTPConfig.EnableHTTP {
 		utils.DebugHTTPDump(h.DebugHTTP, r, false)
 	}
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, FeaturesResponse{
 		Posture:       h.PostureEnabled,
+		Events:        h.Events != nil,
+		EventTopics:   h.eventTopics(),
 		ServiceConfig: h.ServiceConfigEnabled,
 		LogSinks:      h.LogSinksEnabled,
 		AuthProviders: h.AuthProvidersEnabled,
@@ -45,4 +56,11 @@ func (h *HandlersApi) FeaturesHandler(w http.ResponseWriter, r *http.Request) {
 		FileExplorer:  h.OsqueryValues.Query && h.OsqueryValues.FileExplorer,
 		Health:        h.Health != nil,
 	})
+}
+
+func (h *HandlersApi) eventTopics() []string {
+	if h.Events == nil {
+		return []string{}
+	}
+	return []string{"queries", "carves"}
 }

--- a/cmd/api/handlers/features_test.go
+++ b/cmd/api/handlers/features_test.go
@@ -34,6 +34,9 @@ func TestFeaturesHandlerReportsPostureDisabledByDefault(t *testing.T) {
 	if resp.Alerts {
 		t.Fatalf("alerts feature: got true want false with nil manager")
 	}
+	if resp.Events || len(resp.EventTopics) != 0 {
+		t.Fatal("events must default off with no advertised topics")
+	}
 }
 
 func TestFeaturesHandlerReportsServiceConfigEnabled(t *testing.T) {

--- a/cmd/api/handlers/handlers.go
+++ b/cmd/api/handlers/handlers.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"github.com/jmpsec/osctrl/pkg/events"
+	"net/http"
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/alerts"
@@ -36,7 +38,9 @@ const errorContent = "❌"
 const okContent = "✅"
 
 type HandlersApi struct {
-	DB *gorm.DB
+	DB                 *gorm.DB
+	Events             events.Subscriber
+	EventsAuthenticate func(*http.Request) bool
 	// LogReader is the read side of the status/result/query log store.
 	// When the TLS logger writes to S3, this is the S3-backed reader so
 	// the API can still surface logs to the frontend. When the logger

--- a/cmd/api/handlers/queries.go
+++ b/cmd/api/handlers/queries.go
@@ -261,6 +261,7 @@ func (h *HandlersApi) QueriesRunHandler(w http.ResponseWriter, r *http.Request) 
 	// Return query name as serialized response
 	log.Debug().Msgf("Created query %s with id %d", newQuery.Name, newQuery.ID)
 	h.AuditLog.NewQuery(ctx[ctxUser], newQuery.Query, strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	h.Queries.NotifyChange(newQuery.Name, env.ID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiQueriesResponse{Name: newQuery.Name})
 }
 
@@ -351,6 +352,7 @@ func (h *HandlersApi) QueriesActionHandler(w http.ResponseWriter, r *http.Reques
 	// Return message as serialized response
 	log.Debug().Msgf("Returned message %s", msgReturn)
 	h.AuditLog.QueryAction(ctx[ctxUser], actionVar+" query "+nameVar, strings.Split(r.RemoteAddr, ":")[0], env.ID)
+	h.Queries.NotifyChange(nameVar, env.ID)
 	utils.HTTPResponse(w, utils.JSONApplicationUTF8, http.StatusOK, types.ApiGenericResponse{Message: msgReturn})
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/jmpsec/osctrl/cmd/api/handlers"
@@ -23,6 +25,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/console"
 	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/events"
 	"github.com/jmpsec/osctrl/pkg/fileexplorer"
 	"github.com/jmpsec/osctrl/pkg/geoip"
 	"github.com/jmpsec/osctrl/pkg/health"
@@ -602,6 +605,17 @@ func osctrlAPIService() {
 		return serviceConfigMgr.PersistToFile(config.ServiceAPI, path, loadedYAMLToServiceParams(loaded, path), settings.NoEnvironmentID)
 	}
 
+	var eventBus *events.Bus
+	if flagParams.Service.EventsEnabled {
+		eventBus, err = events.New(redis.Client, flagParams.Service.EventsNamespace, true)
+		if err != nil {
+			log.Fatal().Err(err).Msg("invalid events configuration")
+		}
+		defer eventBus.Close()
+		queriesmgr.Events = eventBus
+		filecarves.Events = eventBus
+	}
+
 	handlersApi = handlers.CreateHandlersApi(
 		handlers.WithDB(db.Conn),
 		handlers.WithLogReader(logReader),
@@ -646,10 +660,20 @@ func osctrlAPIService() {
 		handlers.WithRestartCh(restartCh),
 	)
 
+	if eventBus != nil {
+		handlersApi.Events = eventBus
+	}
+	handlersApi.EventsAuthenticate = func(r *http.Request) bool {
+		return eventSessionValid(r, flagParams.Service.Auth, flagParams.JWT.JWTSecret)
+	}
+
 	// ///////////////////////// API
 	log.Info().Msg("Initializing router")
 	// Create router for API endpoint
 	muxAPI := http.NewServeMux()
+	if eventBus != nil {
+		muxAPI.Handle("GET /api/v1/events", handlerAuthCheck(http.HandlerFunc(handlersApi.EventsHandler), flagParams.Service.Auth, flagParams.JWT.JWTSecret))
+	}
 	// API: root
 	muxAPI.HandleFunc("GET /", handlersApi.RootHandler)
 	// API: testing
@@ -1347,13 +1371,29 @@ func osctrlAPIService() {
 			serverErr <- srv.ListenAndServe()
 		}
 	}()
+	// Stop live streams before draining on process shutdown or restart.
+	shutdownSignals := make(chan os.Signal, 1)
+	signal.Notify(shutdownSignals, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(shutdownSignals)
 	// Wait for either a server error or a restart signal.
 	select {
 	case err := <-serverErr:
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatal().Msgf("ListenAndServe: %v", err)
 		}
+	case <-shutdownSignals:
+		if eventBus != nil {
+			eventBus.Close()
+		}
+		drainCtx, cancelDrain := context.WithTimeout(context.Background(), restartDrainTimeout)
+		defer cancelDrain()
+		if err := srv.Shutdown(drainCtx); err != nil {
+			log.Err(err).Msg("error draining HTTP server")
+		}
 	case <-restartCh:
+		if eventBus != nil {
+			eventBus.Close()
+		}
 		log.Info().Msg("Service config apply triggered — draining requests before restart")
 		// Drain first. Exiting straight off the signal raced the apply
 		// handler's own 202: the handler had written the response but the

--- a/cmd/tls/main.go
+++ b/cmd/tls/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jmpsec/osctrl/pkg/carves"
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/environments"
+	"github.com/jmpsec/osctrl/pkg/events"
 	"github.com/jmpsec/osctrl/pkg/health"
 	"github.com/jmpsec/osctrl/pkg/logging"
 	"github.com/jmpsec/osctrl/pkg/logsinks"
@@ -467,6 +468,17 @@ func osctrlService() {
 
 	// Initialize TLS handlers before router
 	log.Info().Msg("Initializing handlers")
+	var eventBus *events.Bus
+	if flagParams.Service.EventsEnabled {
+		eventBus, err = events.New(redis.Client, flagParams.Service.EventsNamespace, false)
+		if err != nil {
+			log.Fatal().Err(err).Msg("invalid events configuration")
+		}
+		defer eventBus.Close()
+		queriesmgr.Events = eventBus
+		filecarves.Events = eventBus
+	}
+
 	handlersTLS = handlers.CreateHandlersTLS(
 		handlers.WithEnvs(envs),
 		handlers.WithEnvCache(envCache),

--- a/deploy/config/api.yml
+++ b/deploy/config/api.yml
@@ -10,6 +10,10 @@ version: 3
 
 # Main HTTP service behavior and shared service-level features.
 service:
+  # Optional live query/carve notifications. Enable on both API and TLS.
+  eventsEnabled: false
+  # Set a shared deployment-unique Redis channel namespace before enabling.
+  eventsNamespace: ""
   # Address to bind. Use 0.0.0.0 inside containers or behind a proxy.
   listener: 127.0.0.1
   # TCP port for osctrl-api.

--- a/deploy/config/tls.yml
+++ b/deploy/config/tls.yml
@@ -10,6 +10,10 @@ version: 3
 
 # Main HTTP service behavior and shared service-level features.
 service:
+  # Optional live query/carve notifications. Enable on both API and TLS.
+  eventsEnabled: false
+  # Set a shared deployment-unique Redis channel namespace before enabling.
+  eventsNamespace: ""
   # Address to bind. Use 0.0.0.0 inside containers or behind a proxy.
   listener: 127.0.0.1
   # TCP port for osctrl-tls.

--- a/frontend/src/api/events.test.ts
+++ b/frontend/src/api/events.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { ApiError, AuthError } from './client';
+import { EventParser, readEvents } from './events';
+
+afterEach(() => vi.unstubAllGlobals());
+
+it('parses split frames, CRLF, multiline JSON and heartbeat comments', () => {
+  const receive = vi.fn();
+  const parser = new EventParser(receive);
+  parser.push(': heartbeat\n\nevent: resource.');
+  parser.push('changed\r\ndata: {"name":\r\ndata: "café"}\r\n');
+  expect(receive).not.toHaveBeenCalled();
+  parser.push('\r\n');
+  expect(receive).toHaveBeenCalledExactlyOnceWith({ event: 'resource.changed', data: { name: 'café' } });
+});
+
+it('ignores malformed JSON and bounds incomplete and complete frames', () => {
+  const receive = vi.fn();
+  const parser = new EventParser(receive);
+  parser.push('data: not-json\n\n');
+  expect(receive).not.toHaveBeenCalled();
+  expect(() => parser.push('x'.repeat(8193))).toThrow('too large');
+  expect(() => new EventParser(receive).push('data: '+ 'x'.repeat(8193)+'\n\n')).toThrow('too large');
+});
+
+it('exposes authentication and permission failures without interpreting HTML as events', async () => {
+  const fetch = vi.fn().mockResolvedValue({ status: 401, ok: false });
+  vi.stubGlobal('fetch', fetch);
+  await expect(readEvents('dev', ['queries'], new AbortController().signal, vi.fn())).rejects.toBeInstanceOf(AuthError);
+  fetch.mockResolvedValue({ status: 403, ok: false });
+  await expect(readEvents('dev', ['queries'], new AbortController().signal, vi.fn())).rejects.toBeInstanceOf(ApiError);
+  const [url, init] = fetch.mock.calls[0];
+  expect(url).toBe('/api/v1/events?env=dev&topic=queries');
+  expect(init.credentials).toBe('include');
+  expect(init.headers).toEqual({ Accept: 'text/event-stream' });
+});

--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -1,0 +1,69 @@
+import { ApiError, AuthError } from './client';
+
+export type EventTopic = 'queries' | 'carves';
+export interface StreamEvent { event: string; data: unknown }
+
+// Fetch-based SSE exposes 401/403/429/503 to the caller. The JSON apiFetch
+// wrapper intentionally remains unchanged for snapshots and mutations.
+export async function readEvents(
+  env: string,
+  topics: EventTopic[],
+  signal: AbortSignal,
+  receive: (event: StreamEvent) => void,
+): Promise<void> {
+  const params = new URLSearchParams({ env });
+  for (const topic of topics) params.append('topic', topic);
+  const response = await fetch(`/api/v1/events?${params}`, {
+    credentials: 'include', headers: { Accept: 'text/event-stream' }, signal,
+  });
+  if (response.status === 401) throw new AuthError();
+  if (!response.ok) throw new ApiError('Live updates unavailable', response.status);
+  if (!response.headers.get('Content-Type')?.startsWith('text/event-stream') || !response.body) {
+    throw new ApiError('Invalid event stream', 502);
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const parser = new EventParser(receive);
+  try {
+    while (!signal.aborted) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      parser.push(decoder.decode(value, { stream: true }));
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
+// Parses the LF/CRLF frames emitted by our API, including split UTF-8 chunks
+// (decoded by readEvents), multiline data, and ignored heartbeat comments.
+export class EventParser {
+  private buffer = '';
+  constructor(private receive: (event: StreamEvent) => void) {}
+
+  push(chunk: string) {
+    this.buffer += chunk;
+    let boundary: RegExpExecArray | null;
+    while ((boundary = /\r?\n\r?\n/.exec(this.buffer))) {
+      const frame = this.buffer.slice(0, boundary.index);
+      this.buffer = this.buffer.slice(boundary.index + boundary[0].length);
+      if (frame.length > 8192) throw new Error('Event frame too large');
+      let event = 'message';
+      const data: string[] = [];
+      for (const line of frame.split(/\r?\n/)) {
+        if (line.startsWith(':')) continue;
+        const colon = line.indexOf(':');
+        const key = colon < 0 ? line : line.slice(0, colon);
+        const value = colon < 0 ? '' : line.slice(colon + 1).replace(/^ /, '');
+        if (key === 'event') event = value;
+        if (key === 'data') data.push(value);
+      }
+      if (!data.length) continue;
+      let value: unknown;
+      try { value = JSON.parse(data.join('\n')); } catch { continue; }
+      this.receive({ event, data: value });
+    }
+    if (this.buffer.length > 8192) throw new Error('Event frame too large');
+  }
+}

--- a/frontend/src/api/features.ts
+++ b/frontend/src/api/features.ts
@@ -1,6 +1,8 @@
 import { apiFetch } from './client';
 
 export interface Features {
+  events?: boolean;
+  event_topics?: string[];
   posture: boolean;
   service_config: boolean;
   log_sinks?: boolean;

--- a/frontend/src/features/carves/CarveDetailPage.tsx
+++ b/frontend/src/features/carves/CarveDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useResourceUpdates } from '$/lib/live-updates';
 import { useParams, useNavigate, Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
@@ -66,6 +67,7 @@ function hasRealTimestamp(value?: string): boolean {
 }
 
 export function CarveDetailPage() {
+  useResourceUpdates('carves');
   const { t } = useTranslation();
   usePageTitle(t('pageTitle.carve'));
   const { env, name } = useParams({ from: '/_app/env/$env/carves/$name' });

--- a/frontend/src/features/carves/CarvesListPage.tsx
+++ b/frontend/src/features/carves/CarvesListPage.tsx
@@ -1,3 +1,4 @@
+import { useResourceUpdates } from '$/lib/live-updates';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
@@ -54,6 +55,7 @@ function carveStatusTabs(t: ReturnType<typeof useTranslation>['t']): StatusTab<C
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const;
 
 export function CarvesListPage() {
+  useResourceUpdates('carves');
   const { t } = useTranslation();
   usePageTitle(t('pageTitle.carves'));
   const { env } = useParams({ from: '/_app/env/$env/carves' });

--- a/frontend/src/features/queries/QueriesListPage.tsx
+++ b/frontend/src/features/queries/QueriesListPage.tsx
@@ -1,3 +1,4 @@
+import { useResourceUpdates } from '$/lib/live-updates';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
@@ -52,6 +53,7 @@ const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const;
 // QueriesListPage
 // ---------------------------------------------------------------------------
 export function QueriesListPage() {
+  useResourceUpdates('queries');
   const { t } = useTranslation();
   usePageTitle(t('pageTitle.queries'));
   const { env } = useParams({ from: '/_app/env/$env/queries' });

--- a/frontend/src/features/queries/QueryDetailPage.tsx
+++ b/frontend/src/features/queries/QueryDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useResourceUpdates } from '$/lib/live-updates';
 import { useParams, useNavigate, useSearch, Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
@@ -43,6 +44,7 @@ function ResultStatusBadge({ code }: { code: number }) {
 const DEFAULT_PAGE_SIZE = 50;
 
 export function QueryDetailPage() {
+  useResourceUpdates('queries');
   const { t } = useTranslation();
   usePageTitle(t('pageTitle.query'));
   const { env, name } = useParams({ from: '/_app/env/$env/queries/$name' });

--- a/frontend/src/lib/live-updates.test.tsx
+++ b/frontend/src/lib/live-updates.test.tsx
@@ -1,0 +1,67 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, expect, it, vi } from 'vitest';
+import { LiveUpdatesProvider, createInvalidator, useResourceUpdates } from './live-updates';
+
+const mocks = vi.hoisted(() => ({ readEvents: vi.fn(), getFeatures: vi.fn() }));
+vi.mock('$/api/events', () => ({ readEvents: mocks.readEvents }));
+vi.mock('$/api/features', () => ({ getFeatures: mocks.getFeatures }));
+afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+it('coalesces query invalidations and preserves other environments and domains', async () => {
+  vi.useFakeTimers();
+  const client = new QueryClient();
+  const invalidate = vi.spyOn(client, 'invalidateQueries');
+  const live = createInvalidator(client, 'dev');
+  for (let i = 0; i < 100; i++) live.add('queries', 'q');
+  await vi.advanceTimersByTimeAsync(250);
+  expect(invalidate.mock.calls.map(([filters]) => filters?.queryKey)).toEqual([
+    ['queries', 'dev'], ['query', 'dev', 'q'], ['query-results', 'dev', 'q'],
+  ]);
+  live.close(); client.clear();
+});
+
+it('refetches after an in-flight snapshot so an invalidation cannot be lost', async () => {
+  vi.useFakeTimers();
+  const client = new QueryClient();
+  let finish: () => void = () => undefined;
+  vi.spyOn(client, 'isFetching').mockReturnValue(1);
+  const invalidate = vi.spyOn(client, 'invalidateQueries').mockImplementationOnce(() => new Promise<void>(resolve => { finish = resolve; })).mockResolvedValue(undefined);
+  const live = createInvalidator(client, 'dev');
+  live.add('carves', 'c');
+  await vi.advanceTimersByTimeAsync(250);
+  const before = invalidate.mock.calls.filter(([f]) => f?.queryKey?.[0] === 'carves').length;
+  finish();
+  await vi.advanceTimersByTimeAsync(1);
+  expect(invalidate.mock.calls.filter(([f]) => f?.queryKey?.[0] === 'carves')).toHaveLength(before + 1);
+  live.close(); client.clear();
+});
+
+function QueriesConsumer() { useResourceUpdates('queries'); return null; }
+
+it('shares one subscription and aborts the old environment on navigation and unmount', async () => {
+  mocks.getFeatures.mockResolvedValue({ events: true, event_topics: ['queries'] });
+  mocks.readEvents.mockImplementation((_env, _topics, signal: AbortSignal) => new Promise<void>(resolve => signal.addEventListener('abort', () => resolve())));
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const tree = (env: string) => <QueryClientProvider client={client}><LiveUpdatesProvider env={env}><QueriesConsumer /><QueriesConsumer /></LiveUpdatesProvider></QueryClientProvider>;
+  const view = render(tree('dev'));
+  await waitFor(() => expect(mocks.readEvents).toHaveBeenCalledTimes(1));
+  const oldSignal = mocks.readEvents.mock.calls[0][2] as AbortSignal;
+  view.rerender(tree('production'));
+  await waitFor(() => expect(mocks.readEvents).toHaveBeenCalledTimes(2));
+  expect(oldSignal.aborted).toBe(true);
+  expect(mocks.readEvents.mock.calls[1][0]).toBe('production');
+  view.unmount();
+  expect((mocks.readEvents.mock.calls[1][2] as AbortSignal).aborted).toBe(true);
+  await act(async () => undefined);
+  client.clear();
+});
+
+it('keeps legacy polling-only deployments free of event connections', async () => {
+  mocks.getFeatures.mockResolvedValue({});
+  const client = new QueryClient();
+  const view = render(<QueryClientProvider client={client}><LiveUpdatesProvider env="dev"><QueriesConsumer /></LiveUpdatesProvider></QueryClientProvider>);
+  await waitFor(() => expect(mocks.getFeatures).toHaveBeenCalled());
+  expect(mocks.readEvents).not.toHaveBeenCalled();
+  view.unmount(); client.clear();
+});

--- a/frontend/src/lib/live-updates.tsx
+++ b/frontend/src/lib/live-updates.tsx
@@ -1,0 +1,124 @@
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
+import { useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { ApiError, AuthError, setCsrfToken } from '$/api/client';
+import { readEvents, type EventTopic, type StreamEvent } from '$/api/events';
+import { getFeatures } from '$/api/features';
+
+type Register = (topic: EventTopic) => () => void;
+const LiveUpdatesContext = createContext<Register | null>(null);
+
+// Coalesces invalidations and performs a trailing refetch if an event arrives
+// while a snapshot is in flight. It never patches authoritative result rows.
+export function createInvalidator(client: QueryClient, env: string) {
+  const pending = new Map<string, { topic: EventTopic; name?: string }>();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let active = true;
+  let running = false;
+  const schedule = () => {
+    if (active && !running && !timer) timer = setTimeout(() => { void flush(); }, 250);
+  };
+  const flush = async () => {
+    timer = undefined;
+    if (!active || running) return;
+    running = true;
+    const batch = [...pending.values()];
+    pending.clear();
+    try {
+      const requests = batch.flatMap(({ topic, name }) => {
+        const keys = topic === 'queries' ? ['queries', 'query', 'query-results'] : ['carves', 'carve'];
+        return keys.map(async key => {
+          const filters = { queryKey: name && key !== topic ? [key, env, name] : [key, env] };
+          const wasFetching = client.isFetching(filters) > 0;
+          await client.invalidateQueries(filters, { cancelRefetch: false });
+          if (active && wasFetching) await client.invalidateQueries(filters, { cancelRefetch: false });
+        });
+      });
+      await Promise.allSettled(requests);
+    } finally {
+      running = false;
+      if (pending.size) schedule();
+    }
+  };
+  return {
+    add(topic: EventTopic, name?: string) {
+      if (!active) return;
+      if (!name || pending.size >= 64) {
+        for (const [key, item] of pending) if (item.topic === topic) pending.delete(key);
+        pending.set(topic, { topic });
+      } else if (!pending.has(topic)) pending.set(`${topic}:${name}`, { topic, name });
+      schedule();
+    },
+    close() { active = false; pending.clear(); if (timer) clearTimeout(timer); },
+  };
+}
+
+export function LiveUpdatesProvider({ env, children }: { env: string; children: ReactNode }) {
+  const client = useQueryClient();
+  const [counts, setCounts] = useState<Record<EventTopic, number>>({ queries: 0, carves: 0 });
+  const register = useCallback<Register>((topic) => {
+    setCounts(current => ({ ...current, [topic]: current[topic] + 1 }));
+    return () => setCounts(current => ({ ...current, [topic]: Math.max(0, current[topic] - 1) }));
+  }, []);
+  const { data: features } = useQuery({ queryKey: ['features'], queryFn: getFeatures });
+  const selection = (Object.keys(counts) as EventTopic[])
+    .filter(topic => counts[topic] > 0 && features?.event_topics?.includes(topic)).sort().join(',');
+
+  useEffect(() => {
+    if (!features?.events || !selection) return;
+    const topics = selection.split(',') as EventTopic[];
+    const invalidator = createInvalidator(client, env);
+    let active = true;
+    let forbidden = false;
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let controller: AbortController | undefined;
+    let environmentUUID: string | undefined;
+    const receive = ({ event, data }: StreamEvent) => {
+      if (!active || !data || typeof data !== 'object') return;
+      const value = data as Record<string, unknown>;
+      if (event === 'auth.expired') {
+        forbidden = true;
+        controller?.abort();
+        // Permissions can change while the login is still valid. Refresh the
+        // current view through REST so its existing 401/403 behavior applies.
+        for (const topic of topics) invalidator.add(topic);
+      } else if (event === 'stream.ready' && typeof value.environment_uuid === 'string') {
+        environmentUUID = value.environment_uuid;
+        attempts = 0;
+        for (const topic of topics) invalidator.add(topic);
+      } else if (event === 'resource.changed' && value.schema_version === 1 &&
+        environmentUUID && value.environment_uuid === environmentUUID &&
+        topics.includes(value.topic as EventTopic) && typeof value.name === 'string' && value.name.length <= 256) {
+        invalidator.add(value.topic as EventTopic, value.name);
+      }
+    };
+    const connect = async () => {
+      if (!active || forbidden) return;
+      environmentUUID = undefined;
+      controller = new AbortController();
+      try { await readEvents(env, topics, controller.signal, receive); }
+      catch (error) {
+        if (!active) return;
+        if (error instanceof AuthError) {
+          setCsrfToken(null);
+          forbidden = true;
+          for (const topic of topics) invalidator.add(topic);
+        } else if (error instanceof ApiError && [400, 403, 404].includes(error.status)) forbidden = true;
+      }
+      if (active && !forbidden) {
+        const delay = Math.min(30_000, 1000 * 2 ** Math.min(attempts++, 5)) * (0.8 + Math.random() * 0.4);
+        timer = setTimeout(() => { void connect(); }, delay);
+      }
+    };
+    void connect();
+    return () => { active = false; controller?.abort(); if (timer) clearTimeout(timer); invalidator.close(); };
+  }, [client, env, features?.events, selection]);
+
+  return <LiveUpdatesContext.Provider value={register}>{children}</LiveUpdatesContext.Provider>;
+}
+
+// Existing polling stays enabled during the initial mixed-version rollout.
+export function useResourceUpdates(topic: EventTopic) {
+  const register = useContext(LiveUpdatesContext);
+  useEffect(() => register?.(topic), [register, topic]);
+}

--- a/frontend/src/routes/_app/env/$env/route.tsx
+++ b/frontend/src/routes/_app/env/$env/route.tsx
@@ -1,10 +1,12 @@
-import { createRoute, Outlet } from '@tanstack/react-router';
+import { createRoute, Outlet, useParams } from '@tanstack/react-router';
+import { LiveUpdatesProvider } from '$/lib/live-updates';
 import { appRoute } from '$/routes/_app/route';
 
 export const envRoute = createRoute({
   getParentRoute: () => appRoute,
   path: 'env/$env',
   component: function EnvLayout() {
-    return <Outlet />;
+    const { env } = useParams({ from: '/_app/env/$env' });
+    return <LiveUpdatesProvider env={env}><Outlet /></LiveUpdatesProvider>;
   },
 });

--- a/osctrl-api.yaml
+++ b/osctrl-api.yaml
@@ -3521,6 +3521,95 @@ paths:
       summary: Update enrolling package URL
       tags:
         - environments
+  /api/v1/events:
+    get:
+      description: Best-effort SSE invalidation hints. No replay; refetch REST
+        snapshots after stream.ready and retain polling. Requires the
+        corresponding environment query/carve permissions.
+      parameters:
+        - description: Environment name or UUID
+          in: query
+          name: env
+          required: true
+          schema:
+            type: string
+        - description: "Topics: queries, carves"
+          in: query
+          name: topic
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: "SSE stream: stream.ready, resource.changed, auth.expired"
+          content:
+            text/event-stream json:
+              schema:
+                type: string
+        "400":
+          description: Bad Request
+          content:
+            text/event-stream json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            text/event-stream json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            text/event-stream json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            text/event-stream json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "429":
+          description: Too Many Requests
+          content:
+            text/event-stream json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            text/event-stream json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Subscribe to resource change notifications
+      tags:
+        - Events
+  /api/v1/features:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/handlers.FeaturesResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/types.ApiErrorResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Get enabled API features
+      tags:
+        - Features
   /api/v1/health/status:
     get:
       description: Component health, per-service runtime detail and upgrade status.
@@ -9614,6 +9703,51 @@ components:
           type: string
         uuid:
           type: string
+      type: object
+    handlers.FeaturesResponse:
+      properties:
+        accelerated:
+          type: boolean
+        alerts:
+          description: |-
+            Alerts gates the Alerts section in the SPA. Tied to
+            --alerts-enabled — when false the /api/v1/alerts routes are not
+            registered and the alert tables are not created.
+          type: boolean
+        auth_providers:
+          type: boolean
+        console:
+          type: boolean
+        event_topics:
+          items:
+            type: string
+          type: array
+        events:
+          type: boolean
+        file_explorer:
+          type: boolean
+        health:
+          description: >-
+            Health gates the Health section in the SPA. Tied to --health-enabled
+            —
+
+            when false the /api/v1/health routes are not registered.
+          type: boolean
+        log_sinks:
+          description: |-
+            LogSinks gates the Log Sinks section in the SPA. Tied to the same
+            flag as ServiceConfig — the log_sinks routes are registered
+            alongside the service-config routes.
+          type: boolean
+        posture:
+          type: boolean
+        service_config:
+          description: >-
+            ServiceConfig gates the whole Service Config section in the SPA.
+            When
+
+            false the /api/v1/service-config routes are not registered at all.
+          type: boolean
       type: object
     handlers.InactiveHoursRequest:
       properties:

--- a/pkg/carves/carves.go
+++ b/pkg/carves/carves.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/dbutil"
+	"github.com/jmpsec/osctrl/pkg/events"
 	"github.com/jmpsec/osctrl/pkg/types"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
@@ -63,6 +64,7 @@ type Carves struct {
 	DB     *gorm.DB
 	S3     *CarverS3
 	Carver string
+	Events events.Publisher
 }
 
 // CreateFileCarves to initialize the carves struct and tables
@@ -293,6 +295,7 @@ func (c *Carves) ChangeStatus(status, sessionid string) error {
 			return fmt.Errorf("update %w", err)
 		}
 	}
+	c.notifyChange(carve)
 	return nil
 }
 
@@ -305,6 +308,7 @@ func (c *Carves) CompleteBlock(sessionid string) error {
 	if err := c.DB.Model(&carve).Update("completed_blocks", carve.CompletedBlocks+1).Error; err != nil {
 		return fmt.Errorf("update %w", err)
 	}
+	c.notifyChange(carve)
 	return nil
 }
 
@@ -413,4 +417,10 @@ func (c *Carves) ArchiveLocal(destPath string, carve CarvedFile, blocks []Carved
 		res.Size += int64(len(toFile))
 	}
 	return res, nil
+}
+
+func (c *Carves) notifyChange(carve CarvedFile) {
+	if c.Events != nil {
+		c.Events.Publish(events.Hint{EnvironmentID: carve.EnvironmentID, Topic: events.Carves, Name: carve.QueryName})
+	}
 }

--- a/pkg/carves/events_test.go
+++ b/pkg/carves/events_test.go
@@ -1,0 +1,40 @@
+package carves
+
+import (
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/events"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type carveEventRecorder struct{ hints []events.Hint }
+
+func (r *carveEventRecorder) Publish(h events.Hint) { r.hints = append(r.hints, h) }
+
+func TestCarveNotificationsFollowSuccessfulPersistence(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	c := CreateFileCarves(db, config.CarverDB, nil)
+	recorder := &carveEventRecorder{}
+	c.Events = recorder
+	file := CarvedFile{EnvironmentID: 1, QueryName: "carve-query", SessionID: "session"}
+	require.NoError(t, c.CreateCarve(file))
+	require.NoError(t, c.CompleteBlock(file.SessionID))
+	require.NoError(t, c.ChangeStatus(StatusCompleted, file.SessionID))
+	stored, err := c.GetBySession(file.SessionID)
+	require.NoError(t, err)
+	require.Equal(t, 1, stored.CompletedBlocks)
+	require.Equal(t, StatusCompleted, stored.Status)
+	require.Equal(t, []events.Hint{
+		{EnvironmentID: 1, Topic: events.Carves, Name: file.QueryName},
+		{EnvironmentID: 1, Topic: events.Carves, Name: file.QueryName},
+	}, recorder.hints)
+	recorder.hints = nil
+	require.NoError(t, db.Migrator().DropTable(&CarvedFile{}))
+	require.Error(t, c.CompleteBlock(file.SessionID))
+	require.Error(t, c.ChangeStatus(StatusCompleted, file.SessionID))
+	require.Empty(t, recorder.hints, "failed writes must not emit notifications")
+}

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -293,6 +293,18 @@ func initServiceFlags(params *ServiceParameters) []cli.Flag {
 			Destination: &params.Service.AlertsEnabled,
 		},
 		&cli.BoolFlag{
+			Name:        "events-enabled",
+			Usage:       "Enable best-effort query/carve change notifications (API and TLS).",
+			Sources:     cli.EnvVars("SERVICE_EVENTS_ENABLED"),
+			Destination: &params.Service.EventsEnabled,
+		},
+		&cli.StringFlag{
+			Name:        "events-namespace",
+			Usage:       "Shared API/TLS event namespace, unique per deployment within Redis (required when enabled).",
+			Sources:     cli.EnvVars("SERVICE_EVENTS_NAMESPACE"),
+			Destination: &params.Service.EventsNamespace,
+		},
+		&cli.BoolFlag{
 			Name:        "health-enabled",
 			Value:       false,
 			Usage:       "Enable the health/system-status subsystem: component health, service heartbeats and runtime stats in the SPA. Disabled by default; when enabled osctrl-tls writes a heartbeat row every 60s and osctrl-api serves /api/v1/health/status. Requires a service restart to change.",

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -142,6 +142,10 @@ type YAMLConfigurationService struct {
 	// service_status table is never created, osctrl-tls writes no
 	// heartbeat, and the /api/v1/health routes are not registered.
 	HealthEnabled bool `yaml:"healthEnabled"`
+	// EventsEnabled enables best-effort SSE invalidation notifications.
+	EventsEnabled bool `yaml:"eventsEnabled"`
+	// EventsNamespace must be shared by API/TLS and unique within Redis.
+	EventsNamespace string `yaml:"eventsNamespace"`
 	// ServiceConfigEnabled controls whether the service-config API and the
 	// matching SPA section exist. It does not change how configuration is
 	// loaded: every boot seeds the YAML sections into the database and

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,0 +1,263 @@
+// Package events distributes best-effort resource invalidation hints. REST and
+// the underlying stores remain authoritative; hints are neither replayable nor
+// proof that a background operation or result export succeeded.
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+var (
+	ErrUnavailable   = errors.New("event transport unavailable")
+	ErrLimit         = errors.New("event connection limit reached")
+	namespacePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+)
+
+const (
+	Queries            = "queries"
+	Carves             = "carves"
+	maxConnections     = 1000
+	maxUserConnections = 8
+	queueSize          = 64
+)
+
+// Hint is an internal routing envelope. Numeric environment IDs never leave
+// the API, which resolves and authorizes the requested environment separately.
+type Hint struct {
+	EnvironmentID uint   `json:"environment_id"`
+	Topic         string `json:"topic"`
+	Name          string `json:"name"`
+}
+
+func (h Hint) Valid() bool {
+	return h.EnvironmentID != 0 && (h.Topic == Queries || h.Topic == Carves) && len(h.Name) > 0 && len(h.Name) <= 256
+}
+
+type Publisher interface{ Publish(Hint) }
+
+type Subscriber interface {
+	Subscribe(string, uint, []string) (<-chan Hint, func(), error)
+}
+
+type subscription struct {
+	user          string
+	environmentID uint
+	topics        map[string]bool
+	ch            chan Hint
+}
+
+// Bus owns one Redis subscription per API process and bounded subscriber queues.
+// A TLS process constructs a publish-only Bus. Call Close before HTTP draining.
+type Bus struct {
+	client   *redis.Client
+	channel  string
+	ctx      context.Context
+	cancel   context.CancelFunc
+	pubsub   *redis.PubSub
+	queue    chan Hint
+	wg       sync.WaitGroup
+	once     sync.Once
+	mu       sync.Mutex
+	healthy  bool
+	lastRead time.Time
+	closed   bool
+	subs     map[*subscription]struct{}
+	dropped  atomic.Uint64
+}
+
+func New(client *redis.Client, namespace string, consume bool) (*Bus, error) {
+	if client == nil || !namespacePattern.MatchString(namespace) {
+		return nil, errors.New("events require Redis and a namespace of 1-64 letters, digits, underscores or hyphens")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	b := &Bus{client: client, channel: "osctrl:" + namespace + ":events:v1", ctx: ctx, cancel: cancel, queue: make(chan Hint, 1024), subs: make(map[*subscription]struct{})}
+	b.wg.Add(1)
+	go b.publishLoop()
+	if consume {
+		b.pubsub = client.Subscribe(ctx, b.channel)
+		b.wg.Add(2)
+		go b.receiveLoop()
+		go b.healthLoop()
+	}
+	return b, nil
+}
+
+func (b *Bus) Publish(h Hint) {
+	if !h.Valid() {
+		return
+	}
+	select {
+	case <-b.ctx.Done():
+	case b.queue <- h:
+	default:
+		b.dropped.Add(1)
+	}
+}
+
+// Dropped includes failed publication and slow-subscriber disconnections.
+func (b *Bus) Dropped() uint64 { return b.dropped.Load() }
+
+func (b *Bus) publishLoop() {
+	defer b.wg.Done()
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case h := <-b.queue:
+			data, err := json.Marshal(h)
+			if err != nil {
+				b.dropped.Add(1)
+				continue
+			}
+			ctx, cancel := context.WithTimeout(b.ctx, time.Second)
+			err = b.client.Publish(ctx, b.channel, data).Err()
+			cancel()
+			if err != nil {
+				b.dropped.Add(1)
+			}
+		}
+	}
+}
+
+func (b *Bus) receiveLoop() {
+	defer b.wg.Done()
+	for b.ctx.Err() == nil {
+		message, err := b.pubsub.ReceiveTimeout(b.ctx, 20*time.Second)
+		if err != nil {
+			b.reset(false)
+			select {
+			case <-b.ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+		b.mu.Lock()
+		b.lastRead = time.Now()
+		b.mu.Unlock()
+		switch message := message.(type) {
+		case *redis.Subscription:
+			// A reconnect may have missed events. Force every browser to
+			// obtain a fresh snapshot, including after a brief Redis outage.
+			b.reset(message.Kind == "subscribe")
+		case *redis.Message:
+			if len(message.Payload) > 4096 {
+				continue
+			}
+			var hint Hint
+			if json.Unmarshal([]byte(message.Payload), &hint) == nil && hint.Valid() {
+				b.deliver(hint)
+			}
+		case *redis.Pong:
+			b.mu.Lock()
+			if !b.closed {
+				b.healthy = true
+			}
+			b.mu.Unlock()
+		}
+	}
+}
+
+func (b *Bus) healthLoop() {
+	defer b.wg.Done()
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-ticker.C:
+			b.mu.Lock()
+			stale := !b.lastRead.IsZero() && time.Since(b.lastRead) > 30*time.Second
+			b.mu.Unlock()
+			if stale {
+				b.reset(false)
+			}
+			ctx, cancel := context.WithTimeout(b.ctx, 2*time.Second)
+			err := b.pubsub.Ping(ctx)
+			cancel()
+			if err != nil {
+				b.reset(false)
+			}
+		}
+	}
+}
+
+func (b *Bus) reset(healthy bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for s := range b.subs {
+		close(s.ch)
+		delete(b.subs, s)
+	}
+	b.healthy = healthy && !b.closed
+}
+
+func (b *Bus) deliver(h Hint) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for s := range b.subs {
+		if s.environmentID != h.EnvironmentID || !s.topics[h.Topic] {
+			continue
+		}
+		select {
+		case s.ch <- h:
+		default:
+			close(s.ch)
+			delete(b.subs, s)
+			b.dropped.Add(1)
+		}
+	}
+}
+
+func (b *Bus) Subscribe(user string, environmentID uint, topics []string) (<-chan Hint, func(), error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed || !b.healthy {
+		return nil, nil, ErrUnavailable
+	}
+	n := 0
+	for s := range b.subs {
+		if s.user == user {
+			n++
+		}
+	}
+	if len(b.subs) >= maxConnections || n >= maxUserConnections {
+		return nil, nil, ErrLimit
+	}
+	s := &subscription{user: user, environmentID: environmentID, topics: make(map[string]bool), ch: make(chan Hint, queueSize)}
+	for _, topic := range topics {
+		s.topics[topic] = true
+	}
+	b.subs[s] = struct{}{}
+	return s.ch, func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if _, ok := b.subs[s]; ok {
+			delete(b.subs, s)
+			close(s.ch)
+		}
+	}, nil
+}
+
+func (b *Bus) Close() {
+	b.once.Do(func() {
+		b.mu.Lock()
+		b.closed = true
+		b.mu.Unlock()
+		b.cancel()
+		if b.pubsub != nil {
+			_ = b.pubsub.Close()
+		}
+		b.reset(false)
+		b.wg.Wait()
+	})
+}

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,0 +1,223 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/require"
+)
+
+func localBus() *Bus { return &Bus{healthy: true, subs: make(map[*subscription]struct{})} }
+
+func TestSubscriptionIsolationAndReset(t *testing.T) {
+	b := localBus()
+	queries, closeQueries, err := b.Subscribe("alice", 1, []string{Queries})
+	require.NoError(t, err)
+	defer closeQueries()
+	carves, closeCarves, err := b.Subscribe("alice", 1, []string{Carves})
+	require.NoError(t, err)
+	defer closeCarves()
+	other, closeOther, err := b.Subscribe("bob", 2, []string{Queries})
+	require.NoError(t, err)
+	defer closeOther()
+	hint := Hint{1, Queries, "q"}
+	b.deliver(hint)
+	require.Equal(t, hint, <-queries)
+	select {
+	case <-carves:
+		t.Fatal("query leaked to carve subscription")
+	default:
+	}
+	select {
+	case <-other:
+		t.Fatal("query leaked across environments")
+	default:
+	}
+	b.reset(false)
+	_, open := <-queries
+	require.False(t, open)
+	_, _, err = b.Subscribe("alice", 1, []string{Queries})
+	require.ErrorIs(t, err, ErrUnavailable)
+	b.reset(true)
+	_, cancel, err := b.Subscribe("alice", 1, []string{Queries})
+	require.NoError(t, err)
+	cancel()
+}
+
+func TestConnectionLimitAndSlowSubscriber(t *testing.T) {
+	b := localBus()
+	for i := 0; i < maxUserConnections; i++ {
+		_, close, err := b.Subscribe("alice", 1, []string{Queries})
+		require.NoError(t, err)
+		defer close()
+	}
+	_, _, err := b.Subscribe("alice", 1, []string{Queries})
+	require.ErrorIs(t, err, ErrLimit)
+	for i := 0; i <= queueSize; i++ {
+		b.deliver(Hint{1, Queries, "q"})
+	}
+	require.Empty(t, b.subs)
+	require.EqualValues(t, maxUserConnections, b.Dropped())
+}
+
+func TestConcurrentSubscriptionCleanup(t *testing.T) {
+	b := localBus()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, cancel, err := b.Subscribe(fmt.Sprint(i), 1, []string{Queries})
+			if err != nil {
+				return
+			}
+			b.deliver(Hint{1, Queries, "q"})
+			cancel()
+			cancel()
+		}(i)
+	}
+	wg.Wait()
+	require.Empty(t, b.subs)
+}
+
+func TestConfigurationAndHintValidation(t *testing.T) {
+	client := redis.NewClient(&redis.Options{Addr: "localhost:1"})
+	defer client.Close()
+	for _, namespace := range []string{"", "a:b", "a*", "../deployment"} {
+		_, err := New(client, namespace, false)
+		require.Error(t, err)
+	}
+	for _, hint := range []Hint{{0, Queries, "q"}, {1, "console", "q"}, {1, Queries, ""}} {
+		require.False(t, hint.Valid())
+	}
+}
+
+// Uses the same opt-in disposable Redis convention as query-dispatch tests.
+func TestRedisFanoutAndNamespaceIsolation(t *testing.T) {
+	addr := os.Getenv("OSCTRL_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("set OSCTRL_TEST_REDIS_ADDR to a disposable Redis instance")
+	}
+	client := redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() { _ = client.Close() })
+	require.NoError(t, client.Ping(context.Background()).Err())
+	namespace := fmt.Sprintf("events-test-%d", time.Now().UnixNano())
+	newBus := func(namespace string, consume bool) *Bus {
+		b, err := New(client, namespace, consume)
+		require.NoError(t, err)
+		t.Cleanup(b.Close)
+		return b
+	}
+	writer := newBus(namespace, false)
+	first := newBus(namespace, true)
+	second := newBus(namespace, true)
+	isolated := newBus(namespace+"-other", true)
+	subscribe := func(b *Bus) <-chan Hint {
+		var ch <-chan Hint
+		require.Eventually(t, func() bool {
+			var cancel func()
+			var err error
+			ch, cancel, err = b.Subscribe("alice", 1, []string{Queries})
+			if err == nil {
+				t.Cleanup(cancel)
+			}
+			return err == nil
+		}, 3*time.Second, 10*time.Millisecond)
+		return ch
+	}
+	a, b, other := subscribe(first), subscribe(second), subscribe(isolated)
+	want := Hint{1, Queries, "q"}
+	writer.Publish(want)
+	for _, ch := range []<-chan Hint{a, b} {
+		select {
+		case got := <-ch:
+			require.Equal(t, want, got)
+		case <-time.After(3 * time.Second):
+			t.Fatal("missing fanout")
+		}
+	}
+	select {
+	case <-other:
+		t.Fatal("cross-namespace event")
+	case <-time.After(50 * time.Millisecond):
+	}
+	first.Close()
+	_, open := <-a
+	require.False(t, open)
+	writer.Publish(want)
+	select {
+	case got := <-b:
+		require.Equal(t, want, got)
+	case <-time.After(3 * time.Second):
+		t.Fatal("closing one replica affected another")
+	}
+}
+
+func TestRedisReconnectResetsExistingStreams(t *testing.T) {
+	addr := os.Getenv("OSCTRL_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("set OSCTRL_TEST_REDIS_ADDR to a disposable Redis instance")
+	}
+	name := fmt.Sprintf("events-reconnect-%d", time.Now().UnixNano())
+	client := redis.NewClient(&redis.Options{Addr: addr, OnConnect: func(ctx context.Context, conn *redis.Conn) error { return conn.ClientSetName(ctx, name).Err() }})
+	defer client.Close()
+	b, err := New(client, name, true)
+	require.NoError(t, err)
+	defer b.Close()
+	var stream <-chan Hint
+	require.Eventually(t, func() bool {
+		var cancel func()
+		stream, cancel, err = b.Subscribe("alice", 1, []string{Queries})
+		if err == nil {
+			t.Cleanup(cancel)
+		}
+		return err == nil
+	}, 3*time.Second, 10*time.Millisecond)
+	clients, err := client.ClientList(context.Background()).Result()
+	require.NoError(t, err)
+	id := ""
+	for _, line := range strings.Split(clients, "\n") {
+		fields := make(map[string]string)
+		for _, field := range strings.Fields(line) {
+			key, value, ok := strings.Cut(field, "=")
+			if ok {
+				fields[key] = value
+			}
+		}
+		if fields["name"] == name && strings.Contains(fields["flags"], "P") {
+			id = fields["id"]
+			break
+		}
+	}
+	require.NotEmpty(t, id)
+	// Disconnect only this test's subscription, never other Redis clients.
+	require.NoError(t, client.Do(context.Background(), "CLIENT", "KILL", "ID", id).Err())
+	select {
+	case _, open := <-stream:
+		require.False(t, open)
+	case <-time.After(3 * time.Second):
+		t.Fatal("stale browser stream remained open")
+	}
+	require.Eventually(t, func() bool {
+		var cancel func()
+		stream, cancel, err = b.Subscribe("alice", 1, []string{Queries})
+		if err == nil {
+			t.Cleanup(cancel)
+		}
+		return err == nil
+	}, 3*time.Second, 10*time.Millisecond)
+	want := Hint{1, Queries, "after-reconnect"}
+	b.Publish(want)
+	select {
+	case got := <-stream:
+		require.Equal(t, want, got)
+	case <-time.After(3 * time.Second):
+		t.Fatal("reconnected stream did not receive changes")
+	}
+}

--- a/pkg/logging/dispatch.go
+++ b/pkg/logging/dispatch.go
@@ -44,4 +44,9 @@ func (l *LoggerTLS) DispatchQueries(queryData types.QueryWriteData, node nodes.O
 		queryData.Name,
 		queryData.Status,
 		debug)
+	// Export completion is only an invalidation hint. Some sinks do not
+	// acknowledge persistence, so clients must retain result polling.
+	if l.Queries != nil {
+		l.Queries.NotifyChange(queryData.Name, node.EnvironmentID)
+	}
 }

--- a/pkg/queries/events_test.go
+++ b/pkg/queries/events_test.go
@@ -1,0 +1,36 @@
+package queries
+
+import (
+	"github.com/jmpsec/osctrl/pkg/events"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type eventRecorder struct{ hints []events.Hint }
+
+func (r *eventRecorder) Publish(h events.Hint) { r.hints = append(r.hints, h) }
+
+func TestQueryEventsExcludeInteractiveAndHiddenTypes(t *testing.T) {
+	for _, kind := range []string{StandardQueryType, CarveQueryType, ConsoleQueryType, FileExplorerQueryType, MetadataQueryType} {
+		t.Run(kind, func(t *testing.T) {
+			db := setupTestDB(t)
+			q := CreateQueries(db)
+			recorder := &eventRecorder{}
+			q.Events = recorder
+			query := DistributedQuery{Name: "events-" + kind, EnvironmentID: 1, Type: kind, Active: true}
+			require.NoError(t, q.Create(&query))
+			require.NoError(t, q.CreateNodeQueries([]uint{1}, query.ID))
+			require.NoError(t, q.UpdateQueryStatus(query.Name, 1, 0))
+			if kind == StandardQueryType || kind == CarveQueryType {
+				require.Len(t, recorder.hints, 1)
+				require.Equal(t, query.Name, recorder.hints[0].Name)
+				require.Equal(t, uint(1), recorder.hints[0].EnvironmentID)
+			} else {
+				require.Empty(t, recorder.hints)
+			}
+			recorder.hints = nil
+			q.NotifyChange(query.Name, 2)
+			require.Empty(t, recorder.hints, "wrong environment must never produce a hint")
+		})
+	}
+}

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jmpsec/osctrl/pkg/dbutil"
+	"github.com/jmpsec/osctrl/pkg/events"
 	"github.com/jmpsec/osctrl/pkg/nodes"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
@@ -143,8 +144,9 @@ type QueryReadQueries map[string]string
 
 // Queries to handle on-demand queries
 type Queries struct {
-	DB    *gorm.DB
-	Cache *QueryDispatchCache
+	DB     *gorm.DB
+	Cache  *QueryDispatchCache
+	Events events.Publisher
 }
 
 // CreateQueries to initialize the queries struct
@@ -613,6 +615,7 @@ func (q *Queries) UpdateQueryStatus(queryName string, nodeID uint, statusCode in
 			return err
 		}
 	}
+	q.notifyChange(query)
 	return nil
 }
 
@@ -700,4 +703,32 @@ func (q *Queries) GetByEnvTargetPaged(envID uint, target, qtype, search string, 
 		return QueryListPage{}, err
 	}
 	return QueryListPage{Items: items, TotalItems: total}, nil
+}
+
+// NotifyChange sends a best-effort invalidation after a caller's write/commit.
+// Interactive/hidden query types are deliberately excluded from broad topics.
+func (q *Queries) NotifyChange(name string, environmentID uint) {
+	if q.Events == nil {
+		return
+	}
+	query, err := q.Get(name, environmentID)
+	if err == nil {
+		q.notifyChange(query)
+	}
+}
+
+func (q *Queries) notifyChange(query DistributedQuery) {
+	if q.Events == nil {
+		return
+	}
+	topic := ""
+	switch query.Type {
+	case StandardQueryType:
+		topic = events.Queries
+	case CarveQueryType:
+		topic = events.Carves
+	default:
+		return
+	}
+	q.Events.Publish(events.Hint{EnvironmentID: query.EnvironmentID, Topic: topic, Name: query.Name})
 }


### PR DESCRIPTION
## Summary

Adds optional SSE notifications for live query and carve updates. REST remains authoritative, and existing polling continues as fallback.

- Distributes notifications across API/TLS replicas through Redis Pub/Sub.
- Enforces environment permissions and revalidates authentication on open streams.
- Bounds queues and connections, with reconnect recovery and shutdown cleanup.
- Shares frontend subscriptions and refreshes only affected query caches.
- Adds configuration, documentation, OpenAPI definitions, and regression tests.

Disabled by default. Enable `--events-enabled` on API and TLS with the same deployment-specific `--events-namespace`.

## Validation

- Full Go test suite
- 407 frontend tests
- TypeScript checking and production frontend build
- Focused race checks
- Redis fan-out, namespace isolation, and reconnect tests
- OpenAPI consistency check

## Follow-up

Result-readiness guarantees, reduced polling, console/file-explorer integration, browser E2E, and load testing remain pending.