### PR TITLE
Adds optional SSE-based live update hints between API/TLS and the frontend

### DIFF
--- a/cmd/api/handlers/events.go
+++ b/cmd/api/handlers/events.go
@@ -19,6 +19,7 @@ type ResourceChanged struct {
 	EnvironmentUUID string `json:"environment_uuid"`
 	Topic           string `json:"topic"`
 	Name            string `json:"name"`
+	Change          string `json:"change,omitempty"`
 }
 
 // EventsHandler streams authorized query/carve invalidations.
@@ -162,7 +163,11 @@ func (h *HandlersApi) EventsHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			for hint := range pending {
-				if err := write("resource.changed", ResourceChanged{1, env.UUID, hint.Topic, hint.Name}); err != nil {
+				change := hint.Change
+				if change == "" {
+					change = events.ChangeMetadata
+				}
+				if err := write("resource.changed", ResourceChanged{SchemaVersion: 1, EnvironmentUUID: env.UUID, Topic: hint.Topic, Name: hint.Name, Change: change}); err != nil {
 					return
 				}
 				delete(pending, hint)

--- a/cmd/api/handlers/events_test.go
+++ b/cmd/api/handlers/events_test.go
@@ -98,8 +98,10 @@ func TestEventStreamRevocationAndCleanup(t *testing.T) {
 				}
 			}
 			require.Contains(t, frame(), "stream.ready")
-			source.ch <- events.Hint{EnvironmentID: env.ID, Topic: events.Queries, Name: "query-1"}
-			require.Contains(t, frame(), "query-1")
+			source.ch <- events.Hint{EnvironmentID: env.ID, Topic: events.Queries, Name: "query-1", Change: events.ChangeResults}
+			queryFrame := frame()
+			require.Contains(t, queryFrame, "query-1")
+			require.Contains(t, queryFrame, `"change":"results"`)
 			if revokeToken {
 				valid.Store(false)
 			} else {

--- a/frontend/src/features/carves/CarveDetailPage.tsx
+++ b/frontend/src/features/carves/CarveDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useResourceUpdates } from '$/lib/live-updates';
+import { resourceRefetchInterval, useResourceUpdates } from '$/lib/live-updates';
 import { useParams, useNavigate, Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
@@ -6,7 +6,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getCarve, getCarveArchiveUrl, actOnCarve } from '$/api/carves';
 import { listNodes } from '$/api/nodes';
 import { AuthError } from '$/api/client';
-import type { CarveFile } from '$/api/types';
+import type { CarveDetail, CarveFile } from '$/api/types';
 import { formatRelative } from '$/lib/time';
 import { cn } from '$/lib/cn';
 import { EmptyState } from '$/components/data/EmptyState';
@@ -66,8 +66,20 @@ function hasRealTimestamp(value?: string): boolean {
   return typeof value === 'string' && value.length > 0 && !value.startsWith('0001-01-01');
 }
 
+function carveRefetchInterval(live: boolean, detail?: CarveDetail) {
+  const query = detail?.query;
+  if (!query) return resourceRefetchInterval(live);
+  const status = (query.carve_status || '').toUpperCase();
+  return resourceRefetchInterval(live, {
+    active: query.active || status === 'PENDING' || status === 'ACTIVE',
+    completed: query.completed || status === 'COMPLETED',
+    expired: query.expired || status === 'EXPIRED',
+    deleted: query.deleted || status === 'DELETED',
+  });
+}
+
 export function CarveDetailPage() {
-  useResourceUpdates('carves');
+  const carvesLive = useResourceUpdates('carves');
   const { t } = useTranslation();
   usePageTitle(t('pageTitle.carve'));
   const { env, name } = useParams({ from: '/_app/env/$env/carves/$name' });
@@ -77,7 +89,7 @@ export function CarveDetailPage() {
     queryKey: ['carve', env, name],
     queryFn: () => getCarve(env, name),
     staleTime: 15_000,
-    refetchInterval: 15_000,
+    refetchInterval: ({ state }) => carveRefetchInterval(carvesLive, state.data),
   });
   const qc = useQueryClient();
   const completeMutation = useMutation({
@@ -223,10 +235,9 @@ export function CarveDetailPage() {
             )}
           </h2>
           <div className="ml-auto flex items-center gap-2">
-            {/* Refresh button — mirrors the query detail page. Reloads the
+            {/* Refresh button mirrors the query detail page. Reloads the
             carve, its carved files, the carves list, and the node lookup so
-            an operator watching blocks land can pull the latest state now
-            instead of waiting for the 15s poll. */}
+            an operator watching blocks land can pull the latest state now. */}
             <button
               type="button"
               onClick={() => {

--- a/frontend/src/features/carves/CarvesListPage.tsx
+++ b/frontend/src/features/carves/CarvesListPage.tsx
@@ -1,4 +1,4 @@
-import { useResourceUpdates } from '$/lib/live-updates';
+import { resourceRefetchInterval, useResourceUpdates } from '$/lib/live-updates';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
@@ -55,7 +55,7 @@ function carveStatusTabs(t: ReturnType<typeof useTranslation>['t']): StatusTab<C
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const;
 
 export function CarvesListPage() {
-  useResourceUpdates('carves');
+  const carvesLive = useResourceUpdates('carves');
   const { t } = useTranslation();
   usePageTitle(t('pageTitle.carves'));
   const { env } = useParams({ from: '/_app/env/$env/carves' });
@@ -100,7 +100,7 @@ export function CarvesListPage() {
         pageSize,
       }),
     staleTime: 15_000,
-    refetchInterval: 15_000,
+    refetchInterval: resourceRefetchInterval(carvesLive),
     placeholderData: (prev: CarvesPagedResponse | undefined) => prev,
   });
 

--- a/frontend/src/features/queries/QueriesListPage.tsx
+++ b/frontend/src/features/queries/QueriesListPage.tsx
@@ -1,4 +1,4 @@
-import { useResourceUpdates } from '$/lib/live-updates';
+import { resourceRefetchInterval, useResourceUpdates } from '$/lib/live-updates';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
@@ -53,7 +53,7 @@ const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const;
 // QueriesListPage
 // ---------------------------------------------------------------------------
 export function QueriesListPage() {
-  useResourceUpdates('queries');
+  const queriesLive = useResourceUpdates('queries');
   const { t } = useTranslation();
   usePageTitle(t('pageTitle.queries'));
   const { env } = useParams({ from: '/_app/env/$env/queries' });
@@ -99,7 +99,7 @@ export function QueriesListPage() {
         pageSize,
       }),
     staleTime: 15_000,
-    refetchInterval: 15_000,
+    refetchInterval: resourceRefetchInterval(queriesLive),
     placeholderData: (prev: QueriesPagedResponse | undefined) => prev,
   });
 

--- a/frontend/src/features/queries/QueryDetailPage.tsx
+++ b/frontend/src/features/queries/QueryDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useResourceUpdates } from '$/lib/live-updates';
+import { resourceRefetchInterval, useResourceUpdates } from '$/lib/live-updates';
 import { useParams, useNavigate, useSearch, Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { usePageTitle } from '$/lib/usePageTitle';
@@ -44,7 +44,7 @@ function ResultStatusBadge({ code }: { code: number }) {
 const DEFAULT_PAGE_SIZE = 50;
 
 export function QueryDetailPage() {
-  useResourceUpdates('queries');
+  const queriesLive = useResourceUpdates('queries');
   const { t } = useTranslation();
   usePageTitle(t('pageTitle.query'));
   const { env, name } = useParams({ from: '/_app/env/$env/queries/$name' });
@@ -65,7 +65,7 @@ export function QueryDetailPage() {
     queryKey: ['query', env, name],
     queryFn: () => getQuery(env, name),
     staleTime: 15_000,
-    refetchInterval: 15_000,
+    refetchInterval: ({ state }) => resourceRefetchInterval(queriesLive, state.data),
   });
 
   const qc = useQueryClient();
@@ -88,7 +88,7 @@ export function QueryDetailPage() {
     queryKey: ['query-results', env, name, page, pageSize, since],
     queryFn: () => listQueryResults({ env, name, page, pageSize, since }),
     staleTime: 15_000,
-    refetchInterval: 15_000,
+    refetchInterval: () => resourceRefetchInterval(queriesLive, query),
     enabled: !!query,
   });
 
@@ -296,10 +296,9 @@ export function QueryDetailPage() {
           )}
         </h2>
         <div className="ml-auto flex items-center gap-2">
-          {/* Refresh button — mirrors the legacy admin's "Refresh table" control.
-              The page also polls every 15s via TanStack Query's refetchInterval,
-              but an explicit button gives operators the same control they had
-              in legacy when watching a long-running distributed query land. */}
+          {/* Refresh button mirrors the legacy admin's "Refresh table" control.
+              Automatic refresh is adaptive, and the explicit button keeps the
+              same operator control when watching a distributed query land. */}
           <button
             type="button"
             // Refresh everything: the query, its results, the queries list,

--- a/frontend/src/lib/live-updates.test.tsx
+++ b/frontend/src/lib/live-updates.test.tsx
@@ -1,7 +1,7 @@
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, expect, it, vi } from 'vitest';
-import { LiveUpdatesProvider, createInvalidator, useResourceUpdates } from './live-updates';
+import { LiveUpdatesProvider, createInvalidator, resourceRefetchInterval, useResourceUpdates } from './live-updates';
 
 const mocks = vi.hoisted(() => ({ readEvents: vi.fn(), getFeatures: vi.fn() }));
 vi.mock('$/api/events', () => ({ readEvents: mocks.readEvents }));
@@ -17,6 +17,22 @@ it('coalesces query invalidations and preserves other environments and domains',
   await vi.advanceTimersByTimeAsync(250);
   expect(invalidate.mock.calls.map(([filters]) => filters?.queryKey)).toEqual([
     ['queries', 'dev'], ['query', 'dev', 'q'], ['query-results', 'dev', 'q'],
+  ]);
+  live.close(); client.clear();
+});
+
+it('uses change kinds to invalidate only affected query caches', async () => {
+  vi.useFakeTimers();
+  const client = new QueryClient();
+  const invalidate = vi.spyOn(client, 'invalidateQueries');
+  const live = createInvalidator(client, 'dev');
+  live.add('queries', 'q', 'metadata');
+  live.add('queries', 'q', 'results');
+  live.add('carves', 'c', 'files');
+  await vi.advanceTimersByTimeAsync(250);
+  expect(invalidate.mock.calls.map(([filters]) => filters?.queryKey)).toEqual([
+    ['queries', 'dev'], ['query', 'dev', 'q'], ['query-results', 'dev', 'q'],
+    ['carve', 'dev', 'c'], ['carves', 'dev'],
   ]);
   live.close(); client.clear();
 });
@@ -38,6 +54,37 @@ it('refetches after an in-flight snapshot so an invalidation cannot be lost', as
 });
 
 function QueriesConsumer() { useResourceUpdates('queries'); return null; }
+function QueryStatusConsumer() {
+  const live = useResourceUpdates('queries');
+  return <div data-testid="queries-live">{live ? 'live' : 'polling'}</div>;
+}
+
+it('uses normal polling until the selected stream is connected', async () => {
+  mocks.getFeatures.mockResolvedValue({ events: true, event_topics: ['queries'] });
+  let receive: ((event: { event: string; data: Record<string, unknown> }) => void) | undefined;
+  let closeStream: (() => void) | undefined;
+  mocks.readEvents.mockImplementation((_env, _topics, _signal: AbortSignal, onEvent) => {
+    receive = onEvent;
+    return new Promise<void>(resolve => { closeStream = resolve; });
+  });
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(<QueryClientProvider client={client}><LiveUpdatesProvider env="dev"><QueryStatusConsumer /></LiveUpdatesProvider></QueryClientProvider>);
+  await waitFor(() => expect(mocks.readEvents).toHaveBeenCalledTimes(1));
+  expect(screen.getByTestId('queries-live')).toHaveTextContent('polling');
+  act(() => receive?.({ event: 'stream.ready', data: { environment_uuid: 'env-uuid' } }));
+  expect(screen.getByTestId('queries-live')).toHaveTextContent('live');
+  await act(async () => closeStream?.());
+  await waitFor(() => expect(screen.getByTestId('queries-live')).toHaveTextContent('polling'));
+  client.clear();
+});
+
+it('keeps polling intervals conservative for non-live and terminal resources', () => {
+  expect(resourceRefetchInterval(false)).toBe(15_000);
+  expect(resourceRefetchInterval(true)).toBe(60_000);
+  expect(resourceRefetchInterval(true, { active: true, completed: false })).toBe(60_000);
+  expect(resourceRefetchInterval(true, { active: false, completed: true })).toBe(false);
+  expect(resourceRefetchInterval(false, { active: true, completed: false })).toBe(15_000);
+});
 
 it('shares one subscription and aborts the old environment on navigation and unmount', async () => {
   mocks.getFeatures.mockResolvedValue({ events: true, event_topics: ['queries'] });

--- a/frontend/src/lib/live-updates.tsx
+++ b/frontend/src/lib/live-updates.tsx
@@ -1,16 +1,35 @@
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { ApiError, AuthError, setCsrfToken } from '$/api/client';
 import { readEvents, type EventTopic, type StreamEvent } from '$/api/events';
 import { getFeatures } from '$/api/features';
 
 type Register = (topic: EventTopic) => () => void;
-const LiveUpdatesContext = createContext<Register | null>(null);
+type LiveStatus = {
+  register: Register;
+  live: Record<EventTopic, boolean>;
+};
+const LiveUpdatesContext = createContext<LiveStatus | null>(null);
+const fallbackRefetchInterval = 15_000;
+const liveReconcileInterval = 60_000;
+type ChangeKind = 'metadata' | 'results' | 'files';
+type PendingInvalidation = { topic: EventTopic; name?: string; change?: ChangeKind };
+
+function invalidationKeys(topic: EventTopic, change?: ChangeKind) {
+  if (topic === 'queries') {
+    if (change === 'metadata') return ['queries', 'query'];
+    if (change === 'results') return ['query-results'];
+    return ['queries', 'query', 'query-results'];
+  }
+  if (change === 'metadata') return ['carves', 'carve'];
+  if (change === 'files') return ['carve', 'carves'];
+  return ['carves', 'carve'];
+}
 
 // Coalesces invalidations and performs a trailing refetch if an event arrives
 // while a snapshot is in flight. It never patches authoritative result rows.
 export function createInvalidator(client: QueryClient, env: string) {
-  const pending = new Map<string, { topic: EventTopic; name?: string }>();
+  const pending = new Map<string, PendingInvalidation>();
   let timer: ReturnType<typeof setTimeout> | undefined;
   let active = true;
   let running = false;
@@ -24,8 +43,8 @@ export function createInvalidator(client: QueryClient, env: string) {
     const batch = [...pending.values()];
     pending.clear();
     try {
-      const requests = batch.flatMap(({ topic, name }) => {
-        const keys = topic === 'queries' ? ['queries', 'query', 'query-results'] : ['carves', 'carve'];
+      const requests = batch.flatMap(({ topic, name, change }) => {
+        const keys = invalidationKeys(topic, change);
         return keys.map(async key => {
           const filters = { queryKey: name && key !== topic ? [key, env, name] : [key, env] };
           const wasFetching = client.isFetching(filters) > 0;
@@ -40,12 +59,12 @@ export function createInvalidator(client: QueryClient, env: string) {
     }
   };
   return {
-    add(topic: EventTopic, name?: string) {
+    add(topic: EventTopic, name?: string, change?: ChangeKind) {
       if (!active) return;
       if (!name || pending.size >= 64) {
         for (const [key, item] of pending) if (item.topic === topic) pending.delete(key);
         pending.set(topic, { topic });
-      } else if (!pending.has(topic)) pending.set(`${topic}:${name}`, { topic, name });
+      } else if (!pending.has(topic)) pending.set(`${topic}:${change || 'all'}:${name}`, { topic, name, change });
       schedule();
     },
     close() { active = false; pending.clear(); if (timer) clearTimeout(timer); },
@@ -55,6 +74,7 @@ export function createInvalidator(client: QueryClient, env: string) {
 export function LiveUpdatesProvider({ env, children }: { env: string; children: ReactNode }) {
   const client = useQueryClient();
   const [counts, setCounts] = useState<Record<EventTopic, number>>({ queries: 0, carves: 0 });
+  const [live, setLive] = useState<Record<EventTopic, boolean>>({ queries: false, carves: false });
   const register = useCallback<Register>((topic) => {
     setCounts(current => ({ ...current, [topic]: current[topic] + 1 }));
     return () => setCounts(current => ({ ...current, [topic]: Math.max(0, current[topic] - 1) }));
@@ -67,6 +87,13 @@ export function LiveUpdatesProvider({ env, children }: { env: string; children: 
     if (!features?.events || !selection) return;
     const topics = selection.split(',') as EventTopic[];
     const invalidator = createInvalidator(client, env);
+    const setTopicsLive = (value: boolean) => {
+      setLive(current => {
+        const next = { ...current };
+        for (const topic of topics) next[topic] = value;
+        return next;
+      });
+    };
     let active = true;
     let forbidden = false;
     let attempts = 0;
@@ -85,11 +112,13 @@ export function LiveUpdatesProvider({ env, children }: { env: string; children: 
       } else if (event === 'stream.ready' && typeof value.environment_uuid === 'string') {
         environmentUUID = value.environment_uuid;
         attempts = 0;
+        setTopicsLive(true);
         for (const topic of topics) invalidator.add(topic);
       } else if (event === 'resource.changed' && value.schema_version === 1 &&
         environmentUUID && value.environment_uuid === environmentUUID &&
         topics.includes(value.topic as EventTopic) && typeof value.name === 'string' && value.name.length <= 256) {
-        invalidator.add(value.topic as EventTopic, value.name);
+        const change = value.change === 'metadata' || value.change === 'results' || value.change === 'files' ? value.change : undefined;
+        invalidator.add(value.topic as EventTopic, value.name, change);
       }
     };
     const connect = async () => {
@@ -105,20 +134,32 @@ export function LiveUpdatesProvider({ env, children }: { env: string; children: 
           for (const topic of topics) invalidator.add(topic);
         } else if (error instanceof ApiError && [400, 403, 404].includes(error.status)) forbidden = true;
       }
+      if (active) setTopicsLive(false);
       if (active && !forbidden) {
         const delay = Math.min(30_000, 1000 * 2 ** Math.min(attempts++, 5)) * (0.8 + Math.random() * 0.4);
         timer = setTimeout(() => { void connect(); }, delay);
       }
     };
     void connect();
-    return () => { active = false; controller?.abort(); if (timer) clearTimeout(timer); invalidator.close(); };
+    return () => { active = false; controller?.abort(); if (timer) clearTimeout(timer); invalidator.close(); setTopicsLive(false); };
   }, [client, env, features?.events, selection]);
 
-  return <LiveUpdatesContext.Provider value={register}>{children}</LiveUpdatesContext.Provider>;
+  const value = useMemo(() => ({ register, live }), [register, live]);
+  return <LiveUpdatesContext.Provider value={value}>{children}</LiveUpdatesContext.Provider>;
 }
 
-// Existing polling stays enabled during the initial mixed-version rollout.
+export function resourceRefetchInterval(
+  live: boolean,
+  resource?: { active?: boolean; completed?: boolean; expired?: boolean; deleted?: boolean },
+) {
+  if (resource && (!resource.active || resource.completed || resource.expired || resource.deleted)) {
+    return false;
+  }
+  return live ? liveReconcileInterval : fallbackRefetchInterval;
+}
+
 export function useResourceUpdates(topic: EventTopic) {
-  const register = useContext(LiveUpdatesContext);
-  useEffect(() => register?.(topic), [register, topic]);
+  const status = useContext(LiveUpdatesContext);
+  useEffect(() => status?.register(topic), [status?.register, topic]);
+  return status?.live[topic] ?? false;
 }

--- a/pkg/carves/carves.go
+++ b/pkg/carves/carves.go
@@ -421,6 +421,6 @@ func (c *Carves) ArchiveLocal(destPath string, carve CarvedFile, blocks []Carved
 
 func (c *Carves) notifyChange(carve CarvedFile) {
 	if c.Events != nil {
-		c.Events.Publish(events.Hint{EnvironmentID: carve.EnvironmentID, Topic: events.Carves, Name: carve.QueryName})
+		c.Events.Publish(events.Hint{EnvironmentID: carve.EnvironmentID, Topic: events.Carves, Name: carve.QueryName, Change: events.ChangeFiles})
 	}
 }

--- a/pkg/carves/events_test.go
+++ b/pkg/carves/events_test.go
@@ -29,8 +29,8 @@ func TestCarveNotificationsFollowSuccessfulPersistence(t *testing.T) {
 	require.Equal(t, 1, stored.CompletedBlocks)
 	require.Equal(t, StatusCompleted, stored.Status)
 	require.Equal(t, []events.Hint{
-		{EnvironmentID: 1, Topic: events.Carves, Name: file.QueryName},
-		{EnvironmentID: 1, Topic: events.Carves, Name: file.QueryName},
+		{EnvironmentID: 1, Topic: events.Carves, Name: file.QueryName, Change: events.ChangeFiles},
+		{EnvironmentID: 1, Topic: events.Carves, Name: file.QueryName, Change: events.ChangeFiles},
 	}, recorder.hints)
 	recorder.hints = nil
 	require.NoError(t, db.Migrator().DropTable(&CarvedFile{}))

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -24,6 +24,9 @@ var (
 const (
 	Queries            = "queries"
 	Carves             = "carves"
+	ChangeMetadata     = "metadata"
+	ChangeResults      = "results"
+	ChangeFiles        = "files"
 	maxConnections     = 1000
 	maxUserConnections = 8
 	queueSize          = 64
@@ -35,10 +38,14 @@ type Hint struct {
 	EnvironmentID uint   `json:"environment_id"`
 	Topic         string `json:"topic"`
 	Name          string `json:"name"`
+	Change        string `json:"change,omitempty"`
 }
 
 func (h Hint) Valid() bool {
-	return h.EnvironmentID != 0 && (h.Topic == Queries || h.Topic == Carves) && len(h.Name) > 0 && len(h.Name) <= 256
+	validChange := h.Change == "" || h.Change == ChangeMetadata ||
+		(h.Topic == Queries && h.Change == ChangeResults) ||
+		(h.Topic == Carves && (h.Change == ChangeResults || h.Change == ChangeFiles))
+	return h.EnvironmentID != 0 && (h.Topic == Queries || h.Topic == Carves) && len(h.Name) > 0 && len(h.Name) <= 256 && validChange
 }
 
 type Publisher interface{ Publish(Hint) }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -26,7 +26,7 @@ func TestSubscriptionIsolationAndReset(t *testing.T) {
 	other, closeOther, err := b.Subscribe("bob", 2, []string{Queries})
 	require.NoError(t, err)
 	defer closeOther()
-	hint := Hint{1, Queries, "q"}
+	hint := Hint{EnvironmentID: 1, Topic: Queries, Name: "q"}
 	b.deliver(hint)
 	require.Equal(t, hint, <-queries)
 	select {
@@ -60,7 +60,7 @@ func TestConnectionLimitAndSlowSubscriber(t *testing.T) {
 	_, _, err := b.Subscribe("alice", 1, []string{Queries})
 	require.ErrorIs(t, err, ErrLimit)
 	for i := 0; i <= queueSize; i++ {
-		b.deliver(Hint{1, Queries, "q"})
+		b.deliver(Hint{EnvironmentID: 1, Topic: Queries, Name: "q"})
 	}
 	require.Empty(t, b.subs)
 	require.EqualValues(t, maxUserConnections, b.Dropped())
@@ -77,7 +77,7 @@ func TestConcurrentSubscriptionCleanup(t *testing.T) {
 			if err != nil {
 				return
 			}
-			b.deliver(Hint{1, Queries, "q"})
+			b.deliver(Hint{EnvironmentID: 1, Topic: Queries, Name: "q"})
 			cancel()
 			cancel()
 		}(i)
@@ -93,7 +93,13 @@ func TestConfigurationAndHintValidation(t *testing.T) {
 		_, err := New(client, namespace, false)
 		require.Error(t, err)
 	}
-	for _, hint := range []Hint{{0, Queries, "q"}, {1, "console", "q"}, {1, Queries, ""}} {
+	for _, hint := range []Hint{
+		{EnvironmentID: 0, Topic: Queries, Name: "q"},
+		{EnvironmentID: 1, Topic: "console", Name: "q"},
+		{EnvironmentID: 1, Topic: Queries, Name: ""},
+		{EnvironmentID: 1, Topic: Queries, Name: "q", Change: "other"},
+		{EnvironmentID: 1, Topic: Queries, Name: "q", Change: ChangeFiles},
+	} {
 		require.False(t, hint.Valid())
 	}
 }
@@ -132,7 +138,7 @@ func TestRedisFanoutAndNamespaceIsolation(t *testing.T) {
 		return ch
 	}
 	a, b, other := subscribe(first), subscribe(second), subscribe(isolated)
-	want := Hint{1, Queries, "q"}
+	want := Hint{EnvironmentID: 1, Topic: Queries, Name: "q"}
 	writer.Publish(want)
 	for _, ch := range []<-chan Hint{a, b} {
 		select {
@@ -212,7 +218,7 @@ func TestRedisReconnectResetsExistingStreams(t *testing.T) {
 		}
 		return err == nil
 	}, 3*time.Second, 10*time.Millisecond)
-	want := Hint{1, Queries, "after-reconnect"}
+	want := Hint{EnvironmentID: 1, Topic: Queries, Name: "after-reconnect"}
 	b.Publish(want)
 	select {
 	case got := <-stream:

--- a/pkg/logging/dispatch.go
+++ b/pkg/logging/dispatch.go
@@ -45,8 +45,8 @@ func (l *LoggerTLS) DispatchQueries(queryData types.QueryWriteData, node nodes.O
 		queryData.Status,
 		debug)
 	// Export completion is only an invalidation hint. Some sinks do not
-	// acknowledge persistence, so clients must retain result polling.
+	// acknowledge persistence, so clients must retain result reconciliation.
 	if l.Queries != nil {
-		l.Queries.NotifyChange(queryData.Name, node.EnvironmentID)
+		l.Queries.NotifyResults(queryData.Name, node.EnvironmentID)
 	}
 }

--- a/pkg/queries/events_test.go
+++ b/pkg/queries/events_test.go
@@ -25,6 +25,7 @@ func TestQueryEventsExcludeInteractiveAndHiddenTypes(t *testing.T) {
 				require.Len(t, recorder.hints, 1)
 				require.Equal(t, query.Name, recorder.hints[0].Name)
 				require.Equal(t, uint(1), recorder.hints[0].EnvironmentID)
+				require.Equal(t, events.ChangeMetadata, recorder.hints[0].Change)
 			} else {
 				require.Empty(t, recorder.hints)
 			}

--- a/pkg/queries/queries.go
+++ b/pkg/queries/queries.go
@@ -615,7 +615,7 @@ func (q *Queries) UpdateQueryStatus(queryName string, nodeID uint, statusCode in
 			return err
 		}
 	}
-	q.notifyChange(query)
+	q.notifyChange(query, events.ChangeMetadata)
 	return nil
 }
 
@@ -705,19 +705,28 @@ func (q *Queries) GetByEnvTargetPaged(envID uint, target, qtype, search string, 
 	return QueryListPage{Items: items, TotalItems: total}, nil
 }
 
-// NotifyChange sends a best-effort invalidation after a caller's write/commit.
+// NotifyChange sends a best-effort metadata invalidation after a caller's write/commit.
 // Interactive/hidden query types are deliberately excluded from broad topics.
 func (q *Queries) NotifyChange(name string, environmentID uint) {
+	q.notifyChangeByName(name, environmentID, events.ChangeMetadata)
+}
+
+// NotifyResults sends a best-effort result invalidation after a query log writer runs.
+func (q *Queries) NotifyResults(name string, environmentID uint) {
+	q.notifyChangeByName(name, environmentID, events.ChangeResults)
+}
+
+func (q *Queries) notifyChangeByName(name string, environmentID uint, change string) {
 	if q.Events == nil {
 		return
 	}
 	query, err := q.Get(name, environmentID)
 	if err == nil {
-		q.notifyChange(query)
+		q.notifyChange(query, change)
 	}
 }
 
-func (q *Queries) notifyChange(query DistributedQuery) {
+func (q *Queries) notifyChange(query DistributedQuery, change string) {
 	if q.Events == nil {
 		return
 	}
@@ -730,5 +739,5 @@ func (q *Queries) notifyChange(query DistributedQuery) {
 	default:
 		return
 	}
-	q.Events.Publish(events.Hint{EnvironmentID: query.EnvironmentID, Topic: topic, Name: query.Name})
+	q.Events.Publish(events.Hint{EnvironmentID: query.EnvironmentID, Topic: topic, Name: query.Name, Change: change})
 }


### PR DESCRIPTION
## Summary

Adds optional SSE-based live update hints between API/TLS and the frontend, with REST kept as the authoritative data path.

- Adds Redis Pub/Sub event fanout for query and carve invalidation hints across API/TLS replicas.
- Adds authenticated `GET /api/v1/events` SSE streaming with environment/topic permission checks.
- Adds frontend live-update subscription sharing per environment.
- Uses typed change hints (`metadata`, `results`, `files`) to refresh only affected query/carve caches.
- Makes query/carve polling adaptive: normal fallback polling, slower live reconciliation, and no polling for terminal detail views.
- Keeps existing polling and REST snapshots as fallback for mixed-version, reconnect, and persistence timing cases.
- Adds config, docs, OpenAPI updates, and tests for event routing and frontend invalidation behavior.

## Validation

- `go test ./...`
- Focused Go tests for events, query/carve notifications, logging dispatch, and API event streaming
- Full frontend Vitest suite: 56 files, 410 tests
- `tsc -p frontend/tsconfig.json --noEmit`
- OpenAPI generation/check from the earlier slice

## Notes

SSE is disabled by default. Enable it on both API and TLS with `--events-enabled` and the same deployment-specific `--events-namespace`.

REST remains authoritative; SSE events are best-effort invalidation hints, not operation completion or replay guarantees.